### PR TITLE
Make the fallback Verify page less confusing on slow connections

### DIFF
--- a/app/views/verify/authentications/new.html.erb
+++ b/app/views/verify/authentications/new.html.erb
@@ -4,7 +4,7 @@
       <h1 class="govuk-heading-xl">Continue to next step</h1>
       <%= hidden_field_tag "relayState" %>
       <%= hidden_field_tag "SAMLRequest", @verify_authentication_request.saml_request %>
-      <p class="govuk-body">Because JavaScript is not enabled on your browser, you must press the continue button</p>
+      <p class="govuk-body">If your browser does not redirect in a few seconds, please press the "Continue" button.</p>
       <%= submit_tag "Continue", class: "govuk-button" %>
     <% end %>
   </div>


### PR DESCRIPTION
On slow connections it may flash up for the user while the JavaScript loads, so it's better not to assume that they are only seeing it because JavaScript is disabled.