### PR TITLE
Add startup script for GOV.UK verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ localhost.key
 # Ignore parameter files
 /azure/parameters/*.json
 !/azure/parameters/*.template.json
+
+# Ignore Verify Service Provider
+bin/vsp/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 /.apt/
 /.heroku/
 /vendor/
+/bin/vsp/

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: bundle exec rails s -b 'ssl://localhost:3000?key=localhost.key&cert=localhost.crt'
 worker: bundle exec rake jobs:work
+vsp: bin/launch-vsp

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Architecture decision records can be found in the
 - PostgreSQL
 - [Yarn](https://yarnpkg.com/en/docs/install)
 
+You will also need Java 11 or a long term supported version of Java 8 installed
+for the Verify Service Provider to run. We recommend [OpenJDK][openjdk].
+
 ## Setting up the app in development
 
 1. In order to integrate with DfE Sign-in's Open ID Connect service we are
@@ -114,3 +117,5 @@ in the _Config Vars_ in Heroku.
 ### Staging
 
 https://dfe-teachers-payment-staging.herokuapp.com/
+
+[openjdk]: https://adoptopenjdk.net/

--- a/bin/launch-vsp
+++ b/bin/launch-vsp
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+VSP_PATH=./bin/vsp/
+VSP_FILENAME=verify-service-provider-2.0.0
+VSP_DOWNLOAD_URL="https://github.com/alphagov/verify-service-provider/releases/download/2.0.0/${VSP_FILENAME}.zip"
+IDENTITY_DATASET="spec/fixtures/verify/test-identity-dataset.json"
+
+if [ ! -d $VSP_PATH ]; then
+  echo "Can't find an installed version of the Verify Service Provider - downloading and installing..."
+  (cd tmp/ && curl -L -O -s $VSP_DOWNLOAD_URL)
+  unzip -qq tmp/${VSP_FILENAME}.zip -d tmp/
+  mv tmp/${VSP_FILENAME}/ $VSP_PATH
+  rm tmp/${VSP_FILENAME}.zip
+  echo
+  echo "Verify Service provider successfully installed!"
+fi
+
+echo "Launching Verify Service Provider..."
+echo
+
+$VSP_PATH/bin/verify-service-provider development \
+  -u https://localhost:3000/verify/authentications \
+  --identityDataset "$(cat $IDENTITY_DATASET)"

--- a/docs/govuk-verify.md
+++ b/docs/govuk-verify.md
@@ -25,24 +25,14 @@ enabled by setting an environment variable in your `.env` file:
   GOVUK_VERIFY_ENABLED=1
 ```
 
-GOV.UK Verify integration requires using a Verify Service Providor (VSP)
-to handle SAML secure messaging. To run a VSP in development, you will
-need to download the latest release ZIP from the [project on Gitub](https://github.com/alphagov/verify-service-provider/releases).
+GOV.UK Verify integration requires using a Verify Service Provider (VSP)
+to handle SAML secure messaging.
 
-Note: you should only work with the pre-compiled releases. Don't try and build
-from source.
+By default, Foreman downloads and runs the VSP via `foreman start` in development
+with sample data for LOA 2. You must have Java 11, or a long-term supported version
+of Java 8 installed for this to run successfully. We recommend [OpenJDK][openjdk].
 
-To run the VSP in development mode with sample data for LOA 2, navigate to the
-downloaded directory and execute the following command:
-
-```bash
-  $ ./bin/verify-service-provider development -u https://localhost:3000/verify/authentications --identityDataset "$(cat PATH/TO/dfe-teachers-payment-service/spec/fixtures/verify/test-identity-dataset.json)"
-```
-
-Replacing PATH/TO with the location of the repository for the main application.
-
-This will start the VSP on port 50300. You can check that it is running ok by
-hitting the healthcheck URL:
+You can check that the VSP is running ok by hitting the healthcheck URL:
 
 ```bash
   curl localhost:50300/admin/healthcheck
@@ -58,3 +48,5 @@ https://www.docs.verify.service.gov.uk/maintain-your-connection/rotate-keys/
 
 More on this to follow once we move towards setting Verify up on staging and
 production.
+
+[openjdk]: https://adoptopenjdk.net/


### PR DESCRIPTION
This replaces a bunch of the Verify documentation with code by adding a simple script that downloads and starts the latest version of Verify Service Provider with the relevant config for development. The only prerequisite is having Java installed. I did consider downloading and installing OpenJDK11 automatically, but thought that was best left for an individual dev to do, as the VSP supports multiple versions of Java and devs may have their own preferences (or indeed, already have a version of Java installed).

For production, this can be better served by a Docker container, but this will be good enough for development purposes.