### PR TITLE
Adding Architecture Decision Records

### DIFF
--- a/docs/architecture-decisions/0008-use-govuk-verify-for-claiment-identity-assurance.md
+++ b/docs/architecture-decisions/0008-use-govuk-verify-for-claiment-identity-assurance.md
@@ -1,0 +1,36 @@
+# 8. Use GOVUK Verify for claimant identity assurance
+
+Date: 2019-06-13
+
+## Status
+
+Accepted
+
+## Context
+
+We need to be confident that a claimant is who they say they are to ensure
+payments are made to eligible claimants only and to minimise fraudulent claims.
+
+## Decision
+
+We will integrate with the [GOVUK Verify](https://www.verify.service.gov.uk/)
+service, a ‘secure way to prove who you are online’.
+
+GOVUK Verify recommend any services that ‘gives users money or benefits’ use
+‘Level of Assurance 2’ or ‘LOA2’, we will follow this guidance.
+
+[Understand Level of Assurance](https://www.verify.service.gov.uk/understand-levels-of-assurance/)
+
+## Consequences
+
+Using GOVUK Verify requires DfE to sign GOVUK Verify’s agreements.
+
+Integrating with GOVUK Verify requires the hosting and management of a ‘Verify
+Service Provider’ or VSP. DfE only needs a single VSP to integrate GOVUK
+Verify with any number of services, including ours.
+
+There will be on-going management of the VSP including security key rotation on
+a regular basis.
+
+Adding LOA2 verification to our user journey increases the time and difficulty
+for a claimant to complete an application.

--- a/docs/architecture-decisions/0009-capture-teacher-reference-number.md
+++ b/docs/architecture-decisions/0009-capture-teacher-reference-number.md
@@ -1,0 +1,27 @@
+# 9. Capture a Teacher Reference Number to validate a claimant’s qualifications
+
+Date: 2019-06-13
+
+## Status
+
+Accepted
+
+## Context
+
+A claimant’s eligibility is, in part, determined by their qualifications. We
+want to be able to validate that a claimant’s qualifications match those of
+the eligibility criteria.
+
+## Decision
+
+To aid DfE in the process of validating a claimant’s qualifications, we will
+collect the claimant’s ‘Teacher Reference Number’ or TRN.
+
+With the TRN, DfE can use the Database of Qualified Teachers ([DQT](https://teacherservices.education.gov.uk/SelfService/Login))
+to validate a claimant’s qualifications.
+
+## Consequences
+
+A claimant’s TRN may be information they do not have readily to hand, so may
+increase the difficulty and time needed for them to complete a claim
+application.

--- a/docs/architecture-decisions/0010-dfe-can-download-claims-data-during-private-beta.md
+++ b/docs/architecture-decisions/0010-dfe-can-download-claims-data-during-private-beta.md
@@ -1,0 +1,34 @@
+# 10. DfE can download claim data during private beta phase
+
+Date: 2019-06-13
+
+## Status
+
+Accepted
+
+## Context
+
+DfE will need to verify claims to confirm eligibility before they can be approved
+and paid. To help design and test the business process for checking and
+verifying claims, the team will carry out a private beta where a limited set of
+teachers will make real claims. The claims will be checked and processed
+manually during the private beta, enabling the team to learn the best way to
+build the tooling into the service that will aid more automated checking and
+processing of claims.
+
+## Decision
+
+To give the team maximum flexibility to work with the claim data and design the
+checks and processes during private beta, the service will include a secure
+download of all the claim data held within the system.
+
+This secure download will only be available during the private beta phase, and
+will be removed before the service goes live for public beta.
+
+## Consequences
+
+The claims data stored in the service is high-value personal data, so strict
+controls must be placed on who has access to the secure download.
+
+Once the private beta phase ends, this functionality will need to be removed
+from the service and any copies of the data destroyed


### PR DESCRIPTION
- 8 Use GOVUK Verify for claimant identity assurance
- 9 Capture a Teacher Reference Number to validate a claimants qualifications
- 10 DfE can download claim data during private beta phase