### PR TITLE
Claimants can enter the amount of student loan they repaid last tax year

### DIFF
--- a/app/assets/stylesheets/components/currency_input.scss
+++ b/app/assets/stylesheets/components/currency_input.scss
@@ -1,0 +1,17 @@
+.govuk-currency-input {
+  &__inner {
+    position: relative;
+    font-family: "nta", Arial, sans-serif;
+
+    &__unit {
+      position: absolute;
+      bottom: 9px;
+      left: 10px;
+      font-weight: bold;
+    }
+
+    &__input.govuk-input {
+      padding-left: 25px;
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_frontend_rails.scss
+++ b/app/assets/stylesheets/govuk_frontend_rails.scss
@@ -11,6 +11,7 @@ $govuk-image-url-function: 'font-url';
 @import "objects/all";
 
 @import "components/flash";
+@import "components/currency_input";
 @import "components/all";
 
 @import "utilities/all";

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -85,6 +85,7 @@ class ClaimsController < ApplicationController
       :date_of_birth,
       :teacher_reference_number,
       :national_insurance_number,
+      :student_loan_repayment_amount,
       :email_address,
     )
   end

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -17,6 +17,7 @@ module ClaimsHelper
       [t("tslr.questions.claim_school"), claim.claim_school_name],
       [t("tslr.questions.current_school"), claim.current_school_name],
       [t("tslr.questions.mostly_teaching_eligible_subjects"), claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"],
+      [t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), number_to_currency(claim.student_loan_repayment_amount)],
     ]
   end
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -62,12 +62,14 @@ class TslrClaim < ApplicationRecord
   validates :date_of_birth,             on: [:"date-of-birth", :submit], presence: {message: "Enter your date of birth"}
 
   validates :teacher_reference_number,  on: [:"teacher-reference-number", :submit], presence: {message: "Enter your teacher reference number"}
-
   validate :trn_must_be_seven_digits
 
   validates :national_insurance_number, on: [:"national-insurance-number", :submit], presence: {message: "Enter your National Insurance number"}
-
   validate  :ni_number_is_correct_format
+
+  validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
+  validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount",
+                                                            allow_nil: true
 
   validates :email_address,             on: [:"email-address", :submit], presence: {message: "Enter an email address"}
   validates :email_address,             format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email address in the correct format, like name@example.com"},

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -10,6 +10,7 @@ class TslrClaim < ApplicationRecord
     "date-of-birth",
     "teacher-reference-number",
     "national-insurance-number",
+    "student-loan-amount",
     "email-address",
     "check-your-answers",
     "confirmation",

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -125,6 +125,10 @@ class TslrClaim < ApplicationRecord
     [address_line_1, address_line_2, address_line_3, address_line_4, postcode].reject(&:blank?).join(", ")
   end
 
+  def student_loan_repayment_amount=(value)
+    super(value.to_s.gsub(/[£,\s]/, ""))
+  end
+
   private
 
   def ineligible_claim_school?

--- a/app/views/claims/student_loan_amount.html.erb
+++ b/app/views/claims/student_loan_amount.html.erb
@@ -1,0 +1,23 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <h1 class="govuk-heading-xl">
+        <%= form.label :student_loan_repayment_amount, t("tslr.questions.student_loan_amount", claim_school_name: current_claim.claim_school_name)  %>
+      </h1>
+
+      <span class="govuk-hint">Only include repayments made through your teaching wages. You can find this information on your payslips.</span>
+      <div class="govuk-form-group govuk-currency-input">
+        <div class="govuk-currency-input__inner">
+          <span class="govuk-currency-input__inner__unit">&pound;</span>
+          <%= form.text_field :student_loan_repayment_amount, class: "govuk-currency-input__inner__input govuk-input govuk-input--width-5" %>
+        </div>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,4 +46,5 @@ en:
       date_of_birth: "What is your date of birth?"
       teacher_reference_number: "What is your teacher reference number?"
       national_insurance_number: "What is your National Insurance number?"
+      student_loan_amount: "How much student loan did you repay while you were at %{claim_school_name} between 6 April XXXX and 5 April XXXX?"
       email_address: "What is your email address?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,10 @@ en:
   date:
     formats:
       default: "%d %B %Y"
+  number:
+    currency:
+      format:
+        unit: "£"
   tslr:
     service_name: "Teachers: claim back student loan repayments"
     questions:

--- a/db/migrate/20190531101710_add_student_loan_repayment_amount_to_tslr_claims.rb
+++ b/db/migrate/20190531101710_add_student_loan_repayment_amount_to_tslr_claims.rb
@@ -1,0 +1,5 @@
+class AddStudentLoanRepaymentAmountToTslrClaims < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :student_loan_repayment_amount, :decimal, precision: 7, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_29_103851) do
+ActiveRecord::Schema.define(version: 2019_05_31_101710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2019_05_29_103851) do
     t.string "email_address", limit: 256
     t.boolean "mostly_teaching_eligible_subjects"
     t.datetime "submitted_at"
+    t.decimal "student_loan_repayment_amount", precision: 7, scale: 2
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
       date_of_birth { 20.years.ago.to_date }
       teacher_reference_number { "1234567" }
       national_insurance_number { "QQ123456C" }
+      student_loan_repayment_amount { 1000 }
       email_address { "test@email.com" }
     end
 

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -65,6 +65,12 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.national_insurance_number).to eq("QQ123456C")
 
+    expect(page).to have_text(I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name))
+    fill_in I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
+    click_on "Continue"
+
+    expect(claim.reload.student_loan_repayment_amount).to eql(1100.00)
+
     expect(page).to have_text(I18n.t("tslr.questions.email_address"))
     expect(page).to have_text("We will only use your email address to update you about your claim.")
     fill_in I18n.t("tslr.questions.email_address"), with: "name@example.tld"

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -20,13 +20,20 @@ describe ClaimsHelper do
   describe "#claim_answers" do
     it "returns an array of questions and answers for displaying to the user for review" do
       school = create(:school)
-      claim = TslrClaim.create(qts_award_year: "2013-2014", claim_school: school, current_school: school, mostly_teaching_eligible_subjects: true)
+      claim = TslrClaim.create(
+        qts_award_year: "2013-2014",
+        claim_school: school,
+        current_school: school,
+        mostly_teaching_eligible_subjects: true,
+        student_loan_repayment_amount: 1987.65,
+      )
 
       expected_answers = [
         [I18n.t("tslr.questions.qts_award_year"), "September 1 2013 - August 31 2014"],
         [I18n.t("tslr.questions.claim_school"), school.name],
         [I18n.t("tslr.questions.current_school"), school.name],
         [I18n.t("tslr.questions.mostly_teaching_eligible_subjects"), "Yes"],
+        [I18n.t("tslr.questions.student_loan_amount", claim_school_name: school.name), "£1,987.65"],
       ]
 
       expect(helper.claim_answers(claim)).to eq expected_answers
@@ -35,7 +42,17 @@ describe ClaimsHelper do
 
   describe "#identity_answers" do
     it "returns an array of questions and answers for displaying to the user for review" do
-      claim = TslrClaim.create(full_name: "Jo Bloggs", address_line_1: "Flat 1", address_line_2: "1 Test Road", address_line_3: "Test Town", postcode: "AB1 2CD", date_of_birth: 20.years.ago.to_date, teacher_reference_number: "1234567", national_insurance_number: "QQ 12 34 56 C", email_address: "test@email.com")
+      claim = TslrClaim.create(
+        full_name: "Jo Bloggs",
+        address_line_1: "Flat 1",
+        address_line_2: "1 Test Road",
+        address_line_3: "Test Town",
+        postcode: "AB1 2CD",
+        date_of_birth: 20.years.ago.to_date,
+        teacher_reference_number: "1234567",
+        national_insurance_number: "QQ 12 34 56 C",
+        email_address: "test@email.com",
+      )
 
       expected_answers = [
         ["Full name", "Jo Bloggs"],

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -168,6 +168,14 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  describe "#student_loan_repayment_amount=" do
+    it "sets loan repayment amount with monetary characters stripped out" do
+      claim = TslrClaim.new
+      claim.student_loan_repayment_amount = "£ 5,000.40"
+      expect(claim.student_loan_repayment_amount).to eql(5000.40)
+    end
+  end
+
   describe "#ineligible?" do
     subject { TslrClaim.new(claim_attributes).ineligible? }
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe TslrClaim, type: :model do
       end
     end
 
+    context "that has a student loan repayment amount" do
+      it "validates that the loan repayment amount is numerical" do
+        expect(TslrClaim.new(student_loan_repayment_amount: "don’t know")).not_to be_valid
+        expect(TslrClaim.new(student_loan_repayment_amount: "£1,234.56")).to be_valid
+      end
+    end
+
     context "that has a full name" do
       it "validates the length of name is 200 characters or less" do
         expect(TslrClaim.new(full_name: "Name " * 50)).not_to be_valid
@@ -46,6 +53,7 @@ RSpec.describe TslrClaim, type: :model do
         expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M1 2WD")).to be_valid
       end
     end
+
     context "that has a address" do
       it "validates the length of address_line_1 is 100 characters or less" do
         valid_address_attributes = {address_line_1: "123 Main Street" * 25, address_line_3: "Twin Peaks", postcode: "12345"}
@@ -124,6 +132,13 @@ RSpec.describe TslrClaim, type: :model do
     it "validates the presence of national_insurance_number" do
       expect(TslrClaim.new).not_to be_valid(:"national-insurance-number")
       expect(TslrClaim.new(national_insurance_number: "QQ123456C")).to be_valid(:"national-insurance-number")
+    end
+  end
+
+  context "when saving in the “student-loan-amount” validation context" do
+    it "validates the presence of student_loan_repayment_amount" do
+      expect(TslrClaim.new).not_to be_valid(:"student-loan-amount")
+      expect(TslrClaim.new(student_loan_repayment_amount: "£1,100")).to be_valid(:"student-loan-amount")
     end
   end
 


### PR DESCRIPTION
So that we know how much to pay the teacher, we need them to tell us how much student loan they paid in the last tax year.

Includes a non-standard GOV.UK pattern for capturing monetary amounts.

https://trello.com/c/3iY89vAu/


# Screenshot

<img width="1065" alt="Screenshot 2019-06-03 at 11 36 15" src="https://user-images.githubusercontent.com/2804149/58795943-de9eb180-85f3-11e9-8e41-e13addf08ee9.png">
