### PR TITLE
Actually wrap markdown at 80 characters

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "printWidth": 120,
+  "proseWrap": "always",
   "overrides": [
     {
       "files": "*.js.erb",

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ## Documentation
 
-Most documentation for the service can be found on the [project's confluence
-wiki](https://dfedigital.atlassian.net/wiki/spaces/TP). Some app-specific
-technical documentation can be found in the [docs](docs) directory.
+Most documentation for the service can be found on the
+[project's confluence wiki](https://dfedigital.atlassian.net/wiki/spaces/TP).
+Some app-specific technical documentation can be found in the [docs](docs)
+directory.
 
 ### ADRs
 
@@ -25,7 +26,8 @@ for the Verify Service Provider to run. We recommend [OpenJDK][openjdk].
 1. In order to integrate with DfE Sign-in's Open ID Connect service we are
    required to communicate over https in development. Create a self-signed
    development certificate.
-   - Run `openssl req -x509 -sha256 -nodes -newkey rsa:2048 -days 365 -keyout localhost.key -out localhost.crt`
+   - Run
+     `openssl req -x509 -sha256 -nodes -newkey rsa:2048 -days 365 -keyout localhost.key -out localhost.crt`
    - Open Keychain Access on your Mac and go to the Certificates category in
      your System keychain. Once there, import the `localhost.crt`
      `File > Import Items`. Double click the imported certificate and change the
@@ -90,8 +92,8 @@ Code linting is performed using:
 
 ### N+1 query detection
 
-[Bullet](https://github.com/flyerhzm/bullet) runs around each spec. If it detects an N+1 query it will raise an
-exception and the tests will fail.
+[Bullet](https://github.com/flyerhzm/bullet) runs around each spec. If it
+detects an N+1 query it will raise an exception and the tests will fail.
 
 ## Production
 
@@ -106,13 +108,14 @@ docker build --target web .
 
 ## Service architecture
 
-The service architecture is currently defined and [on confluence](https://dfedigital.atlassian.net/wiki/spaces/TP/pages/1049559041/Service+Architecture).
+The service architecture is currently defined and
+[on confluence](https://dfedigital.atlassian.net/wiki/spaces/TP/pages/1049559041/Service+Architecture).
 
 ## Access
 
-Staging is protected by HTTP Basic Authentication. The username and password
-are pinned in the _dfe-teacher-payments_ slack channel or can be found
-in the _Config Vars_ in Heroku.
+Staging is protected by HTTP Basic Authentication. The username and password are
+pinned in the _dfe-teacher-payments_ slack channel or can be found in the
+_Config Vars_ in Heroku.
 
 ### Staging
 

--- a/docs/architecture-decisions/0001-record-architecture-decisions.md
+++ b/docs/architecture-decisions/0001-record-architecture-decisions.md
@@ -12,8 +12,12 @@ We need to record the architectural decisions made on this project.
 
 ## Decision
 
-We will use Architecture Decision Records, as described by Michael Nygard in this article: [http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+We will use Architecture Decision Records, as described by Michael Nygard in
+this article:
+[http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
 
 ## Consequences
 
-See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's _adr-tools_ at [https://github.com/npryce/adr-tools](https://github.com/npryce/adr-tools).
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see
+Nat Pryce's _adr-tools_ at
+[https://github.com/npryce/adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/architecture-decisions/0002-use-rspec-for-testing.md
+++ b/docs/architecture-decisions/0002-use-rspec-for-testing.md
@@ -8,7 +8,8 @@ Accepted
 
 ## Context
 
-We need to test the code we're writing, the team has previous experience working with these frameworks.
+We need to test the code we're writing, the team has previous experience working
+with these frameworks.
 
 ## Decision
 

--- a/docs/architecture-decisions/0003-use-rubocop-for-linting.md
+++ b/docs/architecture-decisions/0003-use-rubocop-for-linting.md
@@ -8,7 +8,8 @@ Accepted
 
 ## Context
 
-We need to lint our Ruby code, the team has previous experience working with RuboCop.
+We need to lint our Ruby code, the team has previous experience working with
+RuboCop.
 
 ## Decision
 

--- a/docs/architecture-decisions/0004-deployment-on-heroku.md
+++ b/docs/architecture-decisions/0004-deployment-on-heroku.md
@@ -8,9 +8,9 @@ Accepted
 
 ## Context
 
-Department for Education have a Cloud Infrastructure Program based on Azure
-that they would like digital services to use. Access to Azure is heavily
-restricted for production, and slightly restricted for lower environments.
+Department for Education have a Cloud Infrastructure Program based on Azure that
+they would like digital services to use. Access to Azure is heavily restricted
+for production, and slightly restricted for lower environments.
 
 We need to be able to work quickly, particularly in the early stages of this
 project.

--- a/docs/architecture-decisions/0007-use-dfe-sign-in-for-admin-authentication.md
+++ b/docs/architecture-decisions/0007-use-dfe-sign-in-for-admin-authentication.md
@@ -13,8 +13,9 @@ the service for checking and processing claims.
 
 ## Decision
 
-We will use DfE's single sign-on service [DfE Sign In](https://services.signin.education.gov.uk/)
-and authenticate through OpenID Connect.
+We will use DfE's single sign-on service
+[DfE Sign In](https://services.signin.education.gov.uk/) and authenticate
+through OpenID Connect.
 
 ## Consequences
 

--- a/docs/architecture-decisions/0008-use-govuk-verify-for-claiment-identity-assurance.md
+++ b/docs/architecture-decisions/0008-use-govuk-verify-for-claiment-identity-assurance.md
@@ -26,8 +26,8 @@ GOVUK Verify recommend any services that ‘gives users money or benefits’ use
 Using GOVUK Verify requires DfE to sign GOVUK Verify’s agreements.
 
 Integrating with GOVUK Verify requires the hosting and management of a ‘Verify
-Service Provider’ or VSP. DfE only needs a single VSP to integrate GOVUK
-Verify with any number of services, including ours.
+Service Provider’ or VSP. DfE only needs a single VSP to integrate GOVUK Verify
+with any number of services, including ours.
 
 There will be on-going management of the VSP including security key rotation on
 a regular basis.

--- a/docs/architecture-decisions/0009-capture-teacher-reference-number.md
+++ b/docs/architecture-decisions/0009-capture-teacher-reference-number.md
@@ -9,16 +9,17 @@ Accepted
 ## Context
 
 A claimant’s eligibility is, in part, determined by their qualifications. We
-want to be able to validate that a claimant’s qualifications match those of
-the eligibility criteria.
+want to be able to validate that a claimant’s qualifications match those of the
+eligibility criteria.
 
 ## Decision
 
 To aid DfE in the process of validating a claimant’s qualifications, we will
 collect the claimant’s ‘Teacher Reference Number’ or TRN.
 
-With the TRN, DfE can use the Database of Qualified Teachers ([DQT](https://teacherservices.education.gov.uk/SelfService/Login))
-to validate a claimant’s qualifications.
+With the TRN, DfE can use the Database of Qualified Teachers
+([DQT](https://teacherservices.education.gov.uk/SelfService/Login)) to validate
+a claimant’s qualifications.
 
 ## Consequences
 

--- a/docs/architecture-decisions/0010-dfe-can-download-claims-data-during-private-beta.md
+++ b/docs/architecture-decisions/0010-dfe-can-download-claims-data-during-private-beta.md
@@ -8,8 +8,8 @@ Accepted
 
 ## Context
 
-DfE will need to verify claims to confirm eligibility before they can be approved
-and paid. To help design and test the business process for checking and
+DfE will need to verify claims to confirm eligibility before they can be
+approved and paid. To help design and test the business process for checking and
 verifying claims, the team will carry out a private beta where a limited set of
 teachers will make real claims. The claims will be checked and processed
 manually during the private beta, enabling the team to learn the best way to

--- a/docs/architecture-decisions/0011-make-payments-using-dfes-existing-finance-system-nav.md
+++ b/docs/architecture-decisions/0011-make-payments-using-dfes-existing-finance-system-nav.md
@@ -12,29 +12,28 @@ The service needs to make net-of-tax payments directly to teachers that have
 made successful claims (i.e. net of tax, national insurance and student loan
 recoveries). Doing this requires two things:
 
-1. to operate PAYE as a "supplementary employer" so that DfE can pay any tax,
-   NI and student loan recoveries due on the teachers’ behalf, and report the
+1. to operate PAYE as a "supplementary employer" so that DfE can pay any tax, NI
+   and student loan recoveries due on the teachers’ behalf, and report the
    payments to HMRC
-2. to make BACS payments directly to teachers’ bank accounts for the net
-   amount
+2. to make BACS payments directly to teachers’ bank accounts for the net amount
 
-A number of options for doing these things were considered during the
-project’s alpha phase, including several existing internal systems that are
-already used by DfE for making payments and operating payroll/PAYE. Ultimately
-all the existing systems were deemed not suitable, and the [advice for the beta
-phase] was to source an all-in-one payment solution to perform the above.
+A number of options for doing these things were considered during the project’s
+alpha phase, including several existing internal systems that are already used
+by DfE for making payments and operating payroll/PAYE. Ultimately all the
+existing systems were deemed not suitable, and the [advice for the beta phase]
+was to source an all-in-one payment solution to perform the above.
 
-The beta team re-visited this decision, partly because an all-in-one solution
-to do these things doesn’t exist on the Digital Marketplace, and because it
-would be difficult to procure a system through open tender in time to meet the
+The beta team re-visited this decision, partly because an all-in-one solution to
+do these things doesn’t exist on the Digital Marketplace, and because it would
+be difficult to procure a system through open tender in time to meet the
 project’s deadlines.
 
 ## Decision
 
 The service will use the DfE's existing funding and financial system (NAV) to
-make payments to teachers. This will be made possible with the upgraded
-version (Microsoft Dynamics Business Central), which is due to come online in
-August. The upgraded version will have an employee payroll and expenses module
+make payments to teachers. This will be made possible with the upgraded version
+(Microsoft Dynamics Business Central), which is due to come online in August.
+The upgraded version will have an employee payroll and expenses module
 available, which will make it possible to register teachers in the system as
 "employees" and make direct payments to their bank accounts.
 
@@ -49,12 +48,13 @@ processes, the accounting and reporting for these payments will come for free.
 
 The employee payroll and expenses module within NAV doesn't perform the
 calculations for the tax/NI/SLR that is due on the payments. This will either
-have to be done by the service itself, or as a bespoke add-on to NAV provided
-by FSIP’s supplier partner.
+have to be done by the service itself, or as a bespoke add-on to NAV provided by
+FSIP’s supplier partner.
 
 The employee payroll and expenses module within NAV doesn't support the
 reporting aspect of running payroll (RTI). The team is currently working with
 the FSIP team to explore whether this capability can be built into NAV, or
 whether an alternative mechanism for performing RTI will be required.
 
-[advice for the beta phase]: https://drive.google.com/drive/u/2/folders/1xnbNliEbDNya2HNexS6b05oF5WG7le59
+[advice for the beta phase]:
+  https://drive.google.com/drive/u/2/folders/1xnbNliEbDNya2HNexS6b05oF5WG7le59

--- a/docs/govuk-verify.md
+++ b/docs/govuk-verify.md
@@ -1,12 +1,13 @@
 # GOV.UK Verify Integration
 
-A good place to start is to read the [GOV.UK Verify technical documentation](https://www.docs.verify.service.gov.uk/#gov-uk-verify-technical-documentation).
+A good place to start is to read the
+[GOV.UK Verify technical documentation](https://www.docs.verify.service.gov.uk/#gov-uk-verify-technical-documentation).
 
 ## Getting support
 
 The email address for Verify support is idasupport@digital.cabinet-office.gov.uk
-(which goes through to Zendesk). There is also a #govuk-verify slack channel
-on the ukgovernmentdigital.slack.com slack workspace.
+(which goes through to Zendesk). There is also a #govuk-verify slack channel on
+the ukgovernmentdigital.slack.com slack workspace.
 
 ## Environment variables
 
@@ -25,12 +26,13 @@ enabled by setting an environment variable in your `.env` file:
   GOVUK_VERIFY_ENABLED=1
 ```
 
-GOV.UK Verify integration requires using a Verify Service Provider (VSP)
-to handle SAML secure messaging.
+GOV.UK Verify integration requires using a Verify Service Provider (VSP) to
+handle SAML secure messaging.
 
-By default, Foreman downloads and runs the VSP via `foreman start` in development
-with sample data for LOA 2. You must have Java 11, or a long-term supported version
-of Java 8 installed for this to run successfully. We recommend [OpenJDK][openjdk].
+By default, Foreman downloads and runs the VSP via `foreman start` in
+development with sample data for LOA 2. You must have Java 11, or a long-term
+supported version of Java 8 installed for this to run successfully. We recommend
+[OpenJDK][openjdk].
 
 You can check that the VSP is running ok by hitting the healthcheck URL:
 
@@ -41,8 +43,8 @@ You can check that the VSP is running ok by hitting the healthcheck URL:
 ## Managing Certificates for the IDAP PKI
 
 In development mode, there is no need for key management. For the live service
-we need to run the key rotation process to update certificates when they are
-due to expire:
+we need to run the key rotation process to update certificates when they are due
+to expire:
 
 https://www.docs.verify.service.gov.uk/maintain-your-connection/rotate-keys/
 


### PR DESCRIPTION
By default Prettier preserves existing prose wrapping, but restricting line lengths makes it easier to read prose.