### PR TITLE
Update teaching ineligible message for clarity

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -152,7 +152,7 @@ class TslrClaim < ApplicationRecord
   def full_ineligibility_reason
     case ineligibility_reason
     when :ineligible_claim_school then "#{claim_school_name} is not an eligible school."
-    when :employed_at_no_school then "You must be still working as a teacher to be eligible."
+    when :employed_at_no_school then "You can only get this payment if you’re still working as a teacher."
     when :not_taught_eligible_subjects_enough then "You must have spent at least half your time teaching an eligible subject."
     else "You can only apply for this payment if you meet the eligibility criteria."
     end

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      You’re not eligible for this service
+      You’re not eligible for this payment
     </h1>
 
     <p class="govuk-body">

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -176,7 +176,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
         scenario "Teacher is told they are not eligible" do
           expect(page).to have_text("You’re not eligible")
-          expect(page).to have_text("You must be still working as a teacher to be eligible")
+          expect(page).to have_text("You can only get this payment if you’re still working as a teacher")
         end
       end
     end

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.employment_status).to eq("no_school")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You must be still working as a teacher to be eligible")
+    expect(page).to have_text("You can only get this payment if you’re still working as a teacher")
   end
 
   scenario "does not teach an eligible subject" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Claims", type: :request do
 
         get ineligible_claim_path
         expect(response.body).to include("You’re not eligible")
-        expect(response.body).to include("You must be still working as a teacher to be eligible")
+        expect(response.body).to include("You can only get this payment if you’re still working as a teacher")
       end
     end
 


### PR DESCRIPTION
Change ineligble page to say users are not eligible for this payment as
its clearer that saying service.

Rephrase the must still be teaching ineligible message to make it more
simple.

Amend CI tests to use the new text.