### PR TITLE
Highlight errors in form inputs as described in the design system

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,7 +10,6 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
  *= require_self
  *= require govuk_frontend_rails
  */

--- a/app/assets/stylesheets/components/currency_input.scss
+++ b/app/assets/stylesheets/components/currency_input.scss
@@ -1,17 +1,13 @@
 .govuk-currency-input {
-  &__inner {
-    position: relative;
-    font-family: "nta", Arial, sans-serif;
+  position: relative;
+  &__unit {
+    position: absolute;
+    bottom: 8px;
+    left: 10px;
+    @include govuk-font(19, bold);
+  }
 
-    &__unit {
-      position: absolute;
-      bottom: 9px;
-      left: 10px;
-      font-weight: bold;
-    }
-
-    &__input.govuk-input {
-      padding-left: 25px;
-    }
+  &__input.govuk-input {
+    padding-left: 25px;
   }
 }

--- a/app/assets/stylesheets/components/flash.scss
+++ b/app/assets/stylesheets/components/flash.scss
@@ -1,5 +1,3 @@
-@import "govuk-frontend-rails";
-
 %govuk-flash {
   padding: $govuk-gutter-half;
   margin-bottom: $govuk-gutter;

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -74,7 +74,7 @@ class ClaimsController < ApplicationController
     if params[:school_search].length > 3
       @schools = School.search(params[:school_search])
     else
-      current_claim.errors.add(:base, "Search for the school name with a minimum of four characters")
+      current_claim.errors.add(:school_search, "Search for the school name with a minimum of four characters")
     end
   end
 

--- a/app/helpers/govuk_form_helper.rb
+++ b/app/helpers/govuk_form_helper.rb
@@ -1,0 +1,127 @@
+module GovukFormHelper
+  # = GOVUK Form Tag Helpers
+  #
+  # For usage, components and patterns see:
+  # https://design-system.service.gov.uk/
+
+  # Can be used to wrap multiple or single components.
+  #
+  # Creates a div with the 'govuk-form-group' css class, if the provided object has errors, adds
+  # the 'govuk-form-group--error' css class.
+  #
+  # Passing the attribute symbol will only add the error class if the object contains errors for
+  # the matching symbol.
+  #
+  # Generally pass only an object when wrapping multiple components and pass an object and attribute when
+  # wrapping a single component.
+  #
+  # === Examples
+  # ==== Wrap multiple components
+  #
+  #   <%= form_group_tag object do %>
+  #     <fieldset class="govuk-fieldset">
+  #       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+  #         <h1 class="govuk-fieldset__heading">
+  #           Where do you live?
+  #         </h1>
+  #       </legend>
+  #     ...
+  #     </fieldset>
+  #   <% end %>
+  #
+  #   <div class="govuk-form-group">
+  #     <fieldset class="govuk-fieldset">
+  #       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+  #         <h1 class="govuk-fieldset__heading">
+  #           Where do you live?
+  #         </h1>
+  #       </legend>
+  #        ...
+  #     </fieldset>
+  #   </div>
+  #
+  # ==== Wrap a single component
+  #
+  #   <%= form_group_tag object, :event_name do %>
+  #     ...
+  #   <% end %>
+  #
+  #   <div class="govuk-form-group">
+  #     <label class="govuk-label" for="object_event_name">
+  #       Event name
+  #     </label>
+  #     <input class="govuk-input" id="object_event_name" name="event_name" type="text">
+  #   </div>
+  #
+  def form_group_tag(object, attribute = nil, &block)
+    css_classes = ["govuk-form-group"]
+    if attribute.present? && object.errors.key?(attribute)
+      css_classes << "govuk-form-group--error"
+    elsif attribute.nil? && object.errors.any?
+      css_classes << "govuk-form-group--error"
+    end
+    content_tag(:div, class: css_classes) do
+      yield
+    end
+  end
+
+  # Returns a set of +<span>+ tags that contains the error messages in _object_ that match the
+  # _attribute_ symbol.
+  #
+  # === Examples
+  #   errors_tag(object, :attribute)
+  #
+  #   <span id="object_attibute_name-error" class="govuk-error-message">
+  #     <span class="govuk-visually-hidden">Error: </span>Error message one<br>
+  #     <span class="govuk-visually-hidden">Error: </span>Error message two
+  #   </span>
+  #
+  def errors_tag(object, attribute)
+    return unless object.errors.messages[attribute].present?
+
+    messages = object.errors.messages[attribute].map { |message| content_tag(:span, "Error:", class: "govuk-visually-hidden") + " " + message }
+    content_tag(:span, messages.join("<br>").html_safe, {class: "govuk-error-message", id: error_id(object.class.model_name.singular, attribute)})
+  end
+
+  # Returns a string of the GOVUK css classes for the +<select>+ html element along with any
+  # existing css classes provided.
+  #
+  # When _object_ contains errors for _attribute_ the 'govuk-input--error' css class is added.
+  #
+  # === Example
+  #
+  # css_classes_for_select(object, :attribute, "another-css-class")
+  #
+  #   "govuk-select another-css-class"
+  #
+  def css_classes_for_select(object, attribute, css_classes = "")
+    css_classes = css_classes.split
+    css_classes << "govuk-select"
+    css_classes << "govuk-select--error" if object.errors.key?(attribute)
+    css_classes.join(" ")
+  end
+
+  # Returns a string of the GOVUK css classes for the +<input>+ html element along with any
+  # existing css classes provided.
+  #
+  # When _object_ contains errors for _attribute_ the 'govuk-input--error' css class is added.
+  #
+  # === Example
+  #
+  # css_classes_for_input(object, :attribute, "another-css-class")
+  #
+  #   "govuk-select another-css-class"
+  #
+  def css_classes_for_input(object, attribute, css_classes = "")
+    css_classes = css_classes.split
+    css_classes << "govuk-input"
+    css_classes << "govuk-input--error" if object.errors.key?(attribute)
+    css_classes.join(" ")
+  end
+
+  private
+
+  def error_id(object_name, attribute)
+    "#{object_name}_#{attribute}-error"
+  end
+end

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -10,46 +10,53 @@
           </h1>
         </legend>
 
-        <div class="govuk-form-group">
+        <%= form_group_tag current_claim, :address_line_1 do %>
           <%= form.label :address_line_1, class: "govuk-label" do %>
             Building and street <span class="govuk-visually-hidden">line 1 of 2</span>
           <% end %>
-          <%= form.text_field :address_line_1, autocomplete: "address-line1", class: "govuk-input" %>
-        </div>
+          <%= errors_tag current_claim, :address_line_1 %>
+          <%= form.text_field :address_line_1, autocomplete: "address-line1",
+            class: css_classes_for_input(current_claim, :address_line_1) %>
+        <% end %>
 
-
-        <div class="govuk-form-group">
+        <%= form_group_tag current_claim, :address_line_2 do %>
           <%= form.label :address_line_2, class: "govuk-label" do %>
             <span class="govuk-visually-hidden">Building and street line 2 of 2</span>
           <% end %>
-          <%= form.text_field :address_line_2, autocomplete: "address-line2", class: "govuk-input" %>
-        </div>
+          <%= errors_tag current_claim, :address_line_2 %>
+          <%= form.text_field :address_line_2, autocomplete: "address-line2",
+            class: "govuk-input" %>
+        <% end %>
 
-        <div class="govuk-form-group">
+        <%= form_group_tag current_claim, :address_line_3 do %>
           <%= form.label :address_line_3, class: "govuk-label" do %>
             Town or city
           <% end %>
-          <%= form.text_field :address_line_3, autocomplete: "address-line3", class: "govuk-input govuk-!-width-two-thirds" %>
-        </div>
+          <%= errors_tag current_claim, :address_line_3 %>
+          <%= form.text_field :address_line_3, autocomplete: "address-line3",
+            class: css_classes_for_input(current_claim, :address_line_3, "govuk-!-width-two-thirds") %>
+        <% end %>
 
-        <div class="govuk-form-group">
+        <%= form_group_tag current_claim, :address_line_4 do %>
           <%= form.label :address_line_4, class: "govuk-label" do %>
             County
           <% end %>
-          <%= form.text_field :address_line_4, autocomplete: "region", class: "govuk-input govuk-!-width-two-thirds" %>
-        </div>
+          <%= errors_tag current_claim, :address_line_4 %>
+          <%= form.text_field :address_line_4, autocomplete: "region",
+            class: "govuk-input govuk-!-width-two-thirds" %>
+        <% end %>
 
-        <div class="govuk-form-group">
+        <%= form_group_tag current_claim, :postcode do %>
           <%= form.label :postcode, class: "govuk-label" do %>
             Postcode
           <% end %>
-          <%= form.text_field :postcode, autocomplete: "postal-code", class: "govuk-input govuk-input--width-10" %>
-        </div>
-      </fieldset>
+          <%= errors_tag current_claim, :postcode %>
+          <%= form.text_field :postcode, autocomplete: "postal-code",
+            class: css_classes_for_input(current_claim, :postcode, "govuk-input--width-10") %>
+        <% end %>
 
-      <div class="govuk-form-group">
-        <%= form.submit "Continue", class: "govuk-button" %>
-      </div>
+      </fieldset>
+      <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -11,33 +11,29 @@
             </h1>
           </legend>
 
-          <p class="govuk-body govuk-hint">
+          <span class="govuk-hint">
             We need to collect this information to pay you.
-          </p>
+          </span>
 
-          <div class="govuk-form-group">
+          <%= form_group_tag current_claim, :bank_sort_code do %>
             <%= form.label :bank_sort_code, "Sort code", class: "govuk-label" %>
-            <span  id="sort-code-hint" class="govuk-hint">For example: 44 00 26</span>
+            <span id="sort-code-hint" class="govuk-hint">For example: 44 00 26</span>
+            <%= errors_tag current_claim, :bank_sort_code %>
             <%= form.text_field :bank_sort_code,
-              class: "govuk-input govuk-!-width-one-quarter",
-              "aria-describedby" => "sort-code-hint"
-            %>
-          </div>
+              class: css_classes_for_input(current_claim, :bank_sort_code, "govuk-!-width-one-quarter"),
+              "aria-describedby" => "sort-code-hint" %>
+          <% end %>
 
-          <div class="govuk-form-group">
+          <%= form_group_tag current_claim, :bank_account_number do %>
             <%= form.label :bank_account_number, "Account number", class: "govuk-label" %>
-            <span  id="account-number-hint" class="govuk-hint">For example: 70 87 24 90</span>
+            <span id="account-number-hint" class="govuk-hint">For example: 70 87 24 90</span>
+            <%= errors_tag current_claim, :bank_account_number %>
             <%= form.text_field :bank_account_number,
-              class: "govuk-input govuk-input--width-20",
-              "aria-describedby" => "account-number-hint"
-            %>
-          </div>
-
+              class: css_classes_for_input(current_claim, :bank_account_number, "govuk-input--width-20"),
+              "aria-describedby" => "account-number-hint" %>
+          <% end %>
         </fieldset>
-
-        <div class="govuk-form-group">
-          <%= form.submit "Continue", class: "govuk-button" %>
-        </div>
+        <%= form.submit "Continue", class: "govuk-button" %>
       <% end %>
   </div>
 </div>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -3,27 +3,27 @@
 
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-    <h1 class="govuk-heading-xl">
-      <%= t("tslr.questions.claim_school") %>
-    </h1>
+
+      <h1 class="govuk-heading-xl">
+        <%= t("tslr.questions.claim_school") %>
+      </h1>
 
     <% if @schools.blank? %>
-
-      <% if params[:school_search].present? && current_claim.errors.empty? %>
-        <p class="govuk-body">
-          <strong>No results match that search term. Try again.</strong>
-        </p>
-      <% else %>
-        <span id="school-search-hint" class="govuk-hint">
-          Search for the school name, use at least four characters.
-        </span>
-      <% end %>
-
+        <% if params[:school_search].present? && current_claim.errors.empty? %>
+          <p class="govuk-body">
+            <strong>No results match that search term. Try again.</strong>
+          </p>
+        <% else %>
+          <span id="school-search-hint" class="govuk-hint">
+            Search for the school name, use at least four characters.
+          </span>
+        <% end %>
       <%= form_tag(claim_path("claim-school"), method: :get) do %>
-        <div class="govuk-form-group">
-          <%= label_tag :school_search, "School name", class: "govuk-label" %>
-          <%= text_field_tag :school_search, params[:school_search], class: "govuk-input", value: current_claim.claim_school&.name %>
-        </div>
+          <%= form_group_tag current_claim, :school_search do %>
+            <%= label_tag :school_search, "School name", class: "govuk-label" %>
+            <%= errors_tag current_claim, :school_search %>
+            <%= text_field_tag :school_search, params[:school_search], id: :tslr_claim_school_search, class: css_classes_for_input(current_claim, :school_search), value: current_claim.claim_school&.name  %>
+          <% end %>
         <div class="govuk-form-group">
           <%= submit_tag "Search", class: "govuk-button" %>
         </div>
@@ -37,8 +37,10 @@
       <%= form_for current_claim, url: claim_path do |form| %>
         <%= hidden_field_tag :school_search, params[:school_search] %>
 
-        <div class="govuk-form-group">
+        <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
+            <%= errors_tag current_claim, :claim_school %>
+
             <div class="govuk-radios">
               <%= form.collection_radio_buttons :claim_school_id, @schools, :id, :name do |b| %>
                 <div class="govuk-radios__item">
@@ -49,7 +51,7 @@
               <% end %>
             </div>
           </fieldset>
-        </div>
+        <% end %>
         <%= form.submit "Continue", class: "govuk-button" %>
         <%= link_to "Search again", claim_path, class: "govuk-button govuk-button--secondary" %>
       <% end %>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -3,44 +3,46 @@
 
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-
-      <h1 class="govuk-heading-xl">
-        <%= t("tslr.questions.claim_school") %>
-      </h1>
-
     <% if @schools.blank? %>
-        <% if params[:school_search].present? && current_claim.errors.empty? %>
-          <p class="govuk-body">
-            <strong>No results match that search term. Try again.</strong>
-          </p>
-        <% else %>
-          <span id="school-search-hint" class="govuk-hint">
-            Search for the school name, use at least four characters.
-          </span>
-        <% end %>
+
       <%= form_tag(claim_path("claim-school"), method: :get) do %>
-          <%= form_group_tag current_claim, :school_search do %>
-            <%= label_tag :school_search, "School name", class: "govuk-label" %>
-            <%= errors_tag current_claim, :school_search %>
-            <%= text_field_tag :school_search, params[:school_search], id: :tslr_claim_school_search, class: css_classes_for_input(current_claim, :school_search), value: current_claim.claim_school&.name  %>
+        <%= form_group_tag current_claim, :school_search do %>
+          <h1 class="govuk-label-wrapper">
+            <%= label_tag :tslr_claim_school_search, t("tslr.questions.claim_school"), class: "govuk-label govuk-label--xl" %>
+
+          </h1>
+          <% if params[:school_search].present? && current_claim.errors.empty? %>
+            <p class="govuk-body">
+              <strong>No results match that search term. Try again.</strong>
+            </p>
+          <% else %>
+            <span id="school-search-hint" class="govuk-hint">
+              Search for the school name, use at least four characters.
+            </span>
           <% end %>
-        <div class="govuk-form-group">
-          <%= submit_tag "Search", class: "govuk-button" %>
-        </div>
+          <%= errors_tag current_claim, :school_search %>
+          <%= text_field_tag :school_search, params[:school_search], id: :tslr_claim_school_search, class: css_classes_for_input(current_claim, :school_search), value: current_claim.claim_school&.name %>
+        <% end %>
+        <%= submit_tag "Search", class: "govuk-button" %>
       <% end %>
 
     <% else %>
 
-      <span id="school-search-result-hint" class="govuk-hint">
-        Select your school from the search results.
-      </span>
       <%= form_for current_claim, url: claim_path do |form| %>
-        <%= hidden_field_tag :school_search, params[:school_search] %>
-
-        <%= form_group_tag current_claim do %>
+        <%= form_group_tag current_claim, :claim_school do %>
           <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
-            <%= errors_tag current_claim, :claim_school %>
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("tslr.questions.claim_school") %>
+              </h1>
+            </legend>
+            <span id="school-search-result-hint" class="govuk-hint">
+              Select your school from the search results.
+            </span>
 
+            <%= hidden_field_tag :school_search, params[:school_search] %>
+
+            <%= errors_tag current_claim, :claim_school %>
             <div class="govuk-radios">
               <%= form.collection_radio_buttons :claim_school_id, @schools, :id, :name do |b| %>
                 <div class="govuk-radios__item">
@@ -57,5 +59,6 @@
       <% end %>
 
     <% end %>
+
   </div>
 </div>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
-
     <% if @schools.blank? %>
+
+      <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
       <%= form_tag(claim_path("claim-school"), method: :get) do %>
         <%= form_group_tag current_claim, :school_search do %>
@@ -21,12 +21,26 @@
             </span>
           <% end %>
           <%= errors_tag current_claim, :school_search %>
-          <%= text_field_tag :school_search, params[:school_search], id: :tslr_claim_school_search, class: css_classes_for_input(current_claim, :school_search), value: current_claim.claim_school&.name %>
+          <%=
+            text_field_tag  :school_search,
+                            params[:school_search],
+                            id: :tslr_claim_school_search,
+                            class: css_classes_for_input(current_claim, :school_search),
+                            value: current_claim.claim_school&.name
+          %>
         <% end %>
         <%= submit_tag "Search", class: "govuk-button" %>
       <% end %>
 
     <% else %>
+
+      <%=
+        render(
+            "shared/error_summary",
+            instance: current_claim,
+            errored_field_id_overrides: { claim_school: "tslr_claim_claim_school_id_#{@schools.first.id}"}
+        ) if current_claim.errors.any?
+      %>
 
       <%= form_for current_claim, url: claim_path do |form| %>
         <%= form_group_tag current_claim, :claim_school do %>

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -1,9 +1,9 @@
   <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
-
     <% if @schools.blank? %>
+
+      <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
       <%= form_tag(claim_path("current-school"), method: :get) do %>
         <%= form_group_tag current_claim, :school_search do %>
@@ -21,12 +21,26 @@
             </span>
           <% end %>
           <%= errors_tag current_claim, :school_search %>
-          <%= text_field_tag :school_search, params[:school_search], id: :tslr_claim_school_search, class: css_classes_for_input(current_claim, :school_search), value: current_claim.current_school&.name %>
+          <%=
+            text_field_tag  :school_search,
+                            params[:school_search],
+                            id: :tslr_claim_school_search,
+                            class: css_classes_for_input(current_claim, :school_search),
+                            value: current_claim.current_school&.name
+          %>
         <% end %>
         <%= submit_tag "Search", class: "govuk-button" %>
       <% end %>
 
     <% else %>
+
+      <%=
+        render(
+          "shared/error_summary",
+          instance: current_claim,
+          errored_field_id_overrides: { current_school: "tslr_claim_current_school_id_#{@schools.first.id}"}
+        ) if current_claim.errors.any?
+      %>
 
       <%= form_for current_claim, url: claim_path do |form| %>
         <%= form_group_tag current_claim, :current_school do %>

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -3,39 +3,33 @@
 
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
-    <h1 class="govuk-heading-xl">
-      <%= t("tslr.questions.current_school") %>
-    </h1>
-
     <% if @schools.blank? %>
-
-      <% if params[:school_search].present? && current_claim.errors.empty? %>
-        <p class="govuk-body">
-          <strong>No results match that search term. Try again.</strong>
-        </p>
-      <% else %>
-        <span id="school-search-hint" class="govuk-hint">
-          Search for the school name, use at least four characters.
-        </span>
-      <% end %>
 
       <%= form_tag(claim_path("current-school"), method: :get) do %>
         <%= form_group_tag current_claim, :school_search do %>
-          <%= label_tag :school_search, "School name", class: "govuk-label" %>
-          <%= text_field_tag :school_search, params[:school_search], class: css_classes_for_input(current_claim, :school_search), value: current_claim.current_school&.name %>
+          <h1 class="govuk-label-wrapper">
+            <%= label_tag :tslr_claim_school_search, t("tslr.questions.current_school"), class: "govuk-label govuk-label--xl" %>
+
+          </h1>
+          <% if params[:school_search].present? && current_claim.errors.empty? %>
+            <p class="govuk-body">
+              <strong>No results match that search term. Try again.</strong>
+            </p>
+          <% else %>
+            <span id="school-search-hint" class="govuk-hint">
+              Search for the school name, use at least four characters.
+            </span>
+          <% end %>
+          <%= errors_tag current_claim, :school_search %>
+          <%= text_field_tag :school_search, params[:school_search], id: :tslr_claim_school_search, class: css_classes_for_input(current_claim, :school_search), value: current_claim.current_school&.name %>
         <% end %>
         <%= submit_tag "Search", class: "govuk-button" %>
       <% end %>
 
     <% else %>
 
-      <span id="school-search-result-hint" class="govuk-hint">
-        Select your school from the search results.
-      </span>
       <%= form_for current_claim, url: claim_path do |form| %>
         <%= form_group_tag current_claim, :current_school do %>
-          <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
-
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
                 <%= t("tslr.questions.current_school") %>
@@ -49,7 +43,6 @@
             <%= hidden_field_tag :school_search, params[:school_search] %>
 
             <%= errors_tag current_claim, :current_school %>
-
             <div class="govuk-radios">
               <%= form.collection_radio_buttons :current_school_id, @schools, :id, :name do |b| %>
                 <div class="govuk-radios__item">

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-row">
+  <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
@@ -20,13 +20,11 @@
       <% end %>
 
       <%= form_tag(claim_path("current-school"), method: :get) do %>
-        <div class="govuk-form-group">
+        <%= form_group_tag current_claim, :school_search do %>
           <%= label_tag :school_search, "School name", class: "govuk-label" %>
-          <%= text_field_tag :school_search, params[:school_search], class: "govuk-input", value: current_claim.current_school&.name %>
-        </div>
-        <div class="govuk-form-group">
-          <%= submit_tag "Search", class: "govuk-button" %>
-        </div>
+          <%= text_field_tag :school_search, params[:school_search], class: css_classes_for_input(current_claim, :school_search), value: current_claim.current_school&.name %>
+        <% end %>
+        <%= submit_tag "Search", class: "govuk-button" %>
       <% end %>
 
     <% else %>
@@ -35,10 +33,23 @@
         Select your school from the search results.
       </span>
       <%= form_for current_claim, url: claim_path do |form| %>
-        <%= hidden_field_tag :school_search, params[:school_search] %>
-
-        <div class="govuk-form-group">
+        <%= form_group_tag current_claim, :current_school do %>
           <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("tslr.questions.current_school") %>
+              </h1>
+            </legend>
+
+            <span id="school-search-result-hint" class="govuk-hint">
+              Select your school from the search results.
+            </span>
+
+            <%= hidden_field_tag :school_search, params[:school_search] %>
+
+            <%= errors_tag current_claim, :current_school %>
+
             <div class="govuk-radios">
               <%= form.collection_radio_buttons :current_school_id, @schools, :id, :name do |b| %>
                 <div class="govuk-radios__item">
@@ -49,7 +60,7 @@
               <% end %>
             </div>
           </fieldset>
-        </div>
+        <% end %>
         <%= form.submit "Continue", class: "govuk-button" %>
         <%= link_to "Search again", claim_path, class: "govuk-button govuk-button--secondary" %>
       <% end %>

--- a/app/views/claims/date_of_birth.html.erb
+++ b/app/views/claims/date_of_birth.html.erb
@@ -3,39 +3,42 @@
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
     <%= form_for current_claim, url: claim_path do |form| %>
-      <fieldset class="govuk-fieldset" aria-describedby="date-of-birth-hint" role="group">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            <%= t("tslr.questions.date_of_birth") %>
-          </h1>
-        </legend>
+      <%= form_group_tag current_claim do %>
+        <fieldset class="govuk-fieldset" aria-describedby="date-of-birth-hint" role="group">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              <%= t("tslr.questions.date_of_birth") %>
+            </h1>
+          </legend>
 
-        <span id="date-of-birth-hint" class="govuk-hint">
-          For example, 31 3 1980. We need this information to verify your identity.
-        </span>
+          <span id="date-of-birth-hint" class="govuk-hint">
+            For example, 31 3 1980. We need this information to verify your identity.
+          </span>
 
-        <div class="govuk-date-input">
-          <div class="govuk-date-input__item">
-            <div class="govuk-form-group">
-              <%= label_tag :"tslr_claim_date_of_birth_3i", "Day", class: "govuk-label govuk-date-input__label" %>
-              <%= text_field_tag :"tslr_claim[date_of_birth(3i)]", form.object.date_of_birth.try(:day), id: "tslr_claim_date_of_birth_3i", class: "govuk-input govuk-date-input__input govuk-input--width-2", type: "number", autocomplete: "bday-day", pattern: "[0-9]*" %>
+          <%= errors_tag current_claim, :tslr_claim_date_of_birth %>
+
+          <div class="govuk-date-input">
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <%= label_tag :"tslr_claim_date_of_birth_3i", "Day", class: "govuk-label govuk-date-input__label" %>
+                <%= text_field_tag :"tslr_claim[date_of_birth(3i)]", form.object.date_of_birth.try(:day), id: "tslr_claim_date_of_birth_3i", class: css_classes_for_input(current_claim, :tslr_claim_date_of_birth, "govuk-date-input__input govuk-input--width-2"), type: "number", autocomplete: "bday-day", pattern: "[0-9]*" %>
+              </div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <%= label_tag :"tslr_claim_date_of_birth_2i", "Month", class: "govuk-label govuk-date-input__label" %>
+                <%= text_field_tag :"tslr_claim[date_of_birth(2i)]", form.object.date_of_birth.try(:month), id: "tslr_claim_date_of_birth_2i", class: css_classes_for_input(current_claim, :tslr_claim_date_of_birth, "govuk-date-input__input govuk-input--width-2"), type: "number", autocomplete: "bday-month", pattern: "[0-9]*" %>
+              </div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <%= label_tag :"tslr_claim_date_of_birth_1i", "Year", class: "govuk-label govuk-date-input__label" %>
+                <%= text_field_tag :"tslr_claim[date_of_birth(1i)]", form.object.date_of_birth.try(:year), id: "tslr_claim_date_of_birth_1i", class: css_classes_for_input(current_claim, :tslr_claim_date_of_birth, "govuk-date-input__input govuk-input--width-4"), type: "number", autocomplete: "bday-year", pattern: "[0-9]*" %>
+              </div>
             </div>
           </div>
-          <div class="govuk-date-input__item">
-            <div class="govuk-form-group">
-              <%= label_tag :"tslr_claim_date_of_birth_2i", "Month", class: "govuk-label govuk-date-input__label" %>
-              <%= text_field_tag :"tslr_claim[date_of_birth(2i)]", form.object.date_of_birth.try(:month), id: "tslr_claim_date_of_birth_2i", class: "govuk-input govuk-date-input__input govuk-input--width-2", type: "number", autocomplete: "bday-month", pattern: "[0-9]*" %>
-            </div>
-          </div>
-          <div class="govuk-date-input__item">
-            <div class="govuk-form-group">
-              <%= label_tag :"tslr_claim_date_of_birth_1i", "Year", class: "govuk-label govuk-date-input__label" %>
-              <%= text_field_tag :"tslr_claim[date_of_birth(1i)]", form.object.date_of_birth.try(:year), id: "tslr_claim_date_of_birth_1i", class: "govuk-input govuk-date-input__input govuk-input--width-4", type: "number", autocomplete: "bday-year", pattern: "[0-9]*" %>
-            </div>
-          </div>
-        </div>
-      </fieldset>
-
+        </fieldset>
+      <% end %>
       <div class="govuk-form-group">
         <%= form.submit "Continue", class: "govuk-button" %>
       </div>

--- a/app/views/claims/date_of_birth.html.erb
+++ b/app/views/claims/date_of_birth.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { date_of_birth: "tslr_claim_date_of_birth_3i"}) if current_claim.errors.any? %>
 
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -3,19 +3,18 @@
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
     <%= form_for current_claim, url: claim_path do |form| %>
-      <h1 class="govuk-heading-xl">
-        <%= form.label :email_address, t("tslr.questions.email_address")  %>
-      </h1>
+      <%= form_group_tag current_claim do %>
+        <h1 class="govuk-label-wrapper">
+          <%= form.label :email_address, t("tslr.questions.email_address"), class: "govuk-label govuk-label--xl"  %>
+        </h1>
 
-      <span class="govuk-hint">We will only use your email address to update you about your claim.</span>
+        <span class="govuk-hint">We will only use your email address to update you about your claim.</span>
 
-      <div class="govuk-form-group">
-        <%= form.email_field :email_address, autocomplete: "email", spellcheck: "false", class: "govuk-input" %>
-      </div>
+        <%= errors_tag current_claim, :email_address %>
 
-      <div class="govuk-form-group">
-        <%= form.submit "Continue", class: "govuk-button" %>
-      </div>
+        <%= form.email_field :email_address, autocomplete: "email", spellcheck: "false", class: css_classes_for_input(current_claim, :email_address) %>
+      <% end %>
+      <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/claims/full_name.html.erb
+++ b/app/views/claims/full_name.html.erb
@@ -3,19 +3,16 @@
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
     <%= form_for current_claim, url: claim_path do |form| %>
-      <h1 class="govuk-heading-xl">
-        <%= form.label :full_name, t("tslr.questions.full_name")  %>
-      </h1>
+      <%= form_group_tag current_claim do %>
+        <h1 class="govuk-label-wrapper">
+          <%= form.label :full_name, t("tslr.questions.full_name"), class: "govuk-label govuk-label govuk-label--xl" %>
+        </h1>
+        <span class="govuk-hint">We need this information to verify your identity.</span>
+        <%= errors_tag current_claim, :full_name %>
+        <%= form.text_field :full_name, autocomplete: "name", spellcheck: "false", class: css_classes_for_input(current_claim, :full_name) %>
+      <% end %>
+      <%= form.submit "Continue", class: "govuk-button" %>
 
-      <span class="govuk-hint">We need this information to verify your identity.</span>
-
-      <div class="govuk-form-group">
-        <%= form.text_field :full_name, autocomplete: "name", spellcheck: "false", class: "govuk-input" %>
-      </div>
-
-      <div class="govuk-form-group">
-        <%= form.submit "Continue", class: "govuk-button" %>
-      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/claims/national_insurance_number.html.erb
+++ b/app/views/claims/national_insurance_number.html.erb
@@ -3,19 +3,18 @@
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
     <%= form_for current_claim, url: claim_path do |form| %>
-      <h1 class="govuk-heading-xl">
-        <%= form.label :national_insurance_number, t("tslr.questions.national_insurance_number")  %>
-      </h1>
+      <%= form_group_tag current_claim do %>
+        <h1 class="govuk-heading-xl">
+          <%= form.label :national_insurance_number, t("tslr.questions.national_insurance_number")  %>
+        </h1>
 
-      <span class="govuk-hint">It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.</span>
+        <span class="govuk-hint">It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.</span>
 
-      <div class="govuk-form-group">
-        <%= form.text_field :national_insurance_number, spellcheck: "false", class: "govuk-input" %>
-      </div>
+        <%= errors_tag current_claim, :national_insurance_number %>
 
-      <div class="govuk-form-group">
-        <%= form.submit "Continue", class: "govuk-button" %>
-      </div>
+        <%= form.text_field :national_insurance_number, spellcheck: "false", class: css_classes_for_input(current_claim, :national_insurance_number) %>
+      <% end %>
+      <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -3,22 +3,20 @@
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
     <%= form_for current_claim, url: claim_path do |form| %>
-      <h1 class="govuk-heading-xl">
-        <%= form.label :qts_award_year, t("tslr.questions.qts_award_year") %>
-      </h1>
+      <%= form_group_tag current_claim do %>
+        <h1 class="govuk-heading-xl">
+          <%= form.label :qts_award_year, t("tslr.questions.qts_award_year") %>
+        </h1>
 
-      <span id="tslr_claim_qts_award_year-hint" class="govuk-hint">
-        You are only eligible to claim back student loan repayments if you qualified
-        on or after September 1st 2013.
-      </span>
+        <span id="tslr_claim_qts_award_year-hint" class="govuk-hint">
+          You are only eligible to claim back student loan repayments if you qualified on or after September 1st 2013.
+        </span>
 
-      <div class="govuk-form-group">
-        <%= form.select :qts_award_year, options_for_qts_award_year, { include_blank: true }, class: "govuk-select" %>
-      </div>
+        <%= errors_tag current_claim, :qts_award_year %>
+        <%= form.select :qts_award_year, options_for_qts_award_year, { include_blank: true }, { class: css_classes_for_select(current_claim, :qts_award_year) } %>
 
-      <div class="govuk-form-group">
-        <%= form.submit "Continue", class: "govuk-button" %>
-      </div>
+      <% end %>
+      <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/claims/still_teaching.html.erb
+++ b/app/views/claims/still_teaching.html.erb
@@ -2,11 +2,12 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
     <%= form_for current_claim, url: claim_path do |form| %>
-      <div class="govuk-form-group">
+      <%= form_group_tag current_claim do %>
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">Are you still employed to teach at a school in England?</h1>
           </legend>
+          <%= errors_tag current_claim, :employment_status %>
           <div class="govuk-radios">
             <%= form.hidden_field :employment_status %>
             <div class="govuk-radios__item">
@@ -23,7 +24,7 @@
             </div>
           </div>
         </fieldset>
-      </div>
+      <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>

--- a/app/views/claims/still_teaching.html.erb
+++ b/app/views/claims/still_teaching.html.erb
@@ -1,11 +1,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading">Are you still employed to teach at a school in England?</h1>
+            <h1 class="govuk-fieldset__heading"><%= t("tslr.questions.still_teaching") %></h1>
           </legend>
           <%= errors_tag current_claim, :employment_status %>
           <div class="govuk-radios">

--- a/app/views/claims/student_loan_amount.html.erb
+++ b/app/views/claims/student_loan_amount.html.erb
@@ -12,9 +12,9 @@
 
         <%= errors_tag current_claim, :student_loan_repayment_amount %>
 
-        <div class="govuk-currency-input__inner">
-          <span class="govuk-currency-input__inner__unit">&pound;</span>
-          <%= form.text_field :student_loan_repayment_amount, class: css_classes_for_input(current_claim, :student_loan_repayment_amount, "govuk-currency-input__inner__input govuk-input--width-5") %>
+        <div class="govuk-currency-input">
+          <span class="govuk-currency-input__unit">&pound;</span>
+          <%= form.text_field :student_loan_repayment_amount, class: css_classes_for_input(current_claim, :student_loan_repayment_amount, "govuk-currency-input__input govuk-input--width-5") %>
         </div>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>

--- a/app/views/claims/student_loan_amount.html.erb
+++ b/app/views/claims/student_loan_amount.html.erb
@@ -3,21 +3,21 @@
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
     <%= form_for current_claim, url: claim_path do |form| %>
-      <h1 class="govuk-heading-xl">
-        <%= form.label :student_loan_repayment_amount, t("tslr.questions.student_loan_amount", claim_school_name: current_claim.claim_school_name)  %>
-      </h1>
+      <%= form_group_tag current_claim do %>
+        <h1 class="govuk-form-wrapper">
+          <%= form.label :student_loan_repayment_amount, t("tslr.questions.student_loan_amount", claim_school_name: current_claim.claim_school_name), class: "govuk-label govuk-label--xl" %>
+        </h1>
 
-      <span class="govuk-hint">Only include repayments made through your teaching wages. You can find this information on your payslips.</span>
-      <div class="govuk-form-group govuk-currency-input">
+        <span class="govuk-hint">Only include repayments made through your teaching wages. You can find this information on your payslips.</span>
+
+        <%= errors_tag current_claim, :student_loan_repayment_amount %>
+
         <div class="govuk-currency-input__inner">
           <span class="govuk-currency-input__inner__unit">&pound;</span>
-          <%= form.text_field :student_loan_repayment_amount, class: "govuk-currency-input__inner__input govuk-input govuk-input--width-5" %>
+          <%= form.text_field :student_loan_repayment_amount, class: css_classes_for_input(current_claim, :student_loan_repayment_amount, "govuk-currency-input__inner__input govuk-input--width-5") %>
         </div>
-      </div>
-
-      <div class="govuk-form-group">
-        <%= form.submit "Continue", class: "govuk-button" %>
-      </div>
+      <% end %>
+      <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/claims/subjects_taught.html.erb
+++ b/app/views/claims/subjects_taught.html.erb
@@ -3,7 +3,7 @@
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form.hidden_field :mostly_teaching_eligible_subjects %>
-      <div class="govuk-form-group">
+      <%= form_group_tag current_claim do %>
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">
@@ -25,6 +25,7 @@
               If you've been off on long-term leave or sick, include the time you were scheduled to teach these subjects.
             </span>
           </p>
+          <%= errors_tag current_claim, :mostly_teaching_eligible_subjects %>
           <div class="govuk-radios">
             <div class="govuk-radios__item">
               <%= form.radio_button(:mostly_teaching_eligible_subjects, true, class: "govuk-radios__input") %>
@@ -36,7 +37,7 @@
             </div>
           </div>
         </fieldset>
-      </div>
+      <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>

--- a/app/views/claims/subjects_taught.html.erb
+++ b/app/views/claims/subjects_taught.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { mostly_teaching_eligible_subjects: "tslr_claim_mostly_teaching_eligible_subjects_true"}) if current_claim.errors.any? %>
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form.hidden_field :mostly_teaching_eligible_subjects %>
       <%= form_group_tag current_claim do %>

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -3,19 +3,19 @@
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
     <%= form_for current_claim, url: claim_path do |form| %>
-      <h1 class="govuk-heading-xl">
-        <%= form.label :teacher_reference_number, t("tslr.questions.teacher_reference_number")  %>
-      </h1>
+      <%= form_group_tag current_claim do %>
+        <h1 class="govuk-label-wrapper">
+          <%= form.label :teacher_reference_number, t("tslr.questions.teacher_reference_number"), class: "govuk-label govuk-label--xl" %>
+        </h1>
 
-      <span class="govuk-hint">This is on the certificate you got when you qualified as a teacher, or your school can tell you.</span>
+        <span class="govuk-hint">This is on the certificate you got when you qualified as a teacher, or your school can tell you.</span>
 
-      <div class="govuk-form-group">
-        <%= form.text_field :teacher_reference_number, spellcheck: "false", class: "govuk-input" %>
-      </div>
-
-      <div class="govuk-form-group">
-        <%= form.submit "Continue", class: "govuk-button" %>
-      </div>
+        <div class="govuk-form-group">
+          <%= errors_tag current_claim, :teacher_reference_number %>
+          <%= form.text_field :teacher_reference_number, spellcheck: "false", class: css_classes_for_input(current_claim, :teacher_reference_number) %>
+        </div>
+      <% end %>
+      <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -5,7 +5,9 @@
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">
       <% instance.errors.each do |attribute, error| %>
-        <li><%= link_to error, "##{instance.class.model_name.singular}_#{attribute}" %></li>
+        <li>
+          <%= link_to error, "##{local_assigns.dig(:errored_field_id_overrides, attribute) || "#{instance.class.model_name.singular}_#{attribute}"}" %>
+        </li>
       <% end %>
     </ul>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
     questions:
       qts_award_year: "Which academic year were you awarded qualified teacher status (QTS)?"
       claim_school: "Which school were you employed at between 6 April XXXX and 5 April XXXX?"
-      employment_status: "Are you still employed to teach at a school in England?"
+      still_teaching: "Are you still employed to teach at a school in England?"
       current_school: "Which school are you currently employed at?"
       mostly_teaching_eligible_subjects: "Did you teach eligible subjects for more than 50% of your teaching time between 6 April XXXX and 5 April XXXX?"
       full_name: "What is your full name?"

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     claim = start_tslr_claim
     choose_qts_year
 
-    fill_in "School name", with: "Penistone"
+    fill_in :school_search, with: "Penistone"
     click_on "Search"
 
     click_on "Continue"
@@ -24,12 +24,12 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     claim = start_tslr_claim
     choose_qts_year
 
-    fill_in "School name", with: "hamp"
+    fill_in :school_search, with: "hamp"
     click_on "Search"
 
     click_on "Search again"
 
-    fill_in "School name", with: "penistone"
+    fill_in :school_search, with: "penistone"
     click_on "Search"
 
     choose "Penistone Grammar School"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -107,7 +107,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.employment_status).to eql("different_school")
 
-    fill_in "School name", with: "Hampstead"
+    fill_in :school_search, with: "Hampstead"
     click_on "Search"
 
     choose "Hampstead School"
@@ -244,7 +244,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
           before do
             choose_still_teaching "Yes, at another school"
 
-            fill_in "School name", with: "Hampstead"
+            fill_in :school_search, with: "Hampstead"
             click_on "Search"
 
             choose "Hampstead School"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     choose_school schools(:penistone_grammar_school)
     expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text(I18n.t("tslr.questions.employment_status"))
+    expect(page).to have_text(I18n.t("tslr.questions.still_teaching"))
 
     choose_still_teaching
     expect(claim.reload.employment_status).to eql("claim_school")

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+describe GovukFormHelper do
+  let(:claim) { TslrClaim.new }
+
+  describe "#form_group_tag" do
+    it "wraps the supplied block in a form group <div> tag" do
+      expect(helper.form_group_tag(claim) { content_tag(:div) }).to eq('<div class="govuk-form-group"><div></div></div>')
+    end
+
+    context "when supplied with an object that has errors" do
+      before do
+        claim.errors.add(:attribute, "Test error")
+      end
+
+      it "adds the error class" do
+        expect(helper.form_group_tag(claim) {}).to have_css(".govuk-form-group--error")
+      end
+
+      context "and an attribute is supplied" do
+        it "does not add error class when there are no errors on the attribute" do
+          expect(helper.form_group_tag(claim, :a_different_attribute) {}).not_to have_css(".govuk-form-group--error")
+        end
+
+        it "adds the error class when there are errors on the attribute" do
+          expect(helper.form_group_tag(claim, :attribute) {}).to have_css(".govuk-form-group--error")
+        end
+      end
+    end
+  end
+
+  describe "#errors_tag" do
+    let(:claim) { TslrClaim.new }
+
+    it "returns correctly formatted error messages" do
+      claim.errors.add(:attribute, "Test error one")
+      claim.errors.add(:attribute, "Test error two")
+
+      error_message = helper.errors_tag(claim, :attribute)
+
+      expect(error_message).to have_css(".govuk-error-message")
+      expect(error_message).to include('<span class="govuk-visually-hidden">Error:</span> Test error one<br>')
+      expect(error_message).to include('<span class="govuk-visually-hidden">Error:</span> Test error two')
+    end
+
+    it "only returns if there is a error for the attribute" do
+      claim.errors.add(:attribute, "Test error")
+
+      expect(helper.errors_tag(claim, :a_different_attribute)).to be_nil
+      expect(helper.errors_tag(claim, :attribute)).to be_truthy
+    end
+  end
+
+  describe "#css_classes_for_input" do
+    it "adds the correct css class" do
+      expect(helper.css_classes_for_input(claim, :attribute) {}).to eq("govuk-input")
+    end
+
+    it "adds the error class when there are errors" do
+      claim.errors.add(:attribute, "Test error")
+
+      expect(helper.css_classes_for_input(claim, :attribute) {}).to eq("govuk-input govuk-input--error")
+    end
+
+    it "keeps any existing css classes" do
+      expect(helper.css_classes_for_input(claim, :attribute, "class-one class-two") {}).to eq("class-one class-two govuk-input")
+    end
+  end
+
+  describe "#css_classes_for_select" do
+    it "adds the correct css class" do
+      expect(helper.css_classes_for_select(claim, :attribute) {}).to eq("govuk-select")
+    end
+
+    it "adds the error class when there are errors" do
+      claim.errors.add(:attribute, "Test error")
+
+      expect(helper.css_classes_for_select(claim, :attribute) {}).to eq("govuk-select govuk-select--error")
+    end
+  end
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -11,7 +11,7 @@ module FeatureHelpers
   end
 
   def choose_school(school)
-    fill_in "School name", with: school.name.split(" ").first
+    fill_in :school_search, with: school.name.split(" ").first
     click_on "Search"
 
     choose school.name


### PR DESCRIPTION
We needed a few things to display these errors so there is a `FormHelper` class to wrap up the methods.

Read about the errors and markup required:

https://design-system.service.gov.uk/

The FormHelper implements:

`form_group_tag` is used to render a form group for either the entire form or an individual element.

`errors_tag` is used to render error messages next to the appropriate element.

`css_classes_for_input` adds the appropriate classes to any `<input>` element.

`css_classes_for_select` adds the appropriate classes for a `<select>` element.

`form_field_id_for_errored_attribute` is used to override a error summary link

Becasue the GOVUK errors call for the red indicator bar to include the whole form group I had to change the two school search views to accomadate this. I took the oportunity to re-factor them to use the 'label as heading' and 'legend as heading' patterns:

https://design-system.service.gov.uk/get-started/labels-legends-headings/

After updating the views some of the tests were broken, Capybara could no longer select an element by the label text so this was fixed by changing to `fill_in(:school_search)`

## Trello

Trello: https://trello.com/c/Y73FJPN9

## Example Screenshots
### Before
![Screenshot_2019-06-10 Teachers claim back student loan repayments](https://user-images.githubusercontent.com/480578/59210055-97d92a80-8ba4-11e9-89d0-63f13a4b5b39.png) 

![Screenshot_2019-06-10 Teachers claim back student loan repayments(1)](https://user-images.githubusercontent.com/480578/59210076-a3c4ec80-8ba4-11e9-93d4-339716bc24cf.png)

### After
![Screenshot_2019-06-10 Teachers claim back student loan repayments(2)](https://user-images.githubusercontent.com/480578/59210104-b2ab9f00-8ba4-11e9-9e1d-02273665c358.png)

![Screenshot_2019-06-10 Teachers claim back student loan repayments(3)](https://user-images.githubusercontent.com/480578/59210110-b93a1680-8ba4-11e9-9101-d53b1e947aff.png)

