### PR TITLE
Only capture the most recent verified name and address

### DIFF
--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -42,7 +42,7 @@ module Verify
     private
 
     def address
-      @address ||= parameters.fetch("attributes").fetch("addresses").first.fetch("value")
+      @address ||= most_recent_verified_value(parameters.fetch("attributes").fetch("addresses"))
     end
 
     def address_lines
@@ -50,11 +50,18 @@ module Verify
     end
 
     def full_name
-      first_name = parameters.fetch("attributes").fetch("firstNames").first.fetch("value")
-      middle_name = parameters.fetch("attributes").fetch("middleNames").first.fetch("value")
-      surname = parameters.fetch("attributes").fetch("surnames").first.fetch("value")
+      first_name = most_recent_verified_value(parameters.fetch("attributes").fetch("firstNames"))
+      middle_name = most_recent_verified_value(parameters.fetch("attributes").fetch("middleNames"))
+      surname = most_recent_verified_value(parameters.fetch("attributes").fetch("surnames"))
 
       [first_name, middle_name, surname].join(" ")
+    end
+
+    def most_recent_verified_value(attributes)
+      attributes.sort_by { |attribute| Date.strptime(attribute["to"], "%Y-%m-%d") }
+        .reverse
+        .find { |attribute| attribute["verified"] }
+        .fetch("value")
     end
   end
 end

--- a/spec/fixtures/verify/identity-verified.json
+++ b/spec/fixtures/verify/identity-verified.json
@@ -8,7 +8,19 @@
         "value": "Isambard",
         "verified": true,
         "from": "2019-06-25",
+        "to": "2019-06-30"
+      },
+      {
+        "value": "Thomas",
+        "verified": true,
+        "from": "2015-03-01",
         "to": "2019-06-25"
+      },
+      {
+        "value": "Sam",
+        "verified": false,
+        "from": "2019-06-30",
+        "to": "2019-07-09"
       }
     ],
     "middleNames": [
@@ -17,14 +29,32 @@
         "verified": true,
         "from": "2019-06-25",
         "to": "2019-06-25"
+      },
+      {
+        "value": "K.",
+        "verified": false,
+        "from": "2019-06-25",
+        "to": "2019-07-09"
       }
     ],
     "surnames": [
+      {
+        "value": "Telford",
+        "verified": true,
+        "from": "2015-03-01",
+        "to": "2019-06-24"
+      },
       {
         "value": "Brunel",
         "verified": true,
         "from": "2019-06-25",
         "to": "2019-06-25"
+      },
+      {
+        "value": "",
+        "verified": false,
+        "from": "2019-06-25",
+        "to": "2019-07-09"
       }
     ],
     "datesOfBirth": [
@@ -48,6 +78,15 @@
         "verified": true,
         "from": "2019-06-25",
         "to": "2019-06-25"
+      },
+      {
+        "value": {
+          "lines": ["Unverified Street", "Unverified Town", "Unverified County"],
+          "postCode": "L12 345"
+        },
+        "verified": false,
+        "from": "2019-06-25",
+        "to": "2019-07-25"
       }
     ]
   }

--- a/spec/lib/verify/response_spec.rb
+++ b/spec/lib/verify/response_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Verify::Response, type: :model do
       expect(subject.verified?).to eq(true)
     end
 
-    it "returns the expected parameters" do
+    it "returns the expected verified parameters" do
       expect(subject.claim_parameters[:full_name]).to eq("Isambard Kingdom Brunel")
       expect(subject.claim_parameters[:address_line_1]).to eq("Verified Street")
       expect(subject.claim_parameters[:address_line_2]).to eq("Verified Town")


### PR DESCRIPTION
It is possible to have values returned from Verify that aren't verified. We don't want to capture these values as it's important that the data we have is current, correct and valid.

This PR introduces the concept of `most_recent_verfied_value` that will filter out non-verified attributes, then sort them by `to` date. This makes an assumption that this value will always be present.