### PR TITLE
Add a reference number for a TSLR Claim

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ gem "jbuilder", "~> 2.9"
 # Use Gov UK Kit
 gem "dxw_govuk_frontend_rails"
 
+# Generate human-readable reference numbers
+gem "nanoid"
+
 # Use Rollbar
 gem "rollbar"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
     minitest (5.11.3)
     msgpack (1.2.10)
     multi_json (1.13.1)
+    nanoid (2.0.0)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -307,6 +308,7 @@ DEPENDENCIES
   jbuilder (~> 2.9)
   launchy
   listen (>= 3.0.5, < 3.2)
+  nanoid
   omniauth
   omniauth_openid_connect
   pg (>= 0.18, < 2.0)

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -105,7 +105,11 @@ class TslrClaim < ApplicationRecord
       return false
     end
 
-    touch(:submitted_at) if can_be_submitted?
+    if can_be_submitted?
+      self.submitted_at = Time.zone.now
+      self.reference = unique_reference
+      save!
+    end
   end
 
   def submitted?
@@ -204,5 +208,12 @@ class TslrClaim < ApplicationRecord
   def bank_sort_code_must_be_six_digits
     errors.add(:bank_sort_code, "Sort code must contain six digits") \
       if bank_sort_code.present? && normalised_bank_detail(bank_sort_code) !~ /\A\d{6}\z/
+  end
+
+  def unique_reference
+    loop {
+      ref = Reference.new.to_s
+      break ref unless self.class.exists?(reference: ref)
+    }
   end
 end

--- a/app/services/reference.rb
+++ b/app/services/reference.rb
@@ -1,0 +1,11 @@
+class Reference
+  def to_s
+    Nanoid.generate(alphabet: characters_to_use, size: 8)
+  end
+
+  private
+
+  def characters_to_use
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  end
+end

--- a/db/migrate/20190606152321_add_reference_to_tslr_claim.rb
+++ b/db/migrate/20190606152321_add_reference_to_tslr_claim.rb
@@ -1,0 +1,6 @@
+class AddReferenceToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :reference, :string, limit: 8
+    add_index :tslr_claims, :reference, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_101710) do
+ActiveRecord::Schema.define(version: 2019_06_06_152321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -70,9 +70,11 @@ ActiveRecord::Schema.define(version: 2019_05_31_101710) do
     t.string "bank_account_number", limit: 8
     t.datetime "submitted_at"
     t.decimal "student_loan_repayment_amount", precision: 7, scale: 2
+    t.string "reference", limit: 8
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"
+    t.index ["reference"], name: "index_tslr_claims_on_reference", unique: true
     t.index ["submitted_at"], name: "index_tslr_claims_on_submitted_at"
   end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -367,6 +367,24 @@ RSpec.describe TslrClaim, type: :model do
       it "sets submitted_at to now" do
         expect(tslr_claim.submitted_at).to eq Time.zone.now
       end
+
+      it "generates a reference" do
+        expect(tslr_claim.reference).to_not eq nil
+      end
+
+      context "when a claim with the same reference already exists" do
+        let(:reference) { "12345678" }
+        let!(:other_claim) { create(:tslr_claim, :eligible_and_submittable, reference: reference) }
+
+        before do
+          expect(Reference).to receive(:new).once.and_return(double(to_s: reference), double(to_s: "87654321"))
+          tslr_claim.submit!
+        end
+
+        it "generates a unique reference" do
+          expect(tslr_claim.reference).to eq("87654321")
+        end
+      end
     end
 
     context "when the claim is eligible but unsubmittable" do
@@ -375,6 +393,10 @@ RSpec.describe TslrClaim, type: :model do
       it "doesn't set submitted_at" do
         expect(tslr_claim.submitted_at).to be_nil
       end
+
+      it "doesn't generate a reference" do
+        expect(tslr_claim.reference).to eq nil
+      end
     end
 
     context "when the claim is ineligible" do
@@ -382,6 +404,10 @@ RSpec.describe TslrClaim, type: :model do
 
       it "doesn't set submitted_at" do
         expect(tslr_claim.submitted_at).to be_nil
+      end
+
+      it "doesn't generate a reference" do
+        expect(tslr_claim.reference).to eq nil
       end
 
       it "adds an error" do

--- a/spec/services/reference_spec.rb
+++ b/spec/services/reference_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Reference do
+  subject { described_class.new }
+
+  describe "to_s" do
+    let(:reference) { subject.to_s }
+
+    it "is 8 characters long" do
+      expect(reference.length).to eq(8)
+    end
+
+    it "only contains the specified characters" do
+      expect(reference).to match(/\A[0-9A-Z]+\Z/)
+    end
+  end
+end


### PR DESCRIPTION
This generates a human-friendly, difficult to guess reference number for a claim, so a user can easily refer to their claim if there are any queries.