### PR TITLE
Add eligibility confirmation page

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -5,6 +5,7 @@ class TslrClaim < ApplicationRecord
     "still-teaching",
     "current-school",
     "subjects-taught",
+    "eligibility-confirmed",
     "full-name",
     "address",
     "date-of-birth",

--- a/app/views/claims/eligibility_confirmed.html.erb
+++ b/app/views/claims/eligibility_confirmed.html.erb
@@ -1,0 +1,24 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">You are eligible to claim back student loan repayments</h1>
+    <p class="govuk-body">Based on your answers, you are eligible to claim back the student loan
+    repayments you made between 6 April XXXX and 5 April XXXX.</p>
+    <p class="govuk-body">Now you need to prove who you are using GOV.UK Verify before we can pay
+    the money into your bank account.</p>
+
+    <h2 class="govuk-heading-m">Use GOV.UK Verify</h2>
+    <p class="govuk-body">Registering with GOV.UK Verify usually takes around 15 minutes. It works best if you have:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>a UK address</li>
+      <li>a valid passport or photocard licence</li>
+    </ul>
+
+    <p class="govuk-body">A certified identity provider will check your identity when you register with GOV.UK Verify.
+      They have met all security standards set by the government.</p>
+
+    <%= button_tag "Continue to GOV.UK Verify", {class: "govuk-button  govuk-!-margin-right-1", disabled: "disabled", "aria-disabled": "true"} %>
+    <%= link_to "Skip GOV.UK Verify", claim_path("full-name"), class: "govuk-button" %>
+  </div>
+</div>

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -23,6 +23,10 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.mostly_teaching_eligible_subjects).to eq(true)
 
+    expect(page).to have_text("You are eligible to claim back student loan repayments")
+
+    click_on "Skip GOV.UK Verify"
+
     expect(page).to have_text(I18n.t("tslr.questions.full_name"))
 
     fill_in I18n.t("tslr.questions.full_name"), with: "Margaret Honeycutt"


### PR DESCRIPTION
## Background

Once a user has answered enough questions for the service to confirm they
are eligible to make a claim we show them them a confirmation page.

It was felt important the GOV.UK Verify content and button was included but
disabled to remain close to the real user journey. Once integrated, skipping 
GOV.UK Verify will not be possible.

## Notes

Decided that `eligibility-confirmed` was a good url for this as it speaks to what
the user has achieved at this point in the journey.

Decided not to include the copy in the locales as it is not a question, rather 
a static page that, once live should not change often, appreciate any thoughts 
on when to include in the locales and when to not.

## Trello
https://trello.com/c/sAMnzJ1I

## Views

![Screenshot_2019-06-20 Teachers claim back student loan repayments](https://user-images.githubusercontent.com/480578/59834078-487ec100-933f-11e9-8c2b-ee0c976a7dc0.png)
