### PR TITLE
Change the service name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
       format:
         unit: "£"
   tslr:
-    service_name: "Teachers: claim back student loan repayments"
+    service_name: "Teachers: claim back your student loan repayments"
     questions:
       qts_award_year: "Which academic year were you awarded qualified teacher status (QTS)?"
       claim_school: "Which school were you employed at between 6 April XXXX and 5 April XXXX?"


### PR DESCRIPTION
After input from our content designer and some initial feedback we have a refined name for the service:

> Teachers: claim back your student loan repayments

I've serached the code base for other references to the service name and decided there are none that will not be part of a wider content audit that is to come.

## Trello:
https://trello.com/c/uJTE0LAP

## Before:

![Screenshot_2019-06-19 Teachers claim back student loan repayments](https://user-images.githubusercontent.com/480578/59769799-bfb04880-929e-11e9-9970-1184e92fd8da.png)

## After:

![Screenshot_2019-06-19 Teachers claim back your student loan repayments](https://user-images.githubusercontent.com/480578/59769810-c8088380-929e-11e9-900e-de0f9fb610c4.png)

