### PR TITLE
The asset pre-compile includes autocomplete.css

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,4 @@
 @import "govuk-frontend-rails";
-@import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
+@import "accessible-autocomplete/src/autocomplete";
 
 @import "**/*";

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,4 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w[accessible-autocomplete/src/autocomplete.css]


### PR DESCRIPTION
When using the asset pipeline, non-js assets from the node_modules directory
must be included explicitly, otherwise they are not pre-compiled in production.