### PR TITLE
Fix student loan repayment errors

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -72,6 +72,7 @@ class TslrClaim < ApplicationRecord
   validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
   validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount",
                                                             allow_nil: true,
+                                                            greater_than_or_equal_to: 0,
                                                             less_than_or_equal_to: 99999
 
   validates :email_address,             on: [:"email-address", :submit], presence: {message: "Enter an email address"}

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -71,7 +71,8 @@ class TslrClaim < ApplicationRecord
 
   validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
   validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount",
-                                                            allow_nil: true
+                                                            allow_nil: true,
+                                                            less_than_or_equal_to: 99999
 
   validates :email_address,             on: [:"email-address", :submit], presence: {message: "Enter an email address"}
   validates :email_address,             format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email address in the correct format, like name@example.com"},

--- a/app/views/claims/student_loan_amount.html.erb
+++ b/app/views/claims/student_loan_amount.html.erb
@@ -14,7 +14,7 @@
 
         <div class="govuk-currency-input">
           <span class="govuk-currency-input__unit">&pound;</span>
-          <%= form.text_field :student_loan_repayment_amount, class: css_classes_for_input(current_claim, :student_loan_repayment_amount, "govuk-currency-input__input govuk-input--width-5") %>
+          <%= form.number_field :student_loan_repayment_amount, class: css_classes_for_input(current_claim, :student_loan_repayment_amount, "govuk-currency-input__input govuk-input--width-5"), step: 'any', min: 0, max: 99999 %>
         </div>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe TslrClaim, type: :model do
       expect(TslrClaim.new(student_loan_repayment_amount: "don’t know")).not_to be_valid
       expect(TslrClaim.new(student_loan_repayment_amount: "£1,234.56")).to be_valid
     end
+
+    it "validates that the loan repayment is under £99,999" do
+      expect(TslrClaim.new(student_loan_repayment_amount: "100000000")).not_to be_valid
+      expect(TslrClaim.new(student_loan_repayment_amount: "99999")).to be_valid
+    end
   end
 
   context "that has a full name" do

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe TslrClaim, type: :model do
       expect(TslrClaim.new(student_loan_repayment_amount: "100000000")).not_to be_valid
       expect(TslrClaim.new(student_loan_repayment_amount: "99999")).to be_valid
     end
+
+    it "validates that the loan repayment a positive number" do
+      expect(TslrClaim.new(student_loan_repayment_amount: "-99")).not_to be_valid
+      expect(TslrClaim.new(student_loan_repayment_amount: "150")).to be_valid
+    end
   end
 
   context "that has a full name" do


### PR DESCRIPTION
If a user enters an amount of £99999 for their student loan repayment, the database raises an error, as there is a hard precision of 7 and a scale of 2 set in the database (which translates to a 5 figure number with two decimal places). I've altered this so the validations take place in the model, but also limited it on the frontend too, by changing the field to an `<input type="number">` with a max value of `99999`. Not sure if this is worth doing, but is an extra belt and braces step.