### PR TITLE
Introduce student loans eligibility model and port the QTS award year attribute

### DIFF
--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ClaimsController < Admin::BaseAdminController
   def index
-    claims = TslrClaim.includes(:claim_school, :current_school).submitted.order(:submitted_at)
+    claims = TslrClaim.includes(:claim_school, :current_school, :eligibility).submitted.order(:submitted_at)
     csv = TslrClaimsCsv.new(claims)
 
     respond_to do |format|

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -12,7 +12,7 @@ class ClaimsController < ApplicationController
   end
 
   def create
-    claim = TslrClaim.create!
+    claim = TslrClaim.create!(eligibility: StudentLoans::Eligibility.new)
     session[:tslr_claim_id] = claim.to_param
 
     redirect_to claim_path("qts-year")

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -62,7 +62,6 @@ class ClaimsController < ApplicationController
 
   def claim_params
     params.fetch(:tslr_claim, {}).permit(
-      :qts_award_year,
       :claim_school_id,
       :employment_status,
       :current_school_id,
@@ -84,7 +83,8 @@ class ClaimsController < ApplicationController
       :email_address,
       :bank_sort_code,
       :bank_account_number,
-      TslrClaim::SUBJECT_FIELDS
+      TslrClaim::SUBJECT_FIELDS,
+      eligibility_attributes: [:qts_award_year],
     )
   end
 

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -57,9 +57,9 @@ module ClaimsHelper
     )
   end
 
-  private
-
   def academic_years(year_range)
+    return unless year_range.present?
+
     start_year, end_year = year_range.split("_")
 
     "September 1 #{start_year} - August 31 #{end_year}"

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -16,5 +16,15 @@ module StudentLoans
     }, _prefix: :awarded_qualified_status
 
     validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select the academic year you were awarded qualified teacher status"}
+
+    def ineligible?
+      ineligible_qts_award_year?
+    end
+
+    private
+
+    def ineligible_qts_award_year?
+      awarded_qualified_status_before_2013?
+    end
   end
 end

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -21,6 +21,12 @@ module StudentLoans
       ineligible_qts_award_year?
     end
 
+    def ineligibility_reason
+      [
+        :ineligible_qts_award_year,
+      ].find { |eligibility_check| send("#{eligibility_check}?") }
+    end
+
     private
 
     def ineligible_qts_award_year?

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -27,8 +27,6 @@ module StudentLoans
       ].find { |eligibility_check| send("#{eligibility_check}?") }
     end
 
-    private
-
     def ineligible_qts_award_year?
       awarded_qualified_status_before_2013?
     end

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -3,5 +3,18 @@
 module StudentLoans
   class Eligibility < ApplicationRecord
     self.table_name = "student_loans_eligibilities"
+
+    enum qts_award_year: {
+      "before_2013": 0,
+      "2013_2014": 1,
+      "2014_2015": 2,
+      "2015_2016": 3,
+      "2016_2017": 4,
+      "2017_2018": 5,
+      "2018_2019": 6,
+      "2019_2020": 7,
+    }, _prefix: :awarded_qualified_status
+
+    validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select the academic year you were awarded qualified teacher status"}
   end
 end

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module StudentLoans
+  class Eligibility < ApplicationRecord
+    self.table_name = "student_loans_eligibilities"
+  end
+end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -36,6 +36,8 @@ class TslrClaim < ApplicationRecord
     "2019_2020": 7,
   }, _prefix: :awarded_qualified_status
 
+  belongs_to :eligibility, polymorphic: true
+
   belongs_to :claim_school, optional: true, class_name: "School"
   belongs_to :current_school, optional: true, class_name: "School"
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -25,26 +25,20 @@ class TslrClaim < ApplicationRecord
     no_school: 2,
   }, _prefix: :employed_at
 
-  enum qts_award_year: {
-    "before_2013": 0,
-    "2013_2014": 1,
-    "2014_2015": 2,
-    "2015_2016": 3,
-    "2016_2017": 4,
-    "2017_2018": 5,
-    "2018_2019": 6,
-    "2019_2020": 7,
-  }, _prefix: :awarded_qualified_status
+  # NOTE: Attribute migration in progress
+  delegate :qts_award_year, to: :eligibility
+
+  # NOTE: Temporary delegation of eligibility methods
+  delegate :ineligible_qts_award_year?, to: :eligibility, allow_nil: nil
 
   belongs_to :eligibility, polymorphic: true
+  accepts_nested_attributes_for :eligibility, update_only: true
 
   belongs_to :claim_school, optional: true, class_name: "School"
   belongs_to :current_school, optional: true, class_name: "School"
 
   validates :claim_school,                      on: [:"claim-school", :submit], presence: {message: "Select a school from the list"}
   validates :current_school,                    on: [:"current-school", :submit], presence: {message: "Select a school from the list"}
-
-  validates :qts_award_year,                    on: [:"qts-year", :submit], presence: {message: "Select the academic year you were awarded qualified teacher status"}
 
   validates :employment_status,                 on: [:"still-teaching", :submit], presence: {message: "Choose the option that describes your current employment status"}
 
@@ -161,10 +155,6 @@ class TslrClaim < ApplicationRecord
   end
 
   private
-
-  def ineligible_qts_award_year?
-    awarded_qualified_status_before_2013?
-  end
 
   def ineligible_claim_school?
     claim_school.present? && !claim_school.eligible_for_tslr?

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -1,26 +1,28 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: {qts_award_year: "tslr_claim_qts_award_year_before_2013"}) if current_claim.errors.any? %>
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: {:"eligibility.qts_award_year" => "tslr_claim_eligibility_attributes_qts_award_year_before_2013"}) if current_claim.errors.any? %>
 
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
-        <h1 class="govuk-label-wrapper">
-          <%= form.label :qts_award_year, t("tslr.questions.qts_award_year"), {class: "govuk-label govuk-label--xl"} %>
-        </h1>
-        <span id="tslr_claim_qts_award_year-hint" class="govuk-hint">
-          You are only eligible to claim back student loan repayments if you qualified on or after September 1st 2013.
-        </span>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+          <h1 class="govuk-label-wrapper">
+            <%= fields.label :qts_award_year, t("tslr.questions.qts_award_year"), {class: "govuk-label govuk-label--xl"} %>
+          </h1>
+          <span id="tslr_claim_qts_award_year-hint" class="govuk-hint">
+            You are only eligible to claim back student loan repayments if you qualified on or after September 1st 2013.
+          </span>
 
-        <%= errors_tag current_claim, :qts_award_year %>
-        <div class="govuk-radios">
-          <%= form.hidden_field :qts_award_year %>
-          <% TslrClaim.qts_award_years.each_key do |option| %>
-            <div class="govuk-radios__item">
-              <%= form.radio_button(:qts_award_year, option, class: "govuk-radios__input") %>
-              <%= form.label "qts_award_year_#{option}", t("tslr.questions.qts_award_years.#{option}"), class: "govuk-label govuk-radios__label" %>
-            </div>
-          <% end %>
-        </div>
+          <%= errors_tag current_claim, :qts_award_year %>
+          <div class="govuk-radios">
+            <%= fields.hidden_field :qts_award_year %>
+            <% StudentLoans::Eligibility.qts_award_years.each_key do |option| %>
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:qts_award_year, option, class: "govuk-radios__input") %>
+                <%= fields.label "qts_award_year_#{option}", t("tslr.questions.qts_award_years.#{option}"), class: "govuk-label govuk-radios__label" %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,24 +3,24 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "986bcf3b3075cf77a2c4b4b4d382be6fb3d5233bd0c9b943bfd3274bc4099145",
+      "fingerprint": "4b211194d02b7ce69b81b6f7f9232bf911beaf094d9cb272098d62f31bc9f983",
       "check_name": "SendFile",
       "message": "Model attribute used in file name",
       "file": "app/controllers/admin/claims_controller.rb",
       "line": 7,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(TslrClaimsCsv.new(TslrClaim.includes(:claim_school, :current_school).submitted.order(:submitted_at)).file, :type => \"text/csv\", :filename => \"claims.csv\")",
+      "code": "send_file(TslrClaimsCsv.new(TslrClaim.includes(:claim_school, :current_school, :eligibility).submitted.order(:submitted_at)).file, :type => \"text/csv\", :filename => \"claims.csv\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "Admin::ClaimsController",
         "method": "index"
       },
-      "user_input": "TslrClaim.includes(:claim_school, :current_school).submitted",
+      "user_input": "TslrClaim.includes(:claim_school, :current_school, :eligibility).submitted",
       "confidence": "Weak",
       "note": ""
     }
   ],
-  "updated": "2019-06-27 17:40:58 +0100",
-  "brakeman_version": "4.5.1"
+  "updated": "2019-07-30 11:24:07 +0100",
+  "brakeman_version": "4.6.1"
 }

--- a/db/migrate/20190725125658_create_student_loans_eligibilities.rb
+++ b/db/migrate/20190725125658_create_student_loans_eligibilities.rb
@@ -1,0 +1,7 @@
+class CreateStudentLoansEligibilities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :student_loans_eligibilities, id: :uuid do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190725145000_add_qts_award_year_to_student_loans_eligibilities.rb
+++ b/db/migrate/20190725145000_add_qts_award_year_to_student_loans_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddQtsAwardYearToStudentLoansEligibilities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :student_loans_eligibilities, :qts_award_year, :integer
+  end
+end

--- a/db/migrate/20190725145500_remove_qts_award_year_from_tslr_claims.rb
+++ b/db/migrate/20190725145500_remove_qts_award_year_from_tslr_claims.rb
@@ -1,0 +1,5 @@
+class RemoveQtsAwardYearFromTslrClaims < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :tslr_claims, :qts_award_year, :integer
+  end
+end

--- a/db/migrate/20190729143440_add_eligibility_reference_to_tslr_claims.rb
+++ b/db/migrate/20190729143440_add_eligibility_reference_to_tslr_claims.rb
@@ -1,0 +1,7 @@
+class AddEligibilityReferenceToTslrClaims < ActiveRecord::Migration[5.2]
+  def change
+    change_table :tslr_claims do |t|
+      t.references :eligibility, type: :uuid, polymorphic: true, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,7 +70,6 @@ ActiveRecord::Schema.define(version: 2019_07_29_143440) do
   end
 
   create_table "tslr_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.integer "qts_award_year"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "claim_school_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2019_07_25_145000) do
+ActiveRecord::Schema.define(version: 2019_07_29_143440) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -103,8 +102,11 @@ ActiveRecord::Schema.define(version: 2019_07_25_145000) do
     t.integer "student_loan_courses"
     t.integer "student_loan_start_date"
     t.integer "student_loan_plan"
+    t.string "eligibility_type"
+    t.uuid "eligibility_id"
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
+    t.index ["eligibility_type", "eligibility_id"], name: "index_tslr_claims_on_eligibility_type_and_eligibility_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"
     t.index ["reference"], name: "index_tslr_claims_on_reference", unique: true
     t.index ["submitted_at"], name: "index_tslr_claims_on_submitted_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_22_101055) do
+ActiveRecord::Schema.define(version: 2019_07_25_125658) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -62,6 +62,11 @@ ActiveRecord::Schema.define(version: 2019_07_22_101055) do
     t.index ["local_authority_district_id"], name: "index_schools_on_local_authority_district_id"
     t.index ["local_authority_id"], name: "index_schools_on_local_authority_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true
+  end
+
+  create_table "student_loans_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tslr_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_25_125658) do
 
+ActiveRecord::Schema.define(version: 2019_07_25_145000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2019_07_25_125658) do
   create_table "student_loans_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "qts_award_year"
   end
 
   create_table "tslr_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/student_loans/eligibilities.rb
+++ b/spec/factories/student_loans/eligibilities.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :student_loans_eligibility, class: "StudentLoans::Eligibility" do
+  end
+end

--- a/spec/factories/student_loans/eligibilities.rb
+++ b/spec/factories/student_loans/eligibilities.rb
@@ -2,5 +2,8 @@
 
 FactoryBot.define do
   factory :student_loans_eligibility, class: "StudentLoans::Eligibility" do
+    trait :submittable do
+      qts_award_year { "2013_2014" }
+    end
   end
 end

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :tslr_claim do
+    association(:eligibility, factory: :student_loans_eligibility)
+
     trait :submittable do
       claim_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
       current_school { claim_school }

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     trait :submittable do
       claim_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
       current_school { claim_school }
-      qts_award_year { "2013_2014" }
       employment_status { :claim_school }
       physics_taught { true }
       mostly_teaching_eligible_subjects { true }
@@ -25,6 +24,8 @@ FactoryBot.define do
       email_address { "test@email.com" }
       bank_sort_code { 123456 }
       bank_account_number { 12345678 }
+
+      association(:eligibility, factory: [:student_loans_eligibility, :submittable])
     end
 
     trait :submitted do

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -1,17 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments claims" do
-  let(:school) { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
-  let(:claim) do
-    create(:tslr_claim,
-      claim_school: school,
-      current_school: school,
-      qts_award_year: "2013_2014",
-      employment_status: :claim_school)
-  end
-
   before do
-    allow_any_instance_of(ClaimsController).to receive(:current_claim) { claim }
+    start_tslr_claim
     visit claim_path("subjects-taught")
   end
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -139,4 +139,14 @@ describe ClaimsHelper do
       end
     end
   end
+
+  describe "#academic_years" do
+    it "returns a string showing the date range for the academic year based on the qts_award_year input" do
+      expect(helper.academic_years("2012_2013")).to eq "September 1 2012 - August 31 2013"
+    end
+
+    it "doesn't fall over if the qts_award_year has not been set yet" do
+      expect(helper.academic_years(nil)).to be_nil
+    end
+  end
 end

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -6,13 +6,13 @@ describe ClaimsHelper do
       school = schools(:penistone_grammar_school)
       claim = build(
         :tslr_claim,
-        qts_award_year: "2013_2014",
         claim_school: school,
         current_school: school,
         chemistry_taught: true,
         physics_taught: true,
         mostly_teaching_eligible_subjects: true,
         student_loan_repayment_amount: 1987.65,
+        eligibility_attributes: {qts_award_year: "2013_2014"},
       )
 
       expected_answers = [

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -4,7 +4,8 @@ describe ClaimsHelper do
   describe "#claim_answers" do
     it "returns an array of questions and answers for displaying to the user for review" do
       school = create(:school)
-      claim = TslrClaim.create(
+      claim = create(
+        :tslr_claim,
         qts_award_year: "2013_2014",
         claim_school: school,
         current_school: school,
@@ -29,7 +30,8 @@ describe ClaimsHelper do
 
   describe "#identity_answers" do
     it "returns an array of questions and answers for displaying to the user for review" do
-      claim = TslrClaim.create(
+      claim = create(
+        :tslr_claim,
         full_name: "Jo Bloggs",
         address_line_1: "Flat 1",
         address_line_2: "1 Test Road",
@@ -55,10 +57,7 @@ describe ClaimsHelper do
 
     describe "#payment_answers" do
       it "returns an array of questions and answers for displaying to the user for review" do
-        claim = TslrClaim.create(
-          bank_sort_code: "12 34 56",
-          bank_account_number: "12 34 56 78",
-        )
+        claim = create(:tslr_claim, bank_sort_code: "12 34 56", bank_account_number: "12 34 56 78")
 
         expected_answers = [
           ["Bank sort code", "123456", "bank-details"],
@@ -72,7 +71,8 @@ describe ClaimsHelper do
 
   describe "#student_loan_answers" do
     it "returns an array of question and answers for the student loan questions" do
-      claim = TslrClaim.new(
+      claim = build(
+        :tslr_claim,
         has_student_loan: true,
         student_loan_country: StudentLoans::ENGLAND,
         student_loan_courses: :one_course,
@@ -90,7 +90,8 @@ describe ClaimsHelper do
     end
 
     it "adjusts the loan start date question and answer according to the number of courses answer" do
-      claim = TslrClaim.new(
+      claim = build(
+        :tslr_claim,
         has_student_loan: true,
         student_loan_country: StudentLoans::ENGLAND,
         student_loan_courses: :two_or_more_courses,
@@ -108,10 +109,7 @@ describe ClaimsHelper do
     end
 
     it "excludes unanswered questions" do
-      claim = TslrClaim.new(
-        has_student_loan: true,
-        student_loan_country: StudentLoans::SCOTLAND,
-      )
+      claim = build(:tslr_claim, has_student_loan: true, student_loan_country: StudentLoans::SCOTLAND)
 
       expected_answers = [
         [t("tslr.questions.has_student_loan"), "Yes", "student-loan"],

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe ClaimsHelper do
   describe "#claim_answers" do
     it "returns an array of questions and answers for displaying to the user for review" do
-      school = create(:school)
-      claim = create(
+      school = schools(:penistone_grammar_school)
+      claim = build(
         :tslr_claim,
         qts_award_year: "2013_2014",
         claim_school: school,
@@ -30,7 +30,7 @@ describe ClaimsHelper do
 
   describe "#identity_answers" do
     it "returns an array of questions and answers for displaying to the user for review" do
-      claim = create(
+      claim = build(
         :tslr_claim,
         full_name: "Jo Bloggs",
         address_line_1: "Flat 1",
@@ -39,7 +39,7 @@ describe ClaimsHelper do
         postcode: "AB1 2CD",
         date_of_birth: 20.years.ago.to_date,
         teacher_reference_number: "1234567",
-        national_insurance_number: "QQ 12 34 56 C",
+        national_insurance_number: "QQ123456C",
         email_address: "test@email.com",
       )
 

--- a/spec/models/claim_update_spec.rb
+++ b/spec/models/claim_update_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe ClaimUpdate do
     end
   end
 
-  describe "changing the answer to the student_loan_country question" do
+  describe "changing the answer to the student_loan question" do
     let(:claim) do
       create(
         :tslr_claim,

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe PageSequence do
-  let(:claim) { TslrClaim.new }
+  let(:claim) { build(:tslr_claim) }
 
   describe "#slugs" do
     it "excludes “current-school” when the claimant still works at the school they are claiming against" do
@@ -53,7 +53,7 @@ RSpec.describe PageSequence do
     end
 
     context "with an ineligible claim" do
-      let(:claim) { TslrClaim.new(employment_status: :no_school) }
+      let(:claim) { build(:tslr_claim, employment_status: :no_school) }
 
       it "returns “ineligible” as the next slug" do
         expect(PageSequence.new(claim, "still-teaching").next_slug).to eq "ineligible"

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     end
   end
 
+  describe "#ineligibility_reason" do
+    it "returns nil when the reason for ineligibility cannot be determined" do
+      expect(StudentLoans::Eligibility.new.ineligibility_reason).to be_nil
+    end
+
+    it "returns a symbol indicating the reason for ineligibility" do
+      expect(StudentLoans::Eligibility.new(qts_award_year: "before_2013").ineligibility_reason).to eq :ineligible_qts_award_year
+    end
+  end
+
   # Validation contexts
   context "when saving in the “qts-year” context" do
     it "is not valid without a value for qts_award_year" do

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -3,4 +3,37 @@
 require "rails_helper"
 
 RSpec.describe StudentLoans::Eligibility, type: :model do
+  describe "qts_award_year attribute" do
+    it "rejects invalid values" do
+      expect { StudentLoans::Eligibility.new(qts_award_year: "non-existence") }.to raise_error(ArgumentError)
+    end
+
+    it "has handily named boolean methods for the possible values" do
+      eligibility = StudentLoans::Eligibility.new(qts_award_year: "2013_2014")
+
+      expect(eligibility.awarded_qualified_status_2013_2014?).to eq true
+      expect(eligibility.awarded_qualified_status_before_2013?).to eq false
+    end
+  end
+
+  # Validation contexts
+  context "when saving in the “qts-year” context" do
+    it "is not valid without a value for qts_award_year" do
+      expect(StudentLoans::Eligibility.new).not_to be_valid(:"qts-year")
+
+      StudentLoans::Eligibility.qts_award_years.each_key do |academic_year|
+        expect(StudentLoans::Eligibility.new(qts_award_year: academic_year)).to be_valid(:"qts-year")
+      end
+    end
+  end
+
+  context "when saving in the “submit” context" do
+    it "is not valid without a value for qts_award_year" do
+      expect(StudentLoans::Eligibility.new).not_to be_valid(:submit)
+
+      StudentLoans::Eligibility.qts_award_years.each_key do |academic_year|
+        expect(StudentLoans::Eligibility.new(qts_award_year: academic_year)).to be_valid(:submit)
+      end
+    end
+  end
 end

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StudentLoans::Eligibility, type: :model do
+end

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     end
   end
 
+  describe "#ineligible?" do
+    it "returns false when the eligibility cannot be determined" do
+      expect(StudentLoans::Eligibility.new.ineligible?).to eql false
+    end
+
+    it "returns true when the qts_award_year is before 2013" do
+      expect(StudentLoans::Eligibility.new(qts_award_year: "before_2013").ineligible?).to eql true
+      expect(StudentLoans::Eligibility.new(qts_award_year: "2013_2014").ineligible?).to eql false
+    end
+  end
+
   # Validation contexts
   context "when saving in the “qts-year” context" do
     it "is not valid without a value for qts_award_year" do

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -121,14 +121,14 @@ RSpec.describe TslrClaim, type: :model do
     let(:custom_validation_context) { :"qts-year" }
 
     it "rejects invalid QTS award years" do
-      expect { build(:tslr_claim, qts_award_year: "123") }.to raise_error(ArgumentError)
+      expect { build(:tslr_claim, eligibility: build(:student_loans_eligibility, qts_award_year: "123")) }.to raise_error(ArgumentError)
     end
 
     it "validates the qts_award_year is one of the allowable values" do
       expect(build(:tslr_claim)).not_to be_valid(custom_validation_context)
 
-      TslrClaim.qts_award_years.each_key do |academic_year|
-        expect(build(:tslr_claim, qts_award_year: academic_year)).to be_valid(custom_validation_context)
+      StudentLoans::Eligibility.qts_award_years.each_key do |academic_year|
+        expect(build(:tslr_claim, eligibility: build(:student_loans_eligibility, qts_award_year: academic_year))).to be_valid(custom_validation_context)
       end
     end
   end
@@ -315,12 +315,12 @@ RSpec.describe TslrClaim, type: :model do
     subject { build(:tslr_claim, claim_attributes).ineligible? }
 
     context "with an ineligible QTS award year" do
-      let(:claim_attributes) { {qts_award_year: "before_2013"} }
+      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, qts_award_year: "before_2013")} }
       it { is_expected.to be true }
     end
 
     context "with an eligible QTS award year" do
-      let(:claim_attributes) { {qts_award_year: "2013_2014"} }
+      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, qts_award_year: "2013_2014")} }
       it { is_expected.to be false }
     end
 
@@ -359,7 +359,7 @@ RSpec.describe TslrClaim, type: :model do
     subject { build(:tslr_claim, claim_attributes).ineligibility_reason }
 
     context "with an ineligible qts_award_year" do
-      let(:claim_attributes) { {qts_award_year: "before_2013"} }
+      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, qts_award_year: "before_2013")} }
       it { is_expected.to eql :ineligible_qts_award_year }
     end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -6,82 +6,82 @@ RSpec.describe TslrClaim, type: :model do
 
   context "that has a teacher_reference_number" do
     it "validates the length of the teacher reference number" do
-      expect(TslrClaim.new(teacher_reference_number: "1/2/3/4/5/6/7")).to be_valid
-      expect(TslrClaim.new(teacher_reference_number: "1/2/3/4/5")).not_to be_valid
-      expect(TslrClaim.new(teacher_reference_number: "12/345678")).not_to be_valid
+      expect(build(:tslr_claim, teacher_reference_number: "1/2/3/4/5/6/7")).to be_valid
+      expect(build(:tslr_claim, teacher_reference_number: "1/2/3/4/5")).not_to be_valid
+      expect(build(:tslr_claim, teacher_reference_number: "12/345678")).not_to be_valid
     end
   end
 
   context "that has a email address" do
     it "validates that the value is in the correct format" do
-      expect(TslrClaim.new(email_address: "notan email@address.com")).not_to be_valid
-      expect(TslrClaim.new(email_address: "name@example.com")).to be_valid
+      expect(build(:tslr_claim, email_address: "notan email@address.com")).not_to be_valid
+      expect(build(:tslr_claim, email_address: "name@example.com")).to be_valid
     end
 
     it "checks that the email address in not longer than 256 characters" do
-      expect(TslrClaim.new(email_address: "#{"e" * 256}@example.com")).not_to be_valid
+      expect(build(:tslr_claim, email_address: "#{"e" * 256}@example.com")).not_to be_valid
     end
   end
 
   context "that has a National Insurance number" do
     it "validates that the National Insurance number is in the correct format" do
-      expect(TslrClaim.new(national_insurance_number: "12 34 56 78 C")).not_to be_valid
-      expect(TslrClaim.new(national_insurance_number: "QQ 11 56 78 DE")).not_to be_valid
+      expect(build(:tslr_claim, national_insurance_number: "12 34 56 78 C")).not_to be_valid
+      expect(build(:tslr_claim, national_insurance_number: "QQ 11 56 78 DE")).not_to be_valid
 
-      expect(TslrClaim.new(national_insurance_number: "QQ 34 56 78 C")).to be_valid
+      expect(build(:tslr_claim, national_insurance_number: "QQ 34 56 78 C")).to be_valid
     end
   end
 
   context "that has a student loan repayment amount" do
     it "validates that the loan repayment amount is numerical" do
-      expect(TslrClaim.new(student_loan_repayment_amount: "don’t know")).not_to be_valid
-      expect(TslrClaim.new(student_loan_repayment_amount: "£1,234.56")).to be_valid
+      expect(build(:tslr_claim, student_loan_repayment_amount: "don’t know")).not_to be_valid
+      expect(build(:tslr_claim, student_loan_repayment_amount: "£1,234.56")).to be_valid
     end
 
     it "validates that the loan repayment is under £99,999" do
-      expect(TslrClaim.new(student_loan_repayment_amount: "100000000")).not_to be_valid
-      expect(TslrClaim.new(student_loan_repayment_amount: "99999")).to be_valid
+      expect(build(:tslr_claim, student_loan_repayment_amount: "100000000")).not_to be_valid
+      expect(build(:tslr_claim, student_loan_repayment_amount: "99999")).to be_valid
     end
 
     it "validates that the loan repayment a positive number" do
-      expect(TslrClaim.new(student_loan_repayment_amount: "-99")).not_to be_valid
-      expect(TslrClaim.new(student_loan_repayment_amount: "150")).to be_valid
+      expect(build(:tslr_claim, student_loan_repayment_amount: "-99")).not_to be_valid
+      expect(build(:tslr_claim, student_loan_repayment_amount: "150")).to be_valid
     end
   end
 
   context "that has a full name" do
     it "validates the length of name is 200 characters or less" do
-      expect(TslrClaim.new(full_name: "Name " * 50)).not_to be_valid
-      expect(TslrClaim.new(full_name: "John Kimble")).to be_valid
+      expect(build(:tslr_claim, full_name: "Name " * 50)).not_to be_valid
+      expect(build(:tslr_claim, full_name: "John Kimble")).to be_valid
     end
   end
 
   context "that has a postcode" do
     it "validates the length of postcode is not greater than 11" do
-      expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M12345 23453WD")).not_to be_valid
-      expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M1 2WD")).to be_valid
+      expect(build(:tslr_claim, address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M12345 23453WD")).not_to be_valid
+      expect(build(:tslr_claim, address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M1 2WD")).to be_valid
     end
   end
 
   context "that has a address" do
     it "validates the length of address_line_1 is 100 characters or less" do
       valid_address_attributes = {address_line_1: "123 Main Street" * 25, address_line_3: "Twin Peaks", postcode: "12345"}
-      expect(TslrClaim.new(valid_address_attributes)).not_to be_valid
+      expect(build(:tslr_claim, valid_address_attributes)).not_to be_valid
     end
   end
 
   context "that has bank details" do
     it "validates the format of bank_account_number and bank_sort_code" do
-      expect(TslrClaim.new(bank_account_number: "ABC12 34 56 789")).not_to be_valid
-      expect(TslrClaim.new(bank_account_number: "12-34-56-78")).to be_valid
+      expect(build(:tslr_claim, bank_account_number: "ABC12 34 56 789")).not_to be_valid
+      expect(build(:tslr_claim, bank_account_number: "12-34-56-78")).to be_valid
 
-      expect(TslrClaim.new(bank_sort_code: "ABC12 34 567")).not_to be_valid
-      expect(TslrClaim.new(bank_sort_code: "12 34 56")).to be_valid
+      expect(build(:tslr_claim, bank_sort_code: "ABC12 34 567")).not_to be_valid
+      expect(build(:tslr_claim, bank_sort_code: "12 34 56")).to be_valid
     end
 
     context "on save" do
       it "strips out white space and the “-” character from bank_account_number and bank_sort_code" do
-        claim = TslrClaim.new(bank_sort_code: "12 34 56", bank_account_number: "12-34-56-78")
+        claim = build(:tslr_claim, bank_sort_code: "12 34 56", bank_account_number: "12-34-56-78")
         claim.save!
 
         expect(claim.bank_sort_code).to eql("123456")
@@ -92,9 +92,9 @@ RSpec.describe TslrClaim, type: :model do
 
   context "that has a student loan plan" do
     it "validates the plan" do
-      expect(TslrClaim.new(student_loan_plan: StudentLoans::PLAN_1)).to be_valid
+      expect(build(:tslr_claim, student_loan_plan: StudentLoans::PLAN_1)).to be_valid
 
-      expect { TslrClaim.new(student_loan_plan: "plan_42") }.to raise_error(ArgumentError)
+      expect { build(:tslr_claim, student_loan_plan: "plan_42") }.to raise_error(ArgumentError)
     end
   end
 
@@ -121,14 +121,14 @@ RSpec.describe TslrClaim, type: :model do
     let(:custom_validation_context) { :"qts-year" }
 
     it "rejects invalid QTS award years" do
-      expect { TslrClaim.new(qts_award_year: "123") }.to raise_error(ArgumentError)
+      expect { build(:tslr_claim, qts_award_year: "123") }.to raise_error(ArgumentError)
     end
 
     it "validates the qts_award_year is one of the allowable values" do
-      expect(TslrClaim.new).not_to be_valid(custom_validation_context)
+      expect(build(:tslr_claim)).not_to be_valid(custom_validation_context)
 
       TslrClaim.qts_award_years.each_key do |academic_year|
-        expect(TslrClaim.new(qts_award_year: academic_year)).to be_valid(custom_validation_context)
+        expect(build(:tslr_claim, qts_award_year: academic_year)).to be_valid(custom_validation_context)
       end
     end
   end
@@ -137,134 +137,134 @@ RSpec.describe TslrClaim, type: :model do
     let(:custom_validation_context) { :"claim-school" }
 
     it "it validates the claim_school" do
-      expect(TslrClaim.new).not_to be_valid(custom_validation_context)
-      expect(TslrClaim.new(claim_school: schools(:penistone_grammar_school))).to be_valid(custom_validation_context)
+      expect(build(:tslr_claim)).not_to be_valid(custom_validation_context)
+      expect(build(:tslr_claim, claim_school: schools(:penistone_grammar_school))).to be_valid(custom_validation_context)
     end
   end
 
   context "when saving in the “still-teaching” validation context" do
     it "validates employment_status has been provided" do
-      expect(TslrClaim.new).not_to be_valid(:"still-teaching")
-      expect(TslrClaim.new(employment_status: :claim_school)).to be_valid(:"still-teaching")
+      expect(build(:tslr_claim)).not_to be_valid(:"still-teaching")
+      expect(build(:tslr_claim, employment_status: :claim_school)).to be_valid(:"still-teaching")
     end
   end
 
   context "when saving in the “current-school” validation context" do
     it "it validates the current_school" do
-      expect(TslrClaim.new).not_to be_valid(:"current-school")
-      expect(TslrClaim.new(current_school: schools(:hampstead_school))).to be_valid(:"current-school")
+      expect(build(:tslr_claim)).not_to be_valid(:"current-school")
+      expect(build(:tslr_claim, current_school: schools(:hampstead_school))).to be_valid(:"current-school")
     end
   end
 
   context "when saving in the “subjects-taught” validation context" do
     it "validates that a subject has been provided" do
-      expect(TslrClaim.new).not_to be_valid(:"subjects-taught")
-      expect(TslrClaim.new(computer_science_taught: true, physics_taught: true)).to be_valid(:"subjects-taught")
+      expect(build(:tslr_claim)).not_to be_valid(:"subjects-taught")
+      expect(build(:tslr_claim, computer_science_taught: true, physics_taught: true)).to be_valid(:"subjects-taught")
     end
 
     it "does not validate that a subject has been provided when mostly_teaching_eligible_subjects is false" do
-      expect(TslrClaim.new).not_to be_valid(:"subjects-taught")
-      expect(TslrClaim.new(mostly_teaching_eligible_subjects: false)).to be_valid(:"subjects-taught")
+      expect(build(:tslr_claim)).not_to be_valid(:"subjects-taught")
+      expect(build(:tslr_claim, mostly_teaching_eligible_subjects: false)).to be_valid(:"subjects-taught")
     end
   end
 
   context "when saving in the “mostly-teaching-eligible-subjects” validation context" do
     it "validates mostly_teaching_eligible_subjects has been provided" do
-      expect(TslrClaim.new).not_to be_valid(:"subjects-taught")
-      expect(TslrClaim.new(mostly_teaching_eligible_subjects: true)).to be_valid(:"mostly-teaching-eligible-subjects")
+      expect(build(:tslr_claim)).not_to be_valid(:"subjects-taught")
+      expect(build(:tslr_claim, mostly_teaching_eligible_subjects: true)).to be_valid(:"mostly-teaching-eligible-subjects")
     end
   end
 
   context "when saving in the “name” validation context" do
     it "validates the presence of full_name" do
-      expect(TslrClaim.new).not_to be_valid(:"full-name")
-      expect(TslrClaim.new(full_name: "John Kimble")).to be_valid(:"full-name")
+      expect(build(:tslr_claim)).not_to be_valid(:"full-name")
+      expect(build(:tslr_claim, full_name: "John Kimble")).to be_valid(:"full-name")
     end
   end
 
   context "when saving in the “address” validation context" do
     it "validates the presence of address_line_1, address_line_3 (i.e. the town or city), and postcode" do
-      expect(TslrClaim.new).not_to be_valid(:address)
+      expect(build(:tslr_claim)).not_to be_valid(:address)
 
       valid_address_attributes = {address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "12345"}
-      expect(TslrClaim.new(valid_address_attributes)).to be_valid(:address)
+      expect(build(:tslr_claim, valid_address_attributes)).to be_valid(:address)
     end
   end
 
   context "when saving in the “date-of-birth” validation context" do
     it "validates the presence of date_of_birth" do
-      expect(TslrClaim.new).not_to be_valid(:"date-of-birth")
-      expect(TslrClaim.new(date_of_birth: Date.new(2000, 2, 1))).to be_valid(:"date-of-birth")
+      expect(build(:tslr_claim)).not_to be_valid(:"date-of-birth")
+      expect(build(:tslr_claim, date_of_birth: Date.new(2000, 2, 1))).to be_valid(:"date-of-birth")
     end
   end
 
   context "when saving in the “teacher-reference-number” validation context" do
     it "validates the presence of teacher_reference_number" do
-      expect(TslrClaim.new).not_to be_valid(:"teacher-reference-number")
-      expect(TslrClaim.new(teacher_reference_number: "1234567")).to be_valid(:"teacher-reference-number")
+      expect(build(:tslr_claim)).not_to be_valid(:"teacher-reference-number")
+      expect(build(:tslr_claim, teacher_reference_number: "1234567")).to be_valid(:"teacher-reference-number")
     end
   end
 
   context "when saving in the “national-insurance-number” validation context" do
     it "validates the presence of national_insurance_number" do
-      expect(TslrClaim.new).not_to be_valid(:"national-insurance-number")
-      expect(TslrClaim.new(national_insurance_number: "QQ123456C")).to be_valid(:"national-insurance-number")
+      expect(build(:tslr_claim)).not_to be_valid(:"national-insurance-number")
+      expect(build(:tslr_claim, national_insurance_number: "QQ123456C")).to be_valid(:"national-insurance-number")
     end
   end
 
   context "when saving in the “student-loan” validation context" do
     it "validates the presence of student_loan" do
-      expect(TslrClaim.new).not_to be_valid(:"student-loan")
-      expect(TslrClaim.new(has_student_loan: true)).to be_valid(:"student-loan")
-      expect(TslrClaim.new(has_student_loan: false)).to be_valid(:"student-loan")
+      expect(build(:tslr_claim)).not_to be_valid(:"student-loan")
+      expect(build(:tslr_claim, has_student_loan: true)).to be_valid(:"student-loan")
+      expect(build(:tslr_claim, has_student_loan: false)).to be_valid(:"student-loan")
     end
   end
 
   context "when saving in the “student-loan-country” validation context" do
     it "validates the presence of student_loan_country" do
-      expect(TslrClaim.new).not_to be_valid(:"student-loan-country")
-      expect(TslrClaim.new(student_loan_country: :england)).to be_valid(:"student-loan-country")
+      expect(build(:tslr_claim)).not_to be_valid(:"student-loan-country")
+      expect(build(:tslr_claim, student_loan_country: :england)).to be_valid(:"student-loan-country")
     end
   end
 
   context "when saving in the “student-loan-how-many-courses” validation context" do
     it "validates the presence of the student_loan_how_many_courses" do
-      expect(TslrClaim.new).not_to be_valid(:"student-loan-how-many-courses")
-      expect(TslrClaim.new(student_loan_courses: :one_course)).to be_valid(:"student-loan-how-many-courses")
+      expect(build(:tslr_claim)).not_to be_valid(:"student-loan-how-many-courses")
+      expect(build(:tslr_claim, student_loan_courses: :one_course)).to be_valid(:"student-loan-how-many-courses")
     end
   end
 
   context "when saving in the “student-loan-start-date” validation context" do
     it "validates the presence of the student_loan_how_many_courses" do
-      expect(TslrClaim.new).not_to be_valid(:"student-loan-start-date")
-      expect(TslrClaim.new(student_loan_start_date: StudentLoans::BEFORE_1_SEPT_2012)).to be_valid(:"student-loan-start-date")
+      expect(build(:tslr_claim)).not_to be_valid(:"student-loan-start-date")
+      expect(build(:tslr_claim, student_loan_start_date: StudentLoans::BEFORE_1_SEPT_2012)).to be_valid(:"student-loan-start-date")
     end
   end
 
   context "when saving in the “student-loan-amount” validation context" do
     it "validates the presence of student_loan_repayment_amount" do
-      expect(TslrClaim.new).not_to be_valid(:"student-loan-amount")
-      expect(TslrClaim.new(student_loan_repayment_amount: "£1,100")).to be_valid(:"student-loan-amount")
+      expect(build(:tslr_claim)).not_to be_valid(:"student-loan-amount")
+      expect(build(:tslr_claim, student_loan_repayment_amount: "£1,100")).to be_valid(:"student-loan-amount")
     end
   end
 
   context "when saving in the “email-address” validation context" do
     it "validates the presence of email_address" do
-      expect(TslrClaim.new).not_to be_valid(:"email-address")
-      expect(TslrClaim.new(email_address: "name@example.tld")).to be_valid(:"email-address")
+      expect(build(:tslr_claim)).not_to be_valid(:"email-address")
+      expect(build(:tslr_claim, email_address: "name@example.tld")).to be_valid(:"email-address")
     end
   end
 
   context "when saving in the “bank-details” validation context" do
     it "validates that the bank_account_number and bank_sort_code are present" do
-      expect(TslrClaim.new).not_to be_valid(:"bank-details")
-      expect(TslrClaim.new(bank_sort_code: "123456", bank_account_number: "87654321")).to be_valid(:"bank-details")
+      expect(build(:tslr_claim)).not_to be_valid(:"bank-details")
+      expect(build(:tslr_claim, bank_sort_code: "123456", bank_account_number: "87654321")).to be_valid(:"bank-details")
     end
   end
 
   context "when saving in the “submit” validation context" do
     it "validates the claim is in a submittable state" do
-      expect(TslrClaim.new).not_to be_valid(:submit)
+      expect(build(:tslr_claim)).not_to be_valid(:submit)
       expect(build(:tslr_claim, :submittable)).to be_valid(:submit)
     end
 
@@ -277,7 +277,7 @@ RSpec.describe TslrClaim, type: :model do
   end
 
   describe "#teacher_reference_number" do
-    let(:claim) { TslrClaim.new(teacher_reference_number: teacher_reference_number) }
+    let(:claim) { build(:tslr_claim, teacher_reference_number: teacher_reference_number) }
 
     context "when the teacher reference number is stored and contains non digits" do
       let(:teacher_reference_number) { "12\\23 /232 " }
@@ -297,7 +297,7 @@ RSpec.describe TslrClaim, type: :model do
 
   describe "#national_insurance_number" do
     it "saves with white space stripped out" do
-      claim = TslrClaim.create!(national_insurance_number: "QQ 12 34 56 C")
+      claim = create(:tslr_claim, national_insurance_number: "QQ 12 34 56 C")
 
       expect(claim.national_insurance_number).to eql("QQ123456C")
     end
@@ -305,14 +305,14 @@ RSpec.describe TslrClaim, type: :model do
 
   describe "#student_loan_repayment_amount=" do
     it "sets loan repayment amount with monetary characters stripped out" do
-      claim = TslrClaim.new
+      claim = build(:tslr_claim)
       claim.student_loan_repayment_amount = "£ 5,000.40"
       expect(claim.student_loan_repayment_amount).to eql(5000.40)
     end
   end
 
   describe "#ineligible?" do
-    subject { TslrClaim.new(claim_attributes).ineligible? }
+    subject { build(:tslr_claim, claim_attributes).ineligible? }
 
     context "with an ineligible QTS award year" do
       let(:claim_attributes) { {qts_award_year: "before_2013"} }
@@ -356,7 +356,7 @@ RSpec.describe TslrClaim, type: :model do
   end
 
   describe "#ineligibility_reason" do
-    subject { TslrClaim.new(claim_attributes).ineligibility_reason }
+    subject { build(:tslr_claim, claim_attributes).ineligibility_reason }
 
     context "with an ineligible qts_award_year" do
       let(:claim_attributes) { {qts_award_year: "before_2013"} }
@@ -386,46 +386,46 @@ RSpec.describe TslrClaim, type: :model do
 
   describe "#student_loan_country" do
     it "captures the country the student loan was received in" do
-      claim = TslrClaim.new(student_loan_country: :england)
+      claim = build(:tslr_claim, student_loan_country: :england)
       expect(claim.student_loan_country).to eq("england")
     end
 
     it "rejects invalid countries" do
-      expect { TslrClaim.new(student_loan_country: :brazil) }.to raise_error(ArgumentError)
+      expect { build(:tslr_claim, student_loan_country: :brazil) }.to raise_error(ArgumentError)
     end
   end
 
   describe "#student_loan_how_many_courses" do
     it "captures how many courses" do
-      claim = TslrClaim.new(student_loan_courses: :one_course)
+      claim = build(:tslr_claim, student_loan_courses: :one_course)
       expect(claim.student_loan_courses).to eq("one_course")
     end
 
     it "rejects invalid responses" do
-      expect { TslrClaim.new(student_loan_courses: :one_hundred_courses) }.to raise_error(ArgumentError)
+      expect { build(:tslr_claim, student_loan_courses: :one_hundred_courses) }.to raise_error(ArgumentError)
     end
   end
 
   describe "#no_student_loan?" do
     it "returns true if the claim has no student loan" do
-      expect(TslrClaim.new(has_student_loan: false).no_student_loan?).to eq true
-      expect(TslrClaim.new(has_student_loan: true).no_student_loan?).to eq false
+      expect(build(:tslr_claim, has_student_loan: false).no_student_loan?).to eq true
+      expect(build(:tslr_claim, has_student_loan: true).no_student_loan?).to eq false
     end
   end
 
   describe "#student_loan_country_with_one_plan?" do
     it "returns true when the student_loan_country is one with only a single student loan plan" do
-      expect(TslrClaim.new.student_loan_country_with_one_plan?).to eq false
+      expect(build(:tslr_claim).student_loan_country_with_one_plan?).to eq false
 
       StudentLoans::PLAN_1_COUNTRIES.each do |country|
-        expect(TslrClaim.new(student_loan_country: country).student_loan_country_with_one_plan?).to eq true
+        expect(build(:tslr_claim, student_loan_country: country).student_loan_country_with_one_plan?).to eq true
       end
     end
   end
 
   describe "#employment_status" do
     it "provides an enum that captures the claimant’s employment status" do
-      claim = TslrClaim.new
+      claim = build(:tslr_claim)
 
       claim.employment_status = :claim_school
       expect(claim.employed_at_claim_school?).to eq true
@@ -434,18 +434,18 @@ RSpec.describe TslrClaim, type: :model do
     end
 
     it "rejects invalid employment statuses" do
-      expect { TslrClaim.new(employment_status: :nonsense) }.to raise_error(ArgumentError)
+      expect { build(:tslr_claim, employment_status: :nonsense) }.to raise_error(ArgumentError)
     end
   end
 
   describe "#claim_school_name" do
     it "returns the name of the claim school" do
-      claim = TslrClaim.new(claim_school: schools(:penistone_grammar_school))
+      claim = build(:tslr_claim, claim_school: schools(:penistone_grammar_school))
       expect(claim.claim_school_name).to eq schools(:penistone_grammar_school).name
     end
 
     it "does not error if the claim school is not set" do
-      expect(TslrClaim.new.claim_school_name).to be_nil
+      expect(build(:tslr_claim).claim_school_name).to be_nil
     end
   end
 

--- a/spec/presenters/tslr_claims_csv_spec.rb
+++ b/spec/presenters/tslr_claims_csv_spec.rb
@@ -2,30 +2,12 @@ require "rails_helper"
 
 RSpec.describe TslrClaimsCsv do
   before do
-    create(:tslr_claim, :submittable,
-      reference: "B2W4L0KC",
-      submitted_at: Time.zone.parse("2019-01-01 17:30:00"),
-      qts_award_year: "2013_2014",
-      current_school: create(:school, name: "Penistone Grammar School"),
-      employment_status: :claim_school,
-      full_name: "Bruce Wayne",
-      address_line_1: "Stately Wayne Manor",
-      address_line_3: "Gotham",
-      postcode: "BAT123",
-      date_of_birth: Date.parse("1939-01-01"),
-      teacher_reference_number: "1234567",
-      national_insurance_number: "QQ123456C",
-      student_loan_country: :england,
-      email_address: "batman@bat.com",
-      mostly_teaching_eligible_subjects: true,
-      bank_sort_code: "440026",
-      bank_account_number: "70872490",
-      student_loan_plan: StudentLoans::PLAN_1,
-      student_loan_repayment_amount: "1500.00")
+    create(:tslr_claim, :submitted)
   end
 
   subject { described_class.new(claims) }
   let(:claims) { TslrClaim.all.order(:submitted_at) }
+  let(:claim) { claims.first }
 
   describe "file" do
     let(:file) { subject.file }
@@ -59,27 +41,27 @@ RSpec.describe TslrClaimsCsv do
 
     it "returns the correct rows" do
       expect(csv[1]).to eq([
-        "B2W4L0KC",
-        "01/01/2019 17:30",
-        "2013_2014",
-        "Penistone Grammar School",
-        "Claim school",
-        "Penistone Grammar School",
-        "Bruce Wayne",
-        "Stately Wayne Manor",
+        claim.reference,
+        claim.submitted_at.strftime("%d/%m/%Y %H:%M"),
+        claim.qts_award_year,
+        claim.claim_school_name,
+        claim.employment_status.humanize,
+        claim.current_school_name,
+        claim.full_name,
+        claim.address_line_1,
         nil,
-        "Gotham",
+        claim.address_line_3,
         nil,
-        "BAT123",
-        "01/01/1939",
-        "1234567",
-        "QQ123456C",
-        "Plan 1",
-        "batman@bat.com",
-        "Yes",
-        "440026",
-        "70872490",
-        "£1500.0",
+        claim.postcode,
+        claim.date_of_birth.strftime("%d/%m/%Y"),
+        claim.teacher_reference_number,
+        claim.national_insurance_number,
+        claim.student_loan_plan.humanize,
+        claim.email_address,
+        claim.mostly_teaching_eligible_subjects ? "Yes" : "No",
+        claim.bank_sort_code,
+        claim.bank_account_number,
+        "£#{claim.student_loan_repayment_amount}",
       ])
     end
   end

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Claim session timing out", type: :request do
 
     it "does not timeout the session" do
       travel before_expiry do
-        put claim_path("qts-year"), params: {tslr_claim: {qts_award_year: "2014_2015"}}
+        put claim_path("qts-year"), params: {tslr_claim: {eligibility_attributes: {qts_award_year: "2014_2015"}}}
 
         expect(response).to redirect_to(claim_path("claim-school"))
         expect(session[:last_seen_at]).not_to be_nil


### PR DESCRIPTION
This is the first in as series of changes to move the eligibility of the student loans claim into it's own class. This work will invlove a lot of big changes so we want to keep the PRs as small and concise as we can to lessen the load on the reviewer.

This first PR introduces the `StudentLoans` namespace and the `Eligibility` class.

We then move on to port the `qts_award_year` from `TslrClaim` to the new eligitibility class. We will have to used some temporary hacks to keep this work green during the move, using some delegates, which will be removed once this work completes.

Along the way there have been some tightening up of tests and fixes as we encountered them.

https://trello.com/c/yt1gsap9