### PR TITLE
Make questions and check answers consistent

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -28,12 +28,12 @@ module ClaimsHelper
 
   def identity_answers(claim)
     [
-      ["Full name", claim.full_name, "full-name"],
-      ["What is your address?", claim.address, "address"],
-      ["What is your date of birth?", l(claim.date_of_birth), "date-of-birth"],
+      ["What's your full name?", claim.full_name, "full-name"],
+      ["What's your address?", claim.address, "address"],
+      ["What's your date of birth?", l(claim.date_of_birth), "date-of-birth"],
       ["What's your teacher reference number?", claim.teacher_reference_number, "teacher-reference-number"],
-      ["National Insurance number", claim.national_insurance_number, "national-insurance-number"],
-      ["Email address", claim.email_address, "email-address"],
+      ["What's your National Insurance number?", claim.national_insurance_number, "national-insurance-number"],
+      ["What's your email address?", claim.email_address, "email-address"],
       ["Account number", claim.bank_account_number, "bank-details"],
       ["Sort code", claim.bank_sort_code, "bank-details"],
     ]

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -29,9 +29,9 @@ module ClaimsHelper
   def identity_answers(claim)
     [
       ["Full name", claim.full_name, "full-name"],
-      ["Address", claim.address, "address"],
-      ["Date of birth", l(claim.date_of_birth), "date-of-birth"],
-      ["Teacher reference number", claim.teacher_reference_number, "teacher-reference-number"],
+      ["What is your address?", claim.address, "address"],
+      ["What is your date of birth?", l(claim.date_of_birth), "date-of-birth"],
+      ["What's your teacher reference number?", claim.teacher_reference_number, "teacher-reference-number"],
       ["National Insurance number", claim.national_insurance_number, "national-insurance-number"],
       ["Email address", claim.email_address, "email-address"],
       ["Account number", claim.bank_account_number, "bank-details"],

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -28,14 +28,19 @@ module ClaimsHelper
 
   def identity_answers(claim)
     [
-      ["What's your full name?", claim.full_name, "full-name"],
-      ["What's your address?", claim.address, "address"],
-      ["What's your date of birth?", l(claim.date_of_birth), "date-of-birth"],
-      ["What's your teacher reference number?", claim.teacher_reference_number, "teacher-reference-number"],
-      ["What's your National Insurance number?", claim.national_insurance_number, "national-insurance-number"],
-      ["What's your email address?", claim.email_address, "email-address"],
-      ["Account number", claim.bank_account_number, "bank-details"],
-      ["Sort code", claim.bank_sort_code, "bank-details"],
+      [t("tslr.questions.full_name"), claim.full_name, "full-name"],
+      [t("tslr.questions.address"), claim.address, "address"],
+      [t("tslr.questions.date_of_birth"), l(claim.date_of_birth), "date-of-birth"],
+      [t("tslr.questions.teacher_reference_number"), claim.teacher_reference_number, "teacher-reference-number"],
+      [t("tslr.questions.national_insurance_number"), claim.national_insurance_number, "national-insurance-number"],
+      [t("tslr.questions.email_address"), claim.email_address, "email-address"],
+    ]
+  end
+
+  def payment_answers(claim)
+    [
+      ["Bank sort code", claim.bank_sort_code, "bank-details"],
+      ["Bank account number", claim.bank_account_number, "bank-details"],
     ]
   end
 

--- a/app/views/claims/check_your_answers.html.erb
+++ b/app/views/claims/check_your_answers.html.erb
@@ -10,6 +10,8 @@
 
     <%= render partial: "check_your_answers_section", locals: {heading: "Identity details", answers: identity_answers(current_claim)} %>
 
+    <%= render partial: "check_your_answers_section", locals: {heading: "Payment details", answers: payment_answers(current_claim)} %>
+
     <%= form_for current_claim, url: claim_path do |form| %>
       <h2 class="govuk-heading-m">Confirm and send your application</h2>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,9 +50,9 @@ en:
       address: "What is your address?"
       date_of_birth: "What is your date of birth?"
       teacher_reference_number: "What's your teacher reference number?"
-      national_insurance_number: "What is your National Insurance number?"
+      national_insurance_number: "National Insurance number"
       student_loan_amount: "How much student loan did you repay while you were at %{claim_school_name} between 6 April XXXX and 5 April XXXX?"
-      email_address: "What is your email address?"
+      email_address: "Email address"
       bank_details: "Enter bank account details"
       eligible_subjects:
         biology_taught: "Biology"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,7 +50,7 @@ en:
       address: "What is your address?"
       date_of_birth: "What is your date of birth?"
       teacher_reference_number: "What's your teacher reference number?"
-      national_insurance_number: "National Insurance number"
+      national_insurance_number: "What's your National Insurance number?"
       student_loan_amount: "How much student loan did you repay while you were at %{claim_school_name} between 6 April XXXX and 5 April XXXX?"
       email_address: "Email address"
       bank_details: "Enter bank account details"

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -55,22 +55,34 @@ describe ClaimsHelper do
         teacher_reference_number: "1234567",
         national_insurance_number: "QQ 12 34 56 C",
         email_address: "test@email.com",
-        bank_account_number: "12 34 56 78",
-        bank_sort_code: "12 34 56",
       )
 
       expected_answers = [
-        ["What's your full name?", "Jo Bloggs", "full-name"],
-        ["What's your address?", "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
-        ["What's your date of birth?", I18n.l(20.years.ago.to_date), "date-of-birth"],
-        ["What's your teacher reference number?", "1234567", "teacher-reference-number"],
-        ["What's your National Insurance number?", "QQ123456C", "national-insurance-number"],
-        ["What's your email address?", "test@email.com", "email-address"],
-        ["Account number", "12345678", "bank-details"],
-        ["Sort code", "123456", "bank-details"],
+        [I18n.t("tslr.questions.full_name"), "Jo Bloggs", "full-name"],
+        [I18n.t("tslr.questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+        [I18n.t("tslr.questions.date_of_birth"), I18n.l(20.years.ago.to_date), "date-of-birth"],
+        [I18n.t("tslr.questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
+        [I18n.t("tslr.questions.national_insurance_number"), "QQ123456C", "national-insurance-number"],
+        [I18n.t("tslr.questions.email_address"), "test@email.com", "email-address"],
       ]
 
       expect(helper.identity_answers(claim)).to eq expected_answers
+    end
+
+    describe "#payment_answers" do
+      it "returns an array of questions and answers for displaying to the user for review" do
+        claim = TslrClaim.create(
+          bank_sort_code: "12 34 56",
+          bank_account_number: "12 34 56 78",
+        )
+
+        expected_answers = [
+          ["Bank sort code", "123456", "bank-details"],
+          ["Bank account number", "12345678", "bank-details"],
+        ]
+
+        expect(helper.payment_answers(claim)).to eq expected_answers
+      end
     end
   end
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -60,12 +60,12 @@ describe ClaimsHelper do
       )
 
       expected_answers = [
-        ["Full name", "Jo Bloggs", "full-name"],
-        ["What is your address?", "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
-        ["What is your date of birth?", I18n.l(20.years.ago.to_date), "date-of-birth"],
+        ["What's your full name?", "Jo Bloggs", "full-name"],
+        ["What's your address?", "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+        ["What's your date of birth?", I18n.l(20.years.ago.to_date), "date-of-birth"],
         ["What's your teacher reference number?", "1234567", "teacher-reference-number"],
-        ["National Insurance number", "QQ123456C", "national-insurance-number"],
-        ["Email address", "test@email.com", "email-address"],
+        ["What's your National Insurance number?", "QQ123456C", "national-insurance-number"],
+        ["What's your email address?", "test@email.com", "email-address"],
         ["Account number", "12345678", "bank-details"],
         ["Sort code", "123456", "bank-details"],
       ]

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -61,9 +61,9 @@ describe ClaimsHelper do
 
       expected_answers = [
         ["Full name", "Jo Bloggs", "full-name"],
-        ["Address", "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
-        ["Date of birth", I18n.l(20.years.ago.to_date), "date-of-birth"],
-        ["Teacher reference number", "1234567", "teacher-reference-number"],
+        ["What is your address?", "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+        ["What is your date of birth?", I18n.l(20.years.ago.to_date), "date-of-birth"],
+        ["What's your teacher reference number?", "1234567", "teacher-reference-number"],
         ["National Insurance number", "QQ123456C", "national-insurance-number"],
         ["Email address", "test@email.com", "email-address"],
         ["Account number", "12345678", "bank-details"],


### PR DESCRIPTION
Make sure the questions asked on page and the summary of answers use the
same questions. This should make it more consistent and easier to
understand as you will now click to change a question and see that same
question shown on the question page.