### PR TITLE
Set up HTTPS for custom domains on Azure

### DIFF
--- a/azure/app/parameters/development.template.json
+++ b/azure/app/parameters/development.template.json
@@ -8,6 +8,9 @@
     "appServiceHostName": {
       "value": "development.additional-teaching-payment.education.gov.uk"
     },
+    "appServiceCertificateSecretName": {
+      "value": "AppServiceCertificate"
+    },
     "databaseName": {
       "value": "development"
     },

--- a/azure/app/parameters/development.template.json
+++ b/azure/app/parameters/development.template.json
@@ -9,7 +9,7 @@
       "value": "development.additional-teaching-payment.education.gov.uk"
     },
     "appServiceCertificateSecretName": {
-      "value": "AppServiceCertificate"
+      "value": "sslCertificate-wildcard-additional-teaching-payment-education-gov-uk"
     },
     "databaseName": {
       "value": "development"

--- a/azure/app/parameters/production.template.json
+++ b/azure/app/parameters/production.template.json
@@ -9,7 +9,7 @@
       "value": "additional-teaching-payment.education.gov.uk"
     },
     "appServiceCertificateSecretName": {
-      "value": "AppServiceCertificate"
+      "value": "sslCertificate-additional-teaching-payment-education-gov-uk"
     },
     "databaseName": {
       "value": "production"

--- a/azure/app/parameters/production.template.json
+++ b/azure/app/parameters/production.template.json
@@ -8,6 +8,9 @@
     "appServiceHostName": {
       "value": "additional-teaching-payment.education.gov.uk"
     },
+    "appServiceCertificateSecretName": {
+      "value": "AppServiceCertificate"
+    },
     "databaseName": {
       "value": "production"
     },

--- a/azure/app/parameters/test.template.json
+++ b/azure/app/parameters/test.template.json
@@ -9,7 +9,7 @@
       "value": "test.additional-teaching-payment.education.gov.uk"
     },
     "appServiceCertificateSecretName": {
-      "value": "AppServiceCertificate"
+      "value": "sslCertificate-wildcard-additional-teaching-payment-education-gov-uk"
     },
     "databaseName": {
       "value": "test"

--- a/azure/app/parameters/test.template.json
+++ b/azure/app/parameters/test.template.json
@@ -8,6 +8,9 @@
     "appServiceHostName": {
       "value": "test.additional-teaching-payment.education.gov.uk"
     },
+    "appServiceCertificateSecretName": {
+      "value": "AppServiceCertificate"
+    },
     "databaseName": {
       "value": "test"
     },

--- a/azure/app/template.json
+++ b/azure/app/template.json
@@ -6,10 +6,19 @@
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
     },
+    "secretsResourceGroupName": {
+      "type": "string"
+    },
+    "keyVaultName": {
+      "type": "string"
+    },
     "appServiceDockerCompose": {
       "type": "string"
     },
     "appServiceHostName": {
+      "type": "string"
+    },
+    "appServiceCertificateSecretName": {
       "type": "string"
     },
     "appServiceAlwaysOn": {
@@ -82,6 +91,7 @@
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
 
+    "appServiceCertificateDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app-service-certificate')]",
     "appServicePlanDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app-service-plan')]",
     "databaseServerFirewallRulesDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database-server-firewall-rules')]",
     "databaseServerDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database-server')]",
@@ -184,12 +194,39 @@
       }
     },
     {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "name": "[variables('appServiceCertificateDeploymentName')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'app-service-certificate.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "keyVaultCertificateName": {
+            "value": "[parameters('appServiceCertificateSecretName')]"
+          },
+          "keyVaultName": {
+            "value": "[parameters('keyVaultName')]"
+          },
+          "keyVaultResourceGroup": {
+            "value": "[parameters('secretsResourceGroupName')]"
+          },
+          "serverFarmId": {
+            "value": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
+          }
+        }
+      }
+    },
+    {
       "type": "Microsoft.Web/sites",
       "apiVersion": "2018-11-01",
       "name": "[variables('appServiceName')]",
       "kind": "app,linux,container",
       "location": "[resourceGroup().location]",
       "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', variables('appServiceCertificateDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('appServicePlanDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('databaseDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('databaseServerDeploymentName'))]"
@@ -293,7 +330,8 @@
       "location": "[resourceGroup().location]",
       "dependsOn": ["[resourceId('Microsoft.Web/sites', variables('appServiceName'))]"],
       "properties": {
-        "sslState": "Disabled"
+        "sslState": "SniEnabled",
+        "thumbprint": "[reference(resourceId('Microsoft.Resources/deployments', variables('appServiceCertificateDeploymentName')), '2018-11-01').outputs.certificateThumbprint.value]"
       }
     },
     {

--- a/azure/secrets/template.json
+++ b/azure/secrets/template.json
@@ -11,6 +11,8 @@
     }
   },
   "variables": {
+    "principal_Microsoft_Azure_App_Service": "a6621090-e704-45ec-b65f-50257f9d4dcd",
+
     "keyVaultName": "[concat(parameters('resourceNamePrefix'), '-kv')]"
   },
   "resources": [
@@ -35,6 +37,13 @@
               "secrets": ["all"],
               "certificates": ["all"]
             }
+          },
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[variables('principal_Microsoft_Azure_App_Service')]",
+            "permissions": {
+              "secrets": ["get"]
+            }
           }
         ]
       }
@@ -48,6 +57,10 @@
     "keyVaultId": {
       "type": "string",
       "value": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+    },
+    "keyVaultName": {
+      "type": "string",
+      "value": "[variables('keyVaultName')]"
     }
   }
 }

--- a/azure/secrets/template.json
+++ b/azure/secrets/template.json
@@ -18,7 +18,7 @@
   "resources": [
     {
       "type": "Microsoft.KeyVault/vaults",
-      "apiVersion": "2015-06-01",
+      "apiVersion": "2018-02-14",
       "name": "[variables('keyVaultName')]",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -28,6 +28,7 @@
           "name": "Standard"
         },
         "enabledForTemplateDeployment": true,
+        "enableSoftDelete": true,
         "accessPolicies": [
           {
             "tenantId": "[subscription().tenantId]",

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -194,6 +194,12 @@ APP_DEPLOYMENT_RESULT=$(
     --resource-group "$APP_RESOURCE_GROUP_NAME" \
     --template-file "$APP_TEMPLATE_FILE_PATH" \
     --parameters "@$APP_PARAMETERS_FILE_PATH" \
+    --parameters "secretsResourceGroupName=$SECRETS_RESOURCE_GROUP_NAME" \
+    --parameters "$(
+      filter-azure-outputs \
+        "$SECRETS_DEPLOYMENT_RESULT" \
+        "['keyVaultName']"
+    )" \
     --mode Complete \
     --verbose
 )


### PR DESCRIPTION
Certificates need to be added to the key vault where they will be imported and assigned to the app service. The key vault needs additional permissions to allow that process.