### PR TITLE
Amend QTS question to use ITT

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
   tslr:
     service_name: "Teachers: claim back your student loan repayments"
     questions:
-      qts_award_year: "Which academic year were you awarded qualified teacher status?"
+      qts_award_year: "Which academic year did you complete your initial teacher training?"
       claim_school: "Which school were you employed at between 6 April XXXX and 5 April XXXX?"
       employment_status: "Are you still employed to teach at a school in England?"
       current_school: "Which school are you currently employed at?"

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Claims", type: :request do
 
       it "renders the requested page in the sequence" do
         get claim_path("qts-year")
-        expect(response.body).to include("Which academic year were you awarded qualified teacher status")
+        expect(response.body).to include(I18n.t("tslr.questions.qts_award_year"))
 
         get claim_path("claim-school")
         expect(response.body).to include("Which school were you employed at")


### PR DESCRIPTION
Users were struggling to answer the QTS question, they were unsure if
they answered Jun YEAR when they got QTS or Sept YEAR when they started
at the school (Newly Qualified Teacher).

We changed it to use Initial Teacher Training as there were no issues
with this in the maths and physics journey.

Amended CI to use the alias for the question so we don't have to keep
updating it.