### PR TITLE
Set up Docker and first-pass Azure web app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/log/
+/node_modules/
+/tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,12 @@ COPY Gemfile ${DEPS_HOME}/Gemfile
 COPY Gemfile.lock ${DEPS_HOME}/Gemfile.lock
 
 RUN gem install bundler
-RUN bundle install --frozen --retry 3 --without development test
+
+RUN if [ ${RAILS_ENV} = "production" ]; then \
+  bundle install --frozen --retry 3 --without development test; \
+  else \
+  bundle install --frozen --retry 3; \
+  fi
 # End
 
 # Install JavaScript dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM ruby:2.6.2-alpine AS web
+
+RUN apk add build-base
+RUN apk add tzdata
+RUN apk add postgresql-dev
+RUN apk add yarn
+
+# Set up install environment
+ENV APP_HOME /app
+
+RUN mkdir -p ${APP_HOME}
+WORKDIR ${APP_HOME}
+
+ARG RAILS_ENV
+ENV RAILS_ENV ${RAILS_ENV:-production}
+ENV NODE_ENV ${RAILS_ENV:-production}
+
+RUN echo "Building with RAILS_ENV=${RAILS_ENV}"
+# End
+
+# Install Ruby dependencies
+COPY Gemfile ${APP_HOME}/Gemfile
+COPY Gemfile.lock ${APP_HOME}/Gemfile.lock
+
+RUN gem install bundler
+RUN bundle install --frozen --retry 3 --without development test
+# End
+
+# Install JavaScript dependencies
+COPY package.json ${APP_HOME}/package.json
+COPY yarn.lock ${APP_HOME}/yarn.lock
+
+RUN yarn install --frozen-lockfile --production
+# End
+
+# Copy app code (sorted by vague frequency of change for caching)
+RUN mkdir -p ${APP_HOME}/log
+RUN mkdir -p ${APP_HOME}/tmp
+
+COPY config.ru ${APP_HOME}/config.ru
+COPY Rakefile ${APP_HOME}/Rakefile
+
+COPY public ${APP_HOME}/public
+COPY vendor ${APP_HOME}/vendor
+COPY bin ${APP_HOME}/bin
+COPY lib ${APP_HOME}/lib
+COPY config ${APP_HOME}/config
+COPY db ${APP_HOME}/db
+COPY app ${APP_HOME}/app
+# End
+
+RUN RAILS_ENV=production DFE_SIGN_IN_ISSUER= DFE_SIGN_IN_REDIRECT_URL= DFE_SIGN_IN_IDENTIFIER= DFE_SIGN_IN_SECRET= bundle exec rake assets:precompile
+
+EXPOSE 3000
+
+CMD [ "rails", "server" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,13 @@ COPY db ${APP_HOME}/db
 COPY app ${APP_HOME}/app
 # End
 
-RUN RAILS_ENV=production DFE_SIGN_IN_ISSUER= DFE_SIGN_IN_REDIRECT_URL= DFE_SIGN_IN_IDENTIFIER= DFE_SIGN_IN_SECRET= bundle exec rake assets:precompile
+RUN if [ ${RAILS_ENV} = "production" ]; then \
+  DFE_SIGN_IN_ISSUER= \
+  DFE_SIGN_IN_REDIRECT_URL= \
+  DFE_SIGN_IN_IDENTIFIER= \
+  DFE_SIGN_IN_SECRET= \
+  bundle exec rake assets:precompile; \
+  fi
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM ruby:2.6.2-alpine AS base
 
+RUN apk add bash
 RUN apk add postgresql-dev
 RUN apk add tzdata
 RUN apk add nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN gem install bundler
 RUN if [ ${RAILS_ENV} = "production" ]; then \
   bundle install --frozen --retry 3 --without development test; \
   else \
-  bundle install --frozen --retry 3; \
+  bundle install --frozen --retry 3 --without test; \
   fi
 # End
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ENV DEPS_HOME /deps
 
 ARG RAILS_ENV
 ENV RAILS_ENV ${RAILS_ENV:-production}
-ENV RACK_ENV ${RAILS_ENV:-production}
 ENV NODE_ENV ${RAILS_ENV:-production}
 
 # ------------------------------------------------------------------------------
@@ -23,7 +22,7 @@ ENV NODE_ENV ${RAILS_ENV:-production}
 
 FROM base AS dependencies
 
-RUN echo "Building with RAILS_ENV=${RAILS_ENV}, RACK_ENV=${RACK_ENV}, NODE_ENV=${NODE_ENV}"
+RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
 
 RUN apk add build-base
 RUN apk add yarn
@@ -59,7 +58,7 @@ RUN yarn install --frozen-lockfile --production
 
 FROM base AS web
 
-RUN echo "Building with RAILS_ENV=${RAILS_ENV}, RACK_ENV=${RACK_ENV}, NODE_ENV=${NODE_ENV}"
+RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
 
 # Set up install environment
 RUN mkdir -p ${APP_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,4 +99,5 @@ RUN if [ ${RAILS_ENV} = "production" ]; then \
 
 EXPOSE 3000
 
+ENTRYPOINT [ "bin/docker-entrypoint" ]
 CMD [ "rails", "server" ]

--- a/azure/parameters/development.json
+++ b/azure/parameters/development.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appServiceDockerImage": {
+      "value": "pezholio/teacher-payment-service"
+    },
+    "databaseName": {
+      "value": "development"
+    },
+    "databaseUsername": {
+      "value": "user"
+    },
+    "databasePassword": {
+      "value": "8dXuq*jvAt-4beU"
+    },
+    "securityAlertEmailAddress": {
+      "value": "foo@example.com"
+    },
+    "SECRET_KEY_BASE": {
+      "value": "827a46887bf03dfbe280c10dc00110ef44c7608e0dadbb16f2fbdd1cace12c005801d847c04db0a132f2f2b9de861eee5dd5b43a979613cb985ff857bdbb7a6b"
+    },
+    "DFE_SIGN_IN_ISSUER": {
+      "value": ""
+    },
+    "DFE_SIGN_IN_REDIRECT_URL": {
+      "value": ""
+    },
+    "DFE_SIGN_IN_IDENTIFIER": {
+      "value": ""
+    },
+    "DFE_SIGN_IN_SECRET": {
+      "value": ""
+    }
+  }
+}

--- a/azure/template.json
+++ b/azure/template.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceNamePrefix": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().name]"
+    },
+    "appServiceDockerImage": {
+      "type": "string"
+    },
+    "databaseName": {
+      "type": "string"
+    },
+    "databaseUsername": {
+      "type": "string"
+    },
+    "databasePassword": {
+      "type": "securestring"
+    },
+    "securityAlertEmailAddress": {
+      "type": "string"
+    },
+    "RAILS_ENV": {
+      "type": "string",
+      "defaultValue": "production"
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "type": "string",
+      "defaultValue": "true"
+    },
+    "SECRET_KEY_BASE": {
+      "type": "securestring"
+    },
+    "DFE_SIGN_IN_ISSUER": {
+      "type": "string"
+    },
+    "DFE_SIGN_IN_REDIRECT_URL": {
+      "type": "string"
+    },
+    "DFE_SIGN_IN_IDENTIFIER": {
+      "type": "securestring"
+    },
+    "DFE_SIGN_IN_SECRET": {
+      "type": "securestring"
+    }
+  },
+  "variables": {
+    "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
+    "storageAccountName": "[replace(concat(parameters('resourceNamePrefix'), 'storage'), '-', '')]",
+    "databaseServerName": "[concat(parameters('resourceNamePrefix'), '-db')]",
+    "appServicePlanName": "[concat(parameters('resourceNamePrefix'), '-asp')]",
+    "appServiceName": "[concat(parameters('resourceNamePrefix'), '-as')]",
+    "appServiceRuntimeStack": "[concat('DOCKER|', parameters('appServiceDockerImage'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2017-05-10",
+      "name": "storage-account",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'storage-account.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "database-server",
+      "type": "Microsoft.Resources/deployments",
+      "dependsOn": ["storage-account"],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'postgresql-server.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "postgresServerName": {
+            "value": "[variables('databaseServerName')]"
+          },
+          "postgresAdminLogin": {
+            "value": "[parameters('databaseUsername')]"
+          },
+          "postgresAdminPassword": {
+            "value": "[parameters('databasePassword')]"
+          },
+          "securityAlertEmailAddress": {
+            "value": "[parameters('securityAlertEmailAddress')]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "database",
+      "type": "Microsoft.Resources/deployments",
+      "dependsOn": ["database-server"],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'postgresql-database.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "serverName": {
+            "value": "[variables('databaseServerName')]"
+          },
+          "databaseName": {
+            "value": "[parameters('databaseName')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "app-service-plan",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'app-service-plan.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appServicePlanName": {
+            "value": "[variables('appServicePlanName')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "app-service",
+      "type": "Microsoft.Resources/deployments",
+      "dependsOn": ["app-service-plan", "database", "database-server"],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'app-service-linux.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appServiceName": {
+            "value": "[variables('appServiceName')]"
+          },
+          "appServicePlanName": {
+            "value": "[variables('appServicePlanName')]"
+          },
+          "appServicePlanResourceGroup": {
+            "value": "[resourceGroup().name]"
+          },
+          "runtimeStack": {
+            "value": "[variables('appServiceRuntimeStack')]"
+          },
+          "appServiceAppSettings": {
+            "value": [
+              {
+                "name": "RAILS_ENV",
+                "value": "[parameters('RAILS_ENV')]"
+              },
+              {
+                "name": "RAILS_SERVE_STATIC_FILES",
+                "value": "[parameters('RAILS_SERVE_STATIC_FILES')]"
+              },
+              {
+                "name": "DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME",
+                "value": "[concat(parameters('databaseUsername'), '@', variables('databaseServerName'))]"
+              },
+              {
+                "name": "DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_PASSWORD",
+                "value": "[parameters('databasePassword')]"
+              },
+              {
+                "name": "DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST",
+                "value": "[reference('database-server').outputs.fullyQualifiedDomainName.value]"
+              },
+              {
+                "name": "DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_NAME",
+                "value": "[parameters('databaseName')]"
+              },
+              {
+                "name": "SECRET_KEY_BASE",
+                "value": "[parameters('SECRET_KEY_BASE')]"
+              },
+              {
+                "name": "DFE_SIGN_IN_ISSUER",
+                "value": "[parameters('DFE_SIGN_IN_ISSUER')]"
+              },
+              {
+                "name": "DFE_SIGN_IN_REDIRECT_URL",
+                "value": "[parameters('DFE_SIGN_IN_REDIRECT_URL')]"
+              },
+              {
+                "name": "DFE_SIGN_IN_IDENTIFIER",
+                "value": "[parameters('DFE_SIGN_IN_IDENTIFIER')]"
+              },
+              {
+                "name": "DFE_SIGN_IN_SECRET",
+                "value": "[parameters('DFE_SIGN_IN_SECRET')]"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "database-server-firewall-rules",
+      "type": "Microsoft.Resources/deployments",
+      "dependsOn": ["app-service", "database-server"],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'postgresql-server-firewall-rules.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "firewallRuleNamePrefix": {
+            "value": "[concat(parameters('resourceNamePrefix'), '-')]"
+          },
+          "ipAddresses": {
+            "value": "[reference('app-service').outputs.possibleOutboundIpAddresses.value]"
+          },
+          "serverName": {
+            "value": "[variables('databaseServerName')]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+ENVIRONMENT_NAME=$1
+DEPLOYMENT_NAME="core"
+RESOURCE_LOCATION="West Europe"
+TEMPLATE_FILE_PATH="azure/template.json"
+PARAMETERS_FILE_PATH="azure/parameters/$ENVIRONMENT_NAME.json"
+
+case $ENVIRONMENT_NAME in
+  "development")
+    # Use `az account show --out json` to find the subscription ID.
+    SUBSCRIPTION_ID="8655985a-2f87-44d7-a541-0be9a8c2779d"
+    RESOURCE_GROUP_NAME="s118d02-core"
+    ;;
+  *)
+    echo "Could not find an known environment with the name: $ENVIRONMENT_NAME"
+    exit 1
+    ;;
+esac
+
+if ! az account show > /dev/null; then
+  echo "Logging in..."
+  az login
+fi
+
+echo "Setting default subscription to $SUBSCRIPTION_ID..."
+az account set --subscription $SUBSCRIPTION_ID
+
+if ! az group show --name $RESOURCE_GROUP_NAME > /dev/null; then
+  echo "Creating new resource group with name $RESOURCE_GROUP_NAME..."
+  az group create \
+    --name $RESOURCE_GROUP_NAME \
+    --location "$RESOURCE_LOCATION" \
+    > /dev/null
+else
+  echo "Using existing resource group with name $RESOURCE_GROUP_NAME..."
+fi
+
+echo "Starting deployment..."
+az group deployment create \
+  --name $DEPLOYMENT_NAME \
+  --resource-group $RESOURCE_GROUP_NAME \
+  --template-file $TEMPLATE_FILE_PATH \
+  --parameters "@$PARAMETERS_FILE_PATH"
+
+echo "Template has been successfully deployed"

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+if rake db:migrate:status > /dev/null; then
+  rails db:migrate
+elif [ "$RAILS_ENV" != "production" ]; then
+  rake db:create db:setup
+fi
+
+exec "$@"

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,7 +21,7 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
-development:
+development: &development
   <<: *default
   database: dfe-teachers-payment-service_development
 
@@ -29,7 +29,7 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: dfe-teachers-payment-service
+  username: <%= ENV["DB_USERNAME"] %>
 
   # The password associated with the postgres role (username).
   #password:
@@ -37,7 +37,7 @@ development:
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  #host: localhost
+  host: <%= ENV["DB_HOST"] %>
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
@@ -56,7 +56,7 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
+  <<: *development
   database: dfe-teachers-payment-service_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
@@ -76,10 +76,10 @@ test:
 # You can use this database configuration with:
 #
 #   production:
-#     url: <%= ENV['DATABASE_URL'] %>
+#     url: <%= ENV["DATABASE_URL"] %>
 #
 production:
   <<: *default
   database: dfe-teachers-payment-service_production
   username: dfe-teachers-payment-service
-  password: <%= ENV['DFE-TEACHERS-PAYMENT-SERVICE_DATABASE_PASSWORD'] %>
+  password: <%= ENV["DFE-TEACHERS-PAYMENT-SERVICE_DATABASE_PASSWORD"] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,7 +12,7 @@
 #       Install PostgreSQL and put its /bin directory on your path.
 #
 # Configure Using Gemfile
-# gem 'pg'
+# gem "pg"
 #
 default: &default
   adapter: postgresql
@@ -23,21 +23,21 @@ default: &default
 
 development: &development
   <<: *default
-  database: dfe-teachers-payment-service_development
+  database: <%= ENV["DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_NAME"] || "dfe-teachers-payment-service_development" %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  username: <%= ENV["DB_USERNAME"] %>
+  username: <%= ENV["DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME"] %>
 
   # The password associated with the postgres role (username).
-  #password:
+  password: <%= ENV["DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_PASSWORD"] %>
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  host: <%= ENV["DB_HOST"] %>
+  host: <%= ENV["DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST"] %>
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
@@ -80,6 +80,7 @@ test:
 #
 production:
   <<: *default
-  database: dfe-teachers-payment-service_production
-  username: dfe-teachers-payment-service
-  password: <%= ENV["DFE-TEACHERS-PAYMENT-SERVICE_DATABASE_PASSWORD"] %>
+  database: <%= ENV["DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_NAME"] || "dfe-teachers-payment-service_production" %>
+  username: <%= ENV["DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME"] || "dfe-teachers-payment-service" %>
+  password: <%= ENV["DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_PASSWORD"] %>
+  host: <%= ENV["DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST"] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+services:
+  web:
+    build:
+      context: .
+      args:
+        RAILS_ENV: development
+    image: local/dfe-teachers-payment-service:development
+    depends_on:
+      - db
+    env_file:
+      - .env.development
+    environment:
+      DB_USERNAME: postgres
+      DB_HOST: db
+    volumes:
+      - ./localhost.key:/app/localhost.key
+      - ./localhost.crt:/app/localhost.crt
+    ports:
+      - 3000:3000
+    tty: true
+    stdin_open: true
+    command: rails server -b ssl://web:3000?key=localhost.key&cert=localhost.crt
+
+  db:
+    image: postgres
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
     env_file:
       - .env.development
     environment:
-      DB_USERNAME: postgres
-      DB_HOST: db
+      DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME: postgres
+      DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST: db
     volumes:
       - ./localhost.key:/app/localhost.key
       - ./localhost.crt:/app/localhost.crt


### PR DESCRIPTION
The `Dockerfile` builds 3 images: a `dependencies` image containing the JS and Ruby dependencies and things needed to build and install them, a `web` image which contains the app (but not the specs) copying dependencies from the `dependencies` image, and a `base` image both of them depend on. `web` is the image that actually gets uploaded and run. We have opted for explicit copies over relying on the `.dockerignore`. The entries in `.dockerignore` are to speed up the build as Docker makes a copy of the build context (the target directory) before running the build, which can be quite large including the temporary files.

The app can be built in development or production mode using `--build-arg`s (defaulting to production), and there's a `docker-compose.yml` set up to build and run a functioning development environment.

Only the development environment is set up. The general template is `azure/template.json` and the parameters belong in `azure/parameters/$ENVIRONMENT_NAME.json`.

The template uses templates from the `master` branch of [DFE-Digital/bat-platform-building-blocks](https://github.com/DFE-Digital/bat-platform-building-blocks). Probably we should pin the version of that at some point.

Parameters are currently included in the repo, but include secrets that should be reset, ignored, and shared via whatever secret management system we end up using. We're currently using a manually built and pushed docker image in @pezholio's DockerHub account.

We are currenly using a new, throwaway resource group to avoid hitting the groups that appear to have been set up for us, until we better understand why they're there.

Note, this changes the production database password envirnment variable to conform with Azure's expected format (Azure has many of those).

To deploy to Azure, run `bin/azure-deploy development`. The script depends on having the Azure CLI installed (`brew install azure-cli`).