### PR TITLE
Refactor page sequence code

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -51,13 +51,13 @@ class ClaimsController < ApplicationController
 
   def next_claim_path
     return ineligible_claim_path if current_claim.ineligible?
-    return claim_path("check-your-answers") if edited_answer?
+    return claim_path("check-your-answers") if edited_answer?  && !on_school_flow?
 
     claim_path(next_slug)
   end
 
   def edited_answer?
-    current_claim.can_be_submitted? && !current_claim.submitted? && !on_school_flow?
+    current_claim.can_be_submitted? && !current_claim.submitted?
   end
 
   def on_school_flow?

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -50,8 +50,7 @@ class ClaimsController < ApplicationController
   end
 
   def next_claim_path
-    return ineligible_claim_path if current_claim.ineligible?
-    return claim_path("check-your-answers") if edited_answer?  && !on_school_flow?
+    return claim_path("check-your-answers") if !current_claim.ineligible? && edited_answer?  && !on_school_flow?
 
     claim_path(next_slug)
   end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -67,8 +67,7 @@ class ClaimsController < ApplicationController
   end
 
   def next_slug
-    current_slug_index = current_claim.page_sequence.index(params[:slug])
-    current_claim.page_sequence[current_slug_index + 1]
+    PageSequence.new(current_claim, params[:slug]).next_slug
   end
 
   def submission_complete?

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -25,7 +25,7 @@ class ClaimsController < ApplicationController
 
   def update
     if update_current_claim!
-      redirect_to next_claim_path
+      redirect_to claim_path(next_slug)
     else
       show
     end
@@ -47,22 +47,6 @@ class ClaimsController < ApplicationController
       current_claim.attributes = claim_params
       current_claim.save(context: params[:slug].to_sym)
     end
-  end
-
-  def next_claim_path
-    return claim_path("check-your-answers") if !current_claim.ineligible? && edited_answer?  && !on_school_flow?
-
-    claim_path(next_slug)
-  end
-
-  def edited_answer?
-    current_claim.can_be_submitted? && !current_claim.submitted?
-  end
-
-  def on_school_flow?
-    return true if params[:slug] == "claim-school"
-    return true if params[:slug] == "still-teaching" && current_claim.employment_status != "claim_school"
-    false
   end
 
   def next_slug

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -44,11 +44,20 @@ class PageSequence
 
   def next_slug
     return "ineligible" if claim.ineligible?
+    return "check-your-answers" if claim_is_ready_for_submission? && !updating_schools_answers?
 
     slugs[current_slug_index + 1]
   end
 
   private
+
+  def claim_is_ready_for_submission?
+    claim.can_be_submitted? && !claim.submitted?
+  end
+
+  def updating_schools_answers?
+    current_slug == "claim-school" || current_slug == "still-teaching" && claim.employed_at_different_school?
+  end
 
   def current_slug_index
     slugs.index(current_slug)

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Represents the pages in the claim process.
+#
+# Depending on the state of `claim`,  the sequence of slugs will change,
+# filtering out pages that are not relevant. For example, the sequence for a
+# claim that states it is still employed at the same school as the
+# `claim_school` will skip the `current-school` page as `current_school` is
+# inferred to be the same as `claim_school.
+class PageSequence
+  SLUGS = [
+    "qts-year",
+    "claim-school",
+    "still-teaching",
+    "current-school",
+    "subjects-taught",
+    "mostly-teaching-eligible-subjects",
+    "eligibility-confirmed",
+    "full-name",
+    "address",
+    "date-of-birth",
+    "teacher-reference-number",
+    "national-insurance-number",
+    "student-loan-amount",
+    "email-address",
+    "bank-details",
+    "check-your-answers",
+    "confirmation",
+  ].freeze
+
+  attr_reader :claim, :current_slug
+
+  def initialize(claim, current_slug)
+    @claim = claim
+    @current_slug = current_slug
+  end
+
+  def slugs
+    SLUGS.dup.tap do |sequence|
+      sequence.delete("current-school") if claim.employed_at_claim_school?
+    end
+  end
+
+  def next_slug
+    slugs[current_slug_index + 1]
+  end
+
+  private
+
+  def current_slug_index
+    slugs.index(current_slug)
+  end
+end

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -26,6 +26,7 @@ class PageSequence
     "bank-details",
     "check-your-answers",
     "confirmation",
+    "ineligible",
   ].freeze
 
   attr_reader :claim, :current_slug
@@ -42,6 +43,8 @@ class PageSequence
   end
 
   def next_slug
+    return "ineligible" if claim.ineligible?
+
     slugs[current_slug_index + 1]
   end
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -1,24 +1,4 @@
 class TslrClaim < ApplicationRecord
-  PAGE_SEQUENCE = [
-    "qts-year",
-    "claim-school",
-    "still-teaching",
-    "current-school",
-    "subjects-taught",
-    "mostly-teaching-eligible-subjects",
-    "eligibility-confirmed",
-    "full-name",
-    "address",
-    "date-of-birth",
-    "teacher-reference-number",
-    "national-insurance-number",
-    "student-loan-amount",
-    "email-address",
-    "bank-details",
-    "check-your-answers",
-    "confirmation",
-  ].freeze
-
   VALID_QTS_YEARS = [
     "2013-2014",
     "2014-2015",
@@ -109,12 +89,6 @@ class TslrClaim < ApplicationRecord
   delegate :name, to: :current_school, prefix: true, allow_nil: true
 
   scope :submitted, -> { where.not(submitted_at: nil) }
-
-  def page_sequence
-    PAGE_SEQUENCE.dup.tap do |sequence|
-      sequence.delete("current-school") if employed_at_claim_school?
-    end
-  end
 
   def submit!
     if ineligible?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
     resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/claim"
   end
 
-  get "/claim/ineligible", to: "claims#ineligible", as: :ineligible_claim
   get "/claim/timeout", to: "claims#timeout", as: :timeout_claim
   get "/claim/refresh-session", to: "claims#refresh_session"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root "claims#new"
 
-  constraints slug: %r{#{TslrClaim::PAGE_SEQUENCE.join("|")}} do
+  constraints slug: %r{#{PageSequence::SLUGS.join("|")}} do
     resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/claim"
   end
 

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PageSequence do
+  let(:claim) { TslrClaim.new }
+
+  describe "#slugs" do
+    it "excludes “current-school” when the claimant still works at the school they are claiming against" do
+      claim.employment_status = :claim_school
+      page_sequence = PageSequence.new(claim, "still-teaching")
+
+      expect(page_sequence.slugs).not_to include("current-school")
+    end
+  end
+
+  describe "#next_slug" do
+    it "returns the next slug in the sequence" do
+      expect(PageSequence.new(claim, "qts-year").next_slug).to eq "claim-school"
+      expect(PageSequence.new(claim, "claim-school").next_slug).to eq "still-teaching"
+    end
+  end
+end

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -19,5 +19,13 @@ RSpec.describe PageSequence do
       expect(PageSequence.new(claim, "qts-year").next_slug).to eq "claim-school"
       expect(PageSequence.new(claim, "claim-school").next_slug).to eq "still-teaching"
     end
+
+    context "with an ineligible claim" do
+      let(:claim) { TslrClaim.new(employment_status: :no_school) }
+
+      it "returns the ineligible slug as the next slug" do
+        expect(PageSequence.new(claim, "still-teaching").next_slug).to eq "ineligible"
+      end
+    end
   end
 end

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -23,8 +23,38 @@ RSpec.describe PageSequence do
     context "with an ineligible claim" do
       let(:claim) { TslrClaim.new(employment_status: :no_school) }
 
-      it "returns the ineligible slug as the next slug" do
+      it "returns “ineligible” as the next slug" do
         expect(PageSequence.new(claim, "still-teaching").next_slug).to eq "ineligible"
+      end
+    end
+
+    context "when the claim is in a submittable state (i.e. all questions have been answered)" do
+      let(:claim) { build(:tslr_claim, :eligible_and_submittable) }
+
+      it "returns “check-your-answers” as the next slug" do
+        expect(PageSequence.new(claim, "qts-year").next_slug).to eq "check-your-answers"
+      end
+
+      context "but they are updating their claim_school" do
+        it "returns the next slug in the schools sequence" do
+          expect(PageSequence.new(claim, "claim-school").next_slug).to eq "still-teaching"
+        end
+      end
+
+      context "they’ve specified they’re still teaching at their claim school" do
+        before { claim.employment_status = :claim_school }
+
+        it "returns “check-your-answers” as the next slug (i.e. skips the current-school question)" do
+          expect(PageSequence.new(claim, "still-teaching").next_slug).to eq "check-your-answers"
+        end
+      end
+
+      context "they’ve specified they’re teaching at a different school" do
+        before { claim.employment_status = :different_school }
+
+        it "returns the final slug in the schools sequence" do
+          expect(PageSequence.new(claim, "still-teaching").next_slug).to eq "current-school"
+        end
       end
     end
   end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -374,23 +374,6 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
-  describe "#page_sequence" do
-    let(:tslr_claim) { TslrClaim.new }
-    it "returns all the pages in the sequence" do
-      expect(tslr_claim.page_sequence).to eq TslrClaim::PAGE_SEQUENCE
-    end
-
-    context "when the claimant still works at the school they are claiming against" do
-      let(:tslr_claim) do
-        TslrClaim.new(claim_school: schools(:penistone_grammar_school), employment_status: :claim_school)
-      end
-
-      it "excludes the “current-school” page from the sequence" do
-        expect(tslr_claim.page_sequence).not_to include("current-school")
-      end
-    end
-  end
-
   describe "#submit!" do
     around do |example|
       freeze_time { example.run }

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -80,19 +80,19 @@ RSpec.describe "Claims", type: :request do
     end
   end
 
-  describe "claims#ineligible request" do
+  describe "the claims ineligible page" do
     context "when a claim is already in progress" do
       before { post claims_path }
 
       it "renders a static ineligibility page" do
-        get ineligible_claim_path
+        get claim_path("ineligible")
         expect(response.body).to include("You’re not eligible")
       end
 
       it "tailors the message to the claim" do
         TslrClaim.order(:created_at).last.update(employment_status: "no_school")
 
-        get ineligible_claim_path
+        get claim_path("ineligible")
         expect(response.body).to include("You’re not eligible")
         expect(response.body).to include("You must be still working as a teacher to be eligible")
       end
@@ -100,7 +100,7 @@ RSpec.describe "Claims", type: :request do
 
     context "when a claim hasn’t been started yet" do
       it "redirects to the start page" do
-        get ineligible_claim_path
+        get claim_path("ineligible")
         expect(response).to redirect_to(root_path)
       end
     end
@@ -160,7 +160,7 @@ RSpec.describe "Claims", type: :request do
         it "redirects to the “ineligible” page" do
           put claim_path("claim-school"), params: {tslr_claim: {claim_school_id: schools(:hampstead_school).to_param}}
 
-          expect(response).to redirect_to(ineligible_claim_path)
+          expect(response).to redirect_to(claim_path("ineligible"))
         end
       end
 


### PR DESCRIPTION
We had logic for determining the sequence of pages in both the model and the controller. With more sequence-related logic coming down the pipe (i.e. the multi-page student loan plan questions), moving all the sequence-related logic into a single place is going to make our lives a lot easier.