### PR TITLE
Validate that `current_school` is set on submit

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -39,7 +39,7 @@ class TslrClaim < ApplicationRecord
   belongs_to :current_school, optional: true, class_name: "School"
 
   validates :claim_school,              on: [:"claim-school", :submit], presence: {message: "Select a school from the list"}
-  validates :current_school,            on: [:"current-school"], presence: {message: "Select a school from the list"}
+  validates :current_school,            on: [:"current-school", :submit], presence: {message: "Select a school from the list"}
 
   validates :qts_award_year,            on: [:"qts-year", :submit], inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}
 
@@ -84,7 +84,8 @@ class TslrClaim < ApplicationRecord
   validate  :bank_account_number_must_be_eight_digits
   validate  :bank_sort_code_must_be_six_digits
 
-  before_save :update_current_school, if: :employment_status_changed?
+  before_validation :update_current_school, if: :employment_status_changed?
+
   before_save :normalise_trn, if: :teacher_reference_number_changed?
   before_save :normalise_ni_number, if: :national_insurance_number_changed?
   before_save :normalise_bank_account_number, if: :bank_account_number_changed?


### PR DESCRIPTION
It's set by the `update_current_school` callback if the user selects same school, otherwise the user should be setting it manually.

We now run `update_current_school` on validation as well as saving. This is fine to do as the value of it is invisible to the user. The other callbacks only run on save so we show the user the values they entered if there's an error with them, not a normalized version of them.