### PR TITLE
Import schools on first deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "mail-notify"
 
 # Database based asynchronous priority queue system
 gem "delayed_job_active_record"
+gem "delayed_cron_job"
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
@@ -68,10 +69,13 @@ end
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem "web-console", ">= 3.3.0"
+
   gem "listen", ">= 3.0.5", "< 3.2"
+
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
+
   gem "foreman"
   gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    delayed_cron_job (0.7.2)
+      delayed_job (>= 4.1)
     delayed_job (4.1.5)
       activesupport (>= 3.0, < 5.3)
     delayed_job_active_record (4.1.3)
@@ -315,6 +317,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara
+  delayed_cron_job
   delayed_job_active_record
   dotenv-rails
   dxw_govuk_frontend_rails

--- a/README.md
+++ b/README.md
@@ -77,12 +77,10 @@ including how to run the verify dependencies locally.
 
 ### Running `CronJob`s
 
-Recurring jobs are scheduled by the `db:schedule_jobs` rake task. This task
-normally runs as part of `db:migrate` or `db:schema:load`, but is disabled in
-development environments. To schedule them during development, run:
+To schedule recurring jobs, run the following:
 
 ```
-rake db:schedule_jobs
+rake jobs:schedule
 ```
 
 ## Running specs, brakeman, and code linting

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ The service uses GOV.UK Verify to verify the identity of teachers that are
 claiming. See [docs/govuk-verify](/docs/govuk-verify.md) for details on this,
 including how to run the verify dependencies locally.
 
+### Running `CronJob`s
+
+Recurring jobs are scheduled by the `db:schedule_jobs` rake task. This task
+normally runs as part of `db:migrate` or `db:schema:load`, but is disabled in
+development environments. To schedule them during development, run:
+
+```
+rake db:schedule_jobs
+```
+
 ## Running specs, brakeman, and code linting
 
 ```

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -1,0 +1,39 @@
+class CronJob < ApplicationJob
+  class_attribute :cron_expression
+  class_attribute :perform_on_schedule
+
+  class << self
+    def schedule
+      remove_schedule if scheduled_job.present? && scheduled_job.cron != cron_expression
+
+      set(cron: cron_expression).perform_later unless scheduled?
+      perform_later if perform_on_schedule && !enqueued?
+    end
+
+    private
+
+    def remove_schedule
+      scheduled_job.destroy if scheduled?
+    end
+
+    def scheduled?
+      scheduled_job.present?
+    end
+
+    def enqueued?
+      enqueued_job.present?
+    end
+
+    def scheduled_job
+      jobs.where.not(cron: nil).first
+    end
+
+    def enqueued_job
+      jobs.where(cron: nil).first
+    end
+
+    def jobs
+      Delayed::Job.where("handler LIKE ?", "%job_class: #{name}%")
+    end
+  end
+end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -1,39 +1,34 @@
 class CronJob < ApplicationJob
   class_attribute :cron_expression
-  class_attribute :perform_on_schedule
 
   class << self
     def schedule
-      remove_schedule if scheduled_job.present? && scheduled_job.cron != cron_expression
+      remove_schedule if delayed_job.present? && delayed_job.cron != cron_expression
 
       set(cron: cron_expression).perform_later unless scheduled?
-      perform_later if perform_on_schedule && !enqueued?
     end
 
     private
 
     def remove_schedule
-      scheduled_job.destroy if scheduled?
+      delayed_job.destroy if scheduled?
+    end
+
+    def remove
+      delayed_job.destroy if scheduled?
     end
 
     def scheduled?
-      scheduled_job.present?
+      delayed_job.present?
     end
 
-    def enqueued?
-      enqueued_job.present?
-    end
-
-    def scheduled_job
-      jobs.where.not(cron: nil).first
-    end
-
-    def enqueued_job
-      jobs.where(cron: nil).first
+    def delayed_job
+      jobs.first
     end
 
     def jobs
-      Delayed::Job.where("handler LIKE ?", "%job_class: #{name}%")
+      Delayed::Job
+        .where("handler LIKE ?", "%job_class: #{name}%")
     end
   end
 end

--- a/app/jobs/school_data_importer_job.rb
+++ b/app/jobs/school_data_importer_job.rb
@@ -1,0 +1,8 @@
+class SchoolDataImporterJob < ApplicationJob
+  queue_as :school_data
+
+  def perform
+    Rails.logger.info "Importing school data..."
+    SchoolDataImporter.new.run
+  end
+end

--- a/app/jobs/school_data_importer_job.rb
+++ b/app/jobs/school_data_importer_job.rb
@@ -1,6 +1,5 @@
 class SchoolDataImporterJob < CronJob
   self.cron_expression = "0 0 * * *"
-  self.perform_on_schedule = true
 
   queue_as :school_data
 

--- a/app/jobs/school_data_importer_job.rb
+++ b/app/jobs/school_data_importer_job.rb
@@ -1,4 +1,7 @@
-class SchoolDataImporterJob < ApplicationJob
+class SchoolDataImporterJob < CronJob
+  self.cron_expression = "0 0 * * *"
+  self.perform_on_schedule = true
+
   queue_as :school_data
 
   def perform

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -15,4 +15,7 @@ else
   fi
 fi
 
+echo "Scheduling Cron Jobs"
+rake jobs:schedule
+
 exec "$@"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,26 +1,26 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "d295fbb2c23775e4923257fd12543b72b959f0b21fd678dc50373e1c62e2ce24",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/claims_controller.rb",
-      "line": 15,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => params[:slug], {})",
+      "warning_type": "File Access",
+      "warning_code": 16,
+      "fingerprint": "986bcf3b3075cf77a2c4b4b4d382be6fb3d5233bd0c9b943bfd3274bc4099145",
+      "check_name": "SendFile",
+      "message": "Model attribute used in file name",
+      "file": "app/controllers/admin/claims_controller.rb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
+      "code": "send_file(TslrClaimsCsv.new(TslrClaim.includes(:claim_school, :current_school).submitted.order(:submitted_at)).file, :type => \"text/csv\", :filename => \"claims.csv\")",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "ClaimsController",
-        "method": "show"
+        "class": "Admin::ClaimsController",
+        "method": "index"
       },
-      "user_input": "params[:slug]",
-      "confidence": "High",
-      "note": "We are using a routing constraint to only route slugs that are in a whitelist, making this a false-positive"
+      "user_input": "TslrClaim.includes(:claim_school, :current_school).submitted",
+      "confidence": "Weak",
+      "note": ""
     }
   ],
-  "updated": "2019-04-29 15:28:26 +0100",
-  "brakeman_version": "4.5.0"
+  "updated": "2019-06-27 17:40:58 +0100",
+  "brakeman_version": "4.5.1"
 }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,17 +37,15 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_options = {
+    from: "mail@example.com",
+  }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  config.action_mailer.delivery_method = :test
-  config.action_mailer.default_options = {
-    from: "mail@example.com",
-  }
 
   config.active_job.queue_adapter = :inline
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = :test
 
   config.after_initialize do
     Bullet.enable = true

--- a/db/migrate/20190627143657_add_cron_to_delayed_jobs.rb
+++ b/db/migrate/20190627143657_add_cron_to_delayed_jobs.rb
@@ -1,0 +1,9 @@
+class AddCronToDelayedJobs < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :delayed_jobs, :cron, :string
+  end
+
+  def self.down
+    remove_column :delayed_jobs, :cron
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_24_101725) do
+ActiveRecord::Schema.define(version: 2019_06_27_143657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2019_06_24_101725) do
     t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "cron"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 

--- a/lib/tasks/import_schools_data.rake
+++ b/lib/tasks/import_schools_data.rake
@@ -3,6 +3,6 @@ require "rake"
 namespace :schools_data do
   desc "Import schools data from Get Information About Schools"
   task import: :environment do
-    SchoolDataImporter.new.run
+    SchoolDataImporterJob.perform_later
   end
 end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -8,8 +8,10 @@ namespace :db do
   end
 end
 
-%w[db:migrate db:schema:load].each do |task|
-  Rake::Task[task].enhance do
-    Rake::Task["db:schedule_jobs"].invoke
+unless Rails.env.development?
+  %w[db:migrate db:schema:load].each do |task|
+    Rake::Task[task].enhance do
+      Rake::Task["db:schedule_jobs"].invoke
+    end
   end
 end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -1,0 +1,15 @@
+namespace :db do
+  desc "Schedule all cron jobs"
+  task schedule_jobs: :environment do
+    glob = Rails.root.join("app", "jobs", "**", "*_job.rb")
+
+    Dir.glob(glob).each { |f| require f }
+    CronJob.subclasses.each { |job| job.schedule }
+  end
+end
+
+%w[db:migrate db:schema:load].each do |task|
+  Rake::Task[task].enhance do
+    Rake::Task["db:schedule_jobs"].invoke
+  end
+end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -1,17 +1,9 @@
-namespace :db do
+namespace :jobs do
   desc "Schedule all cron jobs"
-  task schedule_jobs: :environment do
+  task schedule: :environment do
     glob = Rails.root.join("app", "jobs", "**", "*_job.rb")
 
     Dir.glob(glob).each { |f| require f }
     CronJob.subclasses.each { |job| job.schedule }
-  end
-end
-
-unless Rails.env.development?
-  %w[db:migrate db:schema:load].each do |task|
-    Rake::Task[task].enhance do
-      Rake::Task["db:schedule_jobs"].invoke
-    end
   end
 end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -98,9 +98,11 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_text("Check your answers before sending your application")
 
     freeze_time do
-      expect {
-        click_on "Confirm and send"
-      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      perform_enqueued_jobs do
+        expect {
+          click_on "Confirm and send"
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
 
       expect(claim.reload.submitted_at).to eq(Time.zone.now)
     end

--- a/spec/jobs/cron_job_spec.rb
+++ b/spec/jobs/cron_job_spec.rb
@@ -13,57 +13,7 @@ RSpec.describe "CronJob" do
     it "schedules the job with the cron expression" do
       TestCronJob.schedule
 
-      expect(TestCronJob.send(:scheduled_job).cron).to eq(TestCronJob.cron_expression)
-    end
-
-    context "when the job is not configured to perform on schedule and an unscheduled run of the job exists" do
-      before :each do
-        TestCronJob.perform_later
-      end
-
-      it "leaves the job enqueued" do
-        existing_job = TestCronJob.send(:enqueued_job)
-
-        TestCronJob.schedule
-
-        expect(TestCronJob.send(:enqueued_job)).to eq(existing_job)
-      end
-
-      it "doesn't enqueue another instance of the job" do
-        expect { TestCronJob.schedule }.not_to(change { TestCronJob.send(:jobs).where(cron: nil).count })
-      end
-
-      it "schedules the job" do
-        expect { TestCronJob.schedule }.to change { TestCronJob.send(:jobs).count }.by(1)
-      end
-    end
-
-    context "when the job is configured to perform on schedule" do
-      it "enqueues the job" do
-        expect { TestWithPerformOnScheduleCronJob.schedule }.to change { TestWithPerformOnScheduleCronJob.send(:jobs).where(cron: nil).count }.by(1)
-      end
-    end
-
-    context "when the job is configured to perform on schedule and an unscheduled run of the job exists" do
-      before :each do
-        TestWithPerformOnScheduleCronJob.perform_later
-      end
-
-      it "leaves the job enqueued" do
-        existing_job = TestWithPerformOnScheduleCronJob.send(:enqueued_job)
-
-        TestWithPerformOnScheduleCronJob.schedule
-
-        expect(TestWithPerformOnScheduleCronJob.send(:enqueued_job)).to eq(existing_job)
-      end
-
-      it "doesn't enqueue another instance of the job" do
-        expect { TestWithPerformOnScheduleCronJob.schedule }.not_to(change { TestWithPerformOnScheduleCronJob.send(:jobs).where(cron: nil).count })
-      end
-
-      it "schedules the job" do
-        expect { TestWithPerformOnScheduleCronJob.schedule }.to change { TestWithPerformOnScheduleCronJob.send(:jobs).count }.by(1)
-      end
+      expect(TestCronJob.send(:delayed_job).cron).to eq(TestCronJob.cron_expression)
     end
 
     context "when job was previously scheduled with the same cron expression" do
@@ -72,11 +22,11 @@ RSpec.describe "CronJob" do
       end
 
       it "leaves the existing scheduled job unchanged" do
-        existing_job = TestCronJob.send(:scheduled_job)
+        existing_job = TestCronJob.send(:delayed_job)
 
         TestCronJob.schedule
 
-        expect(TestCronJob.send(:scheduled_job)).to eq(existing_job)
+        expect(TestCronJob.send(:delayed_job)).to eq(existing_job)
       end
 
       it "doesn't create a second scheduled job" do
@@ -90,13 +40,13 @@ RSpec.describe "CronJob" do
       end
 
       it "replaces the scheduled job with one with the new cron expression" do
-        existing_job = TestCronJob.send(:scheduled_job)
+        existing_job = TestCronJob.send(:delayed_job)
 
         allow(TestCronJob).to receive(:cron_expression) { "* 1 * * *" }
 
         expect { TestCronJob.schedule }.not_to(change { TestCronJob.send(:jobs).count })
 
-        new_job = TestCronJob.send(:scheduled_job)
+        new_job = TestCronJob.send(:delayed_job)
 
         expect(new_job).not_to eq(existing_job)
         expect(new_job.cron).to eq("* 1 * * *")

--- a/spec/jobs/cron_job_spec.rb
+++ b/spec/jobs/cron_job_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe "CronJob" do
+  def queue_adapter_for_test
+    DelayedJobTestAdapter.new
+  end
+
+  describe ".schedule" do
+    it "schedules the job" do
+      expect { TestCronJob.schedule }.to change { TestCronJob.send(:jobs).count }.by(1)
+    end
+
+    it "schedules the job with the cron expression" do
+      TestCronJob.schedule
+
+      expect(TestCronJob.send(:scheduled_job).cron).to eq(TestCronJob.cron_expression)
+    end
+
+    context "when the job is not configured to perform on schedule and an unscheduled run of the job exists" do
+      before :each do
+        TestCronJob.perform_later
+      end
+
+      it "leaves the job enqueued" do
+        existing_job = TestCronJob.send(:enqueued_job)
+
+        TestCronJob.schedule
+
+        expect(TestCronJob.send(:enqueued_job)).to eq(existing_job)
+      end
+
+      it "doesn't enqueue another instance of the job" do
+        expect { TestCronJob.schedule }.not_to(change { TestCronJob.send(:jobs).where(cron: nil).count })
+      end
+
+      it "schedules the job" do
+        expect { TestCronJob.schedule }.to change { TestCronJob.send(:jobs).count }.by(1)
+      end
+    end
+
+    context "when the job is configured to perform on schedule" do
+      it "enqueues the job" do
+        expect { TestWithPerformOnScheduleCronJob.schedule }.to change { TestWithPerformOnScheduleCronJob.send(:jobs).where(cron: nil).count }.by(1)
+      end
+    end
+
+    context "when the job is configured to perform on schedule and an unscheduled run of the job exists" do
+      before :each do
+        TestWithPerformOnScheduleCronJob.perform_later
+      end
+
+      it "leaves the job enqueued" do
+        existing_job = TestWithPerformOnScheduleCronJob.send(:enqueued_job)
+
+        TestWithPerformOnScheduleCronJob.schedule
+
+        expect(TestWithPerformOnScheduleCronJob.send(:enqueued_job)).to eq(existing_job)
+      end
+
+      it "doesn't enqueue another instance of the job" do
+        expect { TestWithPerformOnScheduleCronJob.schedule }.not_to(change { TestWithPerformOnScheduleCronJob.send(:jobs).where(cron: nil).count })
+      end
+
+      it "schedules the job" do
+        expect { TestWithPerformOnScheduleCronJob.schedule }.to change { TestWithPerformOnScheduleCronJob.send(:jobs).count }.by(1)
+      end
+    end
+
+    context "when job was previously scheduled with the same cron expression" do
+      before :each do
+        TestCronJob.schedule
+      end
+
+      it "leaves the existing scheduled job unchanged" do
+        existing_job = TestCronJob.send(:scheduled_job)
+
+        TestCronJob.schedule
+
+        expect(TestCronJob.send(:scheduled_job)).to eq(existing_job)
+      end
+
+      it "doesn't create a second scheduled job" do
+        expect { TestCronJob.schedule }.not_to(change { TestCronJob.send(:jobs).count })
+      end
+    end
+
+    context "when job was previously scheduled with a different cron expression" do
+      before :each do
+        TestCronJob.schedule
+      end
+
+      it "replaces the scheduled job with one with the new cron expression" do
+        existing_job = TestCronJob.send(:scheduled_job)
+
+        allow(TestCronJob).to receive(:cron_expression) { "* 1 * * *" }
+
+        expect { TestCronJob.schedule }.not_to(change { TestCronJob.send(:jobs).count })
+
+        new_job = TestCronJob.send(:scheduled_job)
+
+        expect(new_job).not_to eq(existing_job)
+        expect(new_job.cron).to eq("* 1 * * *")
+      end
+    end
+  end
+end

--- a/spec/jobs/school_data_importer_job_spec.rb
+++ b/spec/jobs/school_data_importer_job_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "SchoolDataImporterJob" do
+  describe "#perform" do
+    it "should run the school data importer" do
+      expect_any_instance_of(SchoolDataImporter).to receive(:run)
+
+      SchoolDataImporterJob.new.perform
+    end
+  end
+end

--- a/spec/lib/tasks/import_schools_data_spec.rb
+++ b/spec/lib/tasks/import_schools_data_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "rake schools_data:import" do
   end
 
   it "enqueues SchoolDataImporterJob" do
-    expect(SchoolDataImporterJob).to receive(:perform_later)
-
     Rake::Task["schools_data:import"].invoke
+
+    expect(SchoolDataImporterJob).to have_been_enqueued.on_queue("school_data")
   end
 end

--- a/spec/lib/tasks/import_schools_data_spec.rb
+++ b/spec/lib/tasks/import_schools_data_spec.rb
@@ -2,16 +2,14 @@ require "rails_helper"
 require "rake"
 
 RSpec.describe "rake schools_data:import" do
-  let(:school_data_importer) { instance_spy("SchoolDataImporter") }
   before do
     Rake::Task.define_task(:environment)
     Rake.application.rake_require "tasks/import_schools_data"
-    allow(SchoolDataImporter).to receive(:new).and_return(school_data_importer)
   end
 
-  it "runs the school data importer" do
-    Rake::Task["schools_data:import"].invoke
+  it "enqueues SchoolDataImporterJob" do
+    expect(SchoolDataImporterJob).to receive(:perform_later)
 
-    expect(school_data_importer).to have_received(:run)
+    Rake::Task["schools_data:import"].invoke
   end
 end

--- a/spec/lib/tasks/jobs_spec.rb
+++ b/spec/lib/tasks/jobs_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe "rake db:schedule_jobs" do
     Rake.application.rake_require "tasks/jobs"
   end
 
+  it "schedules and enqueues SchoolDataImporterJob" do
+    Rake::Task["db:schedule_jobs"].invoke
+
+    jobs = SchoolDataImporterJob.send(:jobs)
+
+    expect(jobs.where(cron: nil).count).to eq(1)
+    expect(jobs.where.not(cron: nil).count).to eq(1)
+  end
+
   it "runs automatically after db:migrate" do
     expect(Rake::Task["db:schedule_jobs"]).to receive(:invoke)
 

--- a/spec/lib/tasks/jobs_spec.rb
+++ b/spec/lib/tasks/jobs_spec.rb
@@ -13,13 +13,14 @@ RSpec.describe "rake db:schedule_jobs" do
     Rake.application.rake_require "tasks/jobs"
   end
 
-  it "schedules and enqueues SchoolDataImporterJob" do
-    Rake::Task["db:schedule_jobs"].invoke
-
-    jobs = SchoolDataImporterJob.send(:jobs)
-
-    expect(jobs.where(cron: nil).count).to eq(1)
-    expect(jobs.where.not(cron: nil).count).to eq(1)
+  it "schedules SchoolDataImporterJob" do
+    expect {
+      Rake::Task["db:schedule_jobs"].invoke
+    }.to change {
+      Delayed::Job
+        .where("handler LIKE ?", "%job_class: SchoolDataImporterJob%")
+        .count
+    }.by(1)
   end
 
   it "runs automatically after db:migrate" do

--- a/spec/lib/tasks/jobs_spec.rb
+++ b/spec/lib/tasks/jobs_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "rake db:schedule_jobs" do
+  def queue_adapter_for_test
+    DelayedJobTestAdapter.new
+  end
+
+  before do
+    Rake::Task.define_task(:environment)
+    Rake::Task.define_task(:"db:migrate")
+    Rake::Task.define_task(:"db:schema:load")
+    Rake.application.rake_require "tasks/jobs"
+  end
+
+  it "runs automatically after db:migrate" do
+    expect(Rake::Task["db:schedule_jobs"]).to receive(:invoke)
+
+    Rake::Task["db:migrate"].invoke
+  end
+
+  it "runs automatically after db:schema:load" do
+    expect(Rake::Task["db:schedule_jobs"]).to receive(:invoke)
+
+    Rake::Task["db:schema:load"].invoke
+  end
+end

--- a/spec/lib/tasks/jobs_spec.rb
+++ b/spec/lib/tasks/jobs_spec.rb
@@ -1,37 +1,23 @@
 require "rails_helper"
 require "rake"
 
-RSpec.describe "rake db:schedule_jobs" do
+RSpec.describe "rake jobs:schedule" do
   def queue_adapter_for_test
     DelayedJobTestAdapter.new
   end
 
   before do
     Rake::Task.define_task(:environment)
-    Rake::Task.define_task(:"db:migrate")
-    Rake::Task.define_task(:"db:schema:load")
     Rake.application.rake_require "tasks/jobs"
   end
 
   it "schedules SchoolDataImporterJob" do
     expect {
-      Rake::Task["db:schedule_jobs"].invoke
+      Rake::Task["jobs:schedule"].invoke
     }.to change {
       Delayed::Job
         .where("handler LIKE ?", "%job_class: SchoolDataImporterJob%")
         .count
     }.by(1)
-  end
-
-  it "runs automatically after db:migrate" do
-    expect(Rake::Task["db:schedule_jobs"]).to receive(:invoke)
-
-    Rake::Task["db:migrate"].invoke
-  end
-
-  it "runs automatically after db:schema:load" do
-    expect(Rake::Task["db:schedule_jobs"]).to receive(:invoke)
-
-    Rake::Task["db:schema:load"].invoke
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -62,4 +63,9 @@ RSpec.configure do |config|
 
   config.include FeatureHelpers, type: :feature
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include ActiveJob::TestHelper
+
+  config.before :each do
+    clear_enqueued_jobs
+  end
 end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -169,7 +169,9 @@ RSpec.describe "Claims", type: :request do
           before :each do
             in_progress_claim.update!(attributes_for(:tslr_claim, :eligible_and_submittable))
 
-            put claim_path("check-your-answers")
+            perform_enqueued_jobs do
+              put claim_path("check-your-answers")
+            end
 
             in_progress_claim.reload
           end

--- a/spec/support/delayed_job.rb
+++ b/spec/support/delayed_job.rb
@@ -17,7 +17,6 @@ end
 
 class TestWithPerformOnScheduleCronJob < CronJob
   self.cron_expression = "* * * * *"
-  self.perform_on_schedule = true
 
   def perform
   end

--- a/spec/support/delayed_job.rb
+++ b/spec/support/delayed_job.rb
@@ -1,0 +1,24 @@
+class DelayedJobTestAdapter < ActiveJob::QueueAdapters::DelayedJobAdapter
+  def enqueued_jobs
+    Delayed::Job.all.to_a
+  end
+
+  def performed_jobs
+    []
+  end
+end
+
+class TestCronJob < CronJob
+  self.cron_expression = "* * * * *"
+
+  def perform
+  end
+end
+
+class TestWithPerformOnScheduleCronJob < CronJob
+  self.cron_expression = "* * * * *"
+  self.perform_on_schedule = true
+
+  def perform
+  end
+end


### PR DESCRIPTION
Sets up [`delayed_cron_job`](https://github.com/codez/delayed_cron_job) to manage scheduled tasks through a `CronJob` superclass. The rake task that enqueues the jobs runs after each `db:migrate` and `db:schema:load`, automatically (unless running in development), meaning it runs on every deploy.