### PR TITLE
Fix builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@
 
 FROM ruby:2.6.2-alpine AS base
 
-RUN apk add bash
-RUN apk add postgresql-dev
-RUN apk add tzdata
-RUN apk add nodejs
+RUN apk --no-cache add bash
+RUN apk --no-cache add postgresql-dev
+RUN apk --no-cache add tzdata
+RUN apk --no-cache add nodejs
 
 ENV APP_HOME /app
 ENV DEPS_HOME /deps
@@ -24,8 +24,8 @@ FROM base AS dependencies
 
 RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
 
-RUN apk add build-base
-RUN apk add yarn
+RUN apk --no-cache add build-base
+RUN apk --no-cache add yarn
 
 # Set up install environment
 RUN mkdir -p ${DEPS_HOME}
@@ -112,7 +112,7 @@ FROM web AS test
 
 RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
 
-RUN apk add chromium chromium-chromedriver
+RUN apk --no-cache add chromium chromium-chromedriver
 
 # Copy test code (sorted by vague frequency of change for caching)
 COPY .prettierignore ${APP_HOME}/.prettierignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,9 @@ COPY app ${APP_HOME}/app
 # End
 
 RUN if [ ${RAILS_ENV} = "production" ]; then \
+  DFE_SIGN_IN_API_CLIENT_ID= \
+  DFE_SIGN_IN_API_SECRET= \
+  DFE_SIGN_IN_API_ENDPOINT= \
   bundle exec rake assets:precompile; \
   fi
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,10 +12,8 @@ services:
     environment:
       DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME: postgres
       DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST: db
-      DFE_SIGN_IN_API_CLIENT_ID: teacherpayments
-      DFE_SIGN_IN_API_SECRET: secret
-      DFE_SIGN_IN_API_ENDPOINT: https://example.com
-    env_file: .env.test
+    env_file:
+      - .env.test
     tty: true
     stdin_open: true
     command: bundle exec spring server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     environment:
       DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME: postgres
       DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST: db
+    env_file:
+      - .env
     volumes:
       - ./bin/vsp/:/app/bin/vsp/
       - ./localhost.key:/app/localhost.key


### PR DESCRIPTION
Builds of `master` are currently failing because the asset precompile is missing environment variables.

This also reduces the size of builds by skipping Alpine's caching.

I've added a card to Trello to work out why we're not getting notified of failed builds.