### PR TITLE
Move hostname settings to its own resource

### DIFF
--- a/azure/app/template.json
+++ b/azure/app/template.json
@@ -197,12 +197,6 @@
       "properties": {
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
         "httpsOnly": true,
-        "hostNameSslStates": {
-          "name": "[parameters('appServiceHostName')]",
-          "sslState": "Disabled",
-          "toUpdate": true,
-          "hostType": "Standard"
-        },
         "siteConfig": {
           "alwaysOn": "[parameters('appServiceAlwaysOn')]",
           "httpLoggingEnabled": true,
@@ -290,6 +284,18 @@
             }
           ]
         }
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/hostNameBindings",
+      "apiVersion": "2018-11-01",
+      "name": "[concat(variables('appServiceName'), '/', parameters('appServiceHostName'))]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', variables('appServiceName'))]"
+      ],
+      "properties": {
+        "sslState": "Disabled"
       }
     },
     {


### PR DESCRIPTION
When using hostNameSslStates as a property of the app service it caused the app settings and some of the site config to be ignored. We're not sure why but this resolves the issue.