### PR TITLE
Claimant answers questions to determine their student loan plan

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -76,6 +76,7 @@ class ClaimsController < ApplicationController
       :date_of_birth,
       :teacher_reference_number,
       :national_insurance_number,
+      :has_student_loan,
       :student_loan_repayment_amount,
       :email_address,
       :bank_sort_code,

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -77,6 +77,7 @@ class ClaimsController < ApplicationController
       :teacher_reference_number,
       :national_insurance_number,
       :has_student_loan,
+      :student_loan_country,
       :student_loan_repayment_amount,
       :email_address,
       :bank_sort_code,

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -79,6 +79,7 @@ class ClaimsController < ApplicationController
       :has_student_loan,
       :student_loan_country,
       :student_loan_courses,
+      :student_loan_start_date,
       :student_loan_repayment_amount,
       :email_address,
       :bank_sort_code,

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -78,6 +78,7 @@ class ClaimsController < ApplicationController
       :national_insurance_number,
       :has_student_loan,
       :student_loan_country,
+      :student_loan_courses,
       :student_loan_repayment_amount,
       :email_address,
       :bank_sort_code,

--- a/app/models/claim_update.rb
+++ b/app/models/claim_update.rb
@@ -22,6 +22,7 @@ class ClaimUpdate
       claim.attributes = params
       update_claim_school_dependent_attributes
       update_employment_status_dependent_attributes
+      determine_student_loan_plan
       claim.save(context: context)
     end
   end
@@ -46,5 +47,9 @@ class ClaimUpdate
     if claim.employment_status_changed?
       claim.current_school = claim.employed_at_claim_school? ? claim.claim_school : nil
     end
+  end
+
+  def determine_student_loan_plan
+    claim.student_loan_plan = StudentLoans.determine_plan(claim.student_loan_country, claim.student_loan_start_date)
   end
 end

--- a/app/models/claim_update.rb
+++ b/app/models/claim_update.rb
@@ -50,6 +50,10 @@ class ClaimUpdate
   end
 
   def determine_student_loan_plan
-    claim.student_loan_plan = StudentLoans.determine_plan(claim.student_loan_country, claim.student_loan_start_date)
+    claim.student_loan_plan = if claim.has_student_loan?
+      StudentLoans.determine_plan(claim.student_loan_country, claim.student_loan_start_date)
+    else
+      TslrClaim::NO_STUDENT_LOAN
+    end
   end
 end

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -21,6 +21,7 @@ class PageSequence
     "date-of-birth",
     "teacher-reference-number",
     "national-insurance-number",
+    "student-loan",
     "student-loan-amount",
     "email-address",
     "bank-details",

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -22,6 +22,7 @@ class PageSequence
     "teacher-reference-number",
     "national-insurance-number",
     "student-loan",
+    "student-loan-country",
     "student-loan-amount",
     "email-address",
     "bank-details",
@@ -40,6 +41,7 @@ class PageSequence
   def slugs
     SLUGS.dup.tap do |sequence|
       sequence.delete("current-school") if claim.employed_at_claim_school?
+      sequence.delete("student-loan-country") unless claim.has_student_loan?
     end
   end
 

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -24,6 +24,7 @@ class PageSequence
     "student-loan",
     "student-loan-country",
     "student-loan-how-many-courses",
+    "student-loan-start-date",
     "student-loan-amount",
     "email-address",
     "bank-details",
@@ -44,6 +45,7 @@ class PageSequence
       sequence.delete("current-school") if claim.employed_at_claim_school?
       sequence.delete("student-loan-country") if claim.no_student_loan?
       sequence.delete("student-loan-how-many-courses") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
+      sequence.delete("student-loan-start-date") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
     end
   end
 

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -23,6 +23,7 @@ class PageSequence
     "national-insurance-number",
     "student-loan",
     "student-loan-country",
+    "student-loan-how-many-courses",
     "student-loan-amount",
     "email-address",
     "bank-details",
@@ -41,7 +42,8 @@ class PageSequence
   def slugs
     SLUGS.dup.tap do |sequence|
       sequence.delete("current-school") if claim.employed_at_claim_school?
-      sequence.delete("student-loan-country") unless claim.has_student_loan?
+      sequence.delete("student-loan-country") if claim.no_student_loan?
+      sequence.delete("student-loan-how-many-courses") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
     end
   end
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -62,6 +62,8 @@ class TslrClaim < ApplicationRecord
   validates :national_insurance_number, on: [:"national-insurance-number", :submit], presence: {message: "Enter your National Insurance number"}
   validate  :ni_number_is_correct_format
 
+  validates :has_student_loan,                  on: [:"student-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a student loan"}
+
   validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
   validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount",
                                                             allow_nil: true,

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -7,30 +7,11 @@ class TslrClaim < ApplicationRecord
     :languages_taught,
   ].freeze
 
-  STUDENT_LOAN_COUNTRIES_WITH_ONE_PLAN = [
-    "scotland",
-    "northern_ireland",
-  ].freeze
-
   TRN_LENGTH = 7
 
-  enum student_loan_country: {
-    england: 0,
-    northern_ireland: 1,
-    scotland: 2,
-    wales: 3,
-  }
-
-  enum student_loan_courses: {
-    one_course: 0,
-    two_or_more_courses: 1,
-  }
-
-  enum student_loan_start_date: {
-    before_first_september_2012: 0,
-    on_or_after_first_september_2012: 1,
-    some_before_some_after_first_september_2012: 2,
-  }
+  enum student_loan_country: StudentLoans::COUNTRIES
+  enum student_loan_start_date: StudentLoans::COURSE_START_DATES
+  enum student_loan_courses: {one_course: 0, two_or_more_courses: 1}
 
   enum employment_status: {
     claim_school: 0,
@@ -177,7 +158,7 @@ class TslrClaim < ApplicationRecord
   end
 
   def student_loan_country_with_one_plan?
-    STUDENT_LOAN_COUNTRIES_WITH_ONE_PLAN.include?(student_loan_country)
+    StudentLoans::PLAN_1_COUNTRIES.include?(student_loan_country)
   end
 
   private

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -26,6 +26,12 @@ class TslrClaim < ApplicationRecord
     two_or_more_courses: 1,
   }
 
+  enum student_loan_start_date: {
+    before_first_september_2012: 0,
+    on_or_after_first_september_2012: 1,
+    some_before_some_after_first_september_2012: 2,
+  }
+
   enum employment_status: {
     claim_school: 0,
     different_school: 1,
@@ -82,6 +88,7 @@ class TslrClaim < ApplicationRecord
   validates :has_student_loan,                  on: [:"student-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a student loan"}
   validates :student_loan_country,              on: [:"student-loan-country", :submit], presence: {message: "Select the country in which you first applied for your student loan"}
   validates :student_loan_courses,              on: [:"student-loan-how-many-courses", :submit], presence: {message: "Select the number of higher education courses you have studied"}
+  validates :student_loan_start_date,           on: [:"student-loan-start-date", :submit], presence: {message: "Select when the first year of your higher education course started"}
 
   validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
   validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount",

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -9,6 +9,13 @@ class TslrClaim < ApplicationRecord
 
   TRN_LENGTH = 7
 
+  enum student_loan_country: {
+    england: 0,
+    northern_ireland: 1,
+    scotland: 2,
+    wales: 3,
+  }
+
   enum employment_status: {
     claim_school: 0,
     different_school: 1,
@@ -63,6 +70,7 @@ class TslrClaim < ApplicationRecord
   validate  :ni_number_is_correct_format
 
   validates :has_student_loan,                  on: [:"student-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a student loan"}
+  validates :student_loan_country,              on: [:"student-loan-country", :submit], presence: {message: "Select the country in which you first applied for your student loan"}
 
   validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
   validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount",

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TslrClaim < ApplicationRecord
   SUBJECT_FIELDS = [
     :biology_taught,
@@ -9,10 +11,13 @@ class TslrClaim < ApplicationRecord
 
   TRN_LENGTH = 7
 
+  NO_STUDENT_LOAN = "not_applicable"
+  STUDENT_LOAN_PLAN_OPTIONS = StudentLoans::PLANS.dup << NO_STUDENT_LOAN
+
   enum student_loan_country: StudentLoans::COUNTRIES
   enum student_loan_start_date: StudentLoans::COURSE_START_DATES
   enum student_loan_courses: {one_course: 0, two_or_more_courses: 1}
-  enum student_loan_plan: StudentLoans::PLANS
+  enum student_loan_plan: STUDENT_LOAN_PLAN_OPTIONS
 
   enum employment_status: {
     claim_school: 0,
@@ -68,9 +73,10 @@ class TslrClaim < ApplicationRecord
   validate  :ni_number_is_correct_format
 
   validates :has_student_loan,                  on: [:"student-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a student loan"}
-  validates :student_loan_country,              on: [:"student-loan-country", :submit], presence: {message: "Select the country in which you first applied for your student loan"}
-  validates :student_loan_courses,              on: [:"student-loan-how-many-courses", :submit], presence: {message: "Select the number of higher education courses you have studied"}
-  validates :student_loan_start_date,           on: [:"student-loan-start-date", :submit], presence: {message: "Select when the first year of your higher education course started"}
+  validates :student_loan_country,              on: [:"student-loan-country"], presence: {message: "Select the country in which you first applied for your student loan"}
+  validates :student_loan_courses,              on: [:"student-loan-how-many-courses"], presence: {message: "Select the number of higher education courses you have studied"}
+  validates :student_loan_start_date,           on: [:"student-loan-start-date"], presence: {message: "Select when the first year of your higher education course started"}
+  validates :student_loan_plan,                 on: [:submit], presence: {message: "We have not been able determined your student loan repayment plan. Answer all questions about your student loan."}
 
   validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
   validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount",

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -12,6 +12,7 @@ class TslrClaim < ApplicationRecord
   enum student_loan_country: StudentLoans::COUNTRIES
   enum student_loan_start_date: StudentLoans::COURSE_START_DATES
   enum student_loan_courses: {one_course: 0, two_or_more_courses: 1}
+  enum student_loan_plan: StudentLoans::PLANS
 
   enum employment_status: {
     claim_school: 0,

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -7,6 +7,11 @@ class TslrClaim < ApplicationRecord
     :languages_taught,
   ].freeze
 
+  STUDENT_LOAN_COUNTRIES_WITH_ONE_PLAN = [
+    "scotland",
+    "northern_ireland",
+  ].freeze
+
   TRN_LENGTH = 7
 
   enum student_loan_country: {
@@ -14,6 +19,11 @@ class TslrClaim < ApplicationRecord
     northern_ireland: 1,
     scotland: 2,
     wales: 3,
+  }
+
+  enum student_loan_courses: {
+    one_course: 0,
+    two_or_more_courses: 1,
   }
 
   enum employment_status: {
@@ -71,6 +81,7 @@ class TslrClaim < ApplicationRecord
 
   validates :has_student_loan,                  on: [:"student-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a student loan"}
   validates :student_loan_country,              on: [:"student-loan-country", :submit], presence: {message: "Select the country in which you first applied for your student loan"}
+  validates :student_loan_courses,              on: [:"student-loan-how-many-courses", :submit], presence: {message: "Select the number of higher education courses you have studied"}
 
   validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
   validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount",
@@ -152,6 +163,14 @@ class TslrClaim < ApplicationRecord
 
   def subjects_taught
     SUBJECT_FIELDS.select { |s| send(s) == true }
+  end
+
+  def no_student_loan?
+    !has_student_loan?
+  end
+
+  def student_loan_country_with_one_plan?
+    STUDENT_LOAN_COUNTRIES_WITH_ONE_PLAN.include?(student_loan_country)
   end
 
   private

--- a/app/presenters/tslr_claim_csv_row.rb
+++ b/app/presenters/tslr_claim_csv_row.rb
@@ -28,6 +28,10 @@ class TslrClaimCsvRow < SimpleDelegator
     "£#{model.student_loan_repayment_amount}"
   end
 
+  def student_loan_repayment_plan
+    model.student_loan_plan&.humanize
+  end
+
   def submitted_at
     model.submitted_at.strftime("%d/%m/%Y %H:%M")
   end

--- a/app/presenters/tslr_claims_csv.rb
+++ b/app/presenters/tslr_claims_csv.rb
@@ -19,6 +19,7 @@ class TslrClaimsCsv
     :date_of_birth,
     :teacher_reference_number,
     :national_insurance_number,
+    :student_loan_repayment_plan,
     :email_address,
     :mostly_teaching_eligible_subjects,
     :bank_sort_code,

--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -1,0 +1,36 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { has_student_loan: "tslr_claim_has_student_loan_true" }) if current_claim.errors.any? %>
+
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <%= form.hidden_field :has_student_loan %>
+        <%= form_group_tag current_claim do %>
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("tslr.questions.has_student_loan") %>
+              </h1>
+            </legend>
+            <span class="govuk-hint">
+              We need this information to make sure you do not pay any tax on this payment.
+            </span>
+
+            <%= errors_tag current_claim, :has_student_loan %>
+
+            <div class="govuk-radios govuk-radios--inline">
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:has_student_loan, true, class: "govuk-radios__input")%>
+                <%= form.label :has_student_loan_true, "Yes", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:has_student_loan, false, class: "govuk-radios__input")%>
+                <%= form.label :has_student_loan_false, "No", class: "govuk-label govuk-radios__label" %>
+              </div>
+            </div>
+
+          </fieldset>
+        <% end %>
+        <%= form.submit "Continue", class: "govuk-button" %>
+      <% end %>
+  </div>
+</div>

--- a/app/views/claims/student_loan_country.html.erb
+++ b/app/views/claims/student_loan_country.html.erb
@@ -1,0 +1,41 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { student_loan_country: "tslr_claim_student_loan_country_england" }) if current_claim.errors.any? %>
+
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <%= form.hidden_field :student_loan_country %>
+        <%= form_group_tag current_claim do %>
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("tslr.questions.student_loan_country") %>
+              </h1>
+            </legend>
+
+            <%= errors_tag current_claim, :student_loan_country %>
+
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_country, :england, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_country_england, "England", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_country, :northern_ireland, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_country_northern_ireland, "Northern Ireland", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_country, :scotland, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_country_scotland, "Scotland", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_country, :wales, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_country_wales, "Wales", class: "govuk-label govuk-radios__label" %>
+              </div>
+            </div>
+
+          </fieldset>
+        <% end %>
+        <%= form.submit "Continue", class: "govuk-button" %>
+      <% end %>
+  </div>
+</div>

--- a/app/views/claims/student_loan_country.html.erb
+++ b/app/views/claims/student_loan_country.html.erb
@@ -16,19 +16,19 @@
 
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_country, :england, class: "govuk-radios__input")%>
+                <%= form.radio_button(:student_loan_country, StudentLoans::ENGLAND, class: "govuk-radios__input")%>
                 <%= form.label :student_loan_country_england, "England", class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_country, :northern_ireland, class: "govuk-radios__input")%>
+                <%= form.radio_button(:student_loan_country, StudentLoans::NORTHERN_IRELAND, class: "govuk-radios__input")%>
                 <%= form.label :student_loan_country_northern_ireland, "Northern Ireland", class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_country, :scotland, class: "govuk-radios__input")%>
+                <%= form.radio_button(:student_loan_country, StudentLoans::SCOTLAND, class: "govuk-radios__input")%>
                 <%= form.label :student_loan_country_scotland, "Scotland", class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_country, :wales, class: "govuk-radios__input")%>
+                <%= form.radio_button(:student_loan_country, StudentLoans::WALES, class: "govuk-radios__input")%>
                 <%= form.label :student_loan_country_wales, "Wales", class: "govuk-label govuk-radios__label" %>
               </div>
             </div>

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -1,0 +1,34 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { student_loan_courses: "tslr_claim_student_loan_courses_one_course" }) if current_claim.errors.any? %>
+
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <%= form.hidden_field :student_loan_courses %>
+        <%= form_group_tag current_claim do %>
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("tslr.questions.student_loan_how_many_courses") %>
+              </h1>
+            </legend>
+            <span class="govuk-hint">This includes university degrees, PGCE and Initial Teacher Training courses.</span>
+
+            <%= errors_tag current_claim, :student_loan_courses %>
+
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_courses, :one_course, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_courses_one_course, "1", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_courses, :two_or_more_courses, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_courses_two_or_more_courses, "2 or more", class: "govuk-label govuk-radios__label" %>
+              </div>
+            </div>
+
+          </fieldset>
+        <% end %>
+        <%= form.submit "Continue", class: "govuk-button" %>
+      <% end %>
+  </div>
+</div>

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -1,0 +1,62 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { student_loan_start_date: "tslr_claim_student_loan_start_date_before_first_september_2012" }) if current_claim.errors.any? %>
+
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <%= form.hidden_field :student_loan_start_date %>
+        <%= form_group_tag current_claim do %>
+          <fieldset class="govuk-fieldset">
+          <% if current_claim.student_loan_courses == "one_course" %>
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("tslr.questions.student_loan_start_date.single_course") %>
+              </h1>
+            </legend>
+
+            <%= errors_tag current_claim, :student_loan_start_date %>
+
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_start_date, :before_first_september_2012, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_start_date_before_first_september_2012, "Before 1 September 2012", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_start_date, :on_or_after_first_september_2012, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "On or after 1 September 2012", class: "govuk-label govuk-radios__label" %>
+              </div>
+            </div>
+
+          <% else %>
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("tslr.questions.student_loan_start_date.multiple_courses") %>
+              </h1>
+            </legend>
+
+            <%= errors_tag current_claim, :student_loan_start_date %>
+
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_start_date, :before_first_september_2012, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_start_date_before_first_september_2012, "All my degree courses started before 1 September 2012", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_start_date, :some_before_some_after_first_september_2012, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_start_date_some_before_some_after_first_september_2012, "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button(:student_loan_start_date, :on_or_after_first_september_2012, class: "govuk-radios__input")%>
+                <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "All of my degree courses started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
+              </div>
+            </div>
+
+          <% end %>
+
+          </fieldset>
+        <% end %>
+        <%= form.submit "Continue", class: "govuk-button" %>
+      <% end %>
+  </div>
+</div>

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -18,11 +18,11 @@
 
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_start_date, :before_first_september_2012, class: "govuk-radios__input")%>
+                <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
                 <%= form.label :student_loan_start_date_before_first_september_2012, "Before 1 September 2012", class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_start_date, :on_or_after_first_september_2012, class: "govuk-radios__input")%>
+                <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
                 <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "On or after 1 September 2012", class: "govuk-label govuk-radios__label" %>
               </div>
             </div>
@@ -39,15 +39,15 @@
 
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_start_date, :before_first_september_2012, class: "govuk-radios__input")%>
+                <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
                 <%= form.label :student_loan_start_date_before_first_september_2012, "All my degree courses started before 1 September 2012", class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_start_date, :some_before_some_after_first_september_2012, class: "govuk-radios__input")%>
+                <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_AND_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
                 <%= form.label :student_loan_start_date_some_before_some_after_first_september_2012, "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_start_date, :on_or_after_first_september_2012, class: "govuk-radios__input")%>
+                <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
                 <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "All of my degree courses started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
               </div>
             </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
 require_relative "../lib/verify"
+require_relative "../lib/student_loans"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,9 @@ en:
       has_student_loan: "Have ever taken out a student loan and not paid it off yet?"
       student_loan_country: "When you applied for your student loan where was your home address?"
       student_loan_how_many_courses: "How many higher education courses have you studied?"
+      student_loan_start_date:
+        single_course: "When did the first year of your higher education course start?"
+        multiple_courses: "When did the first year of each higher education course start?"
       student_loan_amount:
         "Exactly how much student loan did you repay while you worked at %{claim_school_name} between 6 April 2018 and 5
         April 2019?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
       date_of_birth: "What is your date of birth?"
       teacher_reference_number: "What's your teacher reference number?"
       national_insurance_number: "What's your National Insurance number?"
+      has_student_loan: "Have ever taken out a student loan and not paid it off yet?"
       student_loan_amount:
         "Exactly how much student loan did you repay while you worked at %{claim_school_name} between 6 April 2018 and 5
         April 2019?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,7 @@ en:
       date_of_birth: "Date of Birth"
       teacher_reference_number: "Teacher Reference"
       national_insurance_number: "NI Number"
+      student_loan_repayment_plan: "Student Loan Repayment Plan"
       email_address: "Email"
       mostly_teaching_eligible_subjects: "Mostly Teaching Eligible Subjects?"
       bank_sort_code: "Sort Code"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
       teacher_reference_number: "What's your teacher reference number?"
       national_insurance_number: "What's your National Insurance number?"
       has_student_loan: "Have ever taken out a student loan and not paid it off yet?"
+      student_loan_country: "When you applied for your student loan where was your home address?"
       student_loan_amount:
         "Exactly how much student loan did you repay while you worked at %{claim_school_name} between 6 April 2018 and 5
         April 2019?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
       national_insurance_number: "What's your National Insurance number?"
       has_student_loan: "Have ever taken out a student loan and not paid it off yet?"
       student_loan_country: "When you applied for your student loan where was your home address?"
+      student_loan_how_many_courses: "How many higher education courses have you studied?"
       student_loan_amount:
         "Exactly how much student loan did you repay while you worked at %{claim_school_name} between 6 April 2018 and 5
         April 2019?"

--- a/db/migrate/20190709100000_add_student_loan_to_tslr_claim.rb
+++ b/db/migrate/20190709100000_add_student_loan_to_tslr_claim.rb
@@ -1,0 +1,5 @@
+class AddStudentLoanToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :has_student_loan, :boolean
+  end
+end

--- a/db/migrate/20190709110000_add_student_loan_country_to_tslr_claim.rb
+++ b/db/migrate/20190709110000_add_student_loan_country_to_tslr_claim.rb
@@ -1,0 +1,5 @@
+class AddStudentLoanCountryToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :student_loan_country, :integer
+  end
+end

--- a/db/migrate/20190709135426_add_student_loan_courses_to_tslr_claim.rb
+++ b/db/migrate/20190709135426_add_student_loan_courses_to_tslr_claim.rb
@@ -1,0 +1,5 @@
+class AddStudentLoanCoursesToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :student_loan_courses, :integer
+  end
+end

--- a/db/migrate/20190710103359_add_student_loan_start_date_to_tslrclaim.rb
+++ b/db/migrate/20190710103359_add_student_loan_start_date_to_tslrclaim.rb
@@ -1,0 +1,5 @@
+class AddStudentLoanStartDateToTslrclaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :student_loan_start_date, :integer
+  end
+end

--- a/db/migrate/20190710133334_add_student_loan_plan_to_tslr_claim.rb
+++ b/db/migrate/20190710133334_add_student_loan_plan_to_tslr_claim.rb
@@ -1,0 +1,5 @@
+class AddStudentLoanPlanToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :student_loan_plan, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 2019_07_22_101055) do
     t.boolean "has_student_loan"
     t.integer "student_loan_country"
     t.integer "student_loan_courses"
+    t.integer "student_loan_start_date"
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 2019_07_22_101055) do
     t.integer "student_loan_country"
     t.integer "student_loan_courses"
     t.integer "student_loan_start_date"
+    t.integer "student_loan_plan"
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2019_07_22_101055) do
     t.boolean "computer_science_taught", default: false
     t.boolean "languages_taught", default: false
     t.boolean "has_student_loan"
+    t.integer "student_loan_country"
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2019_07_22_101055) do
     t.boolean "physics_taught", default: false
     t.boolean "computer_science_taught", default: false
     t.boolean "languages_taught", default: false
+    t.boolean "has_student_loan"
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 2019_07_22_101055) do
     t.boolean "languages_taught", default: false
     t.boolean "has_student_loan"
     t.integer "student_loan_country"
+    t.integer "student_loan_courses"
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/lib/student_loans.rb
+++ b/lib/student_loans.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module StudentLoans
+  COUNTRIES = [
+    ENGLAND = "england",
+    NORTHERN_IRELAND = "northern_ireland",
+    WALES = "wales",
+    SCOTLAND = "scotland",
+  ].freeze
+
+  COURSE_START_DATES = [
+    BEFORE_1_SEPT_2012 = "before_first_september_2012",
+    ON_OR_AFTER_1_SEPT_2012 = "on_or_after_first_september_2012",
+    BEFORE_AND_AFTER_1_SEPT_2012 = "some_before_some_after_first_september_2012",
+  ].freeze
+
+  PLAN_1_COUNTRIES = [NORTHERN_IRELAND, SCOTLAND].freeze
+end

--- a/lib/student_loans.rb
+++ b/lib/student_loans.rb
@@ -15,4 +15,27 @@ module StudentLoans
   ].freeze
 
   PLAN_1_COUNTRIES = [NORTHERN_IRELAND, SCOTLAND].freeze
+
+  PLANS = [
+    PLAN_1 = "plan_1",
+    PLAN_2 = "plan_2",
+    PLAN_1_AND_2 = "plan_1_and_2",
+  ].freeze
+
+  DATES_TO_PLANS_MAP = {
+    BEFORE_1_SEPT_2012 => PLAN_1,
+    ON_OR_AFTER_1_SEPT_2012 => PLAN_2,
+    BEFORE_AND_AFTER_1_SEPT_2012 => PLAN_1_AND_2,
+  }.freeze
+
+  # Used to determine a person's student loan plan based on their country of
+  # study and the start date(s) of their course(s).
+  #
+  # Returns nil if the plan cannot be determined based on the information
+  # provided.
+  def self.determine_plan(country, course_start_date = nil)
+    return PLAN_1 if PLAN_1_COUNTRIES.include?(country)
+
+    DATES_TO_PLANS_MAP[course_start_date]
+  end
 end

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
       date_of_birth { 20.years.ago.to_date }
       teacher_reference_number { "1234567" }
       national_insurance_number { "QQ123456C" }
+      has_student_loan { true }
       student_loan_repayment_amount { 1000 }
       email_address { "test@email.com" }
       bank_sort_code { 123456 }

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
       national_insurance_number { "QQ123456C" }
       has_student_loan { true }
       student_loan_country { :england }
+      student_loan_courses { :one_course }
       student_loan_repayment_amount { 1000 }
       email_address { "test@email.com" }
       bank_sort_code { 123456 }

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
       has_student_loan { true }
       student_loan_country { :england }
       student_loan_courses { :one_course }
+      student_loan_start_date { :before_first_september_2012 }
       student_loan_repayment_amount { 1000 }
       email_address { "test@email.com" }
       bank_sort_code { 123456 }

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
       has_student_loan { true }
       student_loan_country { :england }
       student_loan_courses { :one_course }
-      student_loan_start_date { :before_first_september_2012 }
+      student_loan_start_date { StudentLoans::BEFORE_1_SEPT_2012 }
       student_loan_repayment_amount { 1000 }
       email_address { "test@email.com" }
       bank_sort_code { 123456 }

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
       teacher_reference_number { "1234567" }
       national_insurance_number { "QQ123456C" }
       has_student_loan { true }
+      student_loan_country { :england }
       student_loan_repayment_amount { 1000 }
       email_address { "test@email.com" }
       bank_sort_code { 123456 }

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
       student_loan_country { :england }
       student_loan_courses { :one_course }
       student_loan_start_date { StudentLoans::BEFORE_1_SEPT_2012 }
+      student_loan_plan { StudentLoans::PLAN_1 }
       student_loan_repayment_amount { 1000 }
       email_address { "test@email.com" }
       bank_sort_code { 123456 }

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -73,6 +73,12 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.national_insurance_number).to eq("QQ123456C")
 
+    expect(page).to have_text(I18n.t("tslr.questions.has_student_loan"))
+    choose("Yes")
+    click_on "Continue"
+
+    expect(claim.reload).to have_student_loan
+
     expect(page).to have_text(I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name))
     fill_in I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
     click_on "Continue"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -79,6 +79,12 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload).to have_student_loan
 
+    expect(page).to have_text(I18n.t("tslr.questions.student_loan_country"))
+    choose("England")
+    click_on "Continue"
+
+    expect(claim.reload.student_loan_country).to eq("england")
+
     expect(page).to have_text(I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name))
     fill_in I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
     click_on "Continue"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     choose "Before 1 September 2012"
     click_on "Continue"
 
-    expect(claim.reload.student_loan_start_date).to eq("before_first_september_2012")
+    expect(claim.reload.student_loan_start_date).to eq(StudentLoans::BEFORE_1_SEPT_2012)
 
     expect(page).to have_text(I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name))
     fill_in I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -85,6 +85,12 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.student_loan_country).to eq("england")
 
+    expect(page).to have_text(I18n.t("tslr.questions.student_loan_how_many_courses"))
+    choose("1")
+    click_on "Continue"
+
+    expect(claim.reload.student_loan_courses).to eq("one_course")
+
     expect(page).to have_text(I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name))
     fill_in I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
     click_on "Continue"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -91,6 +91,12 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.student_loan_courses).to eq("one_course")
 
+    expect(page).to have_text(I18n.t("tslr.questions.student_loan_start_date.single_course"))
+    choose "Before 1 September 2012"
+    click_on "Continue"
+
+    expect(claim.reload.student_loan_start_date).to eq("before_first_september_2012")
+
     expect(page).to have_text(I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name))
     fill_in I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
     click_on "Continue"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -96,6 +96,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     click_on "Continue"
 
     expect(claim.reload.student_loan_start_date).to eq(StudentLoans::BEFORE_1_SEPT_2012)
+    expect(claim.student_loan_plan).to eq(StudentLoans::PLAN_1)
 
     expect(page).to have_text(I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name))
     fill_in I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"

--- a/spec/lib/student_loans_spec.rb
+++ b/spec/lib/student_loans_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+require "student_loans"
+
+RSpec.describe StudentLoans do
+  describe "#determine_plan" do
+    it "always returns PLAN_1 for countries with a single student loan plan, i.e. Northern Ireland and Scotland" do
+      expect(StudentLoans.determine_plan(StudentLoans::NORTHERN_IRELAND)).to eq StudentLoans::PLAN_1
+      expect(StudentLoans.determine_plan(StudentLoans::SCOTLAND)).to eq StudentLoans::PLAN_1
+
+      expect(StudentLoans.determine_plan(StudentLoans::SCOTLAND, StudentLoans::BEFORE_1_SEPT_2012)).to eq StudentLoans::PLAN_1
+      expect(StudentLoans.determine_plan(StudentLoans::SCOTLAND, StudentLoans::ON_OR_AFTER_1_SEPT_2012)).to eq StudentLoans::PLAN_1
+    end
+
+    it "returns PLAN_1 when the course(s) started before 1 September 2012" do
+      expect(StudentLoans.determine_plan(StudentLoans::ENGLAND, StudentLoans::BEFORE_1_SEPT_2012)).to eq StudentLoans::PLAN_1
+    end
+
+    it "returns PLAN_2 when the course(s) started on or after 1 Semptember 2012" do
+      expect(StudentLoans.determine_plan(StudentLoans::ENGLAND, StudentLoans::ON_OR_AFTER_1_SEPT_2012)).to eq StudentLoans::PLAN_2
+    end
+
+    it "returns PLAN_1_AND_2 when courses started both before and after 1st Semptember 2012" do
+      expect(StudentLoans.determine_plan(StudentLoans::ENGLAND, StudentLoans::BEFORE_AND_AFTER_1_SEPT_2012)).to eq StudentLoans::PLAN_1_AND_2
+    end
+  end
+end

--- a/spec/models/claim_update_spec.rb
+++ b/spec/models/claim_update_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe ClaimUpdate do
     end
   end
 
+  context "setting student-loan-related parameters" do
+    let(:claim) { create(:tslr_claim, has_student_loan: true, student_loan_country: StudentLoans::ENGLAND) }
+    let(:context) { "student-loan-start-date" }
+    let(:params) { {student_loan_start_date: StudentLoans::ON_OR_AFTER_1_SEPT_2012} }
+
+    it "determines the plan based on the answers" do
+      expect(claim_update.perform).to be_truthy
+      expect(claim.student_loan_plan).to eq StudentLoans::PLAN_2
+    end
+  end
+
   context "when updating claim that is submittable in the “check-your-answers” context" do
     let(:claim) { create(:tslr_claim, :submittable) }
     let(:context) { "check-your-answers" }

--- a/spec/models/claim_update_spec.rb
+++ b/spec/models/claim_update_spec.rb
@@ -28,14 +28,27 @@ RSpec.describe ClaimUpdate do
     end
   end
 
-  context "setting student-loan-related parameters" do
-    let(:claim) { create(:tslr_claim, has_student_loan: true, student_loan_country: StudentLoans::ENGLAND) }
-    let(:context) { "student-loan-start-date" }
-    let(:params) { {student_loan_start_date: StudentLoans::ON_OR_AFTER_1_SEPT_2012} }
+  describe "determining the student_loan_plan" do
+    context "when the claimant has a plan" do
+      let(:claim) { create(:tslr_claim, has_student_loan: true, student_loan_country: StudentLoans::ENGLAND) }
+      let(:context) { "student-loan-start-date" }
+      let(:params) { {student_loan_start_date: StudentLoans::ON_OR_AFTER_1_SEPT_2012} }
 
-    it "determines the plan based on the answers" do
-      expect(claim_update.perform).to be_truthy
-      expect(claim.student_loan_plan).to eq StudentLoans::PLAN_2
+      it "determines the plan based on the answers" do
+        expect(claim_update.perform).to be_truthy
+        expect(claim.student_loan_plan).to eq StudentLoans::PLAN_2
+      end
+    end
+
+    context "when the claimant does not have a plan" do
+      let(:claim) { create(:tslr_claim) }
+      let(:context) { "student-loan" }
+      let(:params) { {has_student_loan: false} }
+
+      it "sets the student_loan_plan to indicate it is not applicable" do
+        expect(claim_update.perform).to be_truthy
+        expect(claim.student_loan_plan).to eq TslrClaim::NO_STUDENT_LOAN
+      end
     end
   end
 

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -18,26 +18,30 @@ RSpec.describe PageSequence do
       page_sequence = PageSequence.new(claim, "still-teaching")
       expect(page_sequence.slugs).not_to include("student-loan-country")
       expect(page_sequence.slugs).not_to include("student-loan-how-many-courses")
+      expect(page_sequence.slugs).not_to include("student-loan-start-date")
 
       claim.has_student_loan = true
       page_sequence = PageSequence.new(claim, "still-teaching")
       expect(page_sequence.slugs).to include("student-loan-country")
       expect(page_sequence.slugs).to include("student-loan-how-many-courses")
+      expect(page_sequence.slugs).to include("student-loan-start-date")
     end
 
-    it "excludes “student-loan-how-many-courses” when the claimant received their student loan in Scotland or Northern Ireland" do
+    it "excludes the remaining student loan-related pages when the claimant received their student loan in Scotland or Northern Ireland" do
       claim.has_student_loan = true
 
       TslrClaim::STUDENT_LOAN_COUNTRIES_WITH_ONE_PLAN.each do |plan_1_country|
         claim.student_loan_country = plan_1_country
         page_sequence = PageSequence.new(claim, "student-loan-country")
         expect(page_sequence.slugs).not_to include("student-loan-how-many-courses")
+        expect(page_sequence.slugs).not_to include("student-loan-start-date")
       end
 
       %w[england wales].each do |variable_plan_country|
         claim.student_loan_country = variable_plan_country
         page_sequence = PageSequence.new(claim, "student-loan-country")
         expect(page_sequence.slugs).to include("student-loan-how-many-courses")
+        expect(page_sequence.slugs).to include("student-loan-start-date")
       end
     end
   end

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe PageSequence do
     it "excludes the remaining student loan-related pages when the claimant received their student loan in Scotland or Northern Ireland" do
       claim.has_student_loan = true
 
-      TslrClaim::STUDENT_LOAN_COUNTRIES_WITH_ONE_PLAN.each do |plan_1_country|
+      StudentLoans::PLAN_1_COUNTRIES.each do |plan_1_country|
         claim.student_loan_country = plan_1_country
         page_sequence = PageSequence.new(claim, "student-loan-country")
         expect(page_sequence.slugs).not_to include("student-loan-how-many-courses")

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe PageSequence do
 
       expect(page_sequence.slugs).not_to include("current-school")
     end
+
+    it "excludes “student-loan-country” when the claimant no longer has a student loan" do
+      claim.has_student_loan = false
+      page_sequence = PageSequence.new(claim, "still-teaching")
+      expect(page_sequence.slugs).not_to include("student-loan-country")
+
+      claim.has_student_loan = true
+      page_sequence = PageSequence.new(claim, "still-teaching")
+      expect(page_sequence.slugs).to include("student-loan-country")
+    end
   end
 
   describe "#next_slug" do

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -13,14 +13,32 @@ RSpec.describe PageSequence do
       expect(page_sequence.slugs).not_to include("current-school")
     end
 
-    it "excludes “student-loan-country” when the claimant no longer has a student loan" do
+    it "excludes student loan-related pages when the claimant no longer has a student loan" do
       claim.has_student_loan = false
       page_sequence = PageSequence.new(claim, "still-teaching")
       expect(page_sequence.slugs).not_to include("student-loan-country")
+      expect(page_sequence.slugs).not_to include("student-loan-how-many-courses")
 
       claim.has_student_loan = true
       page_sequence = PageSequence.new(claim, "still-teaching")
       expect(page_sequence.slugs).to include("student-loan-country")
+      expect(page_sequence.slugs).to include("student-loan-how-many-courses")
+    end
+
+    it "excludes “student-loan-how-many-courses” when the claimant received their student loan in Scotland or Northern Ireland" do
+      claim.has_student_loan = true
+
+      TslrClaim::STUDENT_LOAN_COUNTRIES_WITH_ONE_PLAN.each do |plan_1_country|
+        claim.student_loan_country = plan_1_country
+        page_sequence = PageSequence.new(claim, "student-loan-country")
+        expect(page_sequence.slugs).not_to include("student-loan-how-many-courses")
+      end
+
+      %w[england wales].each do |variable_plan_country|
+        claim.student_loan_country = variable_plan_country
+        page_sequence = PageSequence.new(claim, "student-loan-country")
+        expect(page_sequence.slugs).to include("student-loan-how-many-courses")
+      end
     end
   end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -185,6 +185,14 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving in the “student-loan” validation context" do
+    it "validates the presence of student_loan" do
+      expect(TslrClaim.new).not_to be_valid(:"student-loan")
+      expect(TslrClaim.new(has_student_loan: true)).to be_valid(:"student-loan")
+      expect(TslrClaim.new(has_student_loan: false)).to be_valid(:"student-loan")
+    end
+  end
+
   context "when saving in the “student-loan-amount” validation context" do
     it "validates the presence of student_loan_repayment_amount" do
       expect(TslrClaim.new).not_to be_valid(:"student-loan-amount")

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -193,6 +193,13 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving in the “student-loan-country” validation context" do
+    it "validates the presence of student_loan_country" do
+      expect(TslrClaim.new).not_to be_valid(:"student-loan-country")
+      expect(TslrClaim.new(student_loan_country: :england)).to be_valid(:"student-loan-country")
+    end
+  end
+
   context "when saving in the “student-loan-amount” validation context" do
     it "validates the presence of student_loan_repayment_amount" do
       expect(TslrClaim.new).not_to be_valid(:"student-loan-amount")
@@ -333,6 +340,17 @@ RSpec.describe TslrClaim, type: :model do
     context "when not ineligible" do
       let(:claim_attributes) { {} }
       it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#student_loan_country" do
+    it "captures the country the student loan was received in" do
+      claim = TslrClaim.new(student_loan_country: :england)
+      expect(claim.student_loan_country).to eq("england")
+    end
+
+    it "rejects invalid countries" do
+      expect { TslrClaim.new(student_loan_country: :brazil) }.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -200,6 +200,13 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving in the “student-loan-how-many-courses” validation context" do
+    it "validates the presence of the student_loan_how_many_courses" do
+      expect(TslrClaim.new).not_to be_valid(:"student-loan-how-many-courses")
+      expect(TslrClaim.new(student_loan_courses: :one_course)).to be_valid(:"student-loan-how-many-courses")
+    end
+  end
+
   context "when saving in the “student-loan-amount” validation context" do
     it "validates the presence of student_loan_repayment_amount" do
       expect(TslrClaim.new).not_to be_valid(:"student-loan-amount")
@@ -351,6 +358,34 @@ RSpec.describe TslrClaim, type: :model do
 
     it "rejects invalid countries" do
       expect { TslrClaim.new(student_loan_country: :brazil) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#student_loan_how_many_courses" do
+    it "captures how many courses" do
+      claim = TslrClaim.new(student_loan_courses: :one_course)
+      expect(claim.student_loan_courses).to eq("one_course")
+    end
+
+    it "rejects invalid responses" do
+      expect { TslrClaim.new(student_loan_courses: :one_hundred_courses) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#no_student_loan?" do
+    it "returns true if the claim has no student loan" do
+      expect(TslrClaim.new(has_student_loan: false).no_student_loan?).to eq true
+      expect(TslrClaim.new(has_student_loan: true).no_student_loan?).to eq false
+    end
+  end
+
+  describe "#student_loan_country_with_one_plan?" do
+    it "returns true when the student_loan_country is one with only a single student loan plan" do
+      expect(TslrClaim.new.student_loan_country_with_one_plan?).to eq false
+
+      TslrClaim::STUDENT_LOAN_COUNTRIES_WITH_ONE_PLAN.each do |country|
+        expect(TslrClaim.new(student_loan_country: country).student_loan_country_with_one_plan?).to eq true
+      end
     end
   end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -98,6 +98,25 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  it "is not submittable without a value for the student_loan_plan present" do
+    expect(build(:tslr_claim, :submittable, student_loan_plan: nil)).not_to be_valid(:submit)
+    expect(build(:tslr_claim, :submittable, student_loan_plan: TslrClaim::NO_STUDENT_LOAN)).to be_valid(:submit)
+  end
+
+  it "is submittable with optional student loan questions not answered" do
+    claim = build(
+      :tslr_claim,
+      :submittable,
+      has_student_loan: false,
+      student_loan_plan: TslrClaim::NO_STUDENT_LOAN,
+      student_loan_country: nil,
+      student_loan_courses: nil,
+      student_loan_start_date: nil
+    )
+
+    expect(claim).to be_valid(:submit)
+  end
+
   context "when saving in the “qts-year” validation context" do
     let(:custom_validation_context) { :"qts-year" }
 
@@ -244,7 +263,7 @@ RSpec.describe TslrClaim, type: :model do
   end
 
   context "when saving in the “submit” validation context" do
-    it "validates the presence of all required fields" do
+    it "validates the claim is in a submittable state" do
       expect(TslrClaim.new).not_to be_valid(:submit)
       expect(build(:tslr_claim, :submittable)).to be_valid(:submit)
     end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe TslrClaim, type: :model do
   context "when saving in the “student-loan-start-date” validation context" do
     it "validates the presence of the student_loan_how_many_courses" do
       expect(TslrClaim.new).not_to be_valid(:"student-loan-start-date")
-      expect(TslrClaim.new(student_loan_start_date: :before_first_september_2012)).to be_valid(:"student-loan-start-date")
+      expect(TslrClaim.new(student_loan_start_date: StudentLoans::BEFORE_1_SEPT_2012)).to be_valid(:"student-loan-start-date")
     end
   end
 
@@ -390,7 +390,7 @@ RSpec.describe TslrClaim, type: :model do
     it "returns true when the student_loan_country is one with only a single student loan plan" do
       expect(TslrClaim.new.student_loan_country_with_one_plan?).to eq false
 
-      TslrClaim::STUDENT_LOAN_COUNTRIES_WITH_ONE_PLAN.each do |country|
+      StudentLoans::PLAN_1_COUNTRIES.each do |country|
         expect(TslrClaim.new(student_loan_country: country).student_loan_country_with_one_plan?).to eq true
       end
     end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -207,6 +207,13 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving in the “student-loan-start-date” validation context" do
+    it "validates the presence of the student_loan_how_many_courses" do
+      expect(TslrClaim.new).not_to be_valid(:"student-loan-start-date")
+      expect(TslrClaim.new(student_loan_start_date: :before_first_september_2012)).to be_valid(:"student-loan-start-date")
+    end
+  end
+
   context "when saving in the “student-loan-amount” validation context" do
     it "validates the presence of student_loan_repayment_amount" do
       expect(TslrClaim.new).not_to be_valid(:"student-loan-amount")

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -90,6 +90,14 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "that has a student loan plan" do
+    it "validates the plan" do
+      expect(TslrClaim.new(student_loan_plan: StudentLoans::PLAN_1)).to be_valid
+
+      expect { TslrClaim.new(student_loan_plan: "plan_42") }.to raise_error(ArgumentError)
+    end
+  end
+
   context "when saving in the “qts-year” validation context" do
     let(:custom_validation_context) { :"qts-year" }
 

--- a/spec/presenters/tslr_claim_csv_row_spec.rb
+++ b/spec/presenters/tslr_claim_csv_row_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe TslrClaimCsvRow do
         date_of_birth: Date.parse(date_of_birth),
         mostly_teaching_eligible_subjects: mostly_teaching_eligible_subjects == "Yes",
         student_loan_repayment_amount: student_loan_repayment_amount.delete("£").to_i,
+        student_loan_plan: StudentLoans::PLAN_2,
         submitted_at: DateTime.parse(submitted_at))
     end
 
@@ -42,6 +43,7 @@ RSpec.describe TslrClaimCsvRow do
         date_of_birth,
         claim.teacher_reference_number,
         claim.national_insurance_number,
+        "Plan 2",
         claim.email_address,
         mostly_teaching_eligible_subjects,
         claim.bank_sort_code,

--- a/spec/presenters/tslr_claims_csv_spec.rb
+++ b/spec/presenters/tslr_claims_csv_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe TslrClaimsCsv do
       date_of_birth: Date.parse("1939-01-01"),
       teacher_reference_number: "1234567",
       national_insurance_number: "QQ123456C",
+      student_loan_country: :england,
       email_address: "batman@bat.com",
       mostly_teaching_eligible_subjects: true,
       bank_sort_code: "440026",

--- a/spec/presenters/tslr_claims_csv_spec.rb
+++ b/spec/presenters/tslr_claims_csv_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe TslrClaimsCsv do
       mostly_teaching_eligible_subjects: true,
       bank_sort_code: "440026",
       bank_account_number: "70872490",
+      student_loan_plan: StudentLoans::PLAN_1,
       student_loan_repayment_amount: "1500.00")
   end
 
@@ -47,6 +48,7 @@ RSpec.describe TslrClaimsCsv do
         "Date of Birth",
         "Teacher Reference",
         "NI Number",
+        "Student Loan Repayment Plan",
         "Email",
         "Mostly Teaching Eligible Subjects?",
         "Sort Code",
@@ -72,6 +74,7 @@ RSpec.describe TslrClaimsCsv do
         "01/01/1939",
         "1234567",
         "QQ123456C",
+        "Plan 1",
         "batman@bat.com",
         "Yes",
         "440026",


### PR DESCRIPTION
A claimant can now answer a series of questions that determines whether they are still paying a student loan, and if so, the student loan repayment plan they are on.

Things still outstanding to do:

- Play back the plan on the check-your-answers screen
- The flow that will allow a user to go back "change" their answers to the student loan question

Both those things will be tackled as a separate PR building on this work.

 https://trello.com/c/ioo1e1L1/335-capture-the-student-loan-repayment-plan