### PR TITLE
238 bug users who have javascript disabled cant click anything

### DIFF
--- a/app/assets/javascripts/components/timeout_dialog.js.erb
+++ b/app/assets/javascripts/components/timeout_dialog.js.erb
@@ -11,7 +11,10 @@
     dialog.hide();
   };
 
-  dialog.on("hide", refreshSession);
+  dialog.on("hide", function() {
+    dialogElement.setAttribute("aria-hidden", "true");
+    refreshSession();
+  });
 
   function refreshSession() {
     Rails.ajax({
@@ -31,6 +34,7 @@
 
   function showTimeoutDialog() {
     if (claimInProgress === "true") {
+      dialogElement.setAttribute("aria-hidden", "false");
       dialog.show();
       setTimeout(sessionTimedOut, warningTimeInMinutes * 60 * 1000);
     }

--- a/app/assets/stylesheets/components/a11y_dialog.scss
+++ b/app/assets/stylesheets/components/a11y_dialog.scss
@@ -4,6 +4,10 @@
   display: none;
 }
 
+body:not(.js-enabled) .dialog-overlay{
+  display: none;
+}
+
 dialog[open] {
   display: block;
 }
@@ -93,15 +97,15 @@ dialog::backdrop {
   }
 }
 
-.dialog:not([aria-hidden="true"]) > .dialog-overlay {
+.js-enabled .dialog:not([aria-hidden="true"]) > .dialog-overlay {
   animation: fade-in 200ms 1 forwards;
 }
 
-.dialog > .dialog-overlay {
+.js-enabled .dialog > .dialog-overlay {
   opacity: 0;
 }
 
-.dialog:not([aria-hidden="true"]) > .dialog-content {
+.js-enabled .dialog:not([aria-hidden="true"]) > .dialog-content {
   animation: appear 400ms 150ms 1 both;
 }
 

--- a/app/assets/stylesheets/components/a11y_dialog.scss
+++ b/app/assets/stylesheets/components/a11y_dialog.scss
@@ -4,7 +4,8 @@
   display: none;
 }
 
-body:not(.js-enabled) .dialog-overlay{
+body:not(.js-enabled) .dialog-overlay,
+.dialog[aria-hidden="true"] .dialog-overlay {
   display: none;
 }
 
@@ -98,7 +99,7 @@ dialog::backdrop {
 }
 
 .js-enabled .dialog:not([aria-hidden="true"]) > .dialog-overlay {
-  animation: fade-in 200ms 1 forwards;
+  animation: fade-in 200ms 1 both;
 }
 
 .js-enabled .dialog > .dialog-overlay {
@@ -106,7 +107,7 @@ dialog::backdrop {
 }
 
 .js-enabled .dialog:not([aria-hidden="true"]) > .dialog-content {
-  animation: appear 400ms 150ms 1 both;
+  animation: appear 200ms 200ms 1 both;
 }
 
 .dialog-content {

--- a/app/views/application/_timeout_dialog.html.erb
+++ b/app/views/application/_timeout_dialog.html.erb
@@ -1,4 +1,4 @@
-<div id="timeout_dialog" class="dialog" data-timeout-in-minutes="<%= claim_timeout_in_minutes %>" data-warning-in-minutes="<%= claim_timeout_warning_in_minutes %>" data-claim-in-progress="<%= claim_in_progress? %>">
+<div id="timeout_dialog" class="dialog" aria-hidden="true" data-timeout-in-minutes="<%= claim_timeout_in_minutes %>" data-warning-in-minutes="<%= claim_timeout_warning_in_minutes %>" data-claim-in-progress="<%= claim_in_progress? %>">
   <div class="dialog-overlay" tabindex="-1" data-a11y-dialog-hide=""></div>
   <dialog class="dialog-content" aria-labelledby="timeout_dialog_title">
     <div class="timeout_dialog_titlebar">


### PR DESCRIPTION
Resolves the issue of not being able to click anything if JS is disabled. Also fixes related bug of modal overlay loading in and out on page refresh.