### PR TITLE
Run migrations in Heroku on release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec rake jobs:work
+release: rake db:migrate


### PR DESCRIPTION
This adds a `release` step to the Procfile, so the Rails migrations are run in Heroku on release. At the moment, staging is broken because of this (I'll run migrations manually to fix for now)