### PR TITLE
Setup T&C pages etc

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,13 @@
+class StaticPagesController < ApplicationController
+  def accessibility_statement
+  end
+
+  def cookies
+  end
+
+  def privacy_policy
+  end
+
+  def terms_conditions
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template app-html-class">
   <head>
     <title>
-      <%= content_for(:page_title) || t("tslr.service_name") %>
+      <%= content_for(:page_title) || t("tslr.journey_name") %>
     </title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -52,7 +52,7 @@
         </div>
         <div class="govuk-header__content">
 
-          <%= link_to t("tslr.service_name"), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to t("tslr.journey_name"), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
 
           <% if signed_in? %>
           <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
@@ -102,7 +102,7 @@
                 </a>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="#2">
+                <a class="govuk-footer__link" href="<%= cookies_path %>">
                   Cookies
                 </a>
               </li>
@@ -112,8 +112,18 @@
                 </a>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="#4">
+                <a class="govuk-footer__link" href="<%= terms_conditions_path %>">
                   Terms and conditions
+                </a>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="<%= privacy_policy_path %>">
+                  Privacy Policy
+                </a>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="<%= accessibility_statement_path %>">
+                  Accessibility Statement
                 </a>
               </li>
             </ul>

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -1,0 +1,184 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      Accessibility statement for <%= t("service_name") %>
+    </h1>
+
+    <p class="govuk-body">
+      This website is run by the Department for Education. We want as many people as possible to be able to use this
+      website. For example, that means you should be able to:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>zoom in up to 300&#37; without the text spilling off the screen</li>
+      <li>navigate most of the website using just a keyboard</li>
+      <li>navigate most of the website using speech recognition software</li>
+      <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and
+      VoiceOver)</li>
+      <li>use speech to text to enter information (please note if you are using Dragon Speech Recognition you may need
+      to use the DragonPad tool to enter information)</li>
+    </ul>
+
+    <p class="govuk-body">
+      We’ve also made the website text as simple as possible to understand.
+    </p>
+
+    <p class="govuk-body">
+      <a href="https://mcmw.abilitynet.org.uk/" class="govuk-link">AbilityNet</a> has advice on making your device
+      easier to use if you have a disability.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      How accessible this website is
+    </h2>
+
+    <p class="govuk-body">
+      We know some parts of this website aren’t fully accessible:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you can’t modify the line height or spacing of text</li>
+      <li>you can’t change colours, contrast levels and fonts</li>
+    </ul>
+
+    <h2 class="govuk-heading-l">
+      What to do if you can’t access parts of this website
+    </h2>
+
+    <p class="govuk-body">
+      If you need information on this website in a different format or cannot use the service:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>email [XXXX]</li>
+      <li>call [XXXX]</li>
+    </ul>
+
+    <p class="govuk-body">
+      We’ll consider your request and get back to you in [XXXX] days.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Reporting accessibility problems with this website
+    </h2>
+
+    <p class="govuk-body">
+      We’re always looking to improve the accessibility of this website. If you find any problems that aren’t listed on
+      this page or think we’re not meeting accessibility requirements, contact: [XXXX].
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Enforcement procedure
+    </h2>
+
+    <p class="govuk-body">
+      The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites
+      and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not
+      happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com/" class="govuk-link">
+      contact the Equality Advisory and Support Service (EASS)</a>.
+    </p>
+
+    <h2 class="govuk-heading-l">Technical information about this website’s accessibility</h2>
+
+    <p class="govuk-body">
+      The Department for Education is committed to making its website accessible, in accordance with the Public Sector
+      Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+    </p>
+
+    <p class="govuk-body">
+      This website is partially compliant with the Web Content Accessibility Guidelines version 2.1 AA standard, due to
+      the non-compliances listed below.
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html" class="govuk-link">
+          2.4.2 – Page Titled
+        </a>
+      </li>
+      <li>
+        <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/minimize-error-suggestions.html" class="govuk-link">
+          3.3.3 – Error Suggestion
+        </a>
+      </li>
+      <li>
+        <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-parses.html" class="govuk-link">
+          4.1.1 – Parsing
+        </a>
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-l">Non accessible content</h2>
+
+    <p class="govuk-body">
+      The content listed below is non-accessible for the following reasons.
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        Page titles do not follow accessibility guidelines
+      </li>
+      <li>
+        Some error messages are inconsistently formatted.
+      </li>
+      <li>
+        Auto complete for address may not function correctly
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-l">Non compliance with the accessibility regulations</h2>
+
+    <p class="govuk-body">
+      Page titles are not clear and descriptive. They all have the same content.  This doesn’t meet WCAG 2.1 success
+      criterion 2.4.2 (page titled).
+    </p>
+
+    <p class="govuk-body">
+      We plan to amend the page titles by December 2020. When we create new pages we will be sure to use descriptive
+      page titles.
+    </p>
+
+    <p class="govuk-body">
+      Some error messages are inconsistently formatted. There is a list of all errors at the top of each page, but some
+      pages to not provide guidance on how to resolve the error next to the relevant input.  This doesn’t meet WCAG 2.1
+      success criterion 3.3.3 (error suggestion).
+    </p>
+
+    <p class="govuk-body">
+      We plan to amend the error messages by December 2020. When we create new pages we will make sure to use
+      consistently formatted error messages.
+    </p>
+
+    <p class="govuk-body">
+      Some pages return errors when parsed through a html validator. Although the pages should display correctly they
+      may have invalid html. This doesn’t meet WCAG 2.1 success criterion 4.1.1 (parsing).
+    </p>
+
+    <p class="govuk-body">
+      We plan to amend the pages to ensure they are valid html by December 2020. When we create new pages we will make
+      sure they validate.
+    </p>
+
+    <h2 class="govuk-heading-l">How we tested this website</h2>
+
+    <p class="govuk-body">
+      This website was last tested on 29 July 2019. The test was carried out internally.
+    </p>
+
+    <p class="govuk-body">
+      We tested:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        The ‘<%= t("service_name") %> service’.
+      </li>
+    </ul>
+
+    <p class="govuk-body">
+      This statement was prepared on 31 July 2019. It was last updated on 31 July 2019.
+    </p>
+
+  </div>
+</div>

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -1,0 +1,135 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      Cookies
+    </h1>
+
+    <h2 class="govuk-heading-l">
+      How we use cookies
+    </h2>
+
+    <p class="govuk-body">
+      Cookies are used to:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>track your progress and record your answers as you complete a claim</li>
+      <li>measure how you use the this service so it can be updated and improved based on your needs</li>
+      <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
+    </ul>
+
+    <div class="panel panel-border-wide">
+      <p class="govuk-body"><%= t("service_name") %>  cookies aren’t used to identify you personally.</p>
+    </div>
+
+    <p class="govuk-body">
+      Find out more about <a class="govuk-link" href="http://www.aboutcookies.org/">how to manage cookies.</a>
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Measuring website usage (XXXX)
+    </h2>
+
+    <p class="govuk-body">
+      We use XXXX software to collect information about how you use <%= t("service_name") %>.
+      We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
+    </p>
+
+    <p class="govuk-body">
+      XXXX stores information about:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the pages you visit on <%= t("service_name") %></li>
+      <li>how long you spend on each page</li>
+      <li>how you got to the site</li>
+      <li>what you click on while you’re visiting the site</li>
+    </ul>
+
+    <div class="panel panel-border-wide">
+      <p class="govuk-body">
+        We don’t allow XXXX to use or share our analytics data.
+      </p>
+    </div>
+
+    <p class="govuk-body">
+      XXXX sets the following cookies:
+    </p>
+
+    <table class="govuk-table mb1">
+      <thead class="govuk-table__head">
+        <tr>
+          <th class="govuk-table__header">Name</th>
+          <th class="govuk-table__header">Purpose</th>
+          <th class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">XXXX_ga</td>
+          <td class="govuk-table__cell">This helps us count how many people visit <%= t("service_name") %> by tracking if you’ve visited before</td>
+          <td class="govuk-table__cell">After 2 years</td>
+        </tr>
+        <tr>
+          <tr class="govuk-table__row">
+          <td class="govuk-table__cell">XXXX_gid</td>
+          <td class="govuk-table__cell">This helps us count how many people visit <%= t("service_name") %> by tracking if you’ve visited before</td>
+          <td class="govuk-table__cell">After 24 hours</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p class="govuk-body">
+      You can <a class="govuk-link" href="https://tools.XXXX.com/dlpage/gaoptout">opt out of XXXX</a>.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Sessions
+    </h2>
+
+    <p class="govuk-body">
+      A cookie is set to record your session activity.
+    </p>
+
+    <table class="govuk-table mb1">
+      <thead class="govuk-table__head">
+        <th class="govuk-table__header">Name</th>
+        <th class="govuk-table__header">Purpose</th>
+        <th class="govuk-table__header">Expires</th>
+      </thead>
+      <tbody>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">_dfe_teachers_payment_service_session</td>
+          <td class="govuk-table__cell">Stores session data</td>
+          <td class="govuk-table__cell">After <%= ClaimsController::TIMEOUT_LENGTH_IN_MINUTES %> minutes</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 class="govuk-heading-l">
+      Our introductory message
+    </h2>
+
+    <p class="govuk-body">
+      You may see a pop-up welcome message when you first visit <%= t("service_name") %>.
+      We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.
+    </p>
+
+    <table class="govuk-table mb1">
+      <thead class="govuk-table__head">
+        <th class="govuk-table__header">Name</th>
+        <th class="govuk-table__header">Purpose</th>
+        <th class="govuk-table__header">Expires</th>
+      </thead>
+      <tbody>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">XXXX</td>
+          <td class="govuk-table__cell">Saves a message to let us know that you have seen our cookie message</td>
+          <td class="govuk-table__cell">After 1 month</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</div>

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,0 +1,177 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      Privacy Notice: <%= t("service_name") %>
+    </h1>
+
+    <h2 class="govuk-heading-l">
+      Who we are
+    </h2>
+
+    <p class="govuk-body">
+      This work is being carried out by the Department for Education (DfE) Digital, which is a part of DfE. DfE engages
+      the private companies dxw and Paper Studio to help improve and provide the service. For the purpose of data protection legislation, DfE
+      is the data controller for the personal data processed as part of <%= t("service_name") %>.
+      <%= t("service_name") %> is a free and optional service for eligible teachers to claim back student loan
+      repayments.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      When we collect personal information
+    </h2>
+
+    <p class="govuk-body">
+      We receive your personal data when you submit it:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>when contacting us for support using the service, to leave feedback or for any other matters</li>
+      <li>as a user of the service</li>
+    </ul>
+
+    <h2 class="govuk-heading-l">
+      What personal information we will collect
+    </h2>
+
+    <p class="govuk-body">
+      We will collect:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        your name, email and (if applicable) your phone number when you contact us
+      </li>
+      <li>
+        your email address if you include it with feedback to us on the service or agree to be contacted for user research
+        purposes
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-l">
+      How we will use your information
+    </h3>
+
+    <p class="govuk-body">
+      If you contact us, DfE and (where applicable) dxw and Paper Studio will use your name and contact information for the purpose of
+      responding to you and providing support. We will not share this information with any other parties.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Why our use of your personal data is lawful
+    </h2>
+
+    <p class="govuk-body">
+      In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data
+      protection legislation. For the purpose of this project, your consent forms the basis of this as stated under GDPR
+      Article 6 (1)(a).
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Who we will make your personal data available to
+    </h2>
+
+    <p class="govuk-body">
+      We sometimes need to make personal data available to other organisations. These might include contracted partners
+      (who we have employed to process your personal data on our behalf) and/or other organisations (with whom we need
+      to share your personal data for specific purposes).
+    </p>
+
+    <p class="govuk-body">
+      Where we need to share your personal data with others, we ensure that this data sharing complies with data
+      protection legislation.
+    </p>
+
+    <p class="govuk-body">
+      The Department for Education use your data:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        for security purposes: collecting part of the IP addresses of people visiting the <%= t("service_name") %>
+        website (for example, if we were receiving continuous direct denial of service attacks from an IP address range
+        then we could block it)
+      </li>
+      <li>
+        to enable users to use the service and receive updates
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-l">
+      How long we will keep your personal data
+    </h2>
+
+    <p class="govuk-body">
+      Neither DfE nor its delivery partners will keep your personal data longer than we need it for the purpose(s) of
+      research, security and/or delivery of the service, and in any case not longer than XXXX years. Your data will be
+      deleted when DfE and its delivery partners no longer need it for these purposes, or when XXXX years have passed,
+      whichever comes first.
+    </p>
+
+    <p class="govuk-body">
+      Partial IP addresses will be deleted after XXXX days unless their request caused an error, in which case they remain
+      in our logs for XXXX days.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Your data protection rights
+    </h2>
+
+    <p class="govuk-body">
+      You have the right:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        to ask us for access to information about you that we hold
+      </li>
+      <li>
+        to have your personal data rectified, if it is inaccurate or incomplete
+      </li>
+      <li>
+        to ask us to delete your personal data unless there is a legal reason to continue to store and process it
+      </li>
+      <li>
+        to restrict our processing of your personal data (i.e. permitting its storage but no further processing)
+      </li>
+      <li>
+        to object to direct marketing (including profiling) and processing for the purposes of scientific/historical
+        research and statistics
+      </li>
+      <li>
+        not to be subject to decisions based purely on automated processing where it produces a legal or similarly
+        significant effect on you
+      </li>
+    </ul>
+
+    <p class="govuk-body">
+      If you need to contact us regarding any of the above, or have any other questions about how your personal
+      information will be used, please <a href="https://www.gov.uk/contact-dfe" class="govuk-link">contact the DfE</a>.
+    </p>
+
+    <p class="govuk-body">
+      The Information Commissioner’s Office makes further information about your data protection rights available in
+      their <a href="https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/" class="govuk-link">
+      Guide to the General Data Protection Regulation (GDPR)</a>.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      The right to lodge a complaint
+    </h2>
+
+    <p class="govuk-body">
+      You have the right to raise any concerns with the <a href="https://ico.org.uk/concerns/" class="govuk-link">
+      Information Commissioner’s Office (ICO)</a>.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Last updated
+    </h2>
+
+    <p class="govuk-body">
+      We may need to update this privacy notice periodically so we recommend that you revisit this information from time
+      to time. This version was last updated on 31 July 2019.
+    </p>
+
+  </div>
+</div>

--- a/app/views/static_pages/terms_conditions.html.erb
+++ b/app/views/static_pages/terms_conditions.html.erb
@@ -1,0 +1,180 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      Terms and Conditions
+    </h1>
+
+    <h2 class="govuk-heading-l">
+      All Users
+    </h2>
+
+    <h3 class="govuk-heading-m">
+      Using the <%= t("service_name") %> service
+    </h3>
+
+    <p class="govuk-body">
+      Please read these Terms of Use (“General Terms”) carefully before using this <%= t("service_name") %> service (the “Service”).
+    </p>
+
+    <p class="govuk-body">
+      This Service is maintained for your personal use and viewing. Access and use by you of this Service constitutes
+      your acceptance of these General Terms. This takes effect from the date on which you first use this website. If
+      you do not agree to these terms, you must not use this website.
+    </p>
+
+    <p class="govuk-body">
+      If we change these General Terms we will post the revised document here with an updated effective date. If we
+      make significant changes to these terms, we may notify you by other means such as sending an email or posting a
+      notice on our home page.
+    </p>
+
+    <h3 class="govuk-heading-m">
+      Information About Us
+    </h3>
+
+    <p class="govuk-body">
+      This Service is operated by the Department for Education (“we”, “our”, or
+      “us”). We are a central government department and have our registered office at Sanctuary
+      Buildings, 20 Great Smith Street, London, SW1P 3BT.
+    </p>
+
+    <p class="govuk-body">
+      You can contact us using the following email address:
+      <a href="mailto: XXXX" class="govuk-link">XXXX</a>
+    </p>
+
+    <h3 class="govuk-heading-m">
+      Access to the Service
+    </h3>
+
+    <p class="govuk-body">
+      We shall not be liable if for any reason the Service is unavailable at any time or for any period. From time to time,
+      we may restrict access to all or some parts of the Service to users who have registered with us.
+    </p>
+
+    <p class="govuk-body">
+      If you choose, or are provided with, a user identification code, password or any other piece of information as
+      part of our security procedures, you must treat such information as confidential, and you must not disclose it to
+      any third party.
+    </p>
+
+    <p class="govuk-body">
+      We reserve the right to restrict or deny you access to all or some part of the Service if in our opinion, you have
+      failed to comply with these General Terms.
+    </p>
+
+    <h3 class="govuk-heading-m">
+      Hyperlinking to the Service
+    </h3>
+
+    <p class="govuk-body">
+      We do not object to you linking directly to the Service's home pages and you do not need to ask permission to do so.
+      However, we do not permit our pages to be loaded into frames on your site. The Service pages must be displayed in the user’s entire browser window.
+    </p>
+
+    <h3 class="govuk-heading-m">
+      Third Party Content and hyperlinking from the Service
+    </h3>
+
+    <p class="govuk-body">
+      Where the Service contains links to other sites and resources, we are not liable or responsible for the content or
+      reliability of those websites and resources and do not necessarily endorse the views expressed within them.
+    </p>
+
+    <p class="govuk-body">
+      We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no
+      control over the availability of other sites.
+    </p>
+
+    <h3 class="govuk-heading-m">
+      Virus protection
+    </h3>
+
+    <p class="govuk-body">
+      We make every effort to check and test material at all stages of production. It is always wise for you to run an
+      anti-virus program on all material downloaded from the Internet as we do not guarantee our service will be secure
+      or free from bugs or viruses. We cannot accept any responsibility for any loss, disruption or damage to your data
+      or your computer system which may occur whilst using material derived from this website.
+    </p>
+
+    <p class="govuk-body">
+      You must not misuse our service by knowingly introducing viruses, trojans, worms, logic bombs or other material
+      that is malicious or technologically harmful. You must not attempt to gain unauthorised access to our service,
+      the server on which our service is stored or any server, computer or database connected to our service. You must
+      not attack our site via a denial-of-service attack or a distributed denial-of service attack. Each of these acts
+      is a criminal offence. We will report any such offence to the relevant law enforcement authorities and co-operate
+      with them to determine your identity.
+    </p>
+
+    <h3 class="govuk-heading-m">
+      Disclaimer and Liability
+    </h3>
+
+    <p class="govuk-body">
+      The content of this Service includes both content created by us (included but not limited to content that helps
+      you use the Service) and third-party content. We do not:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>endorse third-party content</li>
+      <li>vouch for its accuracy</li>
+      <li>guarantee that the views, instructions and/or assertions expressed in it are our own</li>
+    </ul>
+
+    <p class="govuk-body">
+      The content we create for the Service is not advice. You should verify any information on the Service yourself
+      and use your own judgement before doing or not doing anything on the basis of the content.
+    </p>
+
+    <p class="govuk-body">
+      Unless expressly stated in writing by us, the Service and material relating to government information, products
+      and services (or to third party information, products and services), is provided ‘as is’, without any
+      representation or endorsement made and without warranty of any kind whether express or implied, including but
+      not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement,
+      compatibility, security and accuracy.
+    </p>
+
+    <p class="govuk-body">
+      We do not warrant that the functions contained in the material contained in this site will be uninterrupted or
+      error free, that defects will be corrected, or that this site or the server that makes it available are free of
+      viruses or represent the full functionality, accuracy, reliability of the materials.
+    </p>
+
+    <p class="govuk-body">
+      In no event will we be liable for:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        any action you may take as a result of relying on any information/materials provided on the Service or for any
+        loss or damage suffered by you as a result of you taking such action  including, without limitation, indirect or
+        consequential loss or damage, or any loss or damages whatsoever arising from or in connection with the use of the
+        Service
+      </li>
+      <li>
+        any dealings you have with third parties (e.g. other users or advertisers) that take place using or facilitated
+        by the Service
+      </li>
+    </ul>
+
+    <h3 class="govuk-heading-m">
+      Validity of these General Terms
+    </h3>
+
+    <p class="govuk-body">
+      If any of these terms and conditions are held to be invalid, unenforceable or illegal for any reason, the
+      remaining terms and conditions will still apply.
+    </p>
+
+    <h3 class="govuk-heading-m">
+      Applicable Law and Jurisdiction
+    </h3>
+
+    <p class="govuk-body">
+      These General Terms are governed by the laws of England and Wales. Any dispute arising under these General Terms
+      will be subject to the exclusive jurisdiction of the courts of England and Wales.
+    </p>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,8 +44,9 @@ en:
         ineligible_claim_school: "The school you were employed at is not eligible"
         employed_at_no_school: "You can only get this payment if you’re still working as a teacher"
         not_taught_eligible_subjects_enough: "You must have spent at least half your time teaching an eligible subject"
+  service_name: "Claim additional payments for teaching"
   tslr:
-    service_name: "Teachers: claim back your student loan repayments"
+    journey_name: "Teachers: claim back your student loan repayments"
     questions:
       qts_award_year: "Which academic year did you complete your initial teacher training?"
       claim_school: "Which school were you employed at between 6 April 2018 and 5 April 2019?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,12 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root "claims#new"
 
+  # setup static pages
+  get "/privacy_policy", to: "static_pages#privacy_policy", as: :privacy_policy
+  get "/terms_conditions", to: "static_pages#terms_conditions", as: :terms_conditions
+  get "/cookies", to: "static_pages#cookies", as: :cookies
+  get "/accessibility_statement", to: "static_pages#accessibility_statement", as: :accessibility_statement
+
   constraints slug: %r{#{PageSequence::SLUGS.join("|")}} do
     resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/claim"
   end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "Static pages", type: :request do
+  %i[privacy_policy terms_conditions cookies accessibility_statement].each do |static_page|
+    it "renders the #{static_page} page" do
+      get public_send("#{static_page}_path")
+
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
- Setup cookie, privacy and T&C pages based on teacher vacacnies content
- Amend layout footer to link to pages
- Setup static pages routing and controller
- Setup Accessibility statement page based on feedback from
  accessibility testing

These pages all have inital text and will need updating as we progress
into private beta and beyond. Also when we resolve certain accessibility
bugs we will need to amend the accessibility statement.

We should get someone more appropriate to look at and review the legal
text on the cookie, privacy and T&C pages.