### PR TITLE
Claimants say if they taught 50% of their time in an eligible subject

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -61,6 +61,7 @@ class ClaimsController < ApplicationController
       :claim_school_id,
       :employment_status,
       :current_school_id,
+      :mostly_teaching_eligible_subjects,
       :full_name,
       :address_line_1,
       :address_line_2,

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -10,6 +10,7 @@ module ClaimsHelper
     case claim.ineligibility_reason
     when :ineligible_claim_school then "#{claim.claim_school_name} is not an eligible school."
     when :employed_at_no_school then "You must be still working as a teacher to be eligible."
+    when :not_taught_eligible_subjects_enough then "You must have spent at least half your time teaching an eligible subject."
     else "You can only apply for this payment if you meet the eligibility criteria."
     end
   end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -66,17 +66,25 @@ class TslrClaim < ApplicationRecord
   end
 
   def ineligible?
-    ineligible_claim_school? || employed_at_no_school?
+    ineligible_claim_school? || employed_at_no_school? || not_taught_eligible_subjects_enough?
   end
 
   def ineligibility_reason
-    [:ineligible_claim_school, :employed_at_no_school].find { |eligibility_check| send("#{eligibility_check}?") }
+    [
+      :ineligible_claim_school,
+      :employed_at_no_school,
+      :not_taught_eligible_subjects_enough,
+    ].find { |eligibility_check| send("#{eligibility_check}?") }
   end
 
   private
 
   def ineligible_claim_school?
     claim_school.present? && !claim_school.eligible_for_tslr?
+  end
+
+  def not_taught_eligible_subjects_enough?
+    mostly_teaching_eligible_subjects == false
   end
 
   def update_current_school

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -4,6 +4,7 @@ class TslrClaim < ApplicationRecord
     "claim-school",
     "still-teaching",
     "current-school",
+    "subjects-taught",
     "full-name",
     "address",
     "date-of-birth",
@@ -37,6 +38,7 @@ class TslrClaim < ApplicationRecord
   validates :claim_school,              on: :"claim-school", presence: {message: "Select a school from the list"}
   validates :qts_award_year,            on: :"qts-year", inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}
   validates :employment_status,         on: :"still-teaching", presence: {message: "Choose the option that describes your current employment status"}
+  validates :mostly_teaching_eligible_subjects, on: :"subjects-taught", inclusion: {in: [true, false], message: "Select either Yes or No"}
   validates :full_name,                 on: :"full-name", presence: {message: "Enter your full name"}
   validates :address_line_1,            on: :address, presence: {message: "Enter your building and street address"}
   validates :address_line_3,            on: :address, presence: {message: "Enter your town or city"}

--- a/app/views/claims/subjects_taught.html.erb
+++ b/app/views/claims/subjects_taught.html.erb
@@ -1,0 +1,41 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <%= form.hidden_field :mostly_teaching_eligible_subjects %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">Did you teach eligible subjects for more than 50% of your teaching time between 6 April XXXX and 5 April XXXX?</h1>
+          </legend>
+          <p class="govuk-body">
+            Eligible subjects are:
+          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>biology</li>
+            <li>chemistry</li>
+            <li>physics</li>
+            <li>computer science</li>
+            <li>languages (not including English)</li>
+          </ul>
+          <p class="govuk-body">
+            <span class="govuk-hint">
+              If you've been off on long-term leave or sick, include the time you were scheduled to teach these subjects.
+            </span>
+          </p>
+          <div class="govuk-radios">
+            <div class="govuk-radios__item">
+              <%= form.radio_button(:mostly_teaching_eligible_subjects, true, class: "govuk-radios__input") %>
+              <%= form.label :mostly_teaching_eligible_subjects_true, "Yes", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button(:mostly_teaching_eligible_subjects, false, class: "govuk-radios__input") %>
+              <%= form.label :mostly_teaching_eligible_subjects_false, "No", class: "govuk-label govuk-radios__label" %>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <%= form.submit "Continue", class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/db/migrate/20190521160036_add_mostly_teaching_eligible_subjects_to_tslr_claim.rb
+++ b/db/migrate/20190521160036_add_mostly_teaching_eligible_subjects_to_tslr_claim.rb
@@ -1,0 +1,5 @@
+class AddMostlyTeachingEligibleSubjectsToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :mostly_teaching_eligible_subjects, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_21_123756) do
+ActiveRecord::Schema.define(version: 2019_05_21_160036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2019_05_21_123756) do
     t.string "teacher_reference_number", limit: 11
     t.string "national_insurance_number", limit: 9
     t.string "email_address", limit: 256
+    t.boolean "mostly_teaching_eligible_subjects"
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -19,6 +19,12 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(claim.reload.employment_status).to eql("claim_school")
     expect(claim.current_school).to eql(schools(:penistone_grammar_school))
 
+    expect(page).to have_text("Did you teach eligible subjects for more than 50% of your teaching time")
+    choose "Yes"
+    click_on "Continue"
+
+    expect(claim.reload.mostly_teaching_eligible_subjects).to eq(true)
+
     expect(page).to have_text("What is your full name")
 
     fill_in "What is your full name?", with: "Margaret Honeycutt"
@@ -89,7 +95,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.current_school).to eql schools(:hampstead_school)
 
-    expect(page).to have_text("What is your full name")
+    expect(page).to have_text("Did you teach eligible subjects for more than 50% of your teaching time")
   end
 
   scenario "chooses an ineligible school" do

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -121,6 +121,23 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_text("You must be still working as a teacher to be eligible")
   end
 
+  scenario "did not teach at least half their time in an eligible subject" do
+    claim = start_tslr_claim
+    choose_qts_year
+    choose_school schools(:penistone_grammar_school)
+
+    choose "Yes, at Penistone Grammar School"
+    click_on "Continue"
+
+    expect(page).to have_text("Did you teach eligible subjects for more than 50% of your teaching time")
+    choose "No"
+    click_on "Continue"
+
+    expect(claim.reload.mostly_teaching_eligible_subjects).to eq(false)
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You must have spent at least half your time teaching an eligible subject.")
+  end
+
   scenario "Teacher cannot go to mid-claim page before starting a claim" do
     visit claim_path("qts-year")
     expect(page).to have_current_path(root_path)

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -13,9 +13,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
     expect(page).to have_text("Are you still employed to teach at a school in England")
 
-    choose "Yes, at Penistone Grammar School"
-    click_on "Continue"
-
+    choose_still_teaching
     expect(claim.reload.employment_status).to eql("claim_school")
     expect(claim.current_school).to eql(schools(:penistone_grammar_school))
 
@@ -82,8 +80,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     choose_qts_year
     choose_school schools(:penistone_grammar_school)
 
-    choose "Yes, at another school"
-    click_on "Continue"
+    choose_still_teaching "Yes, at another school"
 
     expect(claim.reload.employment_status).to eql("different_school")
 
@@ -113,8 +110,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     choose_qts_year
     choose_school schools(:penistone_grammar_school)
 
-    choose "No"
-    click_on "Continue"
+    choose_still_teaching "No"
 
     expect(claim.reload.employment_status).to eq("no_school")
     expect(page).to have_text("You’re not eligible")
@@ -125,9 +121,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     claim = start_tslr_claim
     choose_qts_year
     choose_school schools(:penistone_grammar_school)
-
-    choose "Yes, at Penistone Grammar School"
-    click_on "Continue"
+    choose_still_teaching
 
     expect(page).to have_text("Did you teach eligible subjects for more than 50% of your teaching time")
     choose "No"

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -161,6 +161,16 @@ RSpec.describe TslrClaim, type: :model do
       let(:claim_attributes) { {employment_status: :no_school} }
       it { is_expected.to be true }
     end
+
+    context "when taught less than half time in eligible subjects" do
+      let(:claim_attributes) { {mostly_teaching_eligible_subjects: false} }
+      it { is_expected.to be true }
+    end
+
+    context "when taught at least half time in eligible subjects" do
+      let(:claim_attributes) { {mostly_teaching_eligible_subjects: true} }
+      it { is_expected.to be false }
+    end
   end
 
   describe "#ineligibility_reason" do
@@ -174,6 +184,11 @@ RSpec.describe TslrClaim, type: :model do
     context "when no longer teaching" do
       let(:claim_attributes) { {employment_status: :no_school} }
       it { is_expected.to eql :employed_at_no_school }
+    end
+
+    context "when taught less than half time in eligible subjects" do
+      let(:claim_attributes) { {mostly_teaching_eligible_subjects: false} }
+      it { is_expected.to eql :not_taught_eligible_subjects_enough }
     end
 
     context "when not ineligible" do

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving in the “subjects-taught” validation context" do
+    it "validates mostly_teaching_eligible_subjects has been provided" do
+      expect(TslrClaim.new).not_to be_valid(:"subjects-taught")
+      expect(TslrClaim.new(mostly_teaching_eligible_subjects: true)).to be_valid(:"subjects-taught")
+    end
+  end
+
   context "when saving in the “name” validation context" do
     it "validates the presence of full_name" do
       expect(TslrClaim.new).not_to be_valid(:"full-name")

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -17,4 +17,9 @@ module FeatureHelpers
     choose school.name
     click_on "Continue"
   end
+
+  def choose_still_teaching(teaching_at = "Yes, at Penistone Grammar School")
+    choose teaching_at
+    click_on "Continue"
+  end
 end


### PR DESCRIPTION
So that we can determine if a teacher is eligible for this policy or not, we need to know if they taught the eligible subjects at least 50% of their time.

The content comes from the [TSLR eligibility checker](https://github.com/DFE-Digital/tslr/blob/f01d2713eab4698e11ef55323530bd0e1ca922fa/TSLR.UI/pages/question/subjects-taught.vue) from alpha, we may want to improve it at a later date.