### PR TITLE
Update cron job to run at 4am

### DIFF
--- a/app/jobs/school_data_importer_job.rb
+++ b/app/jobs/school_data_importer_job.rb
@@ -1,5 +1,5 @@
 class SchoolDataImporterJob < CronJob
-  self.cron_expression = "0 0 * * *"
+  self.cron_expression = "0 0 4 * * * "
 
   queue_as :school_data
 


### PR DESCRIPTION
We had a Rollbar error this morning (https://rollbar.com/dxw/teachers-payment-service/items/8/) when importing schools because the CSV for that day didn't yet exist. I've checked with the GIAS team, and they've told us these are generated at around 3am, so this queues the job at 4am when it's more likely that the CSV will be around. If it's not yet imported, the job will retry.