### PR TITLE
Notify the claimant of their application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem "rollbar"
 gem "omniauth"
 gem "omniauth_openid_connect"
 
+# ActionMailer support for GOV.UK Notify
+gem "mail-notify"
+
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem "omniauth_openid_connect"
 # ActionMailer support for GOV.UK Notify
 gem "mail-notify"
 
+# Database based asynchronous priority queue system
+gem "delayed_job_active_record"
+
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,11 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    delayed_job (4.1.5)
+      activesupport (>= 3.0, < 5.3)
+    delayed_job_active_record (4.1.3)
+      activerecord (>= 3.0, < 5.3)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     dotenv (2.7.2)
     dotenv-rails (2.7.2)
@@ -307,6 +312,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara
+  delayed_job_active_record
   dotenv-rails
   dxw_govuk_frontend_rails
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
+    jwt (2.2.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.1.5)
@@ -113,6 +114,9 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    mail-notify (0.1.0)
+      actionmailer (~> 5.0)
+      notifications-ruby-client (~> 3.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
@@ -126,6 +130,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (3.1.0)
+      jwt (>= 1.5, < 3)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
@@ -308,6 +314,7 @@ DEPENDENCIES
   jbuilder (~> 2.9)
   launchy
   listen (>= 3.0.5, < 3.2)
+  mail-notify
   nanoid
   omniauth
   omniauth_openid_connect

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+worker: bundle exec rake jobs:work

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,2 @@
 web: bundle exec rails s -b 'ssl://localhost:3000?key=localhost.key&cert=localhost.crt'
+worker: bundle exec rake jobs:work

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ DFE_SIGN_IN_SECRET=<paste secret>
 
 The identifier and secret are stored in Heroku.
 
+### GOV.UK Notify
+
+We use Notify to send emails however it is turned off by default in development.
+If you want to test Notify in development you will need an API key and template
+ID and add them to your `.env`. Make sure you use a 'test' or 'team' API key
+only.
+
+```
+NOTIFY_API_KEY=<paste api key>
+NOTIFY_TEMPLATE_ID=d72e2ff9-b228-4f16-9099-fd9d411c0334
+```
+
 ## Running specs, brakeman, and code linting
 
 ```

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -42,7 +42,7 @@ class ClaimsController < ApplicationController
 
   def update_current_claim!
     if params[:slug] == "check-your-answers"
-      current_claim.submit!
+      mail_claim_submitted if current_claim.submit!
     else
       current_claim.attributes = claim_params
       current_claim.save(context: params[:slug].to_sym)
@@ -104,6 +104,10 @@ class ClaimsController < ApplicationController
       :bank_sort_code,
       :bank_account_number,
     )
+  end
+
+  def mail_claim_submitted
+    ClaimMailer.submitted(current_claim).deliver_now
   end
 
   def claim_page_template

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -107,7 +107,7 @@ class ClaimsController < ApplicationController
   end
 
   def mail_claim_submitted
-    ClaimMailer.submitted(current_claim).deliver_now
+    ClaimMailer.submitted(current_claim).deliver_later
   end
 
   def claim_page_template

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -1,0 +1,10 @@
+class ClaimMailer < Mail::Notify::Mailer
+  def submitted(claim)
+    @claim = claim
+    view_mail(
+      ENV["NOTIFY_TEMPLATE_ID"],
+      to: @claim.email_address,
+      subject: "Your claim was received"
+    )
+  end
+end

--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -1,0 +1,16 @@
+You application for student loan repayment reimbursement between
+6 April XXXX and 5 April XXXX has been received.
+
+^ Your reference number is <%= @claim.reference %>
+
+# What happens next
+
+We have sent your application to the Department for Education.
+
+They will verify the information you have provided and then send
+you the outcome of your application within X weeks.
+
+You will receive email updates as your application progresses.
+
+It can take up to 8 weeks to process your application and
+make the payment into your account.

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,7 @@ module DfeTeachersPaymentService
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
     end
+
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,8 +29,14 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
-
   config.action_mailer.perform_caching = false
+
+  if ENV["NOTIFY_API_KEY"].present?
+    config.action_mailer.delivery_method = :notify
+    config.action_mailer.notify_settings = {
+      api_key: ENV.fetch("NOTIFY_API_KEY"),
+    }
+  end
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,6 +58,11 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.delivery_method = :notify
+  config.action_mailer.notify_settings = {
+    api_key: ENV["NOTIFY_API_KEY"],
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,6 +49,8 @@ Rails.application.configure do
     from: "mail@example.com",
   }
 
+  config.active_job.queue_adapter = :inline
+
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,6 +44,11 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  config.action_mailer.delivery_method = :test
+  config.action_mailer.default_options = {
+    from: "mail@example.com",
+  }
+
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true

--- a/db/migrate/20190613133709_create_delayed_jobs.rb
+++ b/db/migrate/20190613133709_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_06_152321) do
+ActiveRecord::Schema.define(version: 2019_06_13_133709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
 
   create_table "local_authorities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "code"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -90,7 +90,9 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_text("Check your answers before sending your application")
 
     freeze_time do
-      click_on "Confirm and send"
+      expect {
+        click_on "Confirm and send"
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
       expect(claim.reload.submitted_at).to eq(Time.zone.now)
     end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe ClaimMailer, type: :mailer do
+  describe "#submitted" do
+    let(:claim) { create(:tslr_claim, :eligible_and_submittable) }
+    let(:mail) { ClaimMailer.submitted(claim) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Your claim was received")
+      expect(mail.to).to eq([claim.email_address])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("You application for student loan repayment reimbursement between")
+      expect(mail.body.encoded).to match("Your reference number is #{claim.reference}")
+    end
+  end
+end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -178,6 +178,13 @@ RSpec.describe "Claims", type: :request do
             expect(in_progress_claim.submitted_at).to be_present
           end
 
+          it "sends an email" do
+            email = ActionMailer::Base.deliveries.first
+            expect(email.to).to eql([in_progress_claim.email_address])
+            expect(email.subject).to eql("Your claim was received")
+            expect(email.body).to include("Your reference number is #{in_progress_claim.reference}")
+          end
+
           it "redirects to the confirmation page" do
             expect(response).to redirect_to(claim_path("confirmation"))
           end
@@ -194,6 +201,10 @@ RSpec.describe "Claims", type: :request do
 
           it "doesn't submit the claim" do
             expect(in_progress_claim.submitted_at).to be_nil
+          end
+
+          it "doesn't send an email" do
+            expect(ActionMailer::Base.deliveries).to be_empty
           end
 
           it "re-renders the check-your-answers page with errors" do


### PR DESCRIPTION
So that a user has confidence that they have finished a thing, and so they have a record of having completed their application, we will send the user an email confirming their claim.

We want to include a reference number so that it is easy to find their claim if they need support.

- [delayed_job](https://github.com/collectiveidea/delayed_job) to process background jobs
- [GOV.UK Notify](https://www.notifications.service.gov.uk/) for sending ActionMailer emails

The content used is just temporary and is from the confirmation page.

## Preview of the email

![Screenshot 2019-06-13 at 15 13 44](https://user-images.githubusercontent.com/2804149/59439875-ed544800-8ded-11e9-81fd-e89f55276523.png)
