### PR TITLE
Add length validation to contact fields

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -36,22 +36,41 @@ class TslrClaim < ApplicationRecord
   belongs_to :current_school, optional: true, class_name: "School"
 
   validates :claim_school,              on: :"claim-school", presence: {message: "Select a school from the list"}
+
   validates :qts_award_year,            on: :"qts-year", inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}
+
   validates :employment_status,         on: :"still-teaching", presence: {message: "Choose the option that describes your current employment status"}
+
   validates :mostly_teaching_eligible_subjects, on: :"subjects-taught", inclusion: {in: [true, false], message: "Select either Yes or No"}
+
   validates :full_name,                 on: :"full-name", presence: {message: "Enter your full name"}
+  validates :full_name,                 length: {maximum: 200, message: "Full name must be 200 characters or less"}
+
   validates :address_line_1,            on: :address, presence: {message: "Enter your building and street address"}
+  validates :address_line_1,            length: {maximum: 100, message: "Address lines must be 100 characters or less"}
+
+  validates :address_line_2,            length: {maximum: 100, message: "Address lines must be 100 characters or less"}
+
   validates :address_line_3,            on: :address, presence: {message: "Enter your town or city"}
+  validates :address_line_3,            length: {maximum: 100, message: "Address lines must be 100 characters or less"}
+
   validates :postcode,                  on: :address, presence: {message: "Enter your postcode"}
+  validates :postcode,                  length: {maximum: 11, message: "Postcode must be 11 characters or less"}
+
   validates :date_of_birth,             on: :"date-of-birth", presence: {message: "Enter your date of birth"}
+
   validates :teacher_reference_number,  on: :"teacher-reference-number", presence: {message: "Enter your teacher reference number"}
+
   validate :trn_must_be_seven_digits
+
   validates :national_insurance_number, on: :"national-insurance-number", presence: {message: "Enter your National Insurance number"}
+
   validate  :ni_number_is_correct_format
-  validates :email_address, on: :"email-address", presence: {message: "Enter an email address"}
-  validates :email_address, format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email address in the correct format, like name@example.com"}, \
-                            length: {maximum: 256, message: "Email address must be 256 characters or less"}, \
-                            allow_nil: true
+
+  validates :email_address,             on: :"email-address", presence: {message: "Enter an email address"}
+  validates :email_address,             format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email address in the correct format, like name@example.com"},
+                                        length: {maximum: 256, message: "Email address must be 256 characters or less"},
+                                        allow_nil: true
 
   before_save :update_current_school, if: :employment_status_changed?
   before_save :normalise_trn, if: :teacher_reference_number_changed?

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -4,6 +4,56 @@ RSpec.describe TslrClaim, type: :model do
   it { should belong_to(:claim_school).optional }
   it { should belong_to(:current_school).optional }
 
+  context "when saving a TslrClaim" do
+    context "that has a teacher_reference_number" do
+      it "validates the length of the teacher reference number" do
+        expect(TslrClaim.new(teacher_reference_number: "1/2/3/4/5/6/7")).to be_valid
+        expect(TslrClaim.new(teacher_reference_number: "1/2/3/4/5")).not_to be_valid
+        expect(TslrClaim.new(teacher_reference_number: "12/345678")).not_to be_valid
+      end
+    end
+
+    context "that has a email address" do
+      it "validates that the value is in the correct format" do
+        expect(TslrClaim.new(email_address: "notan email@address.com")).not_to be_valid
+        expect(TslrClaim.new(email_address: "name@example.com")).to be_valid
+      end
+
+      it "checks that the email address in not longer than 256 characters" do
+        expect(TslrClaim.new(email_address: "#{"e" * 256}@example.com")).not_to be_valid
+      end
+    end
+
+    context "that has a National Insurance number" do
+      it "validates that the National Insurance number is in the correct format" do
+        expect(TslrClaim.new(national_insurance_number: "12 34 56 78 C")).not_to be_valid
+        expect(TslrClaim.new(national_insurance_number: "QQ 11 56 78 DE")).not_to be_valid
+
+        expect(TslrClaim.new(national_insurance_number: "QQ 34 56 78 C")).to be_valid
+      end
+    end
+
+    context "that has a full name" do
+      it "validates the length of name is 200 characters or less" do
+        expect(TslrClaim.new(full_name: "Name " * 50)).not_to be_valid
+        expect(TslrClaim.new(full_name: "John Kimble")).to be_valid
+      end
+    end
+
+    context "that has a postcode" do
+      it "validates the length of postcode is not greater than 11" do
+        expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M12345 23453WD")).not_to be_valid
+        expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M1 2WD")).to be_valid
+      end
+    end
+    context "that has a address" do
+      it "validates the length of address_line_1 is 100 characters or less" do
+        valid_address_attributes = {address_line_1: "123 Main Street" * 25, address_line_3: "Twin Peaks", postcode: "12345"}
+        expect(TslrClaim.new(valid_address_attributes)).not_to be_valid
+      end
+    end
+  end
+
   context "when saving in the “qts-year” validation context" do
     let(:custom_validation_context) { :"qts-year" }
 
@@ -70,11 +120,17 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
-  context "when saving a record that has a teacher_reference_number" do
-    it "validates the length of the teacher reference number" do
-      expect(TslrClaim.new(teacher_reference_number: "1/2/3/4/5/6/7")).to be_valid
-      expect(TslrClaim.new(teacher_reference_number: "1/2/3/4/5")).not_to be_valid
-      expect(TslrClaim.new(teacher_reference_number: "12/345678")).not_to be_valid
+  context "when saving in the “national-insurance-number” validation context" do
+    it "validates the presence of national_insurance_number" do
+      expect(TslrClaim.new).not_to be_valid(:"national-insurance-number")
+      expect(TslrClaim.new(national_insurance_number: "QQ123456C")).to be_valid(:"national-insurance-number")
+    end
+  end
+
+  context "when saving in the “email-address” validation context" do
+    it "validates the presence of email_address" do
+      expect(TslrClaim.new).not_to be_valid(:"email-address")
+      expect(TslrClaim.new(email_address: "name@example.tld")).to be_valid(:"email-address")
     end
   end
 
@@ -97,45 +153,11 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
-  context "when saving in the “national-insurance-number” validation context" do
-    it "validates the presence of national_insurance_number" do
-      expect(TslrClaim.new).not_to be_valid(:"national-insurance-number")
-      expect(TslrClaim.new(national_insurance_number: "QQ123456C")).to be_valid(:"national-insurance-number")
-    end
-  end
-
-  context "when saving a record that has a National Insurance number" do
-    it "validates that the National Insurance number is in the correct format" do
-      expect(TslrClaim.new(national_insurance_number: "12 34 56 78 C")).not_to be_valid
-      expect(TslrClaim.new(national_insurance_number: "QQ 11 56 78 DE")).not_to be_valid
-
-      expect(TslrClaim.new(national_insurance_number: "QQ 34 56 78 C")).to be_valid
-    end
-  end
-
   describe "#national_insurance_number" do
     it "saves with white space stripped out" do
       claim = TslrClaim.create!(national_insurance_number: "QQ 12 34 56 C")
 
       expect(claim.national_insurance_number).to eql("QQ123456C")
-    end
-  end
-
-  context "when saving in the “email-address” validation context" do
-    it "validates the presence of email_address" do
-      expect(TslrClaim.new).not_to be_valid(:"email-address")
-      expect(TslrClaim.new(email_address: "name@example.tld")).to be_valid(:"email-address")
-    end
-  end
-
-  context "when saving a record that has a email address" do
-    it "validates that the value is in the correct format" do
-      expect(TslrClaim.new(email_address: "notan email@address.com")).not_to be_valid
-      expect(TslrClaim.new(email_address: "name@example.com")).to be_valid
-    end
-
-    it "checks that the email address in not longer than 256 characters" do
-      expect(TslrClaim.new(email_address: "#{"e" * 256}@example.com")).not_to be_valid
     end
   end
 
@@ -198,7 +220,7 @@ RSpec.describe TslrClaim, type: :model do
   end
 
   describe "#employment_status" do
-    it "provides an enum that captures the claiment’s employment status" do
+    it "provides an enum that captures the claimant’s employment status" do
       claim = TslrClaim.new
 
       claim.employment_status = :claim_school


### PR DESCRIPTION
We have a database length limit on the following fields but no
validation to check it when submitting:

- name (200)
- address_line_1 (100)
- address_line_2 (100)
- address_line_3 (100)
- postcode (11)

Users trying to submit values longer than this would cause an error in our app, so this adds a length validators to stop the problem.

This commit also adds some white space around the validation definitions as
they are getting large and hard to read.