### PR TITLE
Change the school eligibility checkers to allow special schools with unspecified phases

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -82,6 +82,17 @@ class School < ApplicationRecord
     institution_funded_by_other_government_department: 56,
   }.freeze
 
+  SPECIAL_SCHOOL_TYPES = %w[
+    community_special_school
+    non_maintained_special_school
+    other_independent_special_school
+    foundation_special_school
+    special_post_16_institutions
+    academy_special_sponsor_led
+    free_school_special
+    academy_special_converter
+  ].freeze
+
   enum phase: PHASES
   enum school_type_group: SCHOOL_TYPE_GROUPS
   enum school_type: SCHOOL_TYPES
@@ -106,5 +117,9 @@ class School < ApplicationRecord
 
   def state_funded?
     STATE_FUNDED_SCHOOL_TYPE_GROUPS.include?(school_type_group) && school_type != "other_independent_special_school"
+  end
+
+  def special?
+    SPECIAL_SCHOOL_TYPES.include?(school_type)
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -20,7 +20,7 @@ class School < ApplicationRecord
     middle_deemed_secondary: 5,
     sixteen_plus: 6,
     all_through: 7,
-  }
+  }.freeze
 
   SCHOOL_TYPE_GROUPS = {
     colleges: 1,
@@ -32,7 +32,15 @@ class School < ApplicationRecord
     other: 9,
     academies: 10,
     free_schools: 11,
-  }
+  }.freeze
+
+  STATE_FUNDED_SCHOOL_TYPE_GROUPS = %w[
+    colleges
+    la_maintained
+    special_schools
+    academies
+    free_schools
+  ].freeze
 
   SCHOOL_TYPES = {
     community_school: 1,
@@ -72,7 +80,7 @@ class School < ApplicationRecord
     academy_16_to_19_converter: 45,
     academy_16_to_19_sponsor_led: 46,
     institution_funded_by_other_government_department: 56,
-  }
+  }.freeze
 
   enum phase: PHASES
   enum school_type_group: SCHOOL_TYPE_GROUPS
@@ -94,5 +102,9 @@ class School < ApplicationRecord
 
   def eligible_for_maths_and_physics?
     MathsAndPhysics::SchoolEligibility.new(self).check
+  end
+
+  def state_funded?
+    STATE_FUNDED_SCHOOL_TYPE_GROUPS.include?(school_type_group) && school_type != "other_independent_special_school"
   end
 end

--- a/app/services/maths_and_physics/school_eligibility.rb
+++ b/app/services/maths_and_physics/school_eligibility.rb
@@ -66,7 +66,7 @@ module MathsAndPhysics
     end
 
     def eligible_special_school?
-      @school.phase == "not_applicable" && @school.special?
+      @school.phase == "not_applicable" && @school.special? && @school.school_type != "special_post_16_institutions"
     end
   end
 end

--- a/app/services/maths_and_physics/school_eligibility.rb
+++ b/app/services/maths_and_physics/school_eligibility.rb
@@ -52,7 +52,7 @@ module MathsAndPhysics
     end
 
     def check
-      eligible_local_authority_district? && @school.state_funded? && eligible_phase?
+      eligible_local_authority_district? && @school.state_funded? && (eligible_phase? || eligible_special_school?)
     end
 
     private
@@ -63,6 +63,10 @@ module MathsAndPhysics
 
     def eligible_phase?
       ELIGIBLE_PHASES.include?(@school.phase)
+    end
+
+    def eligible_special_school?
+      @school.phase == "not_applicable" && @school.special?
     end
   end
 end

--- a/app/services/maths_and_physics/school_eligibility.rb
+++ b/app/services/maths_and_physics/school_eligibility.rb
@@ -1,7 +1,6 @@
 module MathsAndPhysics
   class SchoolEligibility
     ELIGIBLE_PHASES = %w[secondary middle_deemed_secondary].freeze
-    STATE_FUNDED_TYPE_GROUPS = %w[colleges la_maintained special_schools academies free_schools].freeze
     ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES = [
       "E08000016", # Barnsley
       "E06000009", # Blackpool
@@ -53,7 +52,7 @@ module MathsAndPhysics
     end
 
     def check
-      eligible_local_authority_district? && state_funded? && eligible_phase?
+      eligible_local_authority_district? && @school.state_funded? && eligible_phase?
     end
 
     private
@@ -62,17 +61,8 @@ module MathsAndPhysics
       ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES.include?(@school.local_authority_district.code)
     end
 
-    def state_funded?
-      STATE_FUNDED_TYPE_GROUPS.include?(@school.school_type_group) &&
-        !independent_special_school?
-    end
-
     def eligible_phase?
       ELIGIBLE_PHASES.include?(@school.phase)
-    end
-
-    def independent_special_school?
-      @school.school_type == "other_independent_special_school"
     end
   end
 end

--- a/app/services/tslr/school_eligibility.rb
+++ b/app/services/tslr/school_eligibility.rb
@@ -48,7 +48,7 @@ module Tslr
     end
 
     def eligible_special_school?
-      @school.phase == "not_applicable" && @school.special?
+      @school.phase == "not_applicable" && @school.special? && @school.school_type != "special_post_16_institutions"
     end
   end
 end

--- a/app/services/tslr/school_eligibility.rb
+++ b/app/services/tslr/school_eligibility.rb
@@ -1,7 +1,6 @@
 module Tslr
   class SchoolEligibility
     ELIGIBLE_PHASES = %w[secondary middle_deemed_secondary].freeze
-    STATE_FUNDED_TYPE_GROUPS = %w[colleges la_maintained special_schools academies free_schools].freeze
     ELIGIBLE_LOCAL_AUTHORITY_CODES = [
       370, # Barnsley
       890, # Blackpool
@@ -35,7 +34,7 @@ module Tslr
     end
 
     def check
-      eligible_local_authority? && state_funded? && eligible_phase?
+      eligible_local_authority? && @school.state_funded? && eligible_phase?
     end
 
     private
@@ -44,17 +43,8 @@ module Tslr
       ELIGIBLE_LOCAL_AUTHORITY_CODES.include?(@school.local_authority.code)
     end
 
-    def state_funded?
-      STATE_FUNDED_TYPE_GROUPS.include?(@school.school_type_group) &&
-        !independent_special_school?
-    end
-
     def eligible_phase?
       ELIGIBLE_PHASES.include?(@school.phase)
-    end
-
-    def independent_special_school?
-      @school.school_type == "other_independent_special_school"
     end
   end
 end

--- a/app/services/tslr/school_eligibility.rb
+++ b/app/services/tslr/school_eligibility.rb
@@ -34,7 +34,7 @@ module Tslr
     end
 
     def check
-      eligible_local_authority? && @school.state_funded? && eligible_phase?
+      eligible_local_authority? && @school.state_funded? && (eligible_phase? || eligible_special_school?)
     end
 
     private
@@ -45,6 +45,10 @@ module Tslr
 
     def eligible_phase?
       ELIGIBLE_PHASES.include?(@school.phase)
+    end
+
+    def eligible_special_school?
+      @school.phase == "not_applicable" && @school.special?
     end
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
 
     trait :tslr_eligible do
       local_authority { create(:local_authority, code: Tslr::SchoolEligibility::ELIGIBLE_LOCAL_AUTHORITY_CODES.sample) }
-      school_type_group { Tslr::SchoolEligibility::STATE_FUNDED_TYPE_GROUPS.sample }
+      school_type_group { School::STATE_FUNDED_SCHOOL_TYPE_GROUPS.sample }
       phase { Tslr::SchoolEligibility::ELIGIBLE_PHASES.sample }
     end
   end

--- a/spec/services/maths_and_physics/school_eligibility_spec.rb
+++ b/spec/services/maths_and_physics/school_eligibility_spec.rb
@@ -86,11 +86,11 @@ RSpec.describe MathsAndPhysics::SchoolEligibility do
           let(:school_attributes) { special_school_attributes.merge({school_type: :other_independent_special_school}) }
           it { is_expected.to be false }
         end
+      end
 
-        context "and it is not a state funded school" do
-          let(:school_attributes) { {school_type_group: :independent_schools} }
-          it { is_expected.to be false }
-        end
+      context "and it is not a state funded school" do
+        let(:school_attributes) { {school_type_group: :independent_schools} }
+        it { is_expected.to be false }
       end
     end
 

--- a/spec/services/maths_and_physics/school_eligibility_spec.rb
+++ b/spec/services/maths_and_physics/school_eligibility_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe MathsAndPhysics::SchoolEligibility do
         end
       end
 
-      context "and it is a special school" do
-        let(:special_school_attributes) { {school_type_group: :special_schools} }
+      context "and it is a state funded special school" do
+        let(:special_school_attributes) { {school_type: :community_special_school, school_type_group: :special_schools} }
 
         context "and it has an education phase of secondary or middle deemed secondary" do
           let(:school_attributes) { special_school_attributes.merge({phase: :secondary}) }
@@ -77,13 +77,46 @@ RSpec.describe MathsAndPhysics::SchoolEligibility do
           it { is_expected.to be false }
         end
 
-        context "and it is a state funded special school" do
-          let(:school_attributes) { special_school_attributes.merge({school_type: :community_school}) }
+        context "and it doesn't have an education phase" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :not_applicable}) }
+          it { is_expected.to be true }
+        end
+      end
+
+      context "and it is a special free school" do
+        let(:special_free_school_attributes) { {school_type: :free_school_special, school_type_group: :free_schools} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { special_free_school_attributes.merge({phase: :secondary}) }
           it { is_expected.to be true }
         end
 
-        context "and it is an independent special school" do
-          let(:school_attributes) { special_school_attributes.merge({school_type: :other_independent_special_school}) }
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { special_free_school_attributes.merge({phase: :nursery}) }
+          it { is_expected.to be false }
+        end
+
+        context "and it doesn't have an education phase" do
+          let(:school_attributes) { special_free_school_attributes.merge({phase: :not_applicable}) }
+          it { is_expected.to be true }
+        end
+      end
+
+      context "and it is an independent special school" do
+        let(:special_school_attributes) { {school_type: :other_independent_special_school, school_type_group: :special_schools} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :secondary}) }
+          it { is_expected.to be false }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :nursery}) }
+          it { is_expected.to be false }
+        end
+
+        context "and it doesn't have an education phase" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :not_applicable}) }
           it { is_expected.to be false }
         end
       end

--- a/spec/services/maths_and_physics/school_eligibility_spec.rb
+++ b/spec/services/maths_and_physics/school_eligibility_spec.rb
@@ -121,6 +121,11 @@ RSpec.describe MathsAndPhysics::SchoolEligibility do
         end
       end
 
+      context "and it is a special post 16 institution" do
+        let(:school_attributes) { {school_type: :special_post_16_institutions, school_type_group: :special_schools, phase: :not_applicable} }
+        it { is_expected.to be false }
+      end
+
       context "and it is not a state funded school" do
         let(:school_attributes) { {school_type_group: :independent_schools} }
         it { is_expected.to be false }

--- a/spec/services/tslr/school_eligibility_spec.rb
+++ b/spec/services/tslr/school_eligibility_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Tslr::SchoolEligibility do
         end
       end
 
-      context "and it is a special school" do
-        let(:special_school_attributes) { {school_type_group: :special_schools} }
+      context "and it is a state funded special school" do
+        let(:special_school_attributes) { {school_type: :community_special_school, school_type_group: :special_schools} }
 
         context "and it has an education phase of secondary or middle deemed secondary" do
           let(:school_attributes) { special_school_attributes.merge({phase: :secondary}) }
@@ -77,13 +77,46 @@ RSpec.describe Tslr::SchoolEligibility do
           it { is_expected.to be false }
         end
 
-        context "and it is a state funded special school" do
-          let(:school_attributes) { special_school_attributes.merge({school_type: :community_school}) }
+        context "and it doesn't have an education phase" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :not_applicable}) }
+          it { is_expected.to be true }
+        end
+      end
+
+      context "and it is a special free school" do
+        let(:special_free_school_attributes) { {school_type: :free_school_special, school_type_group: :free_schools} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { special_free_school_attributes.merge({phase: :secondary}) }
           it { is_expected.to be true }
         end
 
-        context "and it is an independent special school" do
-          let(:school_attributes) { special_school_attributes.merge({school_type: :other_independent_special_school}) }
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { special_free_school_attributes.merge({phase: :nursery}) }
+          it { is_expected.to be false }
+        end
+
+        context "and it doesn't have an education phase" do
+          let(:school_attributes) { special_free_school_attributes.merge({phase: :not_applicable}) }
+          it { is_expected.to be true }
+        end
+      end
+
+      context "and it is an independent special school" do
+        let(:special_school_attributes) { {school_type: :other_independent_special_school, school_type_group: :special_schools} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :secondary}) }
+          it { is_expected.to be false }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :nursery}) }
+          it { is_expected.to be false }
+        end
+
+        context "and it doesn't have an education phase" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :not_applicable}) }
           it { is_expected.to be false }
         end
       end

--- a/spec/services/tslr/school_eligibility_spec.rb
+++ b/spec/services/tslr/school_eligibility_spec.rb
@@ -121,6 +121,11 @@ RSpec.describe Tslr::SchoolEligibility do
         end
       end
 
+      context "and it is a special post 16 institution" do
+        let(:school_attributes) { {school_type: :special_post_16_institutions, school_type_group: :special_schools, phase: :not_applicable} }
+        it { is_expected.to be false }
+      end
+
       context "and it is not a state funded school" do
         let(:school_attributes) { {school_type_group: :independent_schools} }
         it { is_expected.to be false }


### PR DESCRIPTION
Most special schools have a "Not Applicable" education phase, so this adds support for those schools.

We use the school type, rather than the school type group for determining if a school is a special school because e.g. free special schools are grouped under free schools, and so would be left out. There maye be other examples.