### PR TITLE
Ensure current school is selected if needed

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -39,6 +39,7 @@ class TslrClaim < ApplicationRecord
   belongs_to :current_school, optional: true, class_name: "School"
 
   validates :claim_school,              on: [:"claim-school", :submit], presence: {message: "Select a school from the list"}
+  validates :current_school,            on: [:"current-school"], presence: {message: "Select a school from the list"}
 
   validates :qts_award_year,            on: [:"qts-year", :submit], inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -109,6 +109,13 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving in the “current-school” validation context" do
+    it "it validates the current_school" do
+      expect(TslrClaim.new).not_to be_valid(:"current-school")
+      expect(TslrClaim.new(current_school: schools(:hampstead_school))).to be_valid(:"current-school")
+    end
+  end
+
   context "when saving in the “subjects-taught” validation context" do
     it "validates mostly_teaching_eligible_subjects has been provided" do
       expect(TslrClaim.new).not_to be_valid(:"subjects-taught")


### PR DESCRIPTION
If the user selects "still teaching at another school", we need to know which school they are teaching at. We don't add this validation to the "submit" context as it isn't always required.

https://trello.com/c/ciJxfVuu