### PR TITLE
Change XXXX dates to be real dates

### DIFF
--- a/app/views/claims/eligibility_confirmed.html.erb
+++ b/app/views/claims/eligibility_confirmed.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">You are eligible to claim back student loan repayments</h1>
-    <p class="govuk-body">Based on your answers, you can claim back the student loan repayments you made between 6 April XXXX and 5 April XXXX.</p>
+    <p class="govuk-body">Based on your answers, you can claim back the student loan repayments you made between 6 April 2018 and 5 April 2019.</p>
     <p class="govuk-body">So we can pay you, we need to check your identity using GOV.UK Verify – our secure way to prove who you are online.</p>
     <p class="govuk-body">If you do not have an account already, you’ll have to sign up for one. This usually takes around 15 minutes. You'll need a passport or photocard driving licence and a debit or credit card.</p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,20 +41,20 @@ en:
     service_name: "Teachers: claim back your student loan repayments"
     questions:
       qts_award_year: "Which academic year did you complete your initial teacher training?"
-      claim_school: "Which school were you employed at between 6 April XXXX and 5 April XXXX?"
+      claim_school: "Which school were you employed at between 6 April 2018 and 5 April 2019?"
       employment_status: "Are you still employed to teach at a school in England?"
       current_school: "Which school are you currently employed at?"
-      subjects_taught: "Did you teach any of the following subjects between 6 April XXXX and 5 April XXXX?"
+      subjects_taught: "Did you teach any of the following subjects between 6 April 2018 and 5 April 2019?"
       mostly_teaching_eligible_subjects:
-        "Were half of your working hours spent teaching %{subjects} between 6 April XXXX and 5 April XXXX?"
+        "Were half of your working hours spent teaching %{subjects} between 6 April 2018 and 5 April 2019?"
       full_name: "What is your full name?"
       address: "What is your address?"
       date_of_birth: "What is your date of birth?"
       teacher_reference_number: "What's your teacher reference number?"
       national_insurance_number: "What's your National Insurance number?"
       student_loan_amount:
-        "How much student loan did you repay while you were at %{claim_school_name} between 6 April XXXX and 5 April
-        XXXX?"
+        "How much student loan did you repay while you were at %{claim_school_name} between 6 April 2018 and 5 April
+        2019?"
       email_address: "Email address"
       bank_details: "Enter bank account details"
       eligible_subjects:


### PR DESCRIPTION
During user testing people were getting confused with the XXXX
placeholder that would in the fullness of time dynamically pull in a
date. All instances of XXXX have been hardcoded to be the last finanical
year and a card made so we don't forget to implement the dates properly.