### PR TITLE
Change half hours question

### DIFF
--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      You’re not eligible for this service
+      You’re not eligible for this payment
     </h1>
 
     <p class="govuk-body">

--- a/app/views/claims/mostly_teaching_eligible_subjects.html.erb
+++ b/app/views/claims/mostly_teaching_eligible_subjects.html.erb
@@ -12,7 +12,8 @@
             </legend>
             <p class="govuk-body">
               <span class="govuk-hint">
-                If you've been off on long-term leave or sick, include the time you were scheduled to teach these subjects.
+                Include your planning, preparation and assessment (PPA) time. If you've been off on long-term leave or
+                sick, include the time you would have spent.
               </span>
             </p>
             <%= errors_tag current_claim, :mostly_teaching_eligible_subjects %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,13 +45,16 @@ en:
       employment_status: "Are you still employed to teach at a school in England?"
       current_school: "Which school are you currently employed at?"
       subjects_taught: "Did you teach any of the following subjects between 6 April XXXX and 5 April XXXX?"
-      mostly_teaching_eligible_subjects: "Did teaching %{subjects} cover 50% of your teaching time between 6 April XXXX and 5 April XXXX?"
+      mostly_teaching_eligible_subjects:
+        "Were half of your working hours spent teaching %{subjects} between 6 April XXXX and 5 April XXXX?"
       full_name: "What is your full name?"
       address: "What is your address?"
       date_of_birth: "What is your date of birth?"
       teacher_reference_number: "What's your teacher reference number?"
       national_insurance_number: "What's your National Insurance number?"
-      student_loan_amount: "How much student loan did you repay while you were at %{claim_school_name} between 6 April XXXX and 5 April XXXX?"
+      student_loan_amount:
+        "How much student loan did you repay while you were at %{claim_school_name} between 6 April XXXX and 5 April
+        XXXX?"
       email_address: "Email address"
       bank_details: "Enter bank account details"
       eligible_subjects:


### PR DESCRIPTION
The second part of the 50% question was shown to be ambiguous in user
testing. Users were unsure what constituted 50% of their teaching time,
50% of hours spent teaching or 50% of contracted hours.

The question was rephrased and hint text expanded upon to make this
clearer for users.

The ineligible page header was also edited to make it clear users
were not eligible for the service.