### PR TITLE
Play back claim reference on confirmation page

### DIFF
--- a/app/views/claims/confirmation.html.erb
+++ b/app/views/claims/confirmation.html.erb
@@ -5,12 +5,12 @@
       <h1 class="govuk-panel__title">Claim submitted</h1>
       <div class="govuk-panel__body">
         Your reference number<br>
-        <strong>XXXXXXX</strong>
+        <strong><%= current_claim.reference %></strong>
       </div>
     </div>
 
     <p class="govuk-body">
-      We have sent you a confirmation email to blah@blah.co.uk.
+      We have sent you a confirmation email to <%= current_claim.email_address %>.
     </p>
 
     <h2 class="govuk-heading-m">What happens next</h2>

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -96,6 +96,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     end
 
     expect(page).to have_text("Claim submitted")
+    expect(page).to have_text(claim.reference)
+    expect(page).to have_text(claim.email_address)
   end
 
   scenario "Teacher now works for a different school" do


### PR DESCRIPTION
Now we have a claim reference we can play it back to the user on the confirmation page.