### PR TITLE
Make `wait_until_visible` take a block to yield the element

### DIFF
--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -298,7 +298,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     end
 
     scenario "Claimants are automatically redirected to the timeout page" do
-      wait_until_visible find("h1", text: "Your session has ended due to inactivity")
+      wait_until_visible { find("h1", text: "Your session has ended due to inactivity") }
       expect(current_path).to eql(timeout_claim_path)
     end
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -23,8 +23,9 @@ module FeatureHelpers
     click_on "Continue"
   end
 
-  def wait_until_visible(element)
+  def wait_until_visible(&block)
     page.document.synchronize do
+      element = yield
       raise Capybara::ElementNotFound unless element.visible?
     end
   end


### PR DESCRIPTION
Passing in an element means finding it at the time when we call `wait_until_visible`, but that might be before it exists. This way it tries to find it on every iteration of the loop, meaning it can look for elements that don't always exist.

This fixes the intermittent test failure that still occurs.