### PR TITLE
Fix JSON formatting in the ARM template

### DIFF
--- a/azure/app/template.json
+++ b/azure/app/template.json
@@ -291,9 +291,7 @@
       "apiVersion": "2018-11-01",
       "name": "[concat(variables('appServiceName'), '/', parameters('appServiceHostName'))]",
       "location": "[resourceGroup().location]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', variables('appServiceName'))]"
-      ],
+      "dependsOn": ["[resourceId('Microsoft.Web/sites', variables('appServiceName'))]"],
       "properties": {
         "sslState": "Disabled"
       }


### PR DESCRIPTION
This should've been flagged on the build of the PR that introduced this change. We're not sure why prettier passed this on Azure pipelines. Let's fix the formatting for now so we don't block other devs.