### PR TITLE
Student loan answers can be changed

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -33,6 +33,14 @@ module ClaimsHelper
     ]
   end
 
+  def student_loan_answers(claim)
+    [[t("tslr.questions.has_student_loan"), (claim.has_student_loan ? "Yes" : "No"), "student-loan"]].tap do |answers|
+      answers << [t("tslr.questions.student_loan_country"), claim.student_loan_country.humanize, "student-loan-country"] if claim.student_loan_country.present?
+      answers << [t("tslr.questions.student_loan_how_many_courses"), claim.student_loan_courses.humanize, "student-loan-how-many-courses"] if claim.student_loan_courses.present?
+      answers << [t("tslr.questions.student_loan_start_date.#{claim.student_loan_courses}"), t("tslr.answers.student_loan_start_date.#{claim.student_loan_courses}.#{claim.student_loan_start_date}"), "student-loan-start-date"] if claim.student_loan_courses.present?
+    end
+  end
+
   def payment_answers(claim)
     [
       ["Bank sort code", claim.bank_sort_code, "bank-details"],

--- a/app/models/claim_update.rb
+++ b/app/models/claim_update.rb
@@ -20,11 +20,11 @@ class ClaimUpdate
       claim.submit! && send_confirmation_email
     else
       claim.attributes = params
-      update_claim_school_dependent_attributes
-      update_employment_status_dependent_attributes
-      update_has_student_loan_dependent_attribute
-      update_student_loan_country_dependent_attribute
-      update_student_loan_courses_dependent_attribute
+      reset_claim_school_dependent_attributes
+      reset_has_student_loan_dependent_attribute
+      reset_student_loan_country_dependent_attribute
+      reset_student_loan_courses_dependent_attribute
+      infer_current_school
       determine_student_loan_plan
       claim.save(context: context)
     end
@@ -40,33 +40,33 @@ class ClaimUpdate
     ClaimMailer.submitted(claim).deliver_later
   end
 
-  def update_claim_school_dependent_attributes
+  def reset_claim_school_dependent_attributes
     if claim.claim_school_id_changed?
       claim.employment_status = nil
     end
   end
 
-  def update_employment_status_dependent_attributes
-    if claim.employment_status_changed?
-      claim.current_school = claim.employed_at_claim_school? ? claim.claim_school : nil
+  def reset_has_student_loan_dependent_attribute
+    if claim.has_student_loan_changed?
+      claim.student_loan_country = nil
     end
   end
 
-  def update_student_loan_courses_dependent_attribute
-    if claim.student_loan_courses_changed?
-      claim.student_loan_start_date = nil
-    end
-  end
-
-  def update_student_loan_country_dependent_attribute
+  def reset_student_loan_country_dependent_attribute
     if claim.student_loan_country_changed?
       claim.student_loan_courses = nil
     end
   end
 
-  def update_has_student_loan_dependent_attribute
-    if claim.has_student_loan_changed?
-      claim.student_loan_country = nil
+  def reset_student_loan_courses_dependent_attribute
+    if claim.student_loan_courses_changed?
+      claim.student_loan_start_date = nil
+    end
+  end
+
+  def infer_current_school
+    if claim.employment_status_changed?
+      claim.current_school = claim.employed_at_claim_school? ? claim.claim_school : nil
     end
   end
 

--- a/app/models/claim_update.rb
+++ b/app/models/claim_update.rb
@@ -6,7 +6,21 @@
 # validations on the claim that are appropriate to that context. For example,
 # Performing an update in the "check-your-answers" context will attempt to
 # submit the claim and send the confirmation email to the claimant.
+#
+# The `DEPENDENT_ANSWERS` hash defines the attributes that depend on the value
+# of another attribute such that if the value of the other attribute changes
+# the dependent attribute should be reset because the value will no longer hold,
+# or may be an answer to a question that should no longer be asked. For example,
+# the `student_loan_course` attribute should only be set if the user
+# `has_student_loan`.
 class ClaimUpdate
+  DEPENDENT_ANSWERS = {
+    "claim_school_id" => "employment_status",
+    "has_student_loan" => "student_loan_country",
+    "student_loan_country" => "student_loan_courses",
+    "student_loan_courses" => "student_loan_start_date",
+  }.freeze
+
   attr_reader :claim, :context, :params
 
   def initialize(claim, params, context)
@@ -20,12 +34,12 @@ class ClaimUpdate
       claim.submit! && send_confirmation_email
     else
       claim.attributes = params
-      reset_claim_school_dependent_attributes
-      reset_has_student_loan_dependent_attribute
-      reset_student_loan_country_dependent_attribute
-      reset_student_loan_courses_dependent_attribute
+
+      reset_dependent_answers
+
       infer_current_school
       determine_student_loan_plan
+
       claim.save(context: context)
     end
   end
@@ -40,27 +54,11 @@ class ClaimUpdate
     ClaimMailer.submitted(claim).deliver_later
   end
 
-  def reset_claim_school_dependent_attributes
-    if claim.claim_school_id_changed?
-      claim.employment_status = nil
-    end
-  end
-
-  def reset_has_student_loan_dependent_attribute
-    if claim.has_student_loan_changed?
-      claim.student_loan_country = nil
-    end
-  end
-
-  def reset_student_loan_country_dependent_attribute
-    if claim.student_loan_country_changed?
-      claim.student_loan_courses = nil
-    end
-  end
-
-  def reset_student_loan_courses_dependent_attribute
-    if claim.student_loan_courses_changed?
-      claim.student_loan_start_date = nil
+  def reset_dependent_answers
+    DEPENDENT_ANSWERS.each do |attribute_name, dependent_attribute_name|
+      if claim.changed.include?(attribute_name)
+        claim.attributes = {dependent_attribute_name => nil}
+      end
     end
   end
 

--- a/app/models/claim_update.rb
+++ b/app/models/claim_update.rb
@@ -22,6 +22,9 @@ class ClaimUpdate
       claim.attributes = params
       update_claim_school_dependent_attributes
       update_employment_status_dependent_attributes
+      update_has_student_loan_dependent_attribute
+      update_student_loan_country_dependent_attribute
+      update_student_loan_courses_dependent_attribute
       determine_student_loan_plan
       claim.save(context: context)
     end
@@ -46,6 +49,24 @@ class ClaimUpdate
   def update_employment_status_dependent_attributes
     if claim.employment_status_changed?
       claim.current_school = claim.employed_at_claim_school? ? claim.claim_school : nil
+    end
+  end
+
+  def update_student_loan_courses_dependent_attribute
+    if claim.student_loan_courses_changed?
+      claim.student_loan_start_date = nil
+    end
+  end
+
+  def update_student_loan_country_dependent_attribute
+    if claim.student_loan_country_changed?
+      claim.student_loan_courses = nil
+    end
+  end
+
+  def update_has_student_loan_dependent_attribute
+    if claim.has_student_loan_changed?
+      claim.student_loan_country = nil
     end
   end
 

--- a/app/views/claims/check_your_answers.html.erb
+++ b/app/views/claims/check_your_answers.html.erb
@@ -10,6 +10,8 @@
 
     <%= render partial: "check_your_answers_section", locals: {heading: "Identity details", answers: identity_answers(current_claim)} %>
 
+    <%= render partial: "check_your_answers_section", locals: {heading: "Student loan details", answers: student_loan_answers(current_claim)} %>
+
     <%= render partial: "check_your_answers_section", locals: {heading: "Payment details", answers: payment_answers(current_claim)} %>
 
     <%= form_for current_claim, url: claim_path do |form| %>

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -6,16 +6,15 @@
       <%= form.hidden_field :student_loan_start_date %>
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("tslr.questions.student_loan_start_date.#{current_claim.student_loan_courses}") %>
+              </h1>
+            </legend>
+
+            <%= errors_tag current_claim, :student_loan_start_date %>
+
             <% if current_claim.student_loan_courses == "one_course" %>
-
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-                <h1 class="govuk-fieldset__heading">
-                  <%= t("tslr.questions.student_loan_start_date.single_course") %>
-                </h1>
-              </legend>
-
-              <%= errors_tag current_claim, :student_loan_start_date %>
-
               <div class="govuk-radios">
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
@@ -26,17 +25,7 @@
                   <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "On or after 1 September 2012", class: "govuk-label govuk-radios__label" %>
                 </div>
               </div>
-
             <% else %>
-
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-                <h1 class="govuk-fieldset__heading">
-                  <%= t("tslr.questions.student_loan_start_date.multiple_courses") %>
-                </h1>
-              </legend>
-
-              <%= errors_tag current_claim, :student_loan_start_date %>
-
               <div class="govuk-radios">
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
@@ -51,7 +40,6 @@
                   <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "All of my degree courses started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
                 </div>
               </div>
-
             <% end %>
           </fieldset>
         <% end %>

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -18,26 +18,26 @@
               <div class="govuk-radios">
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_before_first_september_2012, "Before 1 September 2012", class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_before_first_september_2012, t("tslr.answers.student_loan_start_date.one_course.before_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "On or after 1 September 2012", class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, t("tslr.answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
               </div>
             <% else %>
               <div class="govuk-radios">
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_before_first_september_2012, "All my degree courses started before 1 September 2012", class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_before_first_september_2012, t("tslr.answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_AND_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_some_before_some_after_first_september_2012, "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_some_before_some_after_first_september_2012, t("tslr.answers.student_loan_start_date.two_or_more_courses.some_before_some_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "All of my degree courses started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, t("tslr.answers.student_loan_start_date.two_or_more_courses.on_or_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
               </div>
             <% end %>

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -6,54 +6,53 @@
       <%= form.hidden_field :student_loan_start_date %>
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset">
-          <% if current_claim.student_loan_courses == "one_course" %>
+            <% if current_claim.student_loan_courses == "one_course" %>
 
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-              <h1 class="govuk-fieldset__heading">
-                <%= t("tslr.questions.student_loan_start_date.single_course") %>
-              </h1>
-            </legend>
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                <h1 class="govuk-fieldset__heading">
+                  <%= t("tslr.questions.student_loan_start_date.single_course") %>
+                </h1>
+              </legend>
 
-            <%= errors_tag current_claim, :student_loan_start_date %>
+              <%= errors_tag current_claim, :student_loan_start_date %>
 
-            <div class="govuk-radios">
-              <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
-                <%= form.label :student_loan_start_date_before_first_september_2012, "Before 1 September 2012", class: "govuk-label govuk-radios__label" %>
+              <div class="govuk-radios">
+                <div class="govuk-radios__item">
+                  <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
+                  <%= form.label :student_loan_start_date_before_first_september_2012, "Before 1 September 2012", class: "govuk-label govuk-radios__label" %>
+                </div>
+                <div class="govuk-radios__item">
+                  <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
+                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "On or after 1 September 2012", class: "govuk-label govuk-radios__label" %>
+                </div>
               </div>
-              <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "On or after 1 September 2012", class: "govuk-label govuk-radios__label" %>
+
+            <% else %>
+
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                <h1 class="govuk-fieldset__heading">
+                  <%= t("tslr.questions.student_loan_start_date.multiple_courses") %>
+                </h1>
+              </legend>
+
+              <%= errors_tag current_claim, :student_loan_start_date %>
+
+              <div class="govuk-radios">
+                <div class="govuk-radios__item">
+                  <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
+                  <%= form.label :student_loan_start_date_before_first_september_2012, "All my degree courses started before 1 September 2012", class: "govuk-label govuk-radios__label" %>
+                </div>
+                <div class="govuk-radios__item">
+                  <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_AND_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
+                  <%= form.label :student_loan_start_date_some_before_some_after_first_september_2012, "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
+                </div>
+                <div class="govuk-radios__item">
+                  <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
+                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "All of my degree courses started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
+                </div>
               </div>
-            </div>
 
-          <% else %>
-
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-              <h1 class="govuk-fieldset__heading">
-                <%= t("tslr.questions.student_loan_start_date.multiple_courses") %>
-              </h1>
-            </legend>
-
-            <%= errors_tag current_claim, :student_loan_start_date %>
-
-            <div class="govuk-radios">
-              <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
-                <%= form.label :student_loan_start_date_before_first_september_2012, "All my degree courses started before 1 September 2012", class: "govuk-label govuk-radios__label" %>
-              </div>
-              <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_AND_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                <%= form.label :student_loan_start_date_some_before_some_after_first_september_2012, "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
-              </div>
-              <div class="govuk-radios__item">
-                <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                <%= form.label :student_loan_start_date_on_or_after_first_september_2012, "All of my degree courses started after 1 September 2012", class: "govuk-label govuk-radios__label" %>
-              </div>
-            </div>
-
-          <% end %>
-
+            <% end %>
           </fieldset>
         <% end %>
         <%= form.submit "Continue", class: "govuk-button" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,15 @@ en:
         "2017_2018": "September 1 2017 – August 31 2018"
         "2018_2019": "September 1 2018 – August 31 2019"
         "2019_2020": "September 1 2019 – August 31 2020"
+    answers:
+      student_loan_start_date:
+        one_course:
+          before_first_september_2012: "Before 1 September 2012"
+          on_or_after_first_september_2012: "On or after 1 September 2012"
+        two_or_more_courses:
+          before_first_september_2012: "All my degree courses started before 1 September 2012"
+          some_before_some_after_first_september_2012: "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012"
+          on_or_after_first_september_2012: "All of my degree courses started after 1 September 2012"
     csv_headers:
       reference: "Reference"
       submitted_at: "Submitted at"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,8 +56,8 @@ en:
       student_loan_country: "When you applied for your student loan where was your home address?"
       student_loan_how_many_courses: "How many higher education courses have you studied?"
       student_loan_start_date:
-        single_course: "When did the first year of your higher education course start?"
-        multiple_courses: "When did the first year of each higher education course start?"
+        one_course: "When did the first year of your higher education course start?"
+        two_or_more_courses: "When did the first year of each higher education course start?"
       student_loan_amount:
         "Exactly how much student loan did you repay while you worked at %{claim_school_name} between 6 April 2018 and 5
         April 2019?"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.student_loan_courses).to eq("one_course")
 
-    expect(page).to have_text(I18n.t("tslr.questions.student_loan_start_date.single_course"))
+    expect(page).to have_text(I18n.t("tslr.questions.student_loan_start_date.one_course"))
     choose "Before 1 September 2012"
     click_on "Continue"
 

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(claim.reload.student_loan_courses).to eq("one_course")
 
     expect(page).to have_text(I18n.t("tslr.questions.student_loan_start_date.one_course"))
-    choose "Before 1 September 2012"
+    choose I18n.t("tslr.answers.student_loan_start_date.one_course.before_first_september_2012")
     click_on "Continue"
 
     expect(claim.reload.student_loan_start_date).to eq(StudentLoans::BEFORE_1_SEPT_2012)

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -70,6 +70,58 @@ describe ClaimsHelper do
     end
   end
 
+  describe "#student_loan_answers" do
+    it "returns an array of question and answers for the student loan questions" do
+      claim = TslrClaim.new(
+        has_student_loan: true,
+        student_loan_country: StudentLoans::ENGLAND,
+        student_loan_courses: :one_course,
+        student_loan_start_date: StudentLoans::ON_OR_AFTER_1_SEPT_2012
+      )
+
+      expected_answers = [
+        [t("tslr.questions.has_student_loan"), "Yes", "student-loan"],
+        [t("tslr.questions.student_loan_country"), "England", "student-loan-country"],
+        [t("tslr.questions.student_loan_how_many_courses"), "One course", "student-loan-how-many-courses"],
+        [t("tslr.questions.student_loan_start_date.one_course"), t("tslr.answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), "student-loan-start-date"],
+      ]
+
+      expect(helper.student_loan_answers(claim)).to eq expected_answers
+    end
+
+    it "adjusts the loan start date question and answer according to the number of courses answer" do
+      claim = TslrClaim.new(
+        has_student_loan: true,
+        student_loan_country: StudentLoans::ENGLAND,
+        student_loan_courses: :two_or_more_courses,
+        student_loan_start_date: StudentLoans::BEFORE_1_SEPT_2012
+      )
+
+      expected_answers = [
+        [t("tslr.questions.has_student_loan"), "Yes", "student-loan"],
+        [t("tslr.questions.student_loan_country"), "England", "student-loan-country"],
+        [t("tslr.questions.student_loan_how_many_courses"), "Two or more courses", "student-loan-how-many-courses"],
+        [t("tslr.questions.student_loan_start_date.two_or_more_courses"), t("tslr.answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), "student-loan-start-date"],
+      ]
+
+      expect(helper.student_loan_answers(claim)).to eq expected_answers
+    end
+
+    it "excludes unanswered questions" do
+      claim = TslrClaim.new(
+        has_student_loan: true,
+        student_loan_country: StudentLoans::SCOTLAND,
+      )
+
+      expected_answers = [
+        [t("tslr.questions.has_student_loan"), "Yes", "student-loan"],
+        [t("tslr.questions.student_loan_country"), "Scotland", "student-loan-country"],
+      ]
+
+      expect(helper.student_loan_answers(claim)).to eq expected_answers
+    end
+  end
+
   describe "subject_list" do
     let(:list) { subject_list(subjects) }
 


### PR DESCRIPTION
The answers to the student loan questions now appear on the check-your-answers page and can now be "changed". Changes to certain questions result in dependent questions being reset such that the user has to re-answer them. More details in the individual commits.