### PR TITLE
Submittiable behaviour tweaks

### DIFF
--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -44,16 +44,12 @@ class PageSequence
 
   def next_slug
     return "ineligible" if claim.ineligible?
-    return "check-your-answers" if claim_is_ready_for_submission? && !updating_schools_answers?
+    return "check-your-answers" if claim.submittable? && !updating_schools_answers?
 
     slugs[current_slug_index + 1]
   end
 
   private
-
-  def claim_is_ready_for_submission?
-    claim.valid?(:submit) && !claim.submitted?
-  end
 
   def updating_schools_answers?
     current_slug == "claim-school" || current_slug == "still-teaching" && claim.employed_at_different_school?

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -52,7 +52,7 @@ class PageSequence
   private
 
   def claim_is_ready_for_submission?
-    claim.can_be_submitted? && !claim.submitted?
+    claim.valid?(:submit) && !claim.submitted?
   end
 
   def updating_schools_answers?

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -106,6 +106,10 @@ class TslrClaim < ApplicationRecord
     submitted_at.present?
   end
 
+  def submittable?
+    valid?(:submit) && !submitted?
+  end
+
   def ineligible?
     ineligible_claim_school? || employed_at_no_school? || not_taught_eligible_subjects_enough?
   end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -93,7 +93,7 @@ class TslrClaim < ApplicationRecord
   scope :submitted, -> { where.not(submitted_at: nil) }
 
   def submit!
-    if valid?(:submit)
+    if submittable?
       self.submitted_at = Time.zone.now
       self.reference = unique_reference
       save!

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -20,11 +20,6 @@ FactoryBot.define do
       bank_account_number { 12345678 }
     end
 
-    trait :eligible_but_unsubmittable do
-      eligible_and_submittable
-      email_address { nil }
-    end
-
     trait :submitted do
       eligible_and_submittable
       submitted_at { Time.zone.now }

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :tslr_claim do
-    trait :eligible_and_submittable do
+    trait :submittable do
       claim_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
       current_school { claim_school }
       qts_award_year { "2013-2014" }
@@ -21,7 +21,7 @@ FactoryBot.define do
     end
 
     trait :submitted do
-      eligible_and_submittable
+      submittable
       submitted_at { Time.zone.now }
       reference { Reference.new.to_s }
     end

--- a/spec/features/admin_csv_download_spec.rb
+++ b/spec/features/admin_csv_download_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature "Download CSV of claims" do
     end
 
     scenario "User downloads a CSV" do
-      submitted_claims = create_list(:tslr_claim, 5, :eligible_and_submittable, submitted_at: DateTime.now)
-      create_list(:tslr_claim, 2, :eligible_and_submittable)
+      submitted_claims = create_list(:tslr_claim, 5, :submittable, submitted_at: DateTime.now)
+      create_list(:tslr_claim, 2, :submittable)
 
       click_on "Download claims"
 

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
   let(:claim) do
     create(:tslr_claim,
-      :eligible_and_submittable,
+      :submittable,
       employment_status: :different_school,
       physics_taught: true,
       claim_school: claim_school,

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe ClaimMailer, type: :mailer do
   describe "#submitted" do
-    let(:claim) { create(:tslr_claim, :eligible_and_submittable) }
+    let(:claim) { create(:tslr_claim, :submittable) }
     let(:mail) { ClaimMailer.submitted(claim) }
 
     it "renders the headers" do

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe PageSequence do
     end
 
     context "when the claim is in a submittable state (i.e. all questions have been answered)" do
-      let(:claim) { build(:tslr_claim, :eligible_and_submittable) }
+      let(:claim) { build(:tslr_claim, :submittable) }
 
       it "returns “check-your-answers” as the next slug" do
         expect(PageSequence.new(claim, "qts-year").next_slug).to eq "check-your-answers"

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -402,11 +402,10 @@ RSpec.describe TslrClaim, type: :model do
 
     context "when a claim with the same reference already exists" do
       let(:tslr_claim) { create(:tslr_claim, :submittable) }
-      let(:reference) { "12345678" }
-      let!(:other_claim) { create(:tslr_claim, :submittable, reference: reference) }
 
       before do
-        expect(Reference).to receive(:new).once.and_return(double(to_s: reference), double(to_s: "87654321"))
+        other_claim = create(:tslr_claim, :submittable, reference: "12345678")
+        expect(Reference).to receive(:new).once.and_return(double(to_s: other_claim.reference), double(to_s: "87654321"))
         tslr_claim.submit!
       end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -206,7 +206,14 @@ RSpec.describe TslrClaim, type: :model do
   context "when saving in the “submit” validation context" do
     it "validates the presence of all required fields" do
       expect(TslrClaim.new).not_to be_valid(:submit)
-      expect(TslrClaim.new(attributes_for(:tslr_claim, :eligible_and_submittable))).to be_valid(:submit)
+      expect(build(:tslr_claim, :eligible_and_submittable)).to be_valid(:submit)
+    end
+
+    it "validates the claim is not ineligible" do
+      ineligible_claim = build(:tslr_claim, :eligible_and_submittable, mostly_teaching_eligible_subjects: false)
+
+      expect(ineligible_claim).not_to be_valid(:submit)
+      expect(ineligible_claim.errors[:base]).to include("You must have spent at least half your time teaching an eligible subject.")
     end
   end
 
@@ -381,8 +388,8 @@ RSpec.describe TslrClaim, type: :model do
 
     before { tslr_claim.submit! }
 
-    context "when the claim is eligible and submittable" do
-      let(:tslr_claim) { create(:tslr_claim, :eligible_and_submittable) }
+    context "when the claim is submittable" do
+      let(:tslr_claim) { create(:tslr_claim, :submittable) }
 
       it "sets submitted_at to now" do
         expect(tslr_claim.submitted_at).to eq Time.zone.now
@@ -404,18 +411,6 @@ RSpec.describe TslrClaim, type: :model do
         it "generates a unique reference" do
           expect(tslr_claim.reference).to eq("87654321")
         end
-      end
-    end
-
-    context "when the claim is eligible but unsubmittable" do
-      let(:tslr_claim) { create(:tslr_claim, :eligible_but_unsubmittable) }
-
-      it "doesn't set submitted_at" do
-        expect(tslr_claim.submitted_at).to be_nil
-      end
-
-      it "doesn't generate a reference" do
-        expect(tslr_claim.reference).to eq nil
       end
     end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -386,10 +386,10 @@ RSpec.describe TslrClaim, type: :model do
       freeze_time { example.run }
     end
 
-    before { tslr_claim.submit! }
-
     context "when the claim is submittable" do
       let(:tslr_claim) { create(:tslr_claim, :submittable) }
+
+      before { tslr_claim.submit! }
 
       it "sets submitted_at to now" do
         expect(tslr_claim.submitted_at).to eq Time.zone.now
@@ -416,6 +416,8 @@ RSpec.describe TslrClaim, type: :model do
 
     context "when the claim is ineligible" do
       let(:tslr_claim) { create(:tslr_claim, :submittable, mostly_teaching_eligible_subjects: false) }
+
+      before { tslr_claim.submit! }
 
       it "doesn't set submitted_at" do
         expect(tslr_claim.submitted_at).to be_nil

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -398,19 +398,20 @@ RSpec.describe TslrClaim, type: :model do
       it "generates a reference" do
         expect(tslr_claim.reference).to_not eq nil
       end
+    end
 
-      context "when a claim with the same reference already exists" do
-        let(:reference) { "12345678" }
-        let!(:other_claim) { create(:tslr_claim, :submittable, reference: reference) }
+    context "when a claim with the same reference already exists" do
+      let(:tslr_claim) { create(:tslr_claim, :submittable) }
+      let(:reference) { "12345678" }
+      let!(:other_claim) { create(:tslr_claim, :submittable, reference: reference) }
 
-        before do
-          expect(Reference).to receive(:new).once.and_return(double(to_s: reference), double(to_s: "87654321"))
-          tslr_claim.submit!
-        end
+      before do
+        expect(Reference).to receive(:new).once.and_return(double(to_s: reference), double(to_s: "87654321"))
+        tslr_claim.submit!
+      end
 
-        it "generates a unique reference" do
-          expect(tslr_claim.reference).to eq("87654321")
-        end
+      it "generates a unique reference" do
+        expect(tslr_claim.reference).to eq("87654321")
       end
     end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe TslrClaim, type: :model do
       end
     end
 
-    context "when a claim with the same reference already exists" do
+    context "when a Reference clash with an existing claim occurs" do
       let(:tslr_claim) { create(:tslr_claim, :submittable) }
 
       before do

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -440,6 +440,19 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  describe "#submittable?" do
+    it "returns true when the claim is valid and has not been submitted" do
+      claim = build(:tslr_claim, :submittable)
+
+      expect(claim.submittable?).to eq true
+    end
+    it "returns false when it has already been submitted" do
+      claim = build(:tslr_claim, :submitted)
+
+      expect(claim.submittable?).to eq false
+    end
+  end
+
   describe "#subjects_taught" do
     context "when a claim has subjects" do
       let(:claim) { create(:tslr_claim, biology_taught: true, chemistry_taught: true) }

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -431,6 +431,22 @@ RSpec.describe TslrClaim, type: :model do
         expect(tslr_claim.errors.messages[:base]).to include("You must have spent at least half your time teaching an eligible subject.")
       end
     end
+
+    context "when the claim has already been submitted" do
+      let(:tslr_claim) { create(:tslr_claim, :submitted, submitted_at: 2.days.ago) }
+
+      it "returns false" do
+        expect(tslr_claim.submit!).to eq false
+      end
+
+      it "doesn't change the reference number" do
+        expect { tslr_claim.submit! }.not_to(change { tslr_claim.reference })
+      end
+
+      it "doesn't change the submitted_at" do
+        expect { tslr_claim.submit! }.not_to(change { tslr_claim.submitted_at })
+      end
+    end
   end
 
   describe "submitted" do

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -206,11 +206,11 @@ RSpec.describe TslrClaim, type: :model do
   context "when saving in the “submit” validation context" do
     it "validates the presence of all required fields" do
       expect(TslrClaim.new).not_to be_valid(:submit)
-      expect(build(:tslr_claim, :eligible_and_submittable)).to be_valid(:submit)
+      expect(build(:tslr_claim, :submittable)).to be_valid(:submit)
     end
 
     it "validates the claim is not ineligible" do
-      ineligible_claim = build(:tslr_claim, :eligible_and_submittable, mostly_teaching_eligible_subjects: false)
+      ineligible_claim = build(:tslr_claim, :submittable, mostly_teaching_eligible_subjects: false)
 
       expect(ineligible_claim).not_to be_valid(:submit)
       expect(ineligible_claim.errors[:base]).to include("You must have spent at least half your time teaching an eligible subject.")
@@ -401,7 +401,7 @@ RSpec.describe TslrClaim, type: :model do
 
       context "when a claim with the same reference already exists" do
         let(:reference) { "12345678" }
-        let!(:other_claim) { create(:tslr_claim, :eligible_and_submittable, reference: reference) }
+        let!(:other_claim) { create(:tslr_claim, :submittable, reference: reference) }
 
         before do
           expect(Reference).to receive(:new).once.and_return(double(to_s: reference), double(to_s: "87654321"))
@@ -415,7 +415,7 @@ RSpec.describe TslrClaim, type: :model do
     end
 
     context "when the claim is ineligible" do
-      let(:tslr_claim) { create(:tslr_claim, :eligible_and_submittable, mostly_teaching_eligible_subjects: false) }
+      let(:tslr_claim) { create(:tslr_claim, :submittable, mostly_teaching_eligible_subjects: false) }
 
       it "doesn't set submitted_at" do
         expect(tslr_claim.submitted_at).to be_nil
@@ -433,7 +433,7 @@ RSpec.describe TslrClaim, type: :model do
 
   describe "submitted" do
     let!(:submitted_claims) { create_list(:tslr_claim, 5, :submitted) }
-    let!(:unsubmitted_claims) { create_list(:tslr_claim, 2, :eligible_and_submittable) }
+    let!(:unsubmitted_claims) { create_list(:tslr_claim, 2, :submittable) }
 
     it "returns submitted claims" do
       expect(subject.class.submitted).to match_array(submitted_claims)

--- a/spec/presenters/tslr_claim_csv_row_spec.rb
+++ b/spec/presenters/tslr_claim_csv_row_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TslrClaimCsvRow do
     let(:row) { CSV.parse(subject.to_s).first }
 
     let(:claim) do
-      create(:tslr_claim, :eligible_and_submittable,
+      create(:tslr_claim, :submittable,
         claim_school: create(:school, name: claim_school),
         current_school: create(:school, name: current_school),
         employment_status: TslrClaim.employment_statuses[employment_status.parameterize.underscore],

--- a/spec/presenters/tslr_claims_csv_spec.rb
+++ b/spec/presenters/tslr_claims_csv_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe TslrClaimsCsv do
   before do
-    create(:tslr_claim, :eligible_and_submittable,
+    create(:tslr_claim, :submittable,
       reference: "B2W4L0KC",
       submitted_at: Time.zone.parse("2019-01-01 17:30:00"),
       qts_award_year: "2013-2014",

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Claims", type: :request do
         post claims_path
 
         claim = TslrClaim.order(:created_at).last
-        claim.update_attributes(attributes_for(:tslr_claim, :eligible_and_submittable))
+        claim.update_attributes(attributes_for(:tslr_claim, :submittable))
         claim.submit!
 
         get claim_path("confirmation")
@@ -167,7 +167,7 @@ RSpec.describe "Claims", type: :request do
       context "when updating from check-your-answers" do
         context "with an eligible and submittable claim" do
           before :each do
-            in_progress_claim.update!(attributes_for(:tslr_claim, :eligible_and_submittable))
+            in_progress_claim.update!(attributes_for(:tslr_claim, :submittable))
 
             perform_enqueued_jobs do
               put claim_path("check-your-answers")
@@ -194,7 +194,7 @@ RSpec.describe "Claims", type: :request do
 
         context "with an eligible but unsubmittable claim" do
           before :each do
-            in_progress_claim.update!(attributes_for(:tslr_claim, :eligible_and_submittable, email_address: nil))
+            in_progress_claim.update!(attributes_for(:tslr_claim, :submittable, email_address: nil))
 
             put claim_path("check-your-answers")
 
@@ -217,7 +217,7 @@ RSpec.describe "Claims", type: :request do
 
         context "with an ineligible claim" do
           before :each do
-            in_progress_claim.update!(attributes_for(:tslr_claim, :eligible_and_submittable, mostly_teaching_eligible_subjects: false))
+            in_progress_claim.update!(attributes_for(:tslr_claim, :submittable, mostly_teaching_eligible_subjects: false))
 
             put claim_path("check-your-answers")
 


### PR DESCRIPTION
Whilst working on the Student loan plan journey, we wanted to make the page sequence easier to manage which this refatoring enables.

After this we'll have a more robust way to mange the page sequence, which _should_ make the student loan plan journey much simpler.

