### PR TITLE
Make sure cron jobs can be scheduled independently

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -29,6 +29,7 @@ class CronJob < ApplicationJob
     def jobs
       Delayed::Job
         .where("handler LIKE ?", "%job_class: #{name}%")
+        .where.not(cron: nil)
     end
   end
 end

--- a/spec/jobs/cron_job_spec.rb
+++ b/spec/jobs/cron_job_spec.rb
@@ -52,5 +52,22 @@ RSpec.describe "CronJob" do
         expect(new_job.cron).to eq("* 1 * * *")
       end
     end
+
+    context "when job was previously scheduled without a cron expression" do
+      let(:jobs) { Delayed::Job.where("handler LIKE ?", "%job_class: TestCronJob%") }
+
+      before :each do
+        TestCronJob.perform_later
+      end
+
+      it "does not replace the scheduled job" do
+        TestCronJob.schedule
+
+        expect(jobs.count).to eq(2)
+
+        expect(jobs.first.cron).to eq(nil)
+        expect(jobs.last.cron).to eq(TestCronJob.cron_expression)
+      end
+    end
   end
 end


### PR DESCRIPTION
As part of the initialisation process, we were running the `rake schools_data:import` task, but running `rake jobs:schedule` immediately afterwards stomps all over our previously scheduled job. This makes sure our CronJob superclass `jobs` method only cares about jobs with a cron attached to them