### PR TITLE
Fix issue with prettier file globbing

### DIFF
--- a/lib/tasks/prettier.rake
+++ b/lib/tasks/prettier.rake
@@ -1,5 +1,5 @@
 if Rails.env.development? || Rails.env.test?
-  file_glob = "./**/*.{css,html,js,js.erb,json,md,scss}"
+  file_glob = "'./**/*.{css,html,js,js.erb,json,md,scss}'"
 
   desc "Lint with Prettier"
   task prettier: :environment do


### PR DESCRIPTION
Without the quote marks around the file glob, the shell does the glob
expansion, which results in inconsistent results between local
development and the build servers. Wrapping the glob in quoutes makes
sure that prettier is left to do the expansion.