### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN gem install bundler
 
 RUN if [ ${RAILS_ENV} = "production" ]; then \
   bundle install --frozen --retry 3 --without development test; \
+  elif [ ${RAILS_ENV} = "test" ]; then \
+  bundle install --frozen --retry 3; \
   else \
   bundle install --frozen --retry 3 --without test; \
   fi
@@ -49,7 +51,11 @@ RUN if [ ${RAILS_ENV} = "production" ]; then \
 COPY package.json ${DEPS_HOME}/package.json
 COPY yarn.lock ${DEPS_HOME}/yarn.lock
 
-RUN yarn install --frozen-lockfile --production
+RUN if [ ${RAILS_ENV} = "production" ]; then \
+  yarn install --frozen-lockfile --production; \
+  else \
+  yarn install --frozen-lockfile; \
+  fi
 # End
 
 # ------------------------------------------------------------------------------
@@ -97,3 +103,13 @@ EXPOSE 3000
 
 ENTRYPOINT [ "bin/docker-entrypoint" ]
 CMD [ "rails", "server" ]
+
+# ------------------------------------------------------------------------------
+# test
+# ------------------------------------------------------------------------------
+
+FROM web AS test
+
+RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
+RUN apk add chromium chromium-chromedriver
+COPY spec ${APP_HOME}/spec

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN gem install bundler
 RUN if [ ${RAILS_ENV} = "production" ]; then \
   bundle install --frozen --retry 3 --without development test; \
   elif [ ${RAILS_ENV} = "test" ]; then \
-  bundle install --frozen --retry 3; \
+  bundle install --frozen --retry 3 --without development; \
   else \
   bundle install --frozen --retry 3 --without test; \
   fi

--- a/Gemfile
+++ b/Gemfile
@@ -73,11 +73,11 @@ group :development do
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
   gem "foreman"
+  gem "webdrivers"
 end
 
 group :test do
   gem "selenium-webdriver"
-  gem "webdrivers"
   gem "launchy"
 end
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ NOTIFY_TEMPLATE_ID=d72e2ff9-b228-4f16-9099-fd9d411c0334
 bundle exec rake
 ```
 
+To run the feature specs you will need Chrome installed.
+
 ### Code linting rules
 
 Code linting is performed using:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Code linting is performed using:
 [Bullet](https://github.com/flyerhzm/bullet) runs around each spec. If it detects an N+1 query it will raise an
 exception and the tests will fail.
 
+## Production
+
+### Building the Docker container
+
+Make sure you build the image with the target of `web` to ensure that only
+production assets are added.
+
+```
+docker build --target web .
+```
+
 ## Service architecture
 
 The service architecture is currently defined and [on confluence](https://dfedigital.atlassian.net/wiki/spaces/TP/pages/1049559041/Service+Architecture).

--- a/app.json
+++ b/app.json
@@ -5,6 +5,7 @@
       "buildpacks": [
         { "url": "heroku/nodejs" },
         { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" },
+        { "url": "https://github.com/heroku/heroku-buildpack-chromedriver" },
         { "url": "heroku/ruby" }
       ],
       "scripts": {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,39 @@
+# Ruby
+# Package your Ruby project.
+# Add steps that install rails, analyze code, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/ruby
+
+trigger:
+  - master
+
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+  POSTGRES_IMAGE: postgres
+  POSTGRESS_USER: postgres
+  POSTGRESS_PASSWORD: secret
+
+steps:
+- script: docker run --name=postgres -e $(POSTGRES_USER) -e $(POSTGRES_PASSWORD) -p 5432:5432 -d $(POSTGRES_IMAGE)
+  displayName: Launch Postgres
+
+- script: 'sudo apt-get update && sudo apt-get install postgresql postgresql-contrib libpq-dev'
+  displayName: Install Postgres
+
+- task: UseRubyVersion@0
+  inputs:
+    versionSpec: '>= 2.5'
+
+- script: |
+    gem install bundler
+    bundle install --retry=3 --jobs=4
+  displayName: 'bundle install'
+
+- script: 'docker ps'
+
+- script: DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST=postgres DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME=$POSTGRES_USER DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_PASSWORD=$POSTGRES_PASSWORD bundle exec rake db:create db:test:prepare
+  displayName: 'bundle exec rake db:create db:test:prepare'
+
+- script: DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST=postgres DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME=$POSTGRES_USER DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_PASSWORD=$POSTGRES_PASSWORD bundle exec rake
+  displayName: 'bundle exec rake'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,31 +9,8 @@ trigger:
 pool:
   vmImage: ubuntu-latest
 
-variables:
-  POSTGRES_IMAGE: postgres
-  POSTGRESS_USER: postgres
-  POSTGRESS_PASSWORD: secret
-
 steps:
-- script: docker run --name=postgres -e $(POSTGRES_USER) -e $(POSTGRES_PASSWORD) -p 5432:5432 -d $(POSTGRES_IMAGE)
-  displayName: Launch Postgres
-
-- script: 'sudo apt-get update && sudo apt-get install postgresql postgresql-contrib libpq-dev'
-  displayName: Install Postgres
-
-- task: UseRubyVersion@0
-  inputs:
-    versionSpec: '>= 2.5'
-
-- script: |
-    gem install bundler
-    bundle install --retry=3 --jobs=4
-  displayName: 'bundle install'
-
-- script: 'docker ps'
-
-- script: DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST=postgres DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME=$POSTGRES_USER DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_PASSWORD=$POSTGRES_PASSWORD bundle exec rake db:create db:test:prepare
-  displayName: 'bundle exec rake db:create db:test:prepare'
-
-- script: DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST=postgres DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME=$POSTGRES_USER DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_PASSWORD=$POSTGRES_PASSWORD bundle exec rake
-  displayName: 'bundle exec rake'
+  - script: docker-compose -f docker-compose.test.yml build
+    displayName: Building Docker container
+  - script: docker-compose -f docker-compose.test.yml run --rm web bundle exec rake
+    displayName: Running rake default

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,22 @@
+version: "3.7"
+services:
+  web:
+    build:
+      context: .
+      target: test
+      args:
+        RAILS_ENV: test
+    image: local/dfe-teachers-payment-service:test
+    depends_on:
+      - db
+    environment:
+      DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME: postgres
+      DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST: db
+    tty: true
+    stdin_open: true
+    command: bundle exec spring server
+
+  db:
+    image: postgres
+    volumes:
+      - ./tmp/db_test:/var/lib/postgresql/data

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,9 +1,6 @@
 require "capybara/rspec"
 
-chrome_bin = ENV.fetch("GOOGLE_CHROME_BIN", nil)
-
 Capybara.register_driver :headless_chrome do |app|
-  Selenium::WebDriver::Chrome.path = chrome_bin if chrome_bin.present?
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,9 @@
 require "capybara/rspec"
+begin
+  require "webdrivers"
+rescue LoadError
+  nil
+end
 
 Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new(


### PR DESCRIPTION
## Potential issues

- Azure Pipelines doesn't have any caching so containers are built from scratch each time. The whole CI process takes ~6 minutes, which I think is fine for now.
- Removing `webdrivers` gem may impact devs slightly as they will need to ensure they have `chromedriver` installed when running feature specs.
- We will need to ensure that when we build the production container that we pass in `--target web` so that none of the test container actions are run.