### PR TITLE
Change confirmation to use sample timescales

### DIFF
--- a/app/views/claims/confirmation.html.erb
+++ b/app/views/claims/confirmation.html.erb
@@ -21,7 +21,7 @@
 
     <p class="govuk-body">
       They will verify the information you have provided and then send
-      you the outcome of your application within X weeks.
+      you the outcome of your application within 4 weeks.
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
Remove the x weeks text and put in sample timescales based of the maths
and physics journey to test expecations and make the page easier to
understand