### PR TITLE
Copy test-related files to test Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,10 @@ CMD [ "rails", "server" ]
 
 FROM web AS test
 
+COPY .prettierignore ${APP_HOME}/.prettierignore
+COPY .prettierrc ${APP_HOME}/.prettierrc
+COPY .rspec ${APP_HOME}/.rspec
+
 RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
 RUN apk add chromium chromium-chromedriver
 COPY spec ${APP_HOME}/spec


### PR DESCRIPTION
The Prettier lint steps were failing because our config from `.prettierrc` wasn't being reflected, as it hadn't been copied over to the Docker container. This fixes it. I've also copied over the `.prettierignore` and `.rspec` files too.