### PR TITLE
Move ineligibility error messages to locale file

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -138,16 +138,6 @@ class TslrClaim < ApplicationRecord
     ].find { |eligibility_check| send("#{eligibility_check}?") }
   end
 
-  def full_ineligibility_reason
-    case ineligibility_reason
-    when :ineligible_qts_award_year then "You are only eligible to claim back student loan repayments if you qualified on or after September 1st 2013."
-    when :ineligible_claim_school then "#{claim_school_name} is not an eligible school."
-    when :employed_at_no_school then "You can only get this payment if you’re still working as a teacher."
-    when :not_taught_eligible_subjects_enough then "You must have spent at least half your time teaching an eligible subject."
-    else "You can only apply for this payment if you meet the eligibility criteria."
-    end
-  end
-
   def address
     [address_line_1, address_line_2, address_line_3, address_line_4, postcode].reject(&:blank?).join(", ")
   end
@@ -245,6 +235,6 @@ class TslrClaim < ApplicationRecord
   end
 
   def claim_must_not_be_ineligible
-    errors.add(:base, full_ineligibility_reason) if ineligible?
+    errors.add(:base, ineligibility_reason) if ineligible?
   end
 end

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -5,7 +5,7 @@
     </h1>
 
     <p class="govuk-body">
-      <%= current_claim.full_ineligibility_reason %>
+      <%= t("activerecord.errors.messages.#{current_claim.ineligibility_reason}") %>.
     </p>
 
     <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,13 @@ en:
     currency:
       format:
         unit: "£"
+  activerecord:
+    errors:
+      messages:
+        ineligible_qts_award_year: "You are only eligible to claim back student loan repayments if you qualified on or after September 1st 2013"
+        ineligible_claim_school: "The school you were employed at is not eligible"
+        employed_at_no_school: "You can only get this payment if you’re still working as a teacher"
+        not_taught_eligible_subjects_enough: "You must have spent at least half your time teaching an eligible subject"
   tslr:
     service_name: "Teachers: claim back your student loan repayments"
     questions:

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.qts_award_year).to eql("before_2013")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You are only eligible to claim back student loan repayments if you qualified on or after September 1st 2013")
+    expect(page).to have_text(I18n.t("activerecord.errors.messages.ineligible_qts_award_year"))
   end
 
   scenario "now works for a different school" do
@@ -39,7 +39,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.claim_school).to eq schools(:hampstead_school)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("Hampstead School is not an eligible school")
+    expect(page).to have_text(I18n.t("activerecord.errors.messages.ineligible_claim_school"))
   end
 
   scenario "no longer teaching" do
@@ -51,7 +51,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.employment_status).to eq("no_school")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you’re still working as a teacher")
+    expect(page).to have_text(I18n.t("activerecord.errors.messages.employed_at_no_school"))
   end
 
   scenario "does not teach an eligible subject" do
@@ -65,7 +65,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.mostly_teaching_eligible_subjects).to eq(false)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You must have spent at least half your time teaching an eligible subject.")
+    expect(page).to have_text(I18n.t("activerecord.errors.messages.not_taught_eligible_subjects_enough"))
   end
 
   scenario "does not teach an eligible subject for at least half of their time" do
@@ -82,6 +82,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.mostly_teaching_eligible_subjects).to eq(false)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You must have spent at least half your time teaching an eligible subject.")
+    expect(page).to have_text(I18n.t("activerecord.errors.messages.not_taught_eligible_subjects_enough"))
   end
 end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe TslrClaim, type: :model do
       ineligible_claim = build(:tslr_claim, :submittable, mostly_teaching_eligible_subjects: false)
 
       expect(ineligible_claim).not_to be_valid(:submit)
-      expect(ineligible_claim.errors[:base]).to include("You must have spent at least half your time teaching an eligible subject.")
+      expect(ineligible_claim.errors[:base]).to include(I18n.t("activerecord.errors.messages.not_taught_eligible_subjects_enough"))
     end
   end
 
@@ -496,7 +496,7 @@ RSpec.describe TslrClaim, type: :model do
       end
 
       it "adds an error" do
-        expect(tslr_claim.errors.messages[:base]).to include("You must have spent at least half your time teaching an eligible subject.")
+        expect(tslr_claim.errors.messages[:base]).to include(I18n.t("activerecord.errors.messages.not_taught_eligible_subjects_enough"))
       end
     end
 


### PR DESCRIPTION
This takes a bunch of magic strings out of the model and into the locale file, simplifying the code and making the test suite less brittle. This will also help with an in-progress refactoring that is pulling eligibility criteria out to a separate model.

We do lose some specificity in the error message when the claim school is not eligible. Hopefully a price worth paying to keep the code simpler.