### PR TITLE
Amend text to encourage use of personal email

### DIFF
--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -8,7 +8,7 @@
           <%= form.label :email_address, t("tslr.questions.email_address"), class: "govuk-label govuk-label--xl"  %>
         </h1>
 
-        <span class="govuk-hint">We will only use your email address to update you about your claim. We recomend you use a personal email address.</span>
+        <span class="govuk-hint">We will only use your email address to update you about your claim. We recommend you use a personal email address.</span>
 
         <%= errors_tag current_claim, :email_address %>
 

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -8,7 +8,7 @@
           <%= form.label :email_address, t("tslr.questions.email_address"), class: "govuk-label govuk-label--xl"  %>
         </h1>
 
-        <span class="govuk-hint">We will only use your email address to update you about your claim.</span>
+        <span class="govuk-hint">We will only use your email address to update you about your claim. We recomend you use a personal email address.</span>
 
         <%= errors_tag current_claim, :email_address %>
 


### PR DESCRIPTION
Looked at changing the question itself but it made the question seem
demanding and invasive. So we have ameneded the hint text instead and
we will see how this tests.