### PR TITLE
Ask applicants what subjects they have taught

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem "delayed_job_active_record"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false
 
+# Allows the use of enums as arrays
+gem "array_enum"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     aes_key_wrap (1.0.1)
     arel (9.0.0)
+    array_enum (1.1.0)
+      activemodel
     ast (2.4.0)
     attr_required (1.0.1)
     bindata (2.4.4)
@@ -309,6 +311,7 @@ PLATFORMS
   x86_64-darwin-18
 
 DEPENDENCIES
+  array_enum
   bootsnap (>= 1.1.0)
   brakeman
   bullet

--- a/app/assets/javascripts/components/subjects_taught.js
+++ b/app/assets/javascripts/components/subjects_taught.js
@@ -2,39 +2,33 @@
 
 document.addEventListener("DOMContentLoaded", function() {
   var fieldset = document.querySelector("#tslr_claim_eligible_subjects");
-  var el;
-  var eligibleSubjectsSelector;
-  var notTeachingSubjectsSelector;
 
   if (!fieldset) {
     return;
   }
 
-  fieldset.addEventListener(
-    "click",
-    function(e) {
-      el = e.target;
+  function toggleSubjectValues(event) {
+    var el = event.target;
+    var eligibleSubjectsName = "tslr_claim[eligible_subjects][]";
+    var notTeachingSubjectsName = "tslr_claim[mostly_teaching_eligible_subjects]";
 
-      if (!el) {
-        return;
-      }
-      if (el.checked === false) {
-        return;
-      }
+    if (!el) {
+      return;
+    }
+    if (el.checked === false) {
+      return;
+    }
 
-      eligibleSubjectsSelector = "tslr_claim[eligible_subjects][]";
-      notTeachingSubjectsSelector = "tslr_claim[mostly_teaching_eligible_subjects]";
+    if (el.name == eligibleSubjectsName) {
+      var radioButton = document.querySelector("input[type='radio'][name='" + notTeachingSubjectsName + "']");
+      radioButton.checked = false;
+    } else if (el.name == notTeachingSubjectsName) {
+      var checkboxes = document.querySelectorAll("input[name='" + eligibleSubjectsName + "']");
+      checkboxes.forEach(function(item, index) {
+        item.checked = false;
+      });
+    }
+  }
 
-      if (el.name == eligibleSubjectsSelector) {
-        var radioButton = document.querySelector("input[type='radio'][name='" + notTeachingSubjectsSelector + "']");
-        radioButton.checked = false;
-      } else if (el.name == notTeachingSubjectsSelector) {
-        var checkboxes = document.querySelectorAll("input[name='" + eligibleSubjectsSelector + "']");
-        checkboxes.forEach(function(item, index) {
-          item.checked = false;
-        });
-      }
-    },
-    false
-  );
+  fieldset.addEventListener("click", toggleSubjectValues, false);
 });

--- a/app/assets/javascripts/components/subjects_taught.js
+++ b/app/assets/javascripts/components/subjects_taught.js
@@ -1,0 +1,40 @@
+"use strict";
+
+document.addEventListener("DOMContentLoaded", function() {
+  var fieldset = document.querySelector("#tslr_claim_eligible_subjects");
+  var el;
+  var eligibleSubjectsSelector;
+  var notTeachingSubjectsSelector;
+
+  if (!fieldset) {
+    return;
+  }
+
+  fieldset.addEventListener(
+    "click",
+    function(e) {
+      el = e.target;
+
+      if (!el) {
+        return;
+      }
+      if (el.checked === false) {
+        return;
+      }
+
+      eligibleSubjectsSelector = "tslr_claim[eligible_subjects][]";
+      notTeachingSubjectsSelector = "tslr_claim[mostly_teaching_eligible_subjects]";
+
+      if (el.name == eligibleSubjectsSelector) {
+        var checkbox = document.querySelector("input[type='checkbox'][name='" + notTeachingSubjectsSelector + "']");
+        checkbox.checked = false;
+      } else if (el.name == notTeachingSubjectsSelector) {
+        var checkboxes = document.querySelectorAll("input[name='" + eligibleSubjectsSelector + "']");
+        checkboxes.forEach(function(item, index) {
+          item.checked = false;
+        });
+      }
+    },
+    false
+  );
+});

--- a/app/assets/javascripts/components/subjects_taught.js
+++ b/app/assets/javascripts/components/subjects_taught.js
@@ -26,8 +26,8 @@ document.addEventListener("DOMContentLoaded", function() {
       notTeachingSubjectsSelector = "tslr_claim[mostly_teaching_eligible_subjects]";
 
       if (el.name == eligibleSubjectsSelector) {
-        var checkbox = document.querySelector("input[type='checkbox'][name='" + notTeachingSubjectsSelector + "']");
-        checkbox.checked = false;
+        var radioButton = document.querySelector("input[type='radio'][name='" + notTeachingSubjectsSelector + "']");
+        radioButton.checked = false;
       } else if (el.name == notTeachingSubjectsSelector) {
         var checkboxes = document.querySelectorAll("input[name='" + eligibleSubjectsSelector + "']");
         checkboxes.forEach(function(item, index) {

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -103,6 +103,7 @@ class ClaimsController < ApplicationController
       :email_address,
       :bank_sort_code,
       :bank_account_number,
+      eligible_subjects: []
     )
   end
 

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -38,6 +38,12 @@ module ClaimsHelper
     ]
   end
 
+  def subject_list(subjects)
+    connector = " or "
+    subjects.map! { |subject| I18n.t("tslr.questions.eligible_subjects.#{subject}") }
+    subjects.to_sentence(last_word_connector: connector, two_words_connector: connector)
+  end
+
   private
 
   def academic_years(year_range)

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -20,8 +20,8 @@ module ClaimsHelper
       [t("tslr.questions.qts_award_year"), academic_years(claim.qts_award_year), "qts-year"],
       [t("tslr.questions.claim_school"), claim.claim_school_name, "claim-school"],
       [t("tslr.questions.current_school"), claim.current_school_name, "current-school"],
-      [t("tslr.questions.subjects_taught"), subject_list(claim.eligible_subjects, "and"), "subjects-taught"],
-      [t("tslr.questions.mostly_teaching_eligible_subjects", subjects: subject_list(claim.eligible_subjects, "or")), (claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"), "mostly-teaching-eligible-subjects"],
+      [t("tslr.questions.subjects_taught"), subject_list(claim.eligible_subjects), "subjects-taught"],
+      [t("tslr.questions.mostly_teaching_eligible_subjects", subjects: subject_list(claim.eligible_subjects)), (claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"), "mostly-teaching-eligible-subjects"],
       [t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), number_to_currency(claim.student_loan_repayment_amount), "student-loan-amount"],
     ]
   end
@@ -39,8 +39,8 @@ module ClaimsHelper
     ]
   end
 
-  def subject_list(subjects, connector = "or")
-    connector = " #{connector} "
+  def subject_list(subjects)
+    connector = " or "
     translated_subjects = subjects.map { |subject| I18n.t("tslr.questions.eligible_subjects.#{subject}") }
     translated_subjects.to_sentence(
       last_word_connector: connector,

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -20,7 +20,8 @@ module ClaimsHelper
       [t("tslr.questions.qts_award_year"), academic_years(claim.qts_award_year), "qts-year"],
       [t("tslr.questions.claim_school"), claim.claim_school_name, "claim-school"],
       [t("tslr.questions.current_school"), claim.current_school_name, "current-school"],
-      [t("tslr.questions.mostly_teaching_eligible_subjects"), (claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"), "subjects-taught"],
+      [t("tslr.questions.subjects_taught"), subject_list(claim.eligible_subjects, "and"), "subjects-taught"],
+      [t("tslr.questions.mostly_teaching_eligible_subjects", subjects: subject_list(claim.eligible_subjects, "or")), (claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"), "mostly-teaching-eligible-subjects"],
       [t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), number_to_currency(claim.student_loan_repayment_amount), "student-loan-amount"],
     ]
   end
@@ -38,10 +39,13 @@ module ClaimsHelper
     ]
   end
 
-  def subject_list(subjects)
-    connector = " or "
-    subjects.map! { |subject| I18n.t("tslr.questions.eligible_subjects.#{subject}") }
-    subjects.to_sentence(last_word_connector: connector, two_words_connector: connector)
+  def subject_list(subjects, connector = "or")
+    connector = " #{connector} "
+    translated_subjects = subjects.map { |subject| I18n.t("tslr.questions.eligible_subjects.#{subject}") }
+    translated_subjects.to_sentence(
+      last_word_connector: connector,
+      two_words_connector: connector
+    )
   end
 
   private

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -43,7 +43,7 @@ class TslrClaim < ApplicationRecord
     chemistry: 1,
     physics: 2,
     computer_science: 3,
-    languages: 4
+    languages: 4,
   }
 
   belongs_to :claim_school, optional: true, class_name: "School"
@@ -56,7 +56,9 @@ class TslrClaim < ApplicationRecord
 
   validates :employment_status,         on: [:"still-teaching", :submit], presence: {message: "Choose the option that describes your current employment status"}
 
-  validates :mostly_teaching_eligible_subjects, on: [:"subjects-taught", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
+  validates :eligible_subjects,         on: [:"subjects-taught", :submit], presence: {message: "Choose a subject, or select \"not applicable\""}, unless: ->(c) { c.mostly_teaching_eligible_subjects == false }
+
+  validates :mostly_teaching_eligible_subjects, on: [:"mostly-teaching-eligible-subjects", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
 
   validates :full_name,                 on: [:"full-name", :submit], presence: {message: "Enter your full name"}
   validates :full_name,                 length: {maximum: 200, message: "Full name must be 200 characters or less"}

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -7,6 +7,7 @@ class TslrClaim < ApplicationRecord
     "still-teaching",
     "current-school",
     "subjects-taught",
+    "mostly-teaching-eligible-subjects",
     "eligibility-confirmed",
     "full-name",
     "address",

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -1,4 +1,6 @@
 class TslrClaim < ApplicationRecord
+  extend ArrayEnum
+
   PAGE_SEQUENCE = [
     "qts-year",
     "claim-school",
@@ -35,6 +37,14 @@ class TslrClaim < ApplicationRecord
     different_school: 1,
     no_school: 2,
   }, _prefix: :employed_at
+
+  array_enum eligible_subjects: {
+    biology: 0,
+    chemistry: 1,
+    physics: 2,
+    computer_science: 3,
+    languages: 4
+  }
 
   belongs_to :claim_school, optional: true, class_name: "School"
   belongs_to :current_school, optional: true, class_name: "School"

--- a/app/views/claims/mostly_teaching_eligible_subjects.html.erb
+++ b/app/views/claims/mostly_teaching_eligible_subjects.html.erb
@@ -1,0 +1,34 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { mostly_teaching_eligible_subjects: "tslr_claim_mostly_teaching_eligible_subjects_true"}) if current_claim.errors.any? %>
+      <%= form_for current_claim, url: claim_path do |form| %>
+        <%= form.hidden_field :mostly_teaching_eligible_subjects %>
+        <%= form_group_tag current_claim do %>
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("tslr.questions.mostly_teaching_eligible_subjects", subjects: subject_list(current_claim.eligible_subjects)) %>
+              </h1>
+            </legend>
+            <p class="govuk-body">
+              <span class="govuk-hint">
+                If you've been off on long-term leave or sick, include the time you were scheduled to teach these subjects.
+              </span>
+            </p>
+            <%= errors_tag current_claim, :mostly_teaching_eligible_subjects %>
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:mostly_teaching_eligible_subjects, true, class: "govuk-radios__input") %>
+                <%= form.label :mostly_teaching_eligible_subjects_true, "Yes", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:mostly_teaching_eligible_subjects, false, class: "govuk-radios__input") %>
+                <%= form.label :mostly_teaching_eligible_subjects_false, "No", class: "govuk-label govuk-radios__label" %>
+              </div>
+            </div>
+        </fieldset>
+      <% end %>
+    <%= form.submit "Continue", class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/claims/subjects_taught.html.erb
+++ b/app/views/claims/subjects_taught.html.erb
@@ -16,9 +16,11 @@
                 <%= label_tag "tslr_claim[eligible_subjects][]", t("tslr.questions.eligible_subjects.#{subject}"), class: "govuk-label govuk-checkboxes__label", for: "eligible_subjects_#{subject}"  %>
               </div>
             <% end %>
-            <div class="govuk-checkboxes__item">
-              <%= form.check_box(:mostly_teaching_eligible_subjects, {class: "govuk-checkboxes__input"}, false, '')  %>
-              <%= form.label :mostly_teaching_eligible_subjects_false, "Not applicable, I didn't teach any of these subjects", class: "govuk-label govuk-checkboxes__label" %>
+            <div class="govuk-radios__divider">or</div>
+            <div class="govuk-radios__item">
+              <%= form.hidden_field :mostly_teaching_eligible_subjects, value: '' %>
+              <%= form.radio_button(:mostly_teaching_eligible_subjects, false, class: "govuk-radios__input")  %>
+              <%= form.label :mostly_teaching_eligible_subjects_false, "Not applicable, I didn't teach any of these subjects", class: "govuk-label govuk-radios__label" %>
             </div>
           </div>
         </fieldset>

--- a/app/views/claims/subjects_taught.html.erb
+++ b/app/views/claims/subjects_taught.html.erb
@@ -1,39 +1,24 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { mostly_teaching_eligible_subjects: "tslr_claim_mostly_teaching_eligible_subjects_true"}) if current_claim.errors.any? %>
+    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
     <%= form_for current_claim, url: claim_path do |form| %>
-      <%= form.hidden_field :mostly_teaching_eligible_subjects %>
       <%= form_group_tag current_claim do %>
-        <fieldset class="govuk-fieldset">
+        <fieldset class="govuk-fieldset" id="tslr_claim_eligible_subjects">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">
-              <%= t("tslr.questions.mostly_teaching_eligible_subjects") %>
+              <%= t("tslr.questions.subjects_taught") %>
             </h1>
           </legend>
-          <p class="govuk-body">
-            Eligible subjects are:
-          </p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>biology</li>
-            <li>chemistry</li>
-            <li>physics</li>
-            <li>computer science</li>
-            <li>languages (not including English)</li>
-          </ul>
-          <p class="govuk-body">
-            <span class="govuk-hint">
-              If you've been off on long-term leave or sick, include the time you were scheduled to teach these subjects.
-            </span>
-          </p>
-          <%= errors_tag current_claim, :mostly_teaching_eligible_subjects %>
-          <div class="govuk-radios">
-            <div class="govuk-radios__item">
-              <%= form.radio_button(:mostly_teaching_eligible_subjects, true, class: "govuk-radios__input") %>
-              <%= form.label :mostly_teaching_eligible_subjects_true, "Yes", class: "govuk-label govuk-radios__label" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= form.radio_button(:mostly_teaching_eligible_subjects, false, class: "govuk-radios__input") %>
-              <%= form.label :mostly_teaching_eligible_subjects_false, "No", class: "govuk-label govuk-radios__label" %>
+          <div class="govuk-checkboxes">
+            <% TslrClaim.eligible_subjects.each do |subject, value| -%>
+              <div class="govuk-checkboxes__item">
+                <%= check_box_tag "tslr_claim[eligible_subjects][]", subject, current_claim.eligible_subjects.include?(subject), class: "govuk-checkboxes__input", id: "eligible_subjects_#{subject}"  %>
+                <%= label_tag "tslr_claim[eligible_subjects][]", t("tslr.questions.eligible_subjects.#{subject}"), class: "govuk-label govuk-checkboxes__label", for: "eligible_subjects_#{subject}"  %>
+              </div>
+            <% end %>
+            <div class="govuk-checkboxes__item">
+              <%= form.check_box(:mostly_teaching_eligible_subjects, {class: "govuk-checkboxes__input"}, false, '')  %>
+              <%= form.label :mostly_teaching_eligible_subjects_false, "Not applicable, I didn't teach any of these subjects", class: "govuk-label govuk-checkboxes__label" %>
             </div>
           </div>
         </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
         physics: "Physics"
         computer_science: "Computer Science"
         languages: "Languages"
+        not_applicable: "Not applicable, I didn't teach any of these subjects"
     csv_headers:
       reference: "Reference"
       submitted_at: "Submitted at"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,6 @@ en:
       claim_school: "Which school were you employed at between 6 April XXXX and 5 April XXXX?"
       employment_status: "Are you still employed to teach at a school in England?"
       current_school: "Which school are you currently employed at?"
-      mostly_teaching_eligible_subjects: "Did you teach eligible subjects for more than 50% of your teaching time between 6 April XXXX and 5 April XXXX?"
       subjects_taught: "Did you teach any of the following subjects between 6 April XXXX and 5 April XXXX?"
       mostly_teaching_eligible_subjects: "Did you teach %{subjects} for more than 50% of your teaching time between 6 April XXXX and 5 April XXXX?"
       full_name: "What is your full name?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,8 @@ en:
       employment_status: "Are you still employed to teach at a school in England?"
       current_school: "Which school are you currently employed at?"
       mostly_teaching_eligible_subjects: "Did you teach eligible subjects for more than 50% of your teaching time between 6 April XXXX and 5 April XXXX?"
+      subjects_taught: "Did you teach any of the following subjects between 6 April XXXX and 5 April XXXX?"
+      mostly_teaching_eligible_subjects: "Did you teach %{subjects} for more than 50% of your teaching time between 6 April XXXX and 5 April XXXX?"
       full_name: "What is your full name?"
       address: "What is your address?"
       date_of_birth: "What is your date of birth?"
@@ -53,6 +55,12 @@ en:
       student_loan_amount: "How much student loan did you repay while you were at %{claim_school_name} between 6 April XXXX and 5 April XXXX?"
       email_address: "What is your email address?"
       bank_details: "Enter bank account details"
+      eligible_subjects:
+        biology: "Biology"
+        chemistry: "Chemistry"
+        physics: "Physics"
+        computer_science: "Computer Science"
+        languages: "Languages"
     csv_headers:
       reference: "Reference"
       submitted_at: "Submitted at"

--- a/db/migrate/20190624101725_add_eligible_subjects_to_tslr_claims.rb
+++ b/db/migrate/20190624101725_add_eligible_subjects_to_tslr_claims.rb
@@ -1,0 +1,5 @@
+class AddEligibleSubjectsToTslrClaims < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :eligible_subjects, :integer, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_13_133709) do
+ActiveRecord::Schema.define(version: 2019_06_24_101725) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 2019_06_13_133709) do
     t.datetime "submitted_at"
     t.decimal "student_loan_repayment_amount", precision: 7, scale: 2
     t.string "reference", limit: 8
+    t.integer "eligible_subjects", default: [], null: false, array: true
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
       current_school { claim_school }
       qts_award_year { "2013-2014" }
       employment_status { :claim_school }
+      eligible_subjects { [:physics] }
       mostly_teaching_eligible_subjects { true }
       full_name { "Jo Bloggs" }
       address_line_1 { "1 Test Road" }

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -38,6 +38,78 @@ RSpec.feature "Changing the answers on a submittable claim" do
     expect(find("input[name='school_search']").value).to eq(current_school.name)
   end
 
+  context "when changing subjects taught" do
+    before do
+      find("a[href='#{claim_path("subjects-taught")}']").click
+    end
+
+    scenario "Teacher sees their original choices" do
+      claim.eligible_subjects.each do |subject|
+        expect(find("input[value='#{subject}']").checked?).to eq(true)
+      end
+    end
+
+    context "Teacher changes their subjects" do
+      let(:new_subjects) { ["biology", "chemistry"] }
+      before do
+        claim.eligible_subjects.each do |subject|
+          uncheck I18n.t("tslr.questions.eligible_subjects.#{subject}"), visible: false
+        end
+
+        new_subjects.each do |subject|
+          check I18n.t("tslr.questions.eligible_subjects.#{subject}"), visible: false
+        end
+
+        click_on "Continue"
+      end
+
+      scenario "Eligible subjects are set correctly" do
+        expect(claim.reload.eligible_subjects).to eq(new_subjects)
+      end
+
+      scenario "Teacher is redirected to ask if they were mostly teaching eligible subjects" do
+        expect(current_path).to eq(claim_path("mostly-teaching-eligible-subjects"))
+      end
+
+      scenario "Teacher sees the the correct subjects in the question" do
+        expect(page).to have_text("Biology or Chemistry")
+      end
+
+      context "Teacher taught subjects for more than 50% of their time" do
+        before do
+          choose "Yes"
+
+          click_on "Continue"
+        end
+
+        scenario "Sets mostly teaching elibile subjects correctly" do
+          expect(claim.reload.mostly_teaching_eligible_subjects).to eq(true)
+        end
+
+        scenario "Teacher is redirected to the check your answers page" do
+          expect(current_path).to eq(claim_path("check-your-answers"))
+        end
+      end
+
+      context "Teacher taught subjects for less than 50% of their time" do
+        before do
+          choose "No"
+
+          click_on "Continue"
+        end
+
+        scenario "Sets mostly teaching elibile subjects correctly" do
+          expect(claim.reload.mostly_teaching_eligible_subjects).to eq(false)
+        end
+
+        scenario "Teacher is told they are not eligible" do
+          expect(page).to have_text("You’re not eligible")
+          expect(page).to have_text("You must have spent at least half your time teaching an eligible subject")
+        end
+      end
+    end
+  end
+
   context "When changing claim school" do
     before do
       find("a[href='#{claim_path("claim-school")}']").click

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching
 
-    check "tslr_claim_mostly_teaching_eligible_subjects"
+    choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
     click_on "Continue"
 
     expect(claim.reload.mostly_teaching_eligible_subjects).to eq(false)

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.current_school).to eql schools(:hampstead_school)
 
-    expect(page).to have_text(I18n.t("tslr.questions.mostly_teaching_eligible_subjects"))
+    expect(page).to have_text(I18n.t("tslr.questions.subjects_taught"))
   end
 
   scenario "chooses an ineligible school" do
@@ -43,13 +43,29 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     expect(page).to have_text("You must be still working as a teacher to be eligible")
   end
 
-  scenario "did not teach at least half their time in an eligible subject" do
+  scenario "does not teach an eligible subject" do
     claim = start_tslr_claim
     choose_qts_year
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching
 
-    expect(page).to have_text(I18n.t("tslr.questions.mostly_teaching_eligible_subjects"))
+    check "tslr_claim_mostly_teaching_eligible_subjects"
+    click_on "Continue"
+
+    expect(claim.reload.mostly_teaching_eligible_subjects).to eq(false)
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You must have spent at least half your time teaching an eligible subject.")
+  end
+
+  scenario "does not teach an eligible subject" do
+    claim = start_tslr_claim
+    choose_qts_year
+    choose_school schools(:penistone_grammar_school)
+    choose_still_teaching
+
+    check "Biology"
+    click_on "Continue"
+
     choose "No"
     click_on "Continue"
 

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
     click_button "Continue"
 
-    expect(page).to have_text(I18n.t("tslr.questions.mostly_teaching_eligible_subjects"))
+    expect(page).to have_text(I18n.t("tslr.questions.subjects_taught"))
   end
 
   scenario "School search form still works like a normal form if submitted", js: true do

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments claims", js: true do
+  let(:school) { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
+  let(:claim) do
+    create(:tslr_claim,
+      claim_school: school,
+      current_school: school,
+      qts_award_year: "2013-2014",
+      employment_status: :claim_school)
+  end
+
+  before do
+    allow_any_instance_of(ClaimsController).to receive(:current_claim) { claim }
+    visit claim_path("subjects-taught")
+  end
+
+  scenario "checks subjects and then chooses not applicable" do
+    check "eligible_subjects_biology"
+    check "eligible_subjects_physics"
+
+    expect(page).to have_checked_field("eligible_subjects_biology", visible: false)
+    expect(page).to have_checked_field("eligible_subjects_physics", visible: false)
+
+    check "tslr_claim_mostly_teaching_eligible_subjects", visible: false
+
+    expect(page).to have_checked_field("tslr_claim_mostly_teaching_eligible_subjects", visible: false)
+
+    expect(page).to_not have_checked_field("eligible_subjects_biology", visible: false)
+    expect(page).to_not have_checked_field("eligible_subjects_physics", visible: false)
+
+    click_on "Continue"
+
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You must have spent at least half your time teaching an eligible subject.")
+  end
+
+  scenario "checks not applicable and then chooses a subject" do
+    check "tslr_claim_mostly_teaching_eligible_subjects", visible: false
+
+    expect(page).to have_checked_field("tslr_claim_mostly_teaching_eligible_subjects", visible: false)
+
+    check "eligible_subjects_biology"
+
+    expect(page).to have_checked_field("eligible_subjects_biology", visible: false)
+    expect(page).to_not have_checked_field("tslr_claim_mostly_teaching_eligible_subjects", visible: false)
+
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("tslr.questions.mostly_teaching_eligible_subjects", subjects: "Biology"))
+  end
+end

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments claims", js: true do
+RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments claims" do
   let(:school) { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
   let(:claim) do
     create(:tslr_claim,
@@ -15,38 +15,63 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
     visit claim_path("subjects-taught")
   end
 
-  scenario "checks subjects and then chooses not applicable" do
-    check "eligible_subjects_biology"
-    check "eligible_subjects_physics"
+  context "with JS enabled", js: true do
+    scenario "checks subjects and then chooses not applicable" do
+      check "eligible_subjects_biology"
+      check "eligible_subjects_physics"
 
-    expect(page).to have_checked_field("eligible_subjects_biology", visible: false)
-    expect(page).to have_checked_field("eligible_subjects_physics", visible: false)
+      expect(page).to have_checked_field("eligible_subjects_biology", visible: false)
+      expect(page).to have_checked_field("eligible_subjects_physics", visible: false)
 
-    check "tslr_claim_mostly_teaching_eligible_subjects", visible: false
+      choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
 
-    expect(page).to have_checked_field("tslr_claim_mostly_teaching_eligible_subjects", visible: false)
+      expect(page).to have_checked_field("tslr_claim_mostly_teaching_eligible_subjects_false", visible: false)
 
-    expect(page).to_not have_checked_field("eligible_subjects_biology", visible: false)
-    expect(page).to_not have_checked_field("eligible_subjects_physics", visible: false)
+      expect(page).to_not have_checked_field("eligible_subjects_biology", visible: false)
+      expect(page).to_not have_checked_field("eligible_subjects_physics", visible: false)
 
-    click_on "Continue"
+      click_on "Continue"
 
-    expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You must have spent at least half your time teaching an eligible subject.")
+      expect(page).to have_text("You’re not eligible")
+      expect(page).to have_text("You must have spent at least half your time teaching an eligible subject.")
+    end
+
+    scenario "checks not applicable and then chooses a subject" do
+      choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
+
+      expect(page).to have_checked_field("tslr_claim_mostly_teaching_eligible_subjects_false", visible: false)
+
+      check "eligible_subjects_biology"
+
+      expect(page).to have_checked_field("eligible_subjects_biology", visible: false)
+      expect(page).to_not have_checked_field("tslr_claim_mostly_teaching_eligible_subjects_false", visible: false)
+
+      click_on "Continue"
+
+      expect(page).to have_text(I18n.t("tslr.questions.mostly_teaching_eligible_subjects", subjects: "Biology"))
+    end
   end
 
-  scenario "checks not applicable and then chooses a subject" do
-    check "tslr_claim_mostly_teaching_eligible_subjects", visible: false
+  context "with JS disabled" do
+    scenario "checks subjects and then chooses not applicable" do
+      check "eligible_subjects_biology"
+      check "eligible_subjects_physics"
 
-    expect(page).to have_checked_field("tslr_claim_mostly_teaching_eligible_subjects", visible: false)
+      choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
+      click_on "Continue"
 
-    check "eligible_subjects_biology"
+      expect(page).to have_text("You’re not eligible")
+      expect(page).to have_text("You must have spent at least half your time teaching an eligible subject.")
+    end
 
-    expect(page).to have_checked_field("eligible_subjects_biology", visible: false)
-    expect(page).to_not have_checked_field("tslr_claim_mostly_teaching_eligible_subjects", visible: false)
+    scenario "checks not applicable and then chooses a subject" do
+      choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
 
-    click_on "Continue"
+      check "eligible_subjects_biology"
+      click_on "Continue"
 
-    expect(page).to have_text(I18n.t("tslr.questions.mostly_teaching_eligible_subjects", subjects: "Biology"))
+      expect(page).to have_text("You’re not eligible")
+      expect(page).to have_text("You must have spent at least half your time teaching an eligible subject.")
+    end
   end
 end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -17,7 +17,11 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(claim.reload.employment_status).to eql("claim_school")
     expect(claim.current_school).to eql(schools(:penistone_grammar_school))
 
-    expect(page).to have_text(I18n.t("tslr.questions.mostly_teaching_eligible_subjects"))
+    expect(page).to have_text(I18n.t("tslr.questions.subjects_taught"))
+    check "Physics"
+    click_on "Continue"
+
+    expect(page).to have_text(I18n.t("tslr.questions.mostly_teaching_eligible_subjects", subjects: "Physics"))
     choose "Yes"
     click_on "Continue"
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -24,6 +24,7 @@ describe ClaimsHelper do
         qts_award_year: "2013-2014",
         claim_school: school,
         current_school: school,
+        eligible_subjects: [:physics, :chemistry],
         mostly_teaching_eligible_subjects: true,
         student_loan_repayment_amount: 1987.65,
       )
@@ -32,7 +33,8 @@ describe ClaimsHelper do
         [I18n.t("tslr.questions.qts_award_year"), "September 1 2013 - August 31 2014", "qts-year"],
         [I18n.t("tslr.questions.claim_school"), school.name, "claim-school"],
         [I18n.t("tslr.questions.current_school"), school.name, "current-school"],
-        [I18n.t("tslr.questions.mostly_teaching_eligible_subjects"), "Yes", "subjects-taught"],
+        [I18n.t("tslr.questions.subjects_taught"), "Physics and Chemistry", "subjects-taught"],
+        [I18n.t("tslr.questions.mostly_teaching_eligible_subjects", subjects: "Physics or Chemistry"), "Yes", "mostly-teaching-eligible-subjects"],
         [I18n.t("tslr.questions.student_loan_amount", claim_school_name: school.name), "£1,987.65", "student-loan-amount"],
       ]
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -33,7 +33,7 @@ describe ClaimsHelper do
         [I18n.t("tslr.questions.qts_award_year"), "September 1 2013 - August 31 2014", "qts-year"],
         [I18n.t("tslr.questions.claim_school"), school.name, "claim-school"],
         [I18n.t("tslr.questions.current_school"), school.name, "current-school"],
-        [I18n.t("tslr.questions.subjects_taught"), "Physics and Chemistry", "subjects-taught"],
+        [I18n.t("tslr.questions.subjects_taught"), "Physics or Chemistry", "subjects-taught"],
         [I18n.t("tslr.questions.mostly_teaching_eligible_subjects", subjects: "Physics or Chemistry"), "Yes", "mostly-teaching-eligible-subjects"],
         [I18n.t("tslr.questions.student_loan_amount", claim_school_name: school.name), "£1,987.65", "student-loan-amount"],
       ]

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -127,9 +127,21 @@ RSpec.describe TslrClaim, type: :model do
   end
 
   context "when saving in the “subjects-taught” validation context" do
+    it "validates that a subject has been provided" do
+      expect(TslrClaim.new).not_to be_valid(:"subjects-taught")
+      expect(TslrClaim.new(eligible_subjects: [:computer_science, :physics])).to be_valid(:"subjects-taught")
+    end
+
+    it "does not validate that a subject has been provided when mostly_teaching_eligible_subjects is false" do
+      expect(TslrClaim.new).not_to be_valid(:"subjects-taught")
+      expect(TslrClaim.new(mostly_teaching_eligible_subjects: false)).to be_valid(:"subjects-taught")
+    end
+  end
+
+  context "when saving in the “mostly-teaching-eligible-subjects” validation context" do
     it "validates mostly_teaching_eligible_subjects has been provided" do
       expect(TslrClaim.new).not_to be_valid(:"subjects-taught")
-      expect(TslrClaim.new(mostly_teaching_eligible_subjects: true)).to be_valid(:"subjects-taught")
+      expect(TslrClaim.new(mostly_teaching_eligible_subjects: true)).to be_valid(:"mostly-teaching-eligible-subjects")
     end
   end
 


### PR DESCRIPTION
This PR makes some changes to the flow so we ask applicants what subjects they've taught, followed by asking if they've taught any of the subjects for more than 50% of their time:

Successful path:

![image](http://g.recordit.co/0l9SaOskdj.gif)

Unsuccessful path:

![image](http://g.recordit.co/NG5vR5vnDn.gif)

I've also added some JS so if a user chooses a subject, and then 'not applicable', the unapplicable checkboxes are unchecked, and vice versa:

![image](http://g.recordit.co/AwswTfWj3U.gif)