### PR TITLE
Address CVE-2015-9284

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "rollbar"
 # Use OmniAuth with OpenIDConnect
 gem "omniauth"
 gem "omniauth_openid_connect"
+gem "omniauth-rails_csrf_protection"
 
 # ActionMailer support for GOV.UK Notify
 gem "mail-notify"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,9 @@ GEM
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     omniauth_openid_connect (0.3.1)
       addressable (~> 2.5)
       omniauth (~> 1.3)
@@ -323,6 +326,7 @@ DEPENDENCIES
   mail-notify
   nanoid
   omniauth
+  omniauth-rails_csrf_protection
   omniauth_openid_connect
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)

--- a/app/views/admin/auth/sign_in.html.erb
+++ b/app/views/admin/auth/sign_in.html.erb
@@ -3,6 +3,6 @@
     <h1 class="govuk-heading-xl">
       Sign in with DfE Sign In
     </h1>
-    <%= link_to "Sign in", admin_dfe_sign_in_path, class: "govuk-button" %>
+    <%= button_to "Sign in", admin_dfe_sign_in_path, class: "govuk-button" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,9 @@ Rails.application.routes.draw do
 
     get "/auth/sign-in" => "auth#sign_in", :as => :sign_in
     delete "/auth/sign-out" => "auth#sign_out", :as => :sign_out
-    get "/auth/dfe", as: :dfe_sign_in
+
+    # DfE Sign-in OpenID routes
+    post "/auth/dfe", as: :dfe_sign_in
     get "/auth/callback", to: "auth#callback"
     get "/auth/failure", to: "auth#failure"
 

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Admin", type: :request do
           "provider" => "dfe",
           "info" => {"email" => "test-dfe-sign-in@host.tld"}
         )
-        get admin_dfe_sign_in_path
+        post admin_dfe_sign_in_path
         follow_redirect!
       end
 
@@ -44,7 +44,7 @@ RSpec.describe "Admin", type: :request do
       end
 
       it "shows a not authorised page and doesn’t set a session" do
-        get admin_dfe_sign_in_path
+        post admin_dfe_sign_in_path
         follow_redirect!
 
         expect(session[:login]).to be_nil


### PR DESCRIPTION
There is a known vulnerability in OmniAuth that could potentially be used in combination with a vulnerable OAuth provider to gain a signed-in user's session. Whilst DfE Sign-in uses OpenID, not OAuth, the substance of this patch (adding CSRF protection to the "Sign in" link on the
service) is still worth doing.

For more background see:

https://github.com/DFE-Digital/dfe-teachers-payment-service/network/alert/Gemfile.lock/omniauth/open
and https://github.com/omniauth/omniauth/pull/809
which leads to https://github.com/cookpad/omniauth-rails_csrf_protection