### PR TITLE
Bank account details capture page

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -87,6 +87,8 @@ class ClaimsController < ApplicationController
       :national_insurance_number,
       :student_loan_repayment_amount,
       :email_address,
+      :bank_sort_code,
+      :bank_account_number,
     )
   end
 

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -29,6 +29,8 @@ module ClaimsHelper
       ["Teacher reference number", claim.teacher_reference_number],
       ["National Insurance number", claim.national_insurance_number],
       ["Email address", claim.email_address],
+      ["Account number", claim.bank_account_number],
+      ["Sort code", claim.bank_sort_code],
     ]
   end
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -12,6 +12,7 @@ class TslrClaim < ApplicationRecord
     "national-insurance-number",
     "student-loan-amount",
     "email-address",
+    "bank-details",
     "check-your-answers",
     "confirmation",
   ].freeze
@@ -74,6 +75,13 @@ class TslrClaim < ApplicationRecord
   validates :email_address,             on: [:"email-address", :submit], presence: {message: "Enter an email address"}
   validates :email_address,             format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email address in the correct format, like name@example.com"},
                                         length: {maximum: 256, message: "Email address must be 256 characters or less"},
+                                        allow_nil: true
+
+  validates :bank_sort_code,            on: :"bank-details", presence: {message: "Enter a sort code"}
+  validates :bank_sort_code,            length: {is: 6, message: "Sort code must be 6 digits"},
+                                        allow_nil: true
+  validates :bank_account_number,       on: :"bank-details", presence: {message: "Enter an account number"}
+  validates :bank_account_number,       length: {is: 8, message: "Account number must be 8 digits"},
                                         allow_nil: true
 
   before_save :update_current_school, if: :employment_status_changed?

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -1,0 +1,43 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+      <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+
+      <%= form_for current_claim, url: claim_path do |form| %>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              Your bank account details
+            </h1>
+          </legend>
+
+          <p class="govuk-body govuk-hint">
+            We need to collect this information to pay you.
+          </p>
+
+          <div class="govuk-form-group">
+            <%= form.label :bank_sort_code, "Sort code", class: "govuk-label" %>
+            <span  id="sort-code-hint" class="govuk-hint">For example: 44 00 26</span>
+            <%= form.text_field :bank_sort_code,
+              class: "govuk-input govuk-!-width-one-quarter",
+              "aria-describedby" => "sort-code-hint"
+            %>
+          </div>
+
+          <div class="govuk-form-group">
+            <%= form.label :bank_account_number, "Account number", class: "govuk-label" %>
+            <span  id="account-number-hint" class="govuk-hint">For example: 70 87 24 90</span>
+            <%= form.text_field :bank_account_number,
+              class: "govuk-input govuk-input--width-20",
+              "aria-describedby" => "account-number-hint"
+            %>
+          </div>
+
+        </fieldset>
+
+        <div class="govuk-form-group">
+          <%= form.submit "Continue", class: "govuk-button" %>
+        </div>
+      <% end %>
+  </div>
+</div>

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -7,7 +7,7 @@
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">
-              Your bank account details
+              <%= t("tslr.questions.bank_details") %>
             </h1>
           </legend>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,3 +52,4 @@ en:
       national_insurance_number: "What is your National Insurance number?"
       student_loan_amount: "How much student loan did you repay while you were at %{claim_school_name} between 6 April XXXX and 5 April XXXX?"
       email_address: "What is your email address?"
+      bank_details: "Your bank account details"

--- a/db/migrate/20190529101022_add_bank_details_to_tslr_claim.rb
+++ b/db/migrate/20190529101022_add_bank_details_to_tslr_claim.rb
@@ -1,0 +1,6 @@
+class AddBankDetailsToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :bank_sort_code, :string, limit: 6
+    add_column :tslr_claims, :bank_account_number, :string, limit: 8
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,6 +66,8 @@ ActiveRecord::Schema.define(version: 2019_05_31_101710) do
     t.string "national_insurance_number", limit: 9
     t.string "email_address", limit: 256
     t.boolean "mostly_teaching_eligible_subjects"
+    t.string "bank_sort_code", limit: 6
+    t.string "bank_account_number", limit: 8
     t.datetime "submitted_at"
     t.decimal "student_loan_repayment_amount", precision: 7, scale: 2
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -78,6 +78,15 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.email_address).to eq("name@example.tld")
 
+    expect(page).to have_text("Your bank account details")
+    expect(page).to have_text("We need to collect this information to pay you.")
+    fill_in "Sort code", with: "123456"
+    fill_in "Account number", with: "87654321"
+    click_on "Continue"
+
+    expect(claim.reload.bank_sort_code).to eq("123456")
+    expect(claim.reload.bank_account_number).to eq("87654321")
+
     expect(page).to have_text("Check your answers before sending your application")
 
     freeze_time do

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.email_address).to eq("name@example.tld")
 
-    expect(page).to have_text("Your bank account details")
+    expect(page).to have_text(I18n.t("tslr.questions.bank_details"))
     expect(page).to have_text("We need to collect this information to pay you.")
     fill_in "Sort code", with: "123456"
     fill_in "Account number", with: "87654321"

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -52,6 +52,8 @@ describe ClaimsHelper do
         teacher_reference_number: "1234567",
         national_insurance_number: "QQ 12 34 56 C",
         email_address: "test@email.com",
+        bank_account_number: "12 34 56 78",
+        bank_sort_code: "12 34 56",
       )
 
       expected_answers = [
@@ -61,6 +63,8 @@ describe ClaimsHelper do
         ["Teacher reference number", "1234567"],
         ["National Insurance number", "QQ123456C"],
         ["Email address", "test@email.com"],
+        ["Account number", "12345678"],
+        ["Sort code", "123456"],
       ]
 
       expect(helper.identity_answers(claim)).to eq expected_answers

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -60,6 +60,16 @@ RSpec.describe TslrClaim, type: :model do
         expect(TslrClaim.new(valid_address_attributes)).not_to be_valid
       end
     end
+
+    context "that has bank details" do
+      it "validates the length of account_number and account_sort_code" do
+        expect(TslrClaim.new(bank_account_number: "123456789")).not_to be_valid
+        expect(TslrClaim.new(bank_sort_code: "10111213")).not_to be_valid
+
+        expect(TslrClaim.new(bank_account_number: "12345678")).to be_valid
+        expect(TslrClaim.new(bank_sort_code: "101112")).to be_valid
+      end
+    end
   end
 
   context "when saving in the “qts-year” validation context" do
@@ -146,6 +156,13 @@ RSpec.describe TslrClaim, type: :model do
     it "validates the presence of email_address" do
       expect(TslrClaim.new).not_to be_valid(:"email-address")
       expect(TslrClaim.new(email_address: "name@example.tld")).to be_valid(:"email-address")
+    end
+  end
+
+  context "when saving in the “bank-details” validation context" do
+    it "validates that the bank_account_number and bank_sort_code are present" do
+      expect(TslrClaim.new).not_to be_valid(:"bank-details")
+      expect(TslrClaim.new(bank_sort_code: "123456", bank_account_number: "87654321")).to be_valid(:"bank-details")
     end
   end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -4,70 +4,78 @@ RSpec.describe TslrClaim, type: :model do
   it { should belong_to(:claim_school).optional }
   it { should belong_to(:current_school).optional }
 
-  context "when saving a TslrClaim" do
-    context "that has a teacher_reference_number" do
-      it "validates the length of the teacher reference number" do
-        expect(TslrClaim.new(teacher_reference_number: "1/2/3/4/5/6/7")).to be_valid
-        expect(TslrClaim.new(teacher_reference_number: "1/2/3/4/5")).not_to be_valid
-        expect(TslrClaim.new(teacher_reference_number: "12/345678")).not_to be_valid
-      end
+  context "that has a teacher_reference_number" do
+    it "validates the length of the teacher reference number" do
+      expect(TslrClaim.new(teacher_reference_number: "1/2/3/4/5/6/7")).to be_valid
+      expect(TslrClaim.new(teacher_reference_number: "1/2/3/4/5")).not_to be_valid
+      expect(TslrClaim.new(teacher_reference_number: "12/345678")).not_to be_valid
+    end
+  end
+
+  context "that has a email address" do
+    it "validates that the value is in the correct format" do
+      expect(TslrClaim.new(email_address: "notan email@address.com")).not_to be_valid
+      expect(TslrClaim.new(email_address: "name@example.com")).to be_valid
     end
 
-    context "that has a email address" do
-      it "validates that the value is in the correct format" do
-        expect(TslrClaim.new(email_address: "notan email@address.com")).not_to be_valid
-        expect(TslrClaim.new(email_address: "name@example.com")).to be_valid
-      end
+    it "checks that the email address in not longer than 256 characters" do
+      expect(TslrClaim.new(email_address: "#{"e" * 256}@example.com")).not_to be_valid
+    end
+  end
 
-      it "checks that the email address in not longer than 256 characters" do
-        expect(TslrClaim.new(email_address: "#{"e" * 256}@example.com")).not_to be_valid
-      end
+  context "that has a National Insurance number" do
+    it "validates that the National Insurance number is in the correct format" do
+      expect(TslrClaim.new(national_insurance_number: "12 34 56 78 C")).not_to be_valid
+      expect(TslrClaim.new(national_insurance_number: "QQ 11 56 78 DE")).not_to be_valid
+
+      expect(TslrClaim.new(national_insurance_number: "QQ 34 56 78 C")).to be_valid
+    end
+  end
+
+  context "that has a student loan repayment amount" do
+    it "validates that the loan repayment amount is numerical" do
+      expect(TslrClaim.new(student_loan_repayment_amount: "don’t know")).not_to be_valid
+      expect(TslrClaim.new(student_loan_repayment_amount: "£1,234.56")).to be_valid
+    end
+  end
+
+  context "that has a full name" do
+    it "validates the length of name is 200 characters or less" do
+      expect(TslrClaim.new(full_name: "Name " * 50)).not_to be_valid
+      expect(TslrClaim.new(full_name: "John Kimble")).to be_valid
+    end
+  end
+
+  context "that has a postcode" do
+    it "validates the length of postcode is not greater than 11" do
+      expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M12345 23453WD")).not_to be_valid
+      expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M1 2WD")).to be_valid
+    end
+  end
+
+  context "that has a address" do
+    it "validates the length of address_line_1 is 100 characters or less" do
+      valid_address_attributes = {address_line_1: "123 Main Street" * 25, address_line_3: "Twin Peaks", postcode: "12345"}
+      expect(TslrClaim.new(valid_address_attributes)).not_to be_valid
+    end
+  end
+
+  context "that has bank details" do
+    it "validates the format of bank_account_number and bank_sort_code" do
+      expect(TslrClaim.new(bank_account_number: "ABC12 34 56 789")).not_to be_valid
+      expect(TslrClaim.new(bank_account_number: "12-34-56-78")).to be_valid
+
+      expect(TslrClaim.new(bank_sort_code: "ABC12 34 567")).not_to be_valid
+      expect(TslrClaim.new(bank_sort_code: "12 34 56")).to be_valid
     end
 
-    context "that has a National Insurance number" do
-      it "validates that the National Insurance number is in the correct format" do
-        expect(TslrClaim.new(national_insurance_number: "12 34 56 78 C")).not_to be_valid
-        expect(TslrClaim.new(national_insurance_number: "QQ 11 56 78 DE")).not_to be_valid
+    context "on save" do
+      it "strips out white space and the “-” character from bank_account_number and bank_sort_code" do
+        claim = TslrClaim.new(bank_sort_code: "12 34 56", bank_account_number: "12-34-56-78")
+        claim.save!
 
-        expect(TslrClaim.new(national_insurance_number: "QQ 34 56 78 C")).to be_valid
-      end
-    end
-
-    context "that has a student loan repayment amount" do
-      it "validates that the loan repayment amount is numerical" do
-        expect(TslrClaim.new(student_loan_repayment_amount: "don’t know")).not_to be_valid
-        expect(TslrClaim.new(student_loan_repayment_amount: "£1,234.56")).to be_valid
-      end
-    end
-
-    context "that has a full name" do
-      it "validates the length of name is 200 characters or less" do
-        expect(TslrClaim.new(full_name: "Name " * 50)).not_to be_valid
-        expect(TslrClaim.new(full_name: "John Kimble")).to be_valid
-      end
-    end
-
-    context "that has a postcode" do
-      it "validates the length of postcode is not greater than 11" do
-        expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M12345 23453WD")).not_to be_valid
-        expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M1 2WD")).to be_valid
-      end
-    end
-
-    context "that has a address" do
-      it "validates the length of address_line_1 is 100 characters or less" do
-        valid_address_attributes = {address_line_1: "123 Main Street" * 25, address_line_3: "Twin Peaks", postcode: "12345"}
-        expect(TslrClaim.new(valid_address_attributes)).not_to be_valid
-      end
-    end
-
-    context "that has bank details" do
-      it "validates the length of account_number and account_sort_code" do
-        expect(TslrClaim.new(bank_account_number: "123456789")).not_to be_valid
-        expect(TslrClaim.new(bank_sort_code: "10111213")).not_to be_valid
-
-        expect(TslrClaim.new(bank_account_number: "12345678")).to be_valid
-        expect(TslrClaim.new(bank_sort_code: "101112")).to be_valid
+        expect(claim.bank_sort_code).to eql("123456")
+        expect(claim.bank_account_number).to eql("12345678")
       end
     end
   end


### PR DESCRIPTION
We are not capturing the bank 'account holder name' at this stage as we hope to get that data from elsewhere.

Followed the layout from @titlescreen (ta!),left out the optional 'SSL notice', we can always add it in later if user research shows we need it.

![Screenshot_2019-05-29 Teachers claim back student loan repayments](https://user-images.githubusercontent.com/480578/58558763-8e9da480-8219-11e9-839e-d4aa7deb23bb.png)

Trello: https://trello.com/c/ayr6F6OV

## Queries I had 
This seemed to be as DRY as I could ge the normalisation methods, I couldn't see a way to pass which attribute had changed in the `before_save` hook.

At first I set the fields to integers in the DB but this meant constantly coercing the values to strings all over the place, so in the end I changed the DB to a string, I figured the form submits a string anyway. Wonder if I could've used a `to_i` at the end of the normalisation, be interested in your thoughts on this one?
