### PR TITLE
Stop including the non-existent env file for Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     image: local/dfe-teachers-payment-service:development
     depends_on:
       - db
-    env_file:
-      - .env.development
     environment:
       DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME: postgres
       DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST: db


### PR DESCRIPTION
It causes errors if it's missing, and we don't currently specify env
specific env variables.