### PR TITLE
Admin sessions time out after inactivity

### DIFF
--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -1,11 +1,25 @@
 module Admin
   class BaseAdminController < ApplicationController
-    before_action :ensure_authenticated_user
+    TIMEOUT_LENGTH_IN_MINUTES = 30
+
+    before_action :ensure_authenticated_user, :end_expired_sessions, :update_last_seen_at
 
     private
 
     def ensure_authenticated_user
       redirect_to admin_sign_in_path unless signed_in?
+    end
+
+    def end_expired_sessions
+      if admin_session_timed_out?
+        session.destroy
+        redirect_to admin_sign_in_path, notice: "Your session has timed out due to inactivity, please sign-in again"
+      end
+    end
+
+    def admin_session_timed_out?
+      signed_in? && session.key?(:last_seen_at) &&
+        session[:last_seen_at] < TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
     end
   end
 end

--- a/spec/requests/admin_timeout_spec.rb
+++ b/spec/requests/admin_timeout_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Admin session timing out", type: :request do
+  let(:timeout_length_in_minutes) { Admin::BaseAdminController::TIMEOUT_LENGTH_IN_MINUTES }
+
+  before do
+    OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
+      "provider" => "dfe",
+      "info" => {"email" => "test-dfe-sign-in@host.tld"}
+    )
+    post admin_dfe_sign_in_path
+    follow_redirect!
+  end
+
+  context "no actions performed for more than the timeout period" do
+    let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
+
+    it "clears the session and redirects to the login page" do
+      expect(session[:login]).to eql({"email" => "test-dfe-sign-in@host.tld"})
+      expect(session[:last_seen_at]).not_to be_nil
+
+      travel after_expiry do
+        get admin_claims_path(format: :csv)
+
+        expect(response).to redirect_to(admin_sign_in_path)
+        expect(session[:login]).to be_nil
+        expect(session[:last_seen_at]).to be_nil
+        follow_redirect!
+        expect(response.body).to include("Your session has timed out due to inactivity")
+      end
+    end
+  end
+
+  context "no action performed just within the timeout period" do
+    let(:before_expiry) { timeout_length_in_minutes.minutes - 2.seconds }
+
+    it "does not timeout the session" do
+      travel before_expiry do
+        get admin_claims_path(format: :csv)
+
+        expect(response.code).to eq("200")
+        expect(session[:login]).to_not be_nil
+        expect(session[:last_seen_at]).to_not be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
> Sessions that never expire extend the time-frame for attacks such as cross-site request forgery (CSRF), session hijacking and session fixation.

We should ensure that admin sign-in sessions do not last longer than 30 minutes of inactivity.

There's a bit of duplication of logic between the code here and the code in the claims controller. We think it's best to keep this separate and not mix admin session logic with our normal user session logic.