### PR TITLE
Amend consent page to reflect writing in MPS

### DIFF
--- a/app/views/claims/new.html.erb
+++ b/app/views/claims/new.html.erb
@@ -9,7 +9,7 @@
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        that you were empolyed there
+        that you were employed there
       </li>
       <li>
         that you taught 11 to 16 year olds

--- a/app/views/claims/new.html.erb
+++ b/app/views/claims/new.html.erb
@@ -5,35 +5,25 @@
     </h1>
 
     <p class="govuk-body">
-      To claim your student loan payments back we will contact the school you tell
-      us about in this claim to confirm:
+      By continuing, you consent to the Department for Education contacting your school to confirm:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        that you were employed to teach there
+        that you were empolyed there
       </li>
       <li>
-        that you spent most of your time teaching 11 to 16 year olds or, if you
-        were on leave or off sick, that you were employed to teach this age range
+        that you taught 11 to 16 year olds
       </li>
       <li>
-        how much student loan you paid back through your wages while you were there
+        how much student loan you repaid
       </li>
       <li>
-        the subject that you were employed to teach, if you worked at a state-
-        funded school or academy
+        the subjects that you taught
       </li>
       <li>
-        how much of your time was spent teaching that subject, if you worked at a
-        state-funded school or academy
+        how much time you spent teaching each subject
       </li>
     </ul>
-    <p class="govuk-body">
-      We must do this to process your claim.
-    </p>
-    <p class="govuk-body">
-      By claiming, you are confirming that you consent to us contacting the school.
-    </p>
 
     <%= button_to 'Agree and continue', claims_path, method: :post, class: "govuk-button" %>
   </div>


### PR DESCRIPTION
To provide a more consistent experience we have replicated the writing
style to reflect the maths and phys consent page. This is still subject
to change when our content designer does a formal review but its a step
forwards.