### PR TITLE
Create a script to create and store VSP certificate requests

### DIFF
--- a/bin/request-vsp-certs
+++ b/bin/request-vsp-certs
@@ -103,11 +103,36 @@ function store_key_and_csr_and_challenge_phrase {
     --value "$CHALLENGE_PHRASE"
 }
 
-SIGNING_FILE_PREFIX="TeacherPayments${ENVIRONMENT_SHORT_NAME}VspSamlSigning${VERSION_NUMBER}"
-SIGNING_CSR_COMMON_NAME="Teacher Payments Service $ENVIRONMENT_SHORT_NAME VSP SAML Signing $VERSION_NUMBER"
+function request_cert {
+  local TYPE=$1
+  local FILE_PREFIX=$2
+  local CSR_COMMON_NAME=$3
 
-ENCRYPTION_FILE_PREFIX="TeacherPayments${ENVIRONMENT_SHORT_NAME}VspSamlEncryption${VERSION_NUMBER}"
-ENCRYPTION_CSR_COMMON_NAME="Teacher Payments Service $ENVIRONMENT_SHORT_NAME VSP SAML Encryption $VERSION_NUMBER"
+  echo "Fetching or generating $TYPE key and CSR..."
+  fetch_or_generate_key_and_csr "$FILE_PREFIX" "$CSR_COMMON_NAME"
+
+  if [ "$KEY_EXISTED" ]; then
+    echo "A $TYPE key already existed for $ENVIRONMENT_NAME version $VERSION_NUMBER."
+    read -rp "  Hit return to continue with the pre-existing key, or CTRL+C to stop."
+  fi
+
+  if [ "$CSR_EXISTED" ]; then
+    echo "A $TYPE CSR already existed for $ENVIRONMENT_NAME version $VERSION_NUMBER."
+    read -rp "  Hit return to continue with the pre-existing CSR, or CTRL+C to stop."
+  fi
+
+  echo "Now enrol the generated $TYPE CSR to Verify."
+
+  CHALLENGE_PHRASE=
+
+  while ! [ "$CHALLENGE_PHRASE" ]; do
+    read -rsp "  Enter the \"Challenge Phrase\" used in the enrollment request: " CHALLENGE_PHRASE
+    echo
+  done
+
+  echo "Storing $TYPE key, CSR, and challenge phrase in $KEY_VAULT_NAME..."
+  store_key_and_csr_and_challenge_phrase "$FILE_PREFIX" "$CHALLENGE_PHRASE"
+}
 
 if ! az account show > /dev/null; then
   echo "Logging in to Azure..."
@@ -117,63 +142,17 @@ fi
 echo "Setting default Azure subscription to $AZURE_SUBSCRIPTION_ID..."
 az account set --subscription "$AZURE_SUBSCRIPTION_ID"
 
-echo
-echo "Fetching or generating signing key and CSR..."
-fetch_or_generate_key_and_csr "$SIGNING_FILE_PREFIX" "$SIGNING_CSR_COMMON_NAME"
-echo
+SIGNING_FILE_PREFIX="TeacherPayments${ENVIRONMENT_SHORT_NAME}VspSamlSigning${VERSION_NUMBER}"
+SIGNING_CSR_COMMON_NAME="Teacher Payments Service $ENVIRONMENT_SHORT_NAME VSP SAML Signing $VERSION_NUMBER"
 
-if [ "$KEY_EXISTED" ]; then
-  echo "A signing key already existed for $ENVIRONMENT_NAME version $VERSION_NUMBER."
-  echo "  Hit return to continue with the pre-existing key, or CTRL+C to stop."
-  read -r
-fi
-
-if [ "$CSR_EXISTED" ]; then
-  echo "A signing CSR already existed for $ENVIRONMENT_NAME version $VERSION_NUMBER."
-  echo "  Hit return to continue with the pre-existing CSR, or CTRL+C to stop."
-  read -r
-fi
-
-echo "Now enrol the generated signing CSR to Verify."
-
-SIGNING_CHALLENGE_PHRASE=
-
-while ! [ "$SIGNING_CHALLENGE_PHRASE" ]; do
-  read -rsp "  Enter the \"Challenge Phrase\" used in the request: " SIGNING_CHALLENGE_PHRASE
-  echo
-done
-
-echo "Storing signing key, CSR, and challenge phrase in $KEY_VAULT_NAME..."
-store_key_and_csr_and_challenge_phrase "$SIGNING_FILE_PREFIX" "$SIGNING_CHALLENGE_PHRASE"
+ENCRYPTION_FILE_PREFIX="TeacherPayments${ENVIRONMENT_SHORT_NAME}VspSamlEncryption${VERSION_NUMBER}"
+ENCRYPTION_CSR_COMMON_NAME="Teacher Payments Service $ENVIRONMENT_SHORT_NAME VSP SAML Encryption $VERSION_NUMBER"
 
 echo
-echo "Fetching or generating encryption key and CSR..."
-fetch_or_generate_key_and_csr "$ENCRYPTION_FILE_PREFIX" "$ENCRYPTION_CSR_COMMON_NAME"
+request_cert signing "$SIGNING_FILE_PREFIX" "$SIGNING_CSR_COMMON_NAME"
+
 echo
-
-if [ "$KEY_EXISTED" ]; then
-  echo "A encryption key already existed for $ENVIRONMENT_NAME version $VERSION_NUMBER."
-  echo "  Hit return to continue with the pre-existing key, or CTRL+C to stop."
-  read -r
-fi
-
-if [ "$CSR_EXISTED" ]; then
-  echo "A encryption CSR already existed for $ENVIRONMENT_NAME version $VERSION_NUMBER."
-  echo "  Hit return to continue with the pre-existing CSR, or CTRL+C to stop."
-  read -r
-fi
-
-echo "Now enrol the generated encryption CSR to Verify."
-
-ENCRYPTION_CHALLENGE_PHRASE=
-
-while ! [ "$ENCRYPTION_CHALLENGE_PHRASE" ]; do
-  read -rsp "  Enter the \"Challenge Phrase\" used in the request: " ENCRYPTION_CHALLENGE_PHRASE
-  echo
-done
-
-echo "Storing encryption key, CSR, and challenge phrase in $KEY_VAULT_NAME..."
-store_key_and_csr_and_challenge_phrase "$ENCRYPTION_FILE_PREFIX" "$ENCRYPTION_CHALLENGE_PHRASE"
+request_cert encryption "$ENCRYPTION_FILE_PREFIX" "$ENCRYPTION_CSR_COMMON_NAME"
 
 echo
 echo "Done!"

--- a/bin/request-vsp-certs
+++ b/bin/request-vsp-certs
@@ -26,35 +26,76 @@ case $ENVIRONMENT_NAME in
     ;;
 esac
 
-function generate_key_and_csr {
+function fetch_or_generate_key_and_csr {
   local FILE_PREFIX=$1
   local CSR_COMMON_NAME=$2
   local CSR_SUBJECT="/C=GB/ST=Greater Manchester/L=Manchester/O=DfE/OU=Teaching Workforce Directorate/CN=$CSR_COMMON_NAME"
 
-  openssl genrsa -out "$FILE_PREFIX-tmp.key" 2048
-  openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in "$FILE_PREFIX-tmp.key" -out "$FILE_PREFIX.key"
-  rm "$FILE_PREFIX-tmp.key"
+  if [ -f "$FILE_PREFIX.key" ]; then
+    rm "$FILE_PREFIX.key"
+  fi
 
-  openssl req -new -batch -key "$FILE_PREFIX.key" -subj "$CSR_SUBJECT" -out "$FILE_PREFIX.csr"
-}
+  echo "Attempting to fetch key..."
 
-function store_key_and_csr {
-  local FILE_PREFIX=$1
-
-  az keyvault secret set \
+  if ! az keyvault secret download \
     --vault-name $KEY_VAULT_NAME \
     --name "${FILE_PREFIX}Key" \
-    --file "${FILE_PREFIX}.key"
+    --file "$FILE_PREFIX.key"
+  then
+    KEY_EXISTED=
 
-  az keyvault secret set \
+    echo "Generating key..."
+
+    openssl genrsa -out "$FILE_PREFIX-tmp.key" 2048
+    openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in "$FILE_PREFIX-tmp.key" -out "$FILE_PREFIX.key"
+
+    rm "$FILE_PREFIX-tmp.key"
+  else
+    echo "Key found."
+
+    KEY_EXISTED=1
+  fi
+
+  if [ -f "$FILE_PREFIX.csr" ]; then
+    rm "$FILE_PREFIX.csr"
+  fi
+
+  echo "Attempting to fetch CSR..."
+
+  if ! az keyvault secret download \
     --vault-name $KEY_VAULT_NAME \
     --name "${FILE_PREFIX}Csr" \
-    --file "${FILE_PREFIX}.csr"
+    --file "$FILE_PREFIX.csr"
+  then
+    CSR_EXISTED=
+
+    echo "Generating CSR..."
+
+    openssl req -new -batch -key "$FILE_PREFIX.key" -subj "$CSR_SUBJECT" -out "$FILE_PREFIX.csr"
+  else
+    echo "CSR found."
+
+    CSR_EXISTED=1
+  fi
 }
 
-function store_challenge_phrase {
+function store_key_and_csr_and_challenge_phrase {
   local FILE_PREFIX=$1
   local CHALLENGE_PHRASE=$2
+
+  if ! [ "$KEY_EXISTED" ]; then
+    az keyvault secret set \
+      --vault-name $KEY_VAULT_NAME \
+      --name "${FILE_PREFIX}Key" \
+      --file "${FILE_PREFIX}.key"
+  fi
+
+  if ! [ "$CSR_EXISTED" ]; then
+    az keyvault secret set \
+      --vault-name $KEY_VAULT_NAME \
+      --name "${FILE_PREFIX}Csr" \
+      --file "${FILE_PREFIX}.csr"
+  fi
 
   az keyvault secret set \
     --vault-name $KEY_VAULT_NAME \
@@ -77,36 +118,52 @@ echo "Setting default Azure subscription to $AZURE_SUBSCRIPTION_ID..."
 az account set --subscription "$AZURE_SUBSCRIPTION_ID"
 
 echo
-echo "Generating signing key and CSR..."
-generate_key_and_csr "$SIGNING_FILE_PREFIX" "$SIGNING_CSR_COMMON_NAME"
-
+echo "Fetching or generating signing key and CSR..."
+fetch_or_generate_key_and_csr "$SIGNING_FILE_PREFIX" "$SIGNING_CSR_COMMON_NAME"
 echo
-echo "Storing signing key and CSR in $KEY_VAULT_NAME..."
-store_key_and_csr "$SIGNING_FILE_PREFIX"
 
-echo
+if [ "$KEY_EXISTED" ]; then
+  echo "A signing key already existed for $ENVIRONMENT_NAME version $VERSION_NUMBER."
+  echo "  Hit return to continue with the pre-existing key, or CTRL+C to stop."
+  read -r
+fi
+
+if [ "$CSR_EXISTED" ]; then
+  echo "A signing CSR already existed for $ENVIRONMENT_NAME version $VERSION_NUMBER."
+  echo "  Hit return to continue with the pre-existing CSR, or CTRL+C to stop."
+  read -r
+fi
+
 echo "Now enrol the generated signing CSR to Verify."
-read -rsp "Enter the \"Challenge Phrase\" used in the request: " SIGNING_CHALLENGE_PHRASE
+read -rsp "  Enter the \"Challenge Phrase\" used in the request: " SIGNING_CHALLENGE_PHRASE
 
 echo
-echo "Storing encryption challenge phrase in $KEY_VAULT_NAME..."
-store_challenge_phrase "$SIGNING_FILE_PREFIX" "$SIGNING_CHALLENGE_PHRASE"
+echo "Storing signing key, CSR, and challenge phrase in $KEY_VAULT_NAME..."
+store_key_and_csr_and_challenge_phrase "$SIGNING_FILE_PREFIX" "$SIGNING_CHALLENGE_PHRASE"
 
 echo
-echo "Generating encryption key and CSR..."
-generate_key_and_csr "$ENCRYPTION_FILE_PREFIX" "$ENCRYPTION_CSR_COMMON_NAME"
-
+echo "Fetching or generating encryption key and CSR..."
+fetch_or_generate_key_and_csr "$ENCRYPTION_FILE_PREFIX" "$ENCRYPTION_CSR_COMMON_NAME"
 echo
-echo "Storing encryption key and CSR in $KEY_VAULT_NAME..."
-store_key_and_csr "$ENCRYPTION_FILE_PREFIX"
 
-echo
+if [ "$KEY_EXISTED" ]; then
+  echo "A encryption key already existed for $ENVIRONMENT_NAME version $VERSION_NUMBER."
+  echo "  Hit return to continue with the pre-existing key, or CTRL+C to stop."
+  read -r
+fi
+
+if [ "$CSR_EXISTED" ]; then
+  echo "A encryption CSR already existed for $ENVIRONMENT_NAME version $VERSION_NUMBER."
+  echo "  Hit return to continue with the pre-existing CSR, or CTRL+C to stop."
+  read -r
+fi
+
 echo "Now enrol the generated encryption CSR to Verify."
-read -rsp "Enter the \"Challenge Phrase\" used in the request: " ENCRYPTION_CHALLENGE_PHRASE
+read -rsp "  Enter the \"Challenge Phrase\" used in the request: " ENCRYPTION_CHALLENGE_PHRASE
 
 echo
-echo "Storing encryption challenge phrase in $KEY_VAULT_NAME..."
-store_challenge_phrase "$ENCRYPTION_FILE_PREFIX" "$ENCRYPTION_CHALLENGE_PHRASE"
+echo "Storing encryption key, CSR, and challenge phrase in $KEY_VAULT_NAME..."
+store_key_and_csr_and_challenge_phrase "$ENCRYPTION_FILE_PREFIX" "$ENCRYPTION_CHALLENGE_PHRASE"
 
 echo
 echo "Done!"

--- a/bin/request-vsp-certs
+++ b/bin/request-vsp-certs
@@ -135,9 +135,14 @@ if [ "$CSR_EXISTED" ]; then
 fi
 
 echo "Now enrol the generated signing CSR to Verify."
-read -rsp "  Enter the \"Challenge Phrase\" used in the request: " SIGNING_CHALLENGE_PHRASE
 
-echo
+SIGNING_CHALLENGE_PHRASE=
+
+while ! [ "$SIGNING_CHALLENGE_PHRASE" ]; do
+  read -rsp "  Enter the \"Challenge Phrase\" used in the request: " SIGNING_CHALLENGE_PHRASE
+  echo
+done
+
 echo "Storing signing key, CSR, and challenge phrase in $KEY_VAULT_NAME..."
 store_key_and_csr_and_challenge_phrase "$SIGNING_FILE_PREFIX" "$SIGNING_CHALLENGE_PHRASE"
 
@@ -159,9 +164,14 @@ if [ "$CSR_EXISTED" ]; then
 fi
 
 echo "Now enrol the generated encryption CSR to Verify."
-read -rsp "  Enter the \"Challenge Phrase\" used in the request: " ENCRYPTION_CHALLENGE_PHRASE
 
-echo
+ENCRYPTION_CHALLENGE_PHRASE=
+
+while ! [ "$ENCRYPTION_CHALLENGE_PHRASE" ]; do
+  read -rsp "  Enter the \"Challenge Phrase\" used in the request: " ENCRYPTION_CHALLENGE_PHRASE
+  echo
+done
+
 echo "Storing encryption key, CSR, and challenge phrase in $KEY_VAULT_NAME..."
 store_key_and_csr_and_challenge_phrase "$ENCRYPTION_FILE_PREFIX" "$ENCRYPTION_CHALLENGE_PHRASE"
 

--- a/bin/request-vsp-certs
+++ b/bin/request-vsp-certs
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -e
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 ENVIRONMENT_NAME VERSION_NUMBER"
+  exit 1
+fi
+
+ENVIRONMENT_NAME=$1
+VERSION_NUMBER=$2
+
+case $ENVIRONMENT_NAME in
+  "development")
+    ENVIRONMENT_SHORT_NAME="Dev"
+    AZURE_SUBSCRIPTION_ID="8655985a-2f87-44d7-a541-0be9a8c2779d"
+    KEY_VAULT_NAME="s118d01-secrets-kv"
+    ;;
+  "production")
+    ENVIRONMENT_SHORT_NAME="Prod"
+    AZURE_SUBSCRIPTION_ID="88bd392f-df19-458b-a100-22b4429060ed"
+    KEY_VAULT_NAME="s118p01-secrets-kv"
+    ;;
+  *)
+    echo "Could not find an known environment with the name: $ENVIRONMENT_NAME"
+    exit 1
+    ;;
+esac
+
+function generate_key_and_csr {
+  local FILE_PREFIX=$1
+  local CSR_COMMON_NAME=$2
+  local CSR_SUBJECT="/C=GB/ST=Greater Manchester/L=Manchester/O=DfE/OU=Teaching Workforce Directorate/CN=$CSR_COMMON_NAME"
+
+  openssl genrsa -out "$FILE_PREFIX-tmp.key" 2048
+  openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in "$FILE_PREFIX-tmp.key" -out "$FILE_PREFIX.key"
+  rm "$FILE_PREFIX-tmp.key"
+
+  openssl req -new -batch -key "$FILE_PREFIX.key" -subj "$CSR_SUBJECT" -out "$FILE_PREFIX.csr"
+}
+
+function store_key_and_csr {
+  local FILE_PREFIX=$1
+
+  az keyvault secret set \
+    --vault-name $KEY_VAULT_NAME \
+    --name "${FILE_PREFIX}Key" \
+    --file "${FILE_PREFIX}.key"
+
+  az keyvault secret set \
+    --vault-name $KEY_VAULT_NAME \
+    --name "${FILE_PREFIX}Csr" \
+    --file "${FILE_PREFIX}.csr"
+}
+
+function store_challenge_phrase {
+  local FILE_PREFIX=$1
+  local CHALLENGE_PHRASE=$2
+
+  az keyvault secret set \
+    --vault-name $KEY_VAULT_NAME \
+    --name "${FILE_PREFIX}ChallengePhrase" \
+    --value "$CHALLENGE_PHRASE"
+}
+
+SIGNING_FILE_PREFIX="TeacherPayments${ENVIRONMENT_SHORT_NAME}VspSamlSigning${VERSION_NUMBER}"
+SIGNING_CSR_COMMON_NAME="Teacher Payments Service $ENVIRONMENT_SHORT_NAME VSP SAML Signing $VERSION_NUMBER"
+
+ENCRYPTION_FILE_PREFIX="TeacherPayments${ENVIRONMENT_SHORT_NAME}VspSamlEncryption${VERSION_NUMBER}"
+ENCRYPTION_CSR_COMMON_NAME="Teacher Payments Service $ENVIRONMENT_SHORT_NAME VSP SAML Encryption $VERSION_NUMBER"
+
+if ! az account show > /dev/null; then
+  echo "Logging in to Azure..."
+  az login
+fi
+
+echo "Setting default Azure subscription to $AZURE_SUBSCRIPTION_ID..."
+az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+
+echo
+echo "Generating signing key and CSR..."
+generate_key_and_csr "$SIGNING_FILE_PREFIX" "$SIGNING_CSR_COMMON_NAME"
+
+echo
+echo "Storing signing key and CSR in $KEY_VAULT_NAME..."
+store_key_and_csr "$SIGNING_FILE_PREFIX"
+
+echo
+echo "Now enrol the generated signing CSR to Verify."
+read -rsp "Enter the \"Challenge Phrase\" used in the request: " SIGNING_CHALLENGE_PHRASE
+
+echo
+echo "Storing encryption challenge phrase in $KEY_VAULT_NAME..."
+store_challenge_phrase "$SIGNING_FILE_PREFIX" "$SIGNING_CHALLENGE_PHRASE"
+
+echo
+echo "Generating encryption key and CSR..."
+generate_key_and_csr "$ENCRYPTION_FILE_PREFIX" "$ENCRYPTION_CSR_COMMON_NAME"
+
+echo
+echo "Storing encryption key and CSR in $KEY_VAULT_NAME..."
+store_key_and_csr "$ENCRYPTION_FILE_PREFIX"
+
+echo
+echo "Now enrol the generated encryption CSR to Verify."
+read -rsp "Enter the \"Challenge Phrase\" used in the request: " ENCRYPTION_CHALLENGE_PHRASE
+
+echo
+echo "Storing encryption challenge phrase in $KEY_VAULT_NAME..."
+store_challenge_phrase "$ENCRYPTION_FILE_PREFIX" "$ENCRYPTION_CHALLENGE_PHRASE"
+
+echo
+echo "Done!"

--- a/docs/govuk-verify.md
+++ b/docs/govuk-verify.md
@@ -14,7 +14,7 @@ the ukgovernmentdigital.slack.com slack workspace.
 Verify integration requires certain environment variables be set:
 
 ```bash
-  GOVUK_VERIFY_VSP_HOST=http://URL.FOR.VSP:12345
+GOVUK_VERIFY_VSP_HOST=http://URL.FOR.VSP:12345
 ```
 
 ## Running locally in development
@@ -23,7 +23,7 @@ Currently GOV.UK Verify integration is under active development and can be
 enabled by setting an environment variable in your `.env` file:
 
 ```bash
-  GOVUK_VERIFY_ENABLED=1
+GOVUK_VERIFY_ENABLED=1
 ```
 
 GOV.UK Verify integration requires using a Verify Service Provider (VSP) to
@@ -37,18 +37,43 @@ supported version of Java 8 installed for this to run successfully. We recommend
 You can check that the VSP is running ok by hitting the healthcheck URL:
 
 ```bash
-  curl localhost:50300/admin/healthcheck
+curl localhost:50300/admin/healthcheck
 ```
 
 ## Managing Certificates for the IDAP PKI
 
-In development mode, there is no need for key management. For the live service
-we need to run the key rotation process to update certificates when they are due
-to expire:
+### Local develoment
 
-https://www.docs.verify.service.gov.uk/maintain-your-connection/rotate-keys/
+In local development mode, nothing needs to be done here.
 
-More on this to follow once we move towards setting Verify up on staging and
-production.
+### Live environments
+
+For non-production (integration) environments (`development` and `test`) and
+production environments (`production`), we need to request certificates from
+Verify. The following will guide you though the process of generating and
+enrolling certificate requests.
+
+```bash
+bin/request-vsp-certs <environment> <version>
+```
+
+Where `<environment>` is one of `development` or `production` (we reuse
+`development` certs for the `test` environment) and `<version>` is an integer,
+usually 1 higher than the version of the certificates currently in use.
+
+When `bin/request-vsp-certs` refers to "enrolling" the requests, follow the
+process detailed in the section "2. Submit certificate signing requests" in the
+private Verify docs entitled "GOV.UK Verify Certification Process for Relying
+Party Subscribers". You will be prompted for the challenge phrase you submitted
+during that process.
+
+When it's finished, the generated keys, CSRs, and the challenge phrase will be
+automatically stored in the Key Vault on Azure matching the environment they
+were generated for.
+
+Integration certificates expire after 2 years, while production certificates
+expire after 6 months. See the
+[Verify docs for how to rotate keys](https://www.docs.verify.service.gov.uk/maintain-your-connection/rotate-keys/)
+for more information. `bin/request-vsp-certs` will probably be helpful.
 
 [openjdk]: https://adoptopenjdk.net/


### PR DESCRIPTION
We put them in the secrets key vaults. There is a manual step to do the enrollment with Verify using their web interface.

There is no "test" environment for VSP certificates here, omitted until we have a use case for Verify that wouldn't allow reusing "development" certificates.

This script was already used to generate the certificate requests that we submitted for dev and prod environments.