### PR TITLE
Extract ClaimUpdate object for managing changes to an in-progress claim

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -41,12 +41,7 @@ class ClaimsController < ApplicationController
   private
 
   def update_current_claim!
-    if params[:slug] == "check-your-answers"
-      mail_claim_submitted if current_claim.submit!
-    else
-      current_claim.attributes = claim_params
-      current_claim.save(context: params[:slug].to_sym)
-    end
+    ClaimUpdate.new(current_claim, claim_params, params[:slug]).perform
   end
 
   def next_slug
@@ -66,7 +61,7 @@ class ClaimsController < ApplicationController
   end
 
   def claim_params
-    params.require(:tslr_claim).permit(
+    params.fetch(:tslr_claim, {}).permit(
       :qts_award_year,
       :claim_school_id,
       :employment_status,
@@ -87,10 +82,6 @@ class ClaimsController < ApplicationController
       :bank_account_number,
       TslrClaim::SUBJECT_FIELDS
     )
-  end
-
-  def mail_claim_submitted
-    ClaimMailer.submitted(current_claim).deliver_later
   end
 
   def claim_page_template

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -19,7 +19,7 @@ module ClaimsHelper
     [
       [t("tslr.questions.qts_award_year"), academic_years(claim.qts_award_year), "qts-year"],
       [t("tslr.questions.claim_school"), claim.claim_school_name, "claim-school"],
-      [t("tslr.questions.current_school"), claim.current_school_name, "current-school"],
+      [t("tslr.questions.current_school"), claim.current_school_name, "still-teaching"],
       [t("tslr.questions.subjects_taught"), subject_list(claim.subjects_taught), "subjects-taught"],
       [t("tslr.questions.mostly_teaching_eligible_subjects", subjects: subject_list(claim.subjects_taught)), (claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"), "mostly-teaching-eligible-subjects"],
       [t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), number_to_currency(claim.student_loan_repayment_amount), "student-loan-amount"],

--- a/app/models/claim_update.rb
+++ b/app/models/claim_update.rb
@@ -20,6 +20,7 @@ class ClaimUpdate
       claim.submit! && send_confirmation_email
     else
       claim.attributes = params
+      update_claim_school_dependent_attributes
       update_employment_status_dependent_attributes
       claim.save(context: context)
     end
@@ -33,6 +34,12 @@ class ClaimUpdate
 
   def send_confirmation_email
     ClaimMailer.submitted(claim).deliver_later
+  end
+
+  def update_claim_school_dependent_attributes
+    if claim.claim_school_id_changed?
+      claim.employment_status = nil
+    end
   end
 
   def update_employment_status_dependent_attributes

--- a/app/models/claim_update.rb
+++ b/app/models/claim_update.rb
@@ -20,6 +20,7 @@ class ClaimUpdate
       claim.submit! && send_confirmation_email
     else
       claim.attributes = params
+      update_employment_status_dependent_attributes
       claim.save(context: context)
     end
   end
@@ -32,5 +33,11 @@ class ClaimUpdate
 
   def send_confirmation_email
     ClaimMailer.submitted(claim).deliver_later
+  end
+
+  def update_employment_status_dependent_attributes
+    if claim.employment_status_changed?
+      claim.current_school = claim.employed_at_claim_school? ? claim.claim_school : nil
+    end
   end
 end

--- a/app/models/claim_update.rb
+++ b/app/models/claim_update.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Performs an update on a claim in the context of a user performing an action
+# through the user interface. The `context` tells the object the page on which
+# the user is performing the action, enabling it to carry out actions and
+# validations on the claim that are appropriate to that context. For example,
+# Performing an update in the "check-your-answers" context will attempt to
+# submit the claim and send the confirmation email to the claimant.
+class ClaimUpdate
+  attr_reader :claim, :context, :params
+
+  def initialize(claim, params, context)
+    @claim = claim
+    @params = params
+    @context = context.to_sym
+  end
+
+  def perform
+    if submitting_claim?
+      claim.submit! && send_confirmation_email
+    else
+      claim.attributes = params
+      claim.save(context: context)
+    end
+  end
+
+  private
+
+  def submitting_claim?
+    context == :"check-your-answers"
+  end
+
+  def send_confirmation_email
+    ClaimMailer.submitted(claim).deliver_later
+  end
+end

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -44,16 +44,12 @@ class PageSequence
 
   def next_slug
     return "ineligible" if claim.ineligible?
-    return "check-your-answers" if claim.submittable? && !updating_schools_answers?
+    return "check-your-answers" if claim.submittable?
 
     slugs[current_slug_index + 1]
   end
 
   private
-
-  def updating_schools_answers?
-    current_slug == "claim-school" || current_slug == "still-teaching" && claim.employed_at_different_school?
-  end
 
   def current_slug_index
     slugs.index(current_slug)

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -80,8 +80,6 @@ class TslrClaim < ApplicationRecord
 
   validate :claim_must_not_be_ineligible, on: :submit
 
-  before_validation :reset_inferred_current_school, if: ->(record) { record.persisted? && record.employment_status_changed? }
-
   before_save :normalise_trn, if: :teacher_reference_number_changed?
   before_save :normalise_ni_number, if: :national_insurance_number_changed?
   before_save :normalise_bank_account_number, if: :bank_account_number_changed?
@@ -151,10 +149,6 @@ class TslrClaim < ApplicationRecord
 
   def not_taught_eligible_subjects_enough?
     mostly_teaching_eligible_subjects == false
-  end
-
-  def reset_inferred_current_school
-    self.current_school = employed_at_claim_school? ? claim_school : nil
   end
 
   def normalise_trn

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -33,12 +33,6 @@ RSpec.feature "Changing the answers on a submittable claim" do
     expect(page).to have_content("Check your answers before sending your application")
   end
 
-  scenario "Teacher sees their original current school when editing" do
-    find("a[href='#{claim_path("current-school")}']").click
-
-    expect(find("input[name='school_search']").value).to eq(current_school.name)
-  end
-
   context "when changing subjects taught" do
     before do
       find("a[href='#{claim_path("subjects-taught")}']").click
@@ -180,5 +174,34 @@ RSpec.feature "Changing the answers on a submittable claim" do
         end
       end
     end
+  end
+
+  scenario "changing the are you still employed question (employment_status)" do
+    find("a[href='#{claim_path("still-teaching")}']").click
+
+    choose "Yes, at Claim School"
+    click_on "Continue"
+
+    expect(current_path).to eq(claim_path("check-your-answers"))
+    expect(claim.reload.employment_status).to eq("claim_school")
+    expect(claim.current_school).to eq(claim_school)
+  end
+
+  scenario "going from same school to different school" do
+    claim.update!(employment_status: "claim_school")
+
+    find("a[href='#{claim_path("still-teaching")}']").click
+
+    choose "Yes, at another school"
+    click_on "Continue"
+
+    fill_in :school_search, with: "Hampstead"
+    click_on "Search"
+
+    choose "Hampstead School"
+    click_on "Continue"
+    expect(current_path).to eq(claim_path("check-your-answers"))
+    expect(claim.reload.employment_status).to eq("different_school")
+    expect(claim.current_school).to eq(schools(:hampstead_school))
   end
 end

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -33,7 +33,7 @@ describe ClaimsHelper do
       expected_answers = [
         [I18n.t("tslr.questions.qts_award_year"), "September 1 2013 - August 31 2014", "qts-year"],
         [I18n.t("tslr.questions.claim_school"), school.name, "claim-school"],
-        [I18n.t("tslr.questions.current_school"), school.name, "current-school"],
+        [I18n.t("tslr.questions.current_school"), school.name, "still-teaching"],
         [I18n.t("tslr.questions.subjects_taught"), "Chemistry and Physics", "subjects-taught"],
         [I18n.t("tslr.questions.mostly_teaching_eligible_subjects", subjects: "Chemistry and Physics"), "Yes", "mostly-teaching-eligible-subjects"],
         [I18n.t("tslr.questions.student_loan_amount", claim_school_name: school.name), "£1,987.65", "student-loan-amount"],

--- a/spec/models/claim_update_spec.rb
+++ b/spec/models/claim_update_spec.rb
@@ -92,4 +92,29 @@ RSpec.describe ClaimUpdate do
       end
     end
   end
+
+  describe "setting/resetting employment_status when the claim_school changes" do
+    let(:claim) { create(:tslr_claim, claim_school: schools(:penistone_grammar_school), employment_status: :different_school, current_school: schools(:hampstead_school)) }
+    let(:context) { "claim-school" }
+
+    context "when the update changes the claim_school" do
+      let(:params) { {claim_school_id: schools(:hampstead_school).id} }
+
+      it "resets the subsequent employment_status and current_school answers" do
+        expect(claim_update.perform).to be_truthy
+        expect(claim.reload.employment_status).to be_nil
+        expect(claim.current_school).to be_nil
+      end
+    end
+
+    context "when the update does not change the claim_school" do
+      let(:params) { {claim_school_id: claim.claim_school_id} }
+
+      it "does not reset the subsequent employment_status and current_school answers" do
+        expect(claim_update.perform).to be_truthy
+        expect(claim.reload.employment_status).to eq "different_school"
+        expect(claim.current_school).to eq schools(:hampstead_school)
+      end
+    end
+  end
 end

--- a/spec/models/claim_update_spec.rb
+++ b/spec/models/claim_update_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ClaimUpdate do
+  let(:claim_update) { ClaimUpdate.new(claim, params, context) }
+
+  context "with parameters that are valid for the context" do
+    let(:claim) { create(:tslr_claim) }
+    let(:context) { "bank-details" }
+    let(:params) { {bank_sort_code: "123456", bank_account_number: "12345678"} }
+
+    it "updates the claim and returns a truthy value" do
+      expect(claim_update.perform).to be_truthy
+      expect(claim.reload.bank_sort_code).to eq "123456"
+      expect(claim.bank_account_number).to eq "12345678"
+    end
+  end
+
+  context "with parameters missing for the context" do
+    let(:claim) { create(:tslr_claim) }
+    let(:context) { "bank-details" }
+    let(:params) { {bank_sort_code: nil, bank_account_number: "12345678"} }
+
+    it "doesn't update the claim and returns a falsy value" do
+      expect(claim_update.perform).to be_falsy
+      expect(claim.errors[:bank_sort_code]).to eq ["Enter a sort code"]
+    end
+  end
+
+  context "when updating claim that is submittable in the “check-your-answers” context" do
+    let(:claim) { create(:tslr_claim, :submittable) }
+    let(:context) { "check-your-answers" }
+    let(:params) { {} }
+
+    it "transitions the claim to a submitted state and returns a truthy" do
+      expect(claim_update.perform).to be_truthy
+      expect(claim.reload).to be_submitted
+    end
+
+    it "queues a confirmation email to be sent to the claimant" do
+      claim_update.perform
+      expect(ActionMailer::DeliveryJob).to have_been_enqueued.with("ClaimMailer", "submitted", "deliver_now", claim)
+    end
+  end
+
+  context "when updating an unsubmittable claim in the “check-your-answers” context" do
+    let(:claim) { create(:tslr_claim, :submittable, full_name: nil) }
+    let(:context) { "check-your-answers" }
+    let(:params) { {} }
+
+    it "returns false and does not queue a confirmation email" do
+      expect(claim_update.perform).to be_falsy
+      expect(ActionMailer::DeliveryJob).not_to have_been_enqueued
+    end
+  end
+end

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -34,28 +34,6 @@ RSpec.describe PageSequence do
       it "returns “check-your-answers” as the next slug" do
         expect(PageSequence.new(claim, "qts-year").next_slug).to eq "check-your-answers"
       end
-
-      context "but they are updating their claim_school" do
-        it "returns the next slug in the schools sequence" do
-          expect(PageSequence.new(claim, "claim-school").next_slug).to eq "still-teaching"
-        end
-      end
-
-      context "they’ve specified they’re still teaching at their claim school" do
-        before { claim.employment_status = :claim_school }
-
-        it "returns “check-your-answers” as the next slug (i.e. skips the current-school question)" do
-          expect(PageSequence.new(claim, "still-teaching").next_slug).to eq "check-your-answers"
-        end
-      end
-
-      context "they’ve specified they’re teaching at a different school" do
-        before { claim.employment_status = :different_school }
-
-        it "returns the final slug in the schools sequence" do
-          expect(PageSequence.new(claim, "still-teaching").next_slug).to eq "current-school"
-        end
-      end
     end
   end
 end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -323,51 +323,6 @@ RSpec.describe TslrClaim, type: :model do
     it "rejects invalid employment statuses" do
       expect { TslrClaim.new(employment_status: :nonsense) }.to raise_error(ArgumentError)
     end
-
-    context "with a persisted record" do
-      let(:claim) { TslrClaim.create!(claim_school: schools(:penistone_grammar_school)) }
-
-      it "setting to :claim_school sets the current_school to be the same as claim_school when saved" do
-        claim.employment_status = :claim_school
-        claim.save!
-
-        expect(claim.current_school).to eql(schools(:penistone_grammar_school))
-      end
-
-      it "setting it to :different_school resets the current_school when saved" do
-        claim.update!(current_school: schools(:hampstead_school))
-
-        claim.employment_status = :different_school
-        claim.save!
-
-        expect(claim.current_school).to be_nil
-      end
-    end
-
-    context "with an unpersisted record" do
-      let(:claim) do
-        TslrClaim.new(
-          employment_status: :different_school,
-          claim_school: schools(:penistone_grammar_school),
-          current_school: schools(:hampstead_school)
-        )
-      end
-
-      it "doesn’t reset the current_school when saved" do
-        claim.save!
-        expect(claim.current_school).to eq(schools(:hampstead_school))
-      end
-    end
-
-    context "when value is :different_school" do
-      it "does not automatically reset current_school if employment_status hasn’t changed" do
-        claim = TslrClaim.create!(claim_school: schools(:penistone_grammar_school), employment_status: :different_school)
-        claim.current_school = schools(:hampstead_school)
-        claim.save!
-
-        expect(claim.current_school).to eql(schools(:hampstead_school))
-      end
-    end
   end
 
   describe "#claim_school_name" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "Claims", type: :request do
       end
 
       context "when updating from check-your-answers" do
-        context "with an eligible and submittable claim" do
+        context "with a submittable claim" do
           before :each do
             in_progress_claim.update!(attributes_for(:tslr_claim, :submittable))
 
@@ -192,7 +192,7 @@ RSpec.describe "Claims", type: :request do
           end
         end
 
-        context "with an eligible but unsubmittable claim" do
+        context "with an unsubmittable claim" do
           before :each do
             in_progress_claim.update!(attributes_for(:tslr_claim, :submittable, email_address: nil))
 
@@ -212,25 +212,6 @@ RSpec.describe "Claims", type: :request do
           it "re-renders the check-your-answers page with errors" do
             expect(response.body).to include("Check your answers before sending your application")
             expect(response.body).to include("Enter an email address")
-          end
-        end
-
-        context "with an ineligible claim" do
-          before :each do
-            in_progress_claim.update!(attributes_for(:tslr_claim, :submittable, mostly_teaching_eligible_subjects: false))
-
-            put claim_path("check-your-answers")
-
-            in_progress_claim.reload
-          end
-
-          it "doesn't submit the claim" do
-            expect(in_progress_claim.submitted_at).to be_nil
-          end
-
-          it "re-renders the check-your-answers page with errors" do
-            expect(response.body).to include("Check your answers before sending your application")
-            expect(response.body).to include("You must have spent at least half your time teaching an eligible subject.")
           end
         end
       end


### PR DESCRIPTION
Some refactoring work that extracts a new class for handling updates to an in-progress claim, combining logic that was previously spread across the controller, `PageSequence`, and `TslrClaim` model itself.

It does also modify the behaviour slightly for users that are changing their answers:

- if a user changes the answer to their claim school, the subsequent employment_status and current_school answers are reset as those answers are coupled to claim_school and the question has effectively changed
- a user clicking "change" on the current school answer gets sent to the "still teaching" question, as that answer is coupled to the current school and should also be updated

More details in the individual commit messages.