### PR TITLE
We can determine if a given school meets the MPTR eligibility criteria

### DIFF
--- a/app/models/local_authority_district.rb
+++ b/app/models/local_authority_district.rb
@@ -1,0 +1,3 @@
+class LocalAuthorityDistrict < ApplicationRecord
+  has_many :schools
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -2,6 +2,7 @@ class School < ApplicationRecord
   SEARCH_RESULTS_LIMIT = 50
 
   belongs_to :local_authority
+  belongs_to :local_authority_district
 
   validates :urn, presence: true
   validates :name, presence: true

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -88,4 +88,8 @@ class School < ApplicationRecord
   def eligible_for_tslr?
     Tslr::SchoolEligibility.new(self).check
   end
+
+  def eligible_for_mptr?
+    Mps::SchoolEligibility.new(self).check
+  end
 end

--- a/app/services/mptr/school_eligibility.rb
+++ b/app/services/mptr/school_eligibility.rb
@@ -1,0 +1,78 @@
+module Mptr
+  class SchoolEligibility
+    ELIGIBLE_PHASES = %w[secondary middle_deemed_secondary].freeze
+    STATE_FUNDED_TYPE_GROUPS = %w[colleges la_maintained special_schools academies free_schools].freeze
+    ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES = [
+      "E08000016", # Barnsley
+      "E06000009", # Blackpool
+      "E08000032", # Bradford
+      "E08000033", # Calderdale
+      "E06000047", # County Durham
+      "E07000163", # Craven
+      "E06000005", # Darlington
+      "E06000015", # Derby
+      "E08000017", # Doncaster
+      "E07000009", # East Cambridgeshire aka Fenland and East Cambridgeshire
+      "E06000011", # East Riding of Yorkshire
+      "E07000010", # Fenland aka Fenland and East Cambridgeshire
+      "E08000037", # Gateshead
+      "E07000164", # Hambleton
+      "E07000165", # Harrogate
+      "E06000001", # Hartlepool
+      "E07000062", # Hastings
+      "E07000202", # Ipswich
+      "E06000010", # Kingston upon Hull, city of aka Kingston upon Hull
+      "E08000034", # Kirklees
+      "E08000035", # Leeds
+      "E06000002", # Middlesbrough
+      "E08000021", # Newcastle upon Tyne
+      "E06000012", # North East Lincolnshire
+      "E06000013", # North Lincolnshire
+      "E08000022", # North Tyneside
+      "E06000057", # Northumberland
+      "E07000148", # Norwich
+      "E08000004", # Oldham
+      "E06000003", # Redcar and Cleveland
+      "E07000166", # Richmondshire
+      "E08000018", # Rotherham
+      "E07000167", # Ryedale
+      "E07000168", # Scarborough
+      "E07000169", # Selby
+      "E08000019", # Sheffield
+      "E08000023", # South Tyneside
+      "E06000004", # Stockton-on-Tees
+      "E06000021", # Stoke-on-Trent
+      "E08000024", # Sunderland
+      "E08000036", # Wakefield
+      "E07000191", # West Somerset
+      "E06000014", # York
+    ].freeze
+
+    def initialize(school)
+      @school = school
+    end
+
+    def check
+      eligible_local_authority_district? && state_funded? && eligible_phase?
+    end
+
+    private
+
+    def eligible_local_authority_district?
+      ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES.include?(@school.local_authority_district.code)
+    end
+
+    def state_funded?
+      STATE_FUNDED_TYPE_GROUPS.include?(@school.school_type_group) &&
+        !independent_special_school?
+    end
+
+    def eligible_phase?
+      ELIGIBLE_PHASES.include?(@school.phase)
+    end
+
+    def independent_special_school?
+      @school.school_type == "other_independent_special_school"
+    end
+  end
+end

--- a/app/services/school_data_importer.rb
+++ b/app/services/school_data_importer.rb
@@ -26,6 +26,11 @@ class SchoolDataImporter
     local_authority = LocalAuthority.find_or_initialize_by(code: row.fetch("LA (code)"))
     local_authority.name = row.fetch("LA (name)")
     local_authority.save!
+
+    local_authority_district = LocalAuthorityDistrict.find_or_initialize_by(code: row.fetch("DistrictAdministrative (code)"))
+    local_authority_district.name = row.fetch("DistrictAdministrative (name)")
+    local_authority_district.save!
+
     school = School.find_or_initialize_by(urn: row.fetch("URN"))
     school.name = row.fetch("EstablishmentName")
     school.street = row.fetch("Street")
@@ -37,6 +42,7 @@ class SchoolDataImporter
     school.school_type_group = row.fetch("EstablishmentTypeGroup (code)").to_i
     school.school_type = row.fetch("TypeOfEstablishment (code)").to_i
     school.local_authority = local_authority
+    school.local_authority_district = local_authority_district
     school
   end
 

--- a/db/migrate/20190528121128_create_local_authority_districts.rb
+++ b/db/migrate/20190528121128_create_local_authority_districts.rb
@@ -1,0 +1,10 @@
+class CreateLocalAuthorityDistricts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :local_authority_districts, id: :uuid do |t|
+      t.string :name
+      t.string :code
+
+      t.index :code, unique: true
+    end
+  end
+end

--- a/db/migrate/20190528121606_add_local_authority_disctrict_ref_to_schools.rb
+++ b/db/migrate/20190528121606_add_local_authority_disctrict_ref_to_schools.rb
@@ -1,0 +1,5 @@
+class AddLocalAuthorityDisctrictRefToSchools < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :schools, :local_authority_district, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_21_160036) do
+ActiveRecord::Schema.define(version: 2019_05_28_121606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -20,6 +20,12 @@ ActiveRecord::Schema.define(version: 2019_05_21_160036) do
     t.integer "code"
     t.string "name"
     t.index ["code"], name: "index_local_authorities_on_code", unique: true
+  end
+
+  create_table "local_authority_districts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.string "code"
+    t.index ["code"], name: "index_local_authority_districts_on_code", unique: true
   end
 
   create_table "schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -36,6 +42,8 @@ ActiveRecord::Schema.define(version: 2019_05_21_160036) do
     t.uuid "local_authority_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "local_authority_district_id"
+    t.index ["local_authority_district_id"], name: "index_schools_on_local_authority_district_id"
     t.index ["local_authority_id"], name: "index_schools_on_local_authority_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
@@ -63,6 +71,7 @@ ActiveRecord::Schema.define(version: 2019_05_21_160036) do
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"
   end
 
+  add_foreign_key "schools", "local_authority_districts"
   add_foreign_key "tslr_claims", "schools", column: "claim_school_id"
   add_foreign_key "tslr_claims", "schools", column: "current_school_id"
 end

--- a/spec/factories/local_authority_districts.rb
+++ b/spec/factories/local_authority_districts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :local_authority_district do
+    name { "Barnsley" }
+    sequence(:code, 1000) { |n| "E0000#{n}" }
+  end
+end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     school_type_group { :la_maintained }
     phase { :secondary }
     local_authority
+    local_authority_district
   end
 end

--- a/spec/fixtures/local_authority_districts.yml
+++ b/spec/fixtures/local_authority_districts.yml
@@ -1,0 +1,8 @@
+#MPTR Eligible
+barnsley:
+  code: E08000016
+  name: Barnsley
+#MPTR Ineligible
+camden:
+  code: E09000007
+  name: Camden

--- a/spec/fixtures/schools.yml
+++ b/spec/fixtures/schools.yml
@@ -1,4 +1,4 @@
-# TSLR Eligible
+# TSLR and MPTR Eligible
 penistone_grammar_school:
   name: Penistone Grammar School
   urn: 1234
@@ -6,7 +6,8 @@ penistone_grammar_school:
   school_type_group: la_maintained
   school_type: community_school
   local_authority: barnsley
-# TSLR Ineligible
+  local_authority_district: barnsley
+# TSLR and MPTR Ineligible
 hampstead_school:
   name: Hampstead School
   urn: 4567
@@ -14,3 +15,4 @@ hampstead_school:
   school_type_group: la_maintained
   school_type: community_school
   local_authority: camden
+  local_authority_district: camden

--- a/spec/models/local_authority_district_spec.rb
+++ b/spec/models/local_authority_district_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe LocalAuthorityDistrict, type: :model do
+  it { should have_many(:schools) }
+end

--- a/spec/services/mptr/school_eligibility_spec.rb
+++ b/spec/services/mptr/school_eligibility_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+RSpec.describe Mptr::SchoolEligibility do
+  describe "#check" do
+    subject { Mptr::SchoolEligibility.new(school).check }
+    let(:school) { build(:school, school_attributes.merge({local_authority_district: local_authority_district})) }
+
+    context "when it is in an eligible local authority district" do
+      let(:local_authority_district) { local_authority_districts(:barnsley) }
+
+      context "and it is a college" do
+        let(:college_attributes) { {school_type_group: :colleges} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { college_attributes.merge({phase: :middle_deemed_secondary}) }
+          it { is_expected.to be true }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { college_attributes.merge({phase: :sixteen_plus}) }
+          it { is_expected.to be false }
+        end
+      end
+
+      context "and it is an academy" do
+        let(:academy_school_attributes) { {school_type_group: :academies} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { academy_school_attributes.merge({phase: :secondary}) }
+          it { is_expected.to be true }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { academy_school_attributes.merge({phase: :primary}) }
+          it { is_expected.to be false }
+        end
+      end
+
+      context "and it is a free school" do
+        let(:free_school_attributes) { {school_type_group: :free_schools} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { free_school_attributes.merge({phase: :secondary}) }
+          it { is_expected.to be true }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { free_school_attributes.merge({phase: :middle_deemed_primary}) }
+          it { is_expected.to be false }
+        end
+      end
+
+      context "and it is a LA maintained school" do
+        let(:la_maintained_attributes) { {school_type_group: :la_maintained} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { la_maintained_attributes.merge({phase: :secondary}) }
+          it { is_expected.to be true }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { la_maintained_attributes.merge({phase: :nursery}) }
+          it { is_expected.to be false }
+        end
+      end
+
+      context "and it is a special school" do
+        let(:special_school_attributes) { {school_type_group: :special_schools} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :secondary}) }
+          it { is_expected.to be true }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :nursery}) }
+          it { is_expected.to be false }
+        end
+
+        context "and it is a state funded special school" do
+          let(:school_attributes) { special_school_attributes.merge({school_type: :community_school})}
+          it { is_expected.to be true }
+        end
+
+        context "and it is an independent special school" do
+          let(:school_attributes) { special_school_attributes.merge({school_type: :other_independent_special_school})}
+          it { is_expected.to be false }
+        end
+
+        context "and it is not a state funded school" do
+          let(:school_attributes) { {school_type_group: :independent_schools} }
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    context "when it is not in an eligible local authority district" do
+      let(:local_authority_district) { local_authority_districts(:camden) }
+      let(:school_attributes) {{}}
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/services/school_data_importer_spec.rb
+++ b/spec/services/school_data_importer_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe SchoolDataImporter do
         expect(imported_school.school_type_group).to eql("la_maintained")
         expect(imported_school.local_authority.code).to eql(370)
         expect(imported_school.local_authority.name).to eql("Barnsley")
+        expect(imported_school.local_authority_district.code).to eql("E08000016")
+        expect(imported_school.local_authority_district.name).to eql("Barnsley")
       end
 
       it "correctly handles any Latin1 encoded characters in the data file" do
@@ -66,6 +68,19 @@ RSpec.describe SchoolDataImporter do
           local_authorities(:barnsley).reload
 
           expect(local_authorities(:barnsley).name).to eql("Barnsley")
+        end
+      end
+
+      context "when the local authority district already exists" do
+        before do
+          local_authority_districts(:barnsley).update!(name: "South Yorkshire")
+        end
+
+        it "updates the local authority district" do
+          school_data_importer.run
+          local_authority_districts(:barnsley).reload
+
+          expect(local_authority_districts(:barnsley).name).to eql("Barnsley")
         end
       end
     end


### PR DESCRIPTION
This PR mostly builds on @robbiepaul work on the TSLR eligibility.

MPTR or Mathematics and Physics Teacher Retention uses the more granular 'local authority disctrict' school location from GIAS data so we needed to model that data in our sevice first.

Once we have the LAD we use the same criteria as TSLR for the rest of the checks as it is the same:

- State funded school in England
- Local Authority maintained secondary (including middle deemed
  secondary)
- Local Authority maintained or non-maintained special schools
- Secondary phase academy/free school

Along with:

- In one of the 42 local authority districts listed in the policy

There were a couple of things we confrimed with the policy team:

- The policy states 'Fenland and East Cambridgeshire' which is two separate
LADs in GIAS so we end up with 43 local authority districts in code.

- The policy also lists 'Kingston upon Hull' which is 'Kingston upon Hull, city
of' in GIAS.

Both of these are noted in comments in the code.

The official criteria can be found here:
https://www.gov.uk/guidance/apply-for-mathematics-and-physics-teacher-retention-payments#eligibility-criteria

Trello story: 
https://trello.com/c/FzifCNYR