### PR TITLE
Service name links to root path

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,9 +52,7 @@
         </div>
         <div class="govuk-header__content">
 
-          <a href="#" class="govuk-header__link govuk-header__link--service-name">
-            <%= t("tslr.service_name") %>
-          </a>
+          <%= link_to t("tslr.service_name"), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
 
           <% if signed_in? %>
           <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>


### PR DESCRIPTION
I've been meaning to fix this link for a while but haven't been able to fit it in to other work. I think we either have it link to the root path or remove the link and just have the service name as text. I think the standard thing to do is link it to the home page of the service.