### PR TITLE
Fix intermittent failing JavaScript redirect spec

### DIFF
--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -298,7 +298,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     end
 
     scenario "Claimants are automatically redirected to the timeout page" do
-      sleep 1
+      wait_until_visible find("h1", text: "Your session has ended due to inactivity")
       expect(current_path).to eql(timeout_claim_path)
     end
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -16,4 +16,5 @@ end
 Capybara.configure do |config|
   config.default_driver = :rack_test
   config.javascript_driver = :headless_chrome
+  config.default_max_wait_time = 5
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -22,4 +22,10 @@ module FeatureHelpers
     choose teaching_at
     click_on "Continue"
   end
+
+  def wait_until_visible(element)
+    page.document.synchronize do
+      raise Capybara::ElementNotFound unless element.visible?
+    end
+  end
 end


### PR DESCRIPTION
It's possible for the redirect to take longer than a second, to fix this we can leverage Capybara's `synchronize` helper which will wait until the block has completed up until `default_max_wait_time`.

Extract the functionality out to a helper so that it reads better in the spec.

We also need to increase the `default_max_wait_time` to 5 from the default of 2.