### PR TITLE
A user can change their answers when reviewing their claim

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -52,7 +52,13 @@ class ClaimsController < ApplicationController
   end
 
   def edited_answer?
-    current_claim.can_be_submitted? && !current_claim.submitted?
+    current_claim.can_be_submitted? && !current_claim.submitted? && !on_school_flow?
+  end
+
+  def on_school_flow?
+    return true if params[:slug] == "claim-school"
+    return true if params[:slug] == "still-teaching" && current_claim.employment_status != "claim_school"
+    false
   end
 
   def next_slug

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -45,11 +45,14 @@ class ClaimsController < ApplicationController
   end
 
   def next_claim_path
-    if current_claim.ineligible?
-      ineligible_claim_path
-    else
-      claim_path(next_slug)
-    end
+    return ineligible_claim_path if current_claim.ineligible?
+    return claim_path("check-your-answers") if edited_answer?
+
+    claim_path(next_slug)
+  end
+
+  def edited_answer?
+    current_claim.can_be_submitted? && !current_claim.submitted?
   end
 
   def next_slug

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -13,24 +13,24 @@ module ClaimsHelper
 
   def claim_answers(claim)
     [
-      [t("tslr.questions.qts_award_year"), academic_years(claim.qts_award_year)],
-      [t("tslr.questions.claim_school"), claim.claim_school_name],
-      [t("tslr.questions.current_school"), claim.current_school_name],
-      [t("tslr.questions.mostly_teaching_eligible_subjects"), claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"],
-      [t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), number_to_currency(claim.student_loan_repayment_amount)],
+      [t("tslr.questions.qts_award_year"), academic_years(claim.qts_award_year), "qts-year"],
+      [t("tslr.questions.claim_school"), claim.claim_school_name, "claim-school"],
+      [t("tslr.questions.current_school"), claim.current_school_name, "current-school"],
+      [t("tslr.questions.mostly_teaching_eligible_subjects"), (claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"), "subjects-taught"],
+      [t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), number_to_currency(claim.student_loan_repayment_amount), "student-loan-amount"],
     ]
   end
 
   def identity_answers(claim)
     [
-      ["Full name", claim.full_name],
-      ["Address", claim.address],
-      ["Date of birth", l(claim.date_of_birth)],
-      ["Teacher reference number", claim.teacher_reference_number],
-      ["National Insurance number", claim.national_insurance_number],
-      ["Email address", claim.email_address],
-      ["Account number", claim.bank_account_number],
-      ["Sort code", claim.bank_sort_code],
+      ["Full name", claim.full_name, "full-name"],
+      ["Address", claim.address, "address"],
+      ["Date of birth", l(claim.date_of_birth), "date-of-birth"],
+      ["Teacher reference number", claim.teacher_reference_number, "teacher-reference-number"],
+      ["National Insurance number", claim.national_insurance_number, "national-insurance-number"],
+      ["Email address", claim.email_address, "email-address"],
+      ["Account number", claim.bank_account_number, "bank-details"],
+      ["Sort code", claim.bank_sort_code, "bank-details"],
     ]
   end
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -104,7 +104,7 @@ class TslrClaim < ApplicationRecord
       return false
     end
 
-    touch(:submitted_at) if valid?(:submit)
+    touch(:submitted_at) if can_be_submitted?
   end
 
   def submitted?

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -77,8 +77,8 @@ class TslrClaim < ApplicationRecord
                                         length: {maximum: 256, message: "Email address must be 256 characters or less"},
                                         allow_nil: true
 
-  validates :bank_sort_code,            on: :"bank-details", presence: {message: "Enter a sort code"}
-  validates :bank_account_number,       on: :"bank-details", presence: {message: "Enter an account number"}
+  validates :bank_sort_code,            on: [:"bank-details", :submit], presence: {message: "Enter a sort code"}
+  validates :bank_account_number,       on: [:"bank-details", :submit], presence: {message: "Enter an account number"}
 
   validate  :bank_account_number_must_be_eight_digits
   validate  :bank_sort_code_must_be_six_digits
@@ -109,6 +109,10 @@ class TslrClaim < ApplicationRecord
 
   def submitted?
     submitted_at.present?
+  end
+
+  def can_be_submitted?
+    valid?(:submit)
   end
 
   def ineligible?

--- a/app/views/claims/_check_your_answers_section.html.erb
+++ b/app/views/claims/_check_your_answers_section.html.erb
@@ -3,14 +3,18 @@
 </h2>
 
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-  <%- answers.each do |(key, value)| %>
+  <%- answers.each do |(label, answer, slug)| %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        <%= key %>
+        <%= label %>
       </dt>
 
       <dd class="govuk-summary-list__value">
-        <%= value %>
+        <%= answer %>
+      </dd>
+
+      <dd class="govuk-summary-list__actions">
+        <%= link_to 'Change', claim_path(slug) %>
       </dd>
     </div>
   <% end %>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -22,7 +22,7 @@
       <%= form_tag(claim_path("claim-school"), method: :get) do %>
         <div class="govuk-form-group">
           <%= label_tag :school_search, "School name", class: "govuk-label" %>
-          <%= text_field_tag :school_search, params[:school_search], class: "govuk-input" %>
+          <%= text_field_tag :school_search, params[:school_search], class: "govuk-input", value: current_claim.claim_school&.name %>
         </div>
         <div class="govuk-form-group">
           <%= submit_tag "Search", class: "govuk-button" %>

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -22,7 +22,7 @@
       <%= form_tag(claim_path("current-school"), method: :get) do %>
         <div class="govuk-form-group">
           <%= label_tag :school_search, "School name", class: "govuk-label" %>
-          <%= text_field_tag :school_search, params[:school_search], class: "govuk-input" %>
+          <%= text_field_tag :school_search, params[:school_search], class: "govuk-input", value: current_claim.current_school&.name %>
         </div>
         <div class="govuk-form-group">
           <%= submit_tag "Search", class: "govuk-button" %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,5 +49,6 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.raise = true
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "TslrClaim", association: :current_school
+    Bullet.add_whitelist type: :n_plus_one_query, class_name: "School", association: :local_authority
   end
 end

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :local_authority do
     sequence(:code) { |n| 1000 + n }
     name { "Test LA" }
+
+    initialize_with { LocalAuthority.find_or_create_by(code: code) }
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -7,5 +7,11 @@ FactoryBot.define do
     phase { :secondary }
     local_authority
     local_authority_district
+
+    trait :tslr_eligible do
+      local_authority { create(:local_authority, code: Tslr::SchoolEligibility::ELIGIBLE_LOCAL_AUTHORITY_CODES.sample) }
+      school_type_group { Tslr::SchoolEligibility::STATE_FUNDED_TYPE_GROUPS.sample }
+      phase { Tslr::SchoolEligibility::ELIGIBLE_PHASES.sample }
+    end
   end
 end

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -14,6 +14,8 @@ FactoryBot.define do
       national_insurance_number { "QQ123456C" }
       student_loan_repayment_amount { 1000 }
       email_address { "test@email.com" }
+      bank_sort_code { 123456 }
+      bank_account_number { 12345678 }
     end
 
     trait :eligible_but_unsubmittable do

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -159,4 +159,19 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     visit claim_path("qts-year")
     expect(page).to have_current_path(root_path)
   end
+
+  scenario "Teacher can edit their response" do
+    claim = create(:tslr_claim, :eligible_and_submittable)
+    allow_any_instance_of(ClaimsController).to receive(:current_claim) { claim }
+
+    visit claim_path("check-your-answers")
+
+    find("a[href='#{claim_path("national-insurance-number")}']").click
+
+    fill_in "National Insurance number", with: "AB123456C"
+    click_on "Continue"
+
+    expect(claim.reload.national_insurance_number).to eq("AB123456C")
+    expect(page).to have_content("Check your answers before sending your application")
+  end
 end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -203,16 +203,16 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(find("input[name='school_search']").value).to eq(current_school.name)
     end
 
-    context "Teacher goes to change their claim school" do
+    context "When changing claim school" do
       before do
         find("a[href='#{claim_path("claim-school")}']").click
       end
 
-      scenario "sees their original claim school" do
+      scenario "Teacher sees their original claim school" do
         expect(find("input[name='school_search']").value).to eq(claim.claim_school.name)
       end
 
-      context "changes their claim school" do
+      context "When choosing a new claim school" do
         before do
           choose_school schools(:penistone_grammar_school)
         end
@@ -225,22 +225,22 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
           expect(current_path).to eq(claim_path("still-teaching"))
         end
 
-        context "is still teaching at the same school" do
+        context "When still teaching at the claim school" do
           before do
             choose_still_teaching
           end
 
-          it "current school is set correctly" do
+          scenario "current school is set correctly" do
             expect(claim.reload.employment_status).to eql("claim_school")
             expect(claim.reload.current_school).to eql schools(:penistone_grammar_school)
           end
 
-          it "Teacher is redirected to the check your answers page" do
+          scenario "Teacher is redirected to the check your answers page" do
             expect(current_path).to eq(claim_path("check-your-answers"))
           end
         end
 
-        context "is still teaching at another school" do
+        context "When still teaching but at a different school" do
           before do
             choose_still_teaching "Yes, at another school"
 
@@ -251,26 +251,26 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
             click_on "Continue"
           end
 
-          it "sets school and status correctly" do
+          scenario "School and employment status are set correctly" do
             expect(claim.reload.employment_status).to eql("different_school")
             expect(claim.reload.current_school).to eql schools(:hampstead_school)
           end
 
-          it "Teacher is redirected to the check your answers page" do
+          scenario "Teacher is redirected to the check your answers page" do
             expect(current_path).to eq(claim_path("check-your-answers"))
           end
         end
 
-        context "is no longer teaching" do
+        context "When no longer teaching" do
           before do
             choose_still_teaching "No"
           end
 
-          it "sets the status" do
+          scenario "Employment status is set correctly" do
             expect(claim.reload.employment_status).to eq("no_school")
           end
 
-          it "tells the teacher they are not eligible" do
+          scenario "Teacher is told they are not eligible" do
             expect(page).to have_text("You’re not eligible")
             expect(page).to have_text("You must be still working as a teacher to be eligible")
           end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -164,15 +164,25 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     let(:claim_school) { create(:school, :tslr_eligible, name: "Claim School") }
     let(:current_school) { create(:school, :tslr_eligible, name: "Current School") }
 
-    let(:claim) { create(:tslr_claim, :eligible_and_submittable, claim_school: claim_school, current_school: current_school) }
+    # `current_school` cannot be set in the create, because we have a callback that
+    # sets `current_school` to `nil` if `employed_at_claim_school?` is false. We could
+    # skip the callback here, but it makes more sense to force it here
+    let(:claim) do
+      claim = create(:tslr_claim,
+        :eligible_and_submittable,
+        employment_status: :different_school,
+        claim_school: claim_school)
+      claim.current_school = current_school
+      claim.save
+      claim
+    end
 
     before do
       allow_any_instance_of(ClaimsController).to receive(:current_claim) { claim }
+      visit claim_path("check-your-answers")
     end
 
     scenario "Teacher can edit a field" do
-      visit claim_path("check-your-answers")
-
       find("a[href='#{claim_path("national-insurance-number")}']").click
 
       fill_in "National Insurance number", with: "AB123456C"
@@ -182,20 +192,85 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(page).to have_content("Check your answers before sending your application")
     end
 
-    scenario "Teacher sees their original claim school when editing" do
-      visit claim_path("check-your-answers")
-
-      find("a[href='#{claim_path("claim-school")}']").click
-
-      expect(find("input[name='school_search']").value).to eq(claim.claim_school.name)
-    end
-
     scenario "Teacher sees their original current school when editing" do
-      visit claim_path("check-your-answers")
-
       find("a[href='#{claim_path("current-school")}']").click
 
-      expect(find("input[name='school_search']").value).to eq(claim.current_school.name)
+      expect(find("input[name='school_search']").value).to eq(current_school.name)
+    end
+
+    context "Teacher goes to change their claim school" do
+      before do
+        find("a[href='#{claim_path("claim-school")}']").click
+      end
+
+      scenario "sees their original claim school" do
+        expect(find("input[name='school_search']").value).to eq(claim.claim_school.name)
+      end
+
+      context "changes their claim school" do
+        before do
+          choose_school schools(:penistone_grammar_school)
+        end
+
+        scenario "school is changed correctly" do
+          expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
+        end
+
+        scenario "Teacher is redirected to the are you still employed screen" do
+          expect(current_path).to eq(claim_path("still-teaching"))
+        end
+
+        context "is still teaching at the same school" do
+          before do
+            choose_still_teaching
+          end
+
+          it "current school is set correctly" do
+            expect(claim.reload.employment_status).to eql("claim_school")
+            expect(claim.reload.current_school).to eql schools(:penistone_grammar_school)
+          end
+
+          it "Teacher is redirected to the check your answers page" do
+            expect(current_path).to eq(claim_path("check-your-answers"))
+          end
+        end
+
+        context "is still teaching at another school" do
+          before do
+            choose_still_teaching "Yes, at another school"
+
+            fill_in "School name", with: "Hampstead"
+            click_on "Search"
+
+            choose "Hampstead School"
+            click_on "Continue"
+          end
+
+          it "sets school and status correctly" do
+            expect(claim.reload.employment_status).to eql("different_school")
+            expect(claim.reload.current_school).to eql schools(:hampstead_school)
+          end
+
+          it "Teacher is redirected to the check your answers page" do
+            expect(current_path).to eq(claim_path("check-your-answers"))
+          end
+        end
+
+        context "is no longer teaching" do
+          before do
+            choose_still_teaching "No"
+          end
+
+          it "sets the status" do
+            expect(claim.reload.employment_status).to eq("no_school")
+          end
+
+          it "tells the teacher they are not eligible" do
+            expect(page).to have_text("You’re not eligible")
+            expect(page).to have_text("You must be still working as a teacher to be eligible")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -160,18 +160,42 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_current_path(root_path)
   end
 
-  scenario "Teacher can edit their response" do
-    claim = create(:tslr_claim, :eligible_and_submittable)
-    allow_any_instance_of(ClaimsController).to receive(:current_claim) { claim }
+  context "editing a response" do
+    let(:claim_school) { create(:school, :tslr_eligible, name: "Claim School") }
+    let(:current_school) { create(:school, :tslr_eligible, name: "Current School") }
 
-    visit claim_path("check-your-answers")
+    let(:claim) { create(:tslr_claim, :eligible_and_submittable, claim_school: claim_school, current_school: current_school) }
 
-    find("a[href='#{claim_path("national-insurance-number")}']").click
+    before do
+      allow_any_instance_of(ClaimsController).to receive(:current_claim) { claim }
+    end
 
-    fill_in "National Insurance number", with: "AB123456C"
-    click_on "Continue"
+    scenario "Teacher can edit a field" do
+      visit claim_path("check-your-answers")
 
-    expect(claim.reload.national_insurance_number).to eq("AB123456C")
-    expect(page).to have_content("Check your answers before sending your application")
+      find("a[href='#{claim_path("national-insurance-number")}']").click
+
+      fill_in "National Insurance number", with: "AB123456C"
+      click_on "Continue"
+
+      expect(claim.reload.national_insurance_number).to eq("AB123456C")
+      expect(page).to have_content("Check your answers before sending your application")
+    end
+
+    scenario "Teacher sees their original claim school when editing" do
+      visit claim_path("check-your-answers")
+
+      find("a[href='#{claim_path("claim-school")}']").click
+
+      expect(find("input[name='school_search']").value).to eq(claim.claim_school.name)
+    end
+
+    scenario "Teacher sees their original current school when editing" do
+      visit claim_path("check-your-answers")
+
+      find("a[href='#{claim_path("current-school")}']").click
+
+      expect(find("input[name='school_search']").value).to eq(claim.current_school.name)
+    end
   end
 end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -183,12 +183,17 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     end
 
     scenario "Teacher can edit a field" do
-      find("a[href='#{claim_path("national-insurance-number")}']").click
+      old_number = claim.national_insurance_number
+      new_number = "AB123456C"
 
-      fill_in "National Insurance number", with: "AB123456C"
-      click_on "Continue"
+      expect {
+        find("a[href='#{claim_path("national-insurance-number")}']").click
+        fill_in "National Insurance number", with: new_number
+        click_on "Continue"
+      }.to change {
+        claim.reload.national_insurance_number
+      }.from(old_number).to(new_number)
 
-      expect(claim.reload.national_insurance_number).to eq("AB123456C")
       expect(page).to have_content("Check your answers before sending your application")
     end
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -29,11 +29,11 @@ describe ClaimsHelper do
       )
 
       expected_answers = [
-        [I18n.t("tslr.questions.qts_award_year"), "September 1 2013 - August 31 2014"],
-        [I18n.t("tslr.questions.claim_school"), school.name],
-        [I18n.t("tslr.questions.current_school"), school.name],
-        [I18n.t("tslr.questions.mostly_teaching_eligible_subjects"), "Yes"],
-        [I18n.t("tslr.questions.student_loan_amount", claim_school_name: school.name), "£1,987.65"],
+        [I18n.t("tslr.questions.qts_award_year"), "September 1 2013 - August 31 2014", "qts-year"],
+        [I18n.t("tslr.questions.claim_school"), school.name, "claim-school"],
+        [I18n.t("tslr.questions.current_school"), school.name, "current-school"],
+        [I18n.t("tslr.questions.mostly_teaching_eligible_subjects"), "Yes", "subjects-taught"],
+        [I18n.t("tslr.questions.student_loan_amount", claim_school_name: school.name), "£1,987.65", "student-loan-amount"],
       ]
 
       expect(helper.claim_answers(claim)).to eq expected_answers
@@ -57,14 +57,14 @@ describe ClaimsHelper do
       )
 
       expected_answers = [
-        ["Full name", "Jo Bloggs"],
-        ["Address", "Flat 1, 1 Test Road, Test Town, AB1 2CD"],
-        ["Date of birth", I18n.l(20.years.ago.to_date)],
-        ["Teacher reference number", "1234567"],
-        ["National Insurance number", "QQ123456C"],
-        ["Email address", "test@email.com"],
-        ["Account number", "12345678"],
-        ["Sort code", "123456"],
+        ["Full name", "Jo Bloggs", "full-name"],
+        ["Address", "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+        ["Date of birth", I18n.l(20.years.ago.to_date), "date-of-birth"],
+        ["Teacher reference number", "1234567", "teacher-reference-number"],
+        ["National Insurance number", "QQ123456C", "national-insurance-number"],
+        ["Email address", "test@email.com", "email-address"],
+        ["Account number", "12345678", "bank-details"],
+        ["Sort code", "123456", "bank-details"],
       ]
 
       expect(helper.identity_answers(claim)).to eq expected_answers


### PR DESCRIPTION
Trello card: https://trello.com/c/OhhpWDA2/175-a-user-can-change-their-answers-when-reviewing-their-claim

This adds links for a user to change their responses, as per the pattern in the [GDS design system](https://design-system.service.gov.uk/patterns/check-answers/)

![image](https://user-images.githubusercontent.com/109774/59027149-2588e300-8850-11e9-86ee-cd15b51a8bfc.png)

