### PR TITLE
Fix sass build

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,5 +12,4 @@
  *
  *= require_self
  *= require govuk_frontend_rails
- *= require govuk_frontend_custom
  */

--- a/app/assets/stylesheets/govuk_frontend_custom.scss
+++ b/app/assets/stylesheets/govuk_frontend_custom.scss
@@ -1,3 +1,0 @@
-@import "components/flash";
-@import "components/currency_input";
-@import "components/a11y-dialog";

--- a/app/assets/stylesheets/govuk_frontend_rails.scss
+++ b/app/assets/stylesheets/govuk_frontend_rails.scss
@@ -1,1 +1,19 @@
-@import "govuk-frontend-rails";
+@import "settings/all";
+
+// Using Rails with the asset pipeline so set the helper methods
+$govuk-font-url-function: "image-url";
+$govuk-image-url-function: "font-url";
+
+@import "tools/all";
+@import "helpers/all";
+
+@import "core/all";
+@import "objects/all";
+
+@import "components/flash";
+@import "components/currency_input";
+@import "components/a11y-dialog";
+@import "components/all";
+
+@import "utilities/all";
+@import "overrides/all";


### PR DESCRIPTION
Restore the govuk-frontend build to a single file so that custom components
can read the settings and helpers once the Rails require tree asset helper
is turned off.