### PR TITLE
Automate deployment of Azure

### DIFF
--- a/azure/secrets/template.json
+++ b/azure/secrets/template.json
@@ -28,7 +28,9 @@
             "tenantId": "[subscription().tenantId]",
             "objectId": "[parameters('deliveryTeamUserGroupObjectId')]",
             "permissions": {
-              "secrets": ["get", "list", "set", "delete"]
+              "keys": ["all"],
+              "secrets": ["all"],
+              "certificates": ["all"]
             }
           }
         ]

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 ENVIRONMENT_NAME"
+  exit 1
+fi
+
 ENVIRONMENT_NAME=$1
 
 case $ENVIRONMENT_NAME in

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -110,7 +110,7 @@ az group deployment create \
   --verbose
 
 echo
-echo "secrets deployed!"
+echo "$SECRETS_RESOURCE_GROUP_NAME deployed!"
 echo
 
 if ! az group show --name "$APP_RESOURCE_GROUP_NAME" > /dev/null; then
@@ -152,4 +152,4 @@ az group deployment create \
   --verbose
 
 echo
-echo "app deployed!"
+echo "$APP_RESOURCE_GROUP_NAME deployed!"

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -30,6 +30,26 @@ case $ENVIRONMENT_NAME in
     ;;
 esac
 
+LOGIN_TO_AZURE=1
+CONFIRM_BEFORE_DEPLOY=1
+
+while [ "$2" ]; do
+  case $2 in
+    "--skip-login")
+      LOGIN_TO_AZURE=
+      ;;
+    "--skip-confirmation")
+      CONFIRM_BEFORE_DEPLOY=
+      ;;
+    *)
+      echo "Unexpected argument: $2"
+      exit 1
+      ;;
+  esac
+
+  shift
+done
+
 SCRIPT_PATH=$( cd "$( dirname "$0" )" ; pwd -P )
 
 RESOURCE_LOCATION="West Europe"
@@ -49,7 +69,7 @@ APP_PARAMETERS_FILE_PATH="$SCRIPT_PATH/../azure/app/parameters/$ENVIRONMENT_NAME
 
 KEYVAULT_NAME="$SECRETS_RESOURCE_GROUP_NAME-kv"
 
-if ! az account show > /dev/null; then
+if [ $LOGIN_TO_AZURE ] && ! az account show > /dev/null; then
   echo "Logging in..."
   az login
 fi
@@ -72,10 +92,12 @@ sed \
   -e "s/\${keyVaultName}/$KEYVAULT_NAME/g" \
   "$SECRETS_PARAMETERS_TEMPLATE_FILE_PATH" > "$SECRETS_PARAMETERS_FILE_PATH"
 
-echo
-echo "Are you ready to deploy $SECRETS_RESOURCE_GROUP_NAME?"
-echo "  Hit return to continue, or CTRL+C to stop."
-read -r
+if [ $CONFIRM_BEFORE_DEPLOY ]; then
+  echo
+  echo "Are you ready to deploy $SECRETS_RESOURCE_GROUP_NAME?"
+  echo "  Hit return to continue, or CTRL+C to stop."
+  read -r
+fi
 
 echo "Starting secrets deployment..."
 az group deployment create \
@@ -111,11 +133,13 @@ ruby \
     -e "s/\${keyVaultName}/$KEYVAULT_NAME/g" \
     > "$APP_PARAMETERS_FILE_PATH"
 
-echo
-echo "Are all the secrets up to date?"
-echo "Are you ready to deploy $APP_RESOURCE_GROUP_NAME?"
-echo "  Hit return to continue, or CTRL+C to stop."
-read -r
+if [ $CONFIRM_BEFORE_DEPLOY ]; then
+  echo
+  echo "Are all the secrets up to date?"
+  echo "Are you ready to deploy $APP_RESOURCE_GROUP_NAME?"
+  echo "  Hit return to continue, or CTRL+C to stop."
+  read -r
+fi
 
 echo "Starting app deployment..."
 az group deployment create \

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -106,7 +106,6 @@ az group deployment create \
   --template-file "$SECRETS_TEMPLATE_FILE_PATH" \
   --parameters "@$SECRETS_PARAMETERS_FILE_PATH" \
   --mode Complete \
-  --rollback-on-error \
   --verbose
 
 echo
@@ -148,7 +147,6 @@ az group deployment create \
   --template-file "$APP_TEMPLATE_FILE_PATH" \
   --parameters "@$APP_PARAMETERS_FILE_PATH" \
   --mode Complete \
-  --rollback-on-error \
   --verbose
 
 echo

--- a/docs/infrastructure-deployment.md
+++ b/docs/infrastructure-deployment.md
@@ -10,7 +10,18 @@ the root of the project.
 Many of the ARM templates build on top of building blocks already developed by
 the [Becoming A Teacher team](building_blocks).
 
-## Deploying to development (staging)
+## Automated deployment
+
+[Azure DevOps](https://dfe-ssp.visualstudio.com/S118-Teacher-Payments-Service)
+is responsible for automated infrastructure deployments as part of deploying a
+version of the app.
+
+## Manual deployment
+
+It should rarely (or never) happen, but if manual deployment is required, the
+following will help.
+
+### Deploying to development
 
 There is a script that deploys the ARM templates to the environment that can be
 run like so:
@@ -22,14 +33,14 @@ bin/azure-deploy development
 This creates (if one does not already exist) a KeyVault (where all application
 secrets are added) and applies any new changes to the Azure CIP infrastructure.
 
-## Deploying to test (edge) or production
+### Deploying to test or production
 
 Before deploying to production or test, you need to be added to the production
 or test subscription as a contributor. These permissions are transient and
 expire after a maximum of 8 hours, so usually this will be the first thing you
 do when preparing for a deploy.
 
-### Requesting permissions
+#### Requesting permissions
 
 - In the [Azure Portal](azure_portal), navigate to Azure AD Privileged Identity
   Management.
@@ -40,6 +51,8 @@ do when preparing for a deploy.
   need access and click the button marked 'Activate'.
 - Everyone in the Managers group will then get an email saying you have
   requested permissions and will be able to grant your permissions.
+
+#### Deploying
 
 Once you have permissions, you'll recieve an email from Azure letting you know
 the permissions have been granted, and you can run your command like so:


### PR DESCRIPTION
Adds `--skip-login` and `--skip-confirmation` flags to `bin/azure-deploy`, to support unattended deployment.

Drop `--rollback-on-error` seeing as it doesn't seem to work anymore.

The "Deploy" release configuration will need updating once this is merged, to complete the story.