### PR TITLE
Change loan help text to encourage better response

### DIFF
--- a/app/views/claims/student_loan_amount.html.erb
+++ b/app/views/claims/student_loan_amount.html.erb
@@ -8,7 +8,7 @@
           <%= form.label :student_loan_repayment_amount, t("tslr.questions.student_loan_amount", claim_school_name: current_claim.claim_school_name), class: "govuk-label govuk-label--xl" %>
         </h1>
 
-        <span class="govuk-hint">Only include repayments made through your teaching wages. You can find this information on your payslips.</span>
+        <span class="govuk-hint">You can find this on your annual student loan statement, your P60 or from the <a href="https://www.slc.co.uk/students-and-customers/contact-information-for-customers/loan-repayment-enquiries.aspx">student loans company</a>.</span>
 
         <%= errors_tag current_claim, :student_loan_repayment_amount %>
 


### PR DESCRIPTION
The original hint text on this question looked like it would lead users
to get a payslip and multiply the monthly contribution by 12, which
wouldn't take into account pay rises etc. The hint has changed to
identify documents that would accurately reflect their last years
contribution or point them to the student loans company so they can
find out.