### PR TITLE
Set up exemplar response time and security alerts on CIP

### DIFF
--- a/azure/app/parameters/development.template.json
+++ b/azure/app/parameters/development.template.json
@@ -2,6 +2,9 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "alertActionGroupShortName": {
+      "value": "d01appalerts"
+    },
     "appServiceDockerCompose": {
       "value": "${dockerCompose}"
     },
@@ -27,12 +30,12 @@
         "secretName": "DatabasePassword"
       }
     },
-    "securityAlertEmailAddress": {
+    "alertEmailAddress": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/${subscriptionId}/resourceGroups/${keyVaultResourceGroupName}/providers/Microsoft.KeyVault/vaults/${keyVaultName}"
         },
-        "secretName": "SecurityAlertEmailAddress"
+        "secretName": "AlertEmailAddress"
       }
     },
     "SECRET_KEY_BASE": {

--- a/azure/app/parameters/production.template.json
+++ b/azure/app/parameters/production.template.json
@@ -2,6 +2,9 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "alertActionGroupShortName": {
+      "value": "p01appalerts"
+    },
     "appServiceDockerCompose": {
       "value": "${dockerCompose}"
     },
@@ -24,12 +27,12 @@
         "secretName": "DatabasePassword"
       }
     },
-    "securityAlertEmailAddress": {
+    "alertEmailAddress": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/${subscriptionId}/resourceGroups/${keyVaultResourceGroupName}/providers/Microsoft.KeyVault/vaults/${keyVaultName}"
         },
-        "secretName": "SecurityAlertEmailAddress"
+        "secretName": "AlertEmailAddress"
       }
     },
     "SECRET_KEY_BASE": {

--- a/azure/app/parameters/test.template.json
+++ b/azure/app/parameters/test.template.json
@@ -2,6 +2,9 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "alertActionGroupShortName": {
+      "value": "t01appalerts"
+    },
     "appServiceDockerCompose": {
       "value": "${dockerCompose}"
     },
@@ -27,12 +30,12 @@
         "secretName": "DatabasePassword"
       }
     },
-    "securityAlertEmailAddress": {
+    "alertEmailAddress": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/${subscriptionId}/resourceGroups/${keyVaultResourceGroupName}/providers/Microsoft.KeyVault/vaults/${keyVaultName}"
         },
-        "secretName": "SecurityAlertEmailAddress"
+        "secretName": "AlertEmailAddress"
       }
     },
     "SECRET_KEY_BASE": {

--- a/azure/app/template.json
+++ b/azure/app/template.json
@@ -85,7 +85,8 @@
 
     "alertActionGroupName": "[concat(parameters('resourceNamePrefix'), '-alerts-ag')]",
 
-    "serviceHealthAlertName": "[concat(parameters('resourceNamePrefix'), '-alerts-service-health')]"
+    "serviceHealthAlertName": "[concat(parameters('resourceNamePrefix'), '-alerts-service-health')]",
+    "appServiceResponseTimeAlertName": "[concat(parameters('resourceNamePrefix'), '-alerts-', variables('appServiceName'), '-response-time')]"
   },
   "resources": [
     {
@@ -320,6 +321,42 @@
             }
           ]
         }
+      }
+    },
+    {
+      "apiVersion": "2018-03-01",
+      "type": "Microsoft.Insights/metricAlerts",
+      "name": "[variables('appServiceResponseTimeAlertName')]",
+      "location": "global",
+      "dependsOn": ["[variables('alertActionGroupName')]", "[variables('appServiceName')]"],
+      "properties": {
+        "scopes": ["[resourceId('Microsoft.Web/sites', variables('appServiceName'))]"],
+        "enabled": true,
+        "description": "[concat('Alert when average response times for ', variables('appServiceName'), ' are greater than 2 seconds.')]",
+        "severity": 1,
+        "evaluationFrequency": "PT1M",
+        "windowSize": "PT1M",
+        "targetResourceType": "Microsoft.Web/sites",
+        "targetResourceRegion": "[resourceGroup().location]",
+        "criteria": {
+          "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+          "allOf": [
+            {
+              "criterionType": "StaticThresholdCriterion",
+              "name": "high-response-time",
+              "metricNamespace": "Microsoft.Web/sites",
+              "metricName": "AverageResponseTime",
+              "operator": "GreaterThan",
+              "threshold": 2,
+              "timeAggregation": "Average"
+            }
+          ]
+        },
+        "actions": [
+          {
+            "actionGroupId": "[resourceId('Microsoft.Insights/actionGroups', variables('alertActionGroupName'))]"
+          }
+        ]
       }
     }
   ],

--- a/azure/app/template.json
+++ b/azure/app/template.json
@@ -83,7 +83,9 @@
     "appServiceName": "[concat(parameters('resourceNamePrefix'), '-as')]",
     "appServiceRuntimeStack": "[concat('COMPOSE|', base64(parameters('appServiceDockerCompose')))]",
 
-    "alertActionGroupName": "[concat(parameters('resourceNamePrefix'), '-alerts-ag')]"
+    "alertActionGroupName": "[concat(parameters('resourceNamePrefix'), '-alerts-ag')]",
+
+    "serviceHealthAlertName": "[concat(parameters('resourceNamePrefix'), '-alerts-service-health')]"
   },
   "resources": [
     {
@@ -292,6 +294,32 @@
             "emailAddress": "[parameters('alertEmailAddress')]"
           }
         ]
+      }
+    },
+    {
+      "apiVersion": "2017-04-01",
+      "type": "Microsoft.Insights/activityLogAlerts",
+      "name": "[variables('serviceHealthAlertName')]",
+      "location": "global",
+      "dependsOn": ["[variables('alertActionGroupName')]"],
+      "properties": {
+        "scopes": ["[resourceGroup().id]"],
+        "enabled": true,
+        "condition": {
+          "allOf": [
+            {
+              "field": "Category",
+              "equals": "ServiceHealth"
+            }
+          ]
+        },
+        "actions": {
+          "actionGroups": [
+            {
+              "actionGroupId": "[resourceId('Microsoft.Insights/actionGroups', variables('alertActionGroupName'))]"
+            }
+          ]
+        }
       }
     }
   ],

--- a/azure/app/template.json
+++ b/azure/app/template.json
@@ -6,6 +6,9 @@
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
     },
+    "alertActionGroupShortName": {
+      "type": "string"
+    },
     "appServiceDockerCompose": {
       "type": "string"
     },
@@ -22,7 +25,7 @@
     "databasePassword": {
       "type": "securestring"
     },
-    "securityAlertEmailAddress": {
+    "alertEmailAddress": {
       "type": "string"
     },
     "RAILS_ENV": {
@@ -78,7 +81,9 @@
     "appServicePlanId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
 
     "appServiceName": "[concat(parameters('resourceNamePrefix'), '-as')]",
-    "appServiceRuntimeStack": "[concat('COMPOSE|', base64(parameters('appServiceDockerCompose')))]"
+    "appServiceRuntimeStack": "[concat('COMPOSE|', base64(parameters('appServiceDockerCompose')))]",
+
+    "alertActionGroupName": "[concat(parameters('resourceNamePrefix'), '-alerts-ag')]"
   },
   "resources": [
     {
@@ -120,7 +125,7 @@
             "value": "[parameters('databasePassword')]"
           },
           "securityAlertEmailAddress": {
-            "value": "[parameters('securityAlertEmailAddress')]"
+            "value": "[parameters('alertEmailAddress')]"
           },
           "storageAccountName": {
             "value": "[variables('storageAccountName')]"
@@ -271,6 +276,22 @@
             "value": "[variables('databaseServerName')]"
           }
         }
+      }
+    },
+    {
+      "apiVersion": "2018-03-01",
+      "type": "Microsoft.Insights/actionGroups",
+      "name": "[variables('alertActionGroupName')]",
+      "location": "global",
+      "properties": {
+        "groupShortName": "[parameters('alertActionGroupShortName')]",
+        "enabled": true,
+        "emailReceivers": [
+          {
+            "name": "email",
+            "emailAddress": "[parameters('alertEmailAddress')]"
+          }
+        ]
       }
     }
   ],

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -30,8 +30,15 @@ case $ENVIRONMENT_NAME in
     ;;
 esac
 
+SECRETS_RESOURCE_GROUP_NAME="$RESOURCE_GROUP_PREFIX-secrets"
+SECRETS_DEPLOYMENT_NAME=$SECRETS_RESOURCE_GROUP_NAME
+
+APP_RESOURCE_GROUP_NAME="$RESOURCE_GROUP_PREFIX-app"
+APP_DEPLOYMENT_NAME=$APP_RESOURCE_GROUP_NAME
+
 LOGIN_TO_AZURE=1
 CONFIRM_BEFORE_DEPLOY=1
+DEPLOY_SECRETS=1
 
 while [ "$2" ]; do
   case $2 in
@@ -41,6 +48,16 @@ while [ "$2" ]; do
     "--skip-confirmation")
       CONFIRM_BEFORE_DEPLOY=
       ;;
+    "--skip-secrets")
+      DEPLOY_SECRETS=
+      ;;
+    "--scratch-secrets")
+      SECRETS_RESOURCE_GROUP_NAME="$SECRETS_RESOURCE_GROUP_NAME-scratch"
+      SECRETS_DEPLOYMENT_NAME="$SECRETS_DEPLOYMENT_NAME-scratch"
+      ;;
+    "--scratch-app")
+      APP_RESOURCE_GROUP_NAME="$APP_RESOURCE_GROUP_NAME-scratch"
+      APP_DEPLOYMENT_NAME="$APP_DEPLOYMENT_NAME-scratch"      ;;
     *)
       echo "Unexpected argument: $2"
       exit 1
@@ -54,14 +71,10 @@ SCRIPT_PATH=$( cd "$( dirname "$0" )" ; pwd -P )
 
 RESOURCE_LOCATION="West Europe"
 
-SECRETS_RESOURCE_GROUP_NAME="$RESOURCE_GROUP_PREFIX-secrets"
-SECRETS_DEPLOYMENT_NAME="$RESOURCE_GROUP_PREFIX-secrets"
 SECRETS_TEMPLATE_FILE_PATH="$SCRIPT_PATH/../azure/secrets/template.json"
 SECRETS_PARAMETERS_TEMPLATE_FILE_PATH="$SCRIPT_PATH/../azure/secrets/parameters/$ENVIRONMENT_NAME.template.json"
 SECRETS_PARAMETERS_FILE_PATH="$SCRIPT_PATH/../azure/secrets/parameters/$ENVIRONMENT_NAME.json"
 
-APP_RESOURCE_GROUP_NAME="$RESOURCE_GROUP_PREFIX-app"
-APP_DEPLOYMENT_NAME="$RESOURCE_GROUP_PREFIX-app"
 APP_TEMPLATE_FILE_PATH="$SCRIPT_PATH/../azure/app/template.json"
 APP_DOCKER_COMPOSE_FILE_PATH="$SCRIPT_PATH/../azure/app/files/docker-compose.yml"
 APP_PARAMETERS_TEMPLATE_FILE_PATH="$SCRIPT_PATH/../azure/app/parameters/$ENVIRONMENT_NAME.template.json"
@@ -77,40 +90,42 @@ fi
 echo "Setting default subscription to $SUBSCRIPTION_ID..."
 az account set --subscription "$SUBSCRIPTION_ID"
 
-if ! az group show --name "$SECRETS_RESOURCE_GROUP_NAME" > /dev/null; then
-  echo "Creating new resource group for secrets with name $SECRETS_RESOURCE_GROUP_NAME..."
-  az group create \
-    --name "$SECRETS_RESOURCE_GROUP_NAME" \
-    --location "$RESOURCE_LOCATION" \
-    > /dev/null
-else
-  echo "Using existing secrets resource group with name $SECRETS_RESOURCE_GROUP_NAME..."
-fi
+if [ $DEPLOY_SECRETS ]; then
+  if ! az group show --name "$SECRETS_RESOURCE_GROUP_NAME" > /dev/null; then
+    echo "Creating new resource group for secrets with name $SECRETS_RESOURCE_GROUP_NAME..."
+    az group create \
+      --name "$SECRETS_RESOURCE_GROUP_NAME" \
+      --location "$RESOURCE_LOCATION" \
+      > /dev/null
+  else
+    echo "Using existing secrets resource group with name $SECRETS_RESOURCE_GROUP_NAME..."
+  fi
 
-echo "Rewriting secrets parameters file for $ENVIRONMENT_NAME..."
-sed \
-  -e "s/\${keyVaultName}/$KEYVAULT_NAME/g" \
-  "$SECRETS_PARAMETERS_TEMPLATE_FILE_PATH" > "$SECRETS_PARAMETERS_FILE_PATH"
+  echo "Rewriting secrets parameters file for $ENVIRONMENT_NAME..."
+  sed \
+    -e "s/\${keyVaultName}/$KEYVAULT_NAME/g" \
+    "$SECRETS_PARAMETERS_TEMPLATE_FILE_PATH" > "$SECRETS_PARAMETERS_FILE_PATH"
 
-if [ $CONFIRM_BEFORE_DEPLOY ]; then
+  if [ $CONFIRM_BEFORE_DEPLOY ]; then
+    echo
+    echo "Are you ready to deploy $SECRETS_RESOURCE_GROUP_NAME?"
+    echo "  Hit return to continue, or CTRL+C to stop."
+    read -r
+  fi
+
+  echo "Starting secrets deployment..."
+  az group deployment create \
+    --name "$SECRETS_DEPLOYMENT_NAME" \
+    --resource-group "$SECRETS_RESOURCE_GROUP_NAME" \
+    --template-file "$SECRETS_TEMPLATE_FILE_PATH" \
+    --parameters "@$SECRETS_PARAMETERS_FILE_PATH" \
+    --mode Complete \
+    --verbose
+
   echo
-  echo "Are you ready to deploy $SECRETS_RESOURCE_GROUP_NAME?"
-  echo "  Hit return to continue, or CTRL+C to stop."
-  read -r
+  echo "$SECRETS_RESOURCE_GROUP_NAME deployed!"
+  echo
 fi
-
-echo "Starting secrets deployment..."
-az group deployment create \
-  --name "$SECRETS_DEPLOYMENT_NAME" \
-  --resource-group "$SECRETS_RESOURCE_GROUP_NAME" \
-  --template-file "$SECRETS_TEMPLATE_FILE_PATH" \
-  --parameters "@$SECRETS_PARAMETERS_FILE_PATH" \
-  --mode Complete \
-  --verbose
-
-echo
-echo "$SECRETS_RESOURCE_GROUP_NAME deployed!"
-echo
 
 if ! az group show --name "$APP_RESOURCE_GROUP_NAME" > /dev/null; then
   echo "Creating new resource group for app with name $APP_RESOURCE_GROUP_NAME..."


### PR DESCRIPTION
We'll need to work out what other metrics we want to measure, but this shows the rough skeleton of how to set alerts up. They're configured to email the alert email address stored in the KeyVault, but can also be configured to send SMS, ping webhooks, or a number of other communication methods.

I found the process of working out how to specify an alert in ARM quite challenging. I didn't find any complete documentation on how to do it in a general case, only specific examples of varying completeness which I reverse engineered. The two references that I found useful were the [(incomplete) template specification](https://docs.microsoft.com/en-us/azure/templates/microsoft.insights/2018-03-01/metricalerts) and the [.NET Azure SDK docs](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.monitor.models.metricalertcriteria). To work out the `metricName`, I found the best was was to simply manually set up an alert in the portal and read the name from the resulting value in the "Condition" column.

This PR also adds three new flags to `bin/azure-deploy`:
- `--skip-secrets` to skip deploying the secrets resource group (useful when trying out changes).
- `--scratch-secrets` and `--scratch-app` to deploy `*-scratch` resource groups for experimenting without affecting the staging app.