### PR TITLE
Only reset inferred current school when persisted

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -84,7 +84,7 @@ class TslrClaim < ApplicationRecord
   validate  :bank_account_number_must_be_eight_digits
   validate  :bank_sort_code_must_be_six_digits
 
-  before_validation :update_current_school, if: :employment_status_changed?
+  before_validation :reset_inferred_current_school, if: ->(record) { record.persisted? && record.employment_status_changed? }
 
   before_save :normalise_trn, if: :teacher_reference_number_changed?
   before_save :normalise_ni_number, if: :national_insurance_number_changed?
@@ -162,7 +162,7 @@ class TslrClaim < ApplicationRecord
     mostly_teaching_eligible_subjects == false
   end
 
-  def update_current_school
+  def reset_inferred_current_school
     self.current_school = employed_at_claim_school? ? claim_school : nil
   end
 

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -1,13 +1,8 @@
 FactoryBot.define do
   factory :tslr_claim do
     trait :eligible_and_submittable do
-      # This skips out the `update_current_school` callback, which is used when a user is
-      # filling out a form, but stamps all over our definition of a `current_school`
-      # if we try to define it in tests
-      before(:create) { |claim| claim.class.skip_callback(:save, :before, :update_current_school) }
-      after(:create) { |claim| claim.class.set_callback(:save, :before, :update_current_school, if: :employment_status_changed?) }
-
       claim_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
+      current_school { claim_school }
       qts_award_year { "2013-2014" }
       employment_status { :claim_school }
       mostly_teaching_eligible_subjects { true }

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -295,23 +295,38 @@ RSpec.describe TslrClaim, type: :model do
       expect { TslrClaim.new(employment_status: :nonsense) }.to raise_error(ArgumentError)
     end
 
-    context "when set to :claim_school" do
-      it "automatically sets current_school to the claim_school" do
-        claim = TslrClaim.new(claim_school: schools(:penistone_grammar_school))
+    context "with a persisted record" do
+      let(:claim) { TslrClaim.create!(claim_school: schools(:penistone_grammar_school)) }
+
+      it "setting to :claim_school sets the current_school to be the same as claim_school when saved" do
         claim.employment_status = :claim_school
         claim.save!
 
         expect(claim.current_school).to eql(schools(:penistone_grammar_school))
       end
-    end
 
-    context "when changed to :different_school" do
-      it "automatically resets current_school to nil" do
-        claim = TslrClaim.new(claim_school: schools(:penistone_grammar_school), current_school: schools(:penistone_grammar_school), employment_status: :claim_school)
+      it "setting it to :different_school resets the current_school when saved" do
+        claim.update!(current_school: schools(:hampstead_school))
+
         claim.employment_status = :different_school
         claim.save!
 
         expect(claim.current_school).to be_nil
+      end
+    end
+
+    context "with an unpersisted record" do
+      let(:claim) do
+        TslrClaim.new(
+          employment_status: :different_school,
+          claim_school: schools(:penistone_grammar_school),
+          current_school: schools(:hampstead_school)
+        )
+      end
+
+      it "doesn’t reset the current_school when saved" do
+        claim.save!
+        expect(claim.current_school).to eq(schools(:hampstead_school))
       end
     end
 


### PR DESCRIPTION
The build broke because the before save callback was changed to a before
validation callback. Skipping and setting callbacks in the factories
makes the code brittle. Instead of doing that, this reworks the callback
so that it only resets the current school when the employment status
changes on a persisted record, as it's only on persisted records
(created as part of the claim journey) that we expect to automatically
set/reset the current school based on the answer to the employment
question.