### PR TITLE
Set up a Verify Service Provider (VSP) on staging

### DIFF
--- a/azure/app/parameters/development.template.json
+++ b/azure/app/parameters/development.template.json
@@ -162,7 +162,7 @@
         "keyVault": {
           "id": "${keyVaultId}"
         },
-        "secretName": "VspSamlSigningKey"
+        "secretName": "TeacherPaymentsDevVspSamlSigning2KeyBase64"
       }
     },
     "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
@@ -170,7 +170,7 @@
         "keyVault": {
           "id": "${keyVaultId}"
         },
-        "secretName": "VspSamlPrimaryEncryptionKey"
+        "secretName": "TeacherPaymentsDevVspSamlEncryption2KeyBase64"
       }
     }
   }

--- a/azure/app/parameters/development.template.json
+++ b/azure/app/parameters/development.template.json
@@ -151,6 +151,9 @@
     "ROLLBAR_ENV": {
       "value": "development"
     },
+    "GOVUK_VERIFY_ENABLED": {
+      "value": "1"
+    },
     "VSP.VERIFY_ENVIRONMENT": {
       "value": "INTEGRATION"
     },

--- a/azure/app/parameters/development.template.json
+++ b/azure/app/parameters/development.template.json
@@ -11,6 +11,9 @@
     "appServiceCertificateSecretName": {
       "value": "sslCertificate-wildcard-additional-teaching-payment-education-gov-uk"
     },
+    "vspAppServiceDockerImage": {
+      "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
+    },
     "databaseName": {
       "value": "development"
     },
@@ -147,6 +150,25 @@
     },
     "ROLLBAR_ENV": {
       "value": "development"
+    },
+    "VSP.VERIFY_ENVIRONMENT": {
+      "value": "INTEGRATION"
+    },
+    "VSP.SAML_SIGNING_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "VspSamlSigningKey"
+      }
+    },
+    "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "VspSamlPrimaryEncryptionKey"
+      }
     }
   }
 }

--- a/azure/app/parameters/production.template.json
+++ b/azure/app/parameters/production.template.json
@@ -145,6 +145,9 @@
     "ROLLBAR_ENV": {
       "value": "production"
     },
+    "GOVUK_VERIFY_ENABLED": {
+      "value": ""
+    },
     "VSP.VERIFY_ENVIRONMENT": {
       "value": "PRODUCTION"
     },

--- a/azure/app/parameters/production.template.json
+++ b/azure/app/parameters/production.template.json
@@ -155,20 +155,10 @@
       "value": "PRODUCTION"
     },
     "VSP.SAML_SIGNING_KEY": {
-      "reference": {
-        "keyVault": {
-          "id": "${keyVaultId}"
-        },
-        "secretName": "VspSamlSigningKey"
-      }
+      "value": ""
     },
     "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
-      "reference": {
-        "keyVault": {
-          "id": "${keyVaultId}"
-        },
-        "secretName": "VspSamlPrimaryEncryptionKey"
-      }
+      "value": ""
     }
   }
 }

--- a/azure/app/parameters/production.template.json
+++ b/azure/app/parameters/production.template.json
@@ -144,6 +144,25 @@
     },
     "ROLLBAR_ENV": {
       "value": "production"
+    },
+    "VSP.VERIFY_ENVIRONMENT": {
+      "value": "PRODUCTION"
+    },
+    "VSP.SAML_SIGNING_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "VspSamlSigningKey"
+      }
+    },
+    "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "VspSamlPrimaryEncryptionKey"
+      }
     }
   }
 }

--- a/azure/app/parameters/production.template.json
+++ b/azure/app/parameters/production.template.json
@@ -11,6 +11,9 @@
     "appServiceCertificateSecretName": {
       "value": "sslCertificate-additional-teaching-payment-education-gov-uk"
     },
+    "vspAppServiceDockerImage": {
+      "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
+    },
     "databaseName": {
       "value": "production"
     },

--- a/azure/app/parameters/test.template.json
+++ b/azure/app/parameters/test.template.json
@@ -148,6 +148,9 @@
     "ROLLBAR_ENV": {
       "value": "test"
     },
+    "GOVUK_VERIFY_ENABLED": {
+      "value": ""
+    },
     "VSP.VERIFY_ENVIRONMENT": {
       "value": "INTEGRATION"
     },

--- a/azure/app/parameters/test.template.json
+++ b/azure/app/parameters/test.template.json
@@ -11,6 +11,9 @@
     "appServiceCertificateSecretName": {
       "value": "sslCertificate-wildcard-additional-teaching-payment-education-gov-uk"
     },
+    "vspAppServiceDockerImage": {
+      "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
+    },
     "databaseName": {
       "value": "test"
     },

--- a/azure/app/parameters/test.template.json
+++ b/azure/app/parameters/test.template.json
@@ -147,6 +147,25 @@
     },
     "ROLLBAR_ENV": {
       "value": "test"
+    },
+    "VSP.VERIFY_ENVIRONMENT": {
+      "value": "INTEGRATION"
+    },
+    "VSP.SAML_SIGNING_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "VspSamlSigningKey"
+      }
+    },
+    "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "VspSamlPrimaryEncryptionKey"
+      }
     }
   }
 }

--- a/azure/app/parameters/test.template.json
+++ b/azure/app/parameters/test.template.json
@@ -158,20 +158,10 @@
       "value": "INTEGRATION"
     },
     "VSP.SAML_SIGNING_KEY": {
-      "reference": {
-        "keyVault": {
-          "id": "${keyVaultId}"
-        },
-        "secretName": "VspSamlSigningKey"
-      }
+      "value": ""
     },
     "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
-      "reference": {
-        "keyVault": {
-          "id": "${keyVaultId}"
-        },
-        "secretName": "VspSamlPrimaryEncryptionKey"
-      }
+      "value": ""
     }
   }
 }

--- a/azure/app/template.json
+++ b/azure/app/template.json
@@ -21,6 +21,9 @@
     "appServiceCertificateSecretName": {
       "type": "string"
     },
+    "vspAppServiceDockerImage": {
+      "type": "string"
+    },
     "appServiceAlwaysOn": {
       "type": "bool",
       "defaultValue": true
@@ -86,6 +89,15 @@
     },
     "ROLLBAR_ENV": {
       "type": "string"
+    },
+    "VSP.VERIFY_ENVIRONMENT": {
+      "type": "string"
+    },
+    "VSP.SAML_SIGNING_KEY": {
+      "type": "securestring"
+    },
+    "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
+      "type": "securestring"
     }
   },
   "variables": {
@@ -97,10 +109,17 @@
     "databaseServerDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database-server')]",
     "databaseDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database')]",
     "storageAccountDeploymentName": "[concat(parameters('resourceNamePrefix'), '-storage-account')]",
+    "vspAppServicePlanDeploymentName": "[concat(parameters('resourceNamePrefix'), '-vsp-app-service-plan')]",
 
     "storageAccountName": "[replace(concat(parameters('resourceNamePrefix'), 'storage'), '-', '')]",
 
     "databaseServerName": "[concat(parameters('resourceNamePrefix'), '-db')]",
+
+    "vspAppServicePlanName": "[concat(parameters('resourceNamePrefix'), '-vsp-asp')]",
+    "vspAppServicePlanId": "[resourceId('Microsoft.Web/serverfarms', variables('vspAppServicePlanName'))]",
+
+    "vspAppServiceName": "[concat(parameters('resourceNamePrefix'), '-vsp-as')]",
+    "vspAppServiceRuntimeStack": "[concat('DOCKER|', parameters('vspAppServiceDockerImage'))]",
 
     "appServicePlanName": "[concat(parameters('resourceNamePrefix'), '-asp')]",
 
@@ -193,6 +212,55 @@
         }
       }
     },
+
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "name": "[variables('vspAppServicePlanDeploymentName')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'app-service-plan.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appServicePlanName": {
+            "value": "[variables('vspAppServicePlanName')]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2016-08-01",
+      "name": "[variables('vspAppServiceName')]",
+      "kind": "app,linux,container",
+      "location": "[resourceGroup().location]",
+      "dependsOn": ["[variables('vspAppServicePlanDeploymentName')]"],
+      "properties": {
+        "httpsOnly": true,
+        "serverFarmId": "[variables('vspAppServicePlanId')]",
+        "siteConfig": {
+          "alwaysOn": "[parameters('appServiceAlwaysOn')]",
+          "httpLoggingEnabled": true,
+          "linuxFxVersion": "[variables('vspAppServiceRuntimeStack')]",
+          "appSettings": [
+            {
+              "name": "VERIFY_ENVIRONMENT",
+              "value": "[parameters('VSP.VERIFY_ENVIRONMENT')]"
+            },
+            {
+              "name": "SAML_SIGNING_KEY",
+              "value": "[parameters('VSP.SAML_SIGNING_KEY')]"
+            },
+            {
+              "name": "SAML_PRIMARY_ENCRYPTION_KEY",
+              "value": "[parameters('VSP.SAML_PRIMARY_ENCRYPTION_KEY')]"
+            }
+          ]
+        }
+      }
+    },
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2017-05-10",
@@ -229,7 +297,8 @@
         "[resourceId('Microsoft.Resources/deployments', variables('appServiceCertificateDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('appServicePlanDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('databaseDeploymentName'))]",
-        "[resourceId('Microsoft.Resources/deployments', variables('databaseServerDeploymentName'))]"
+        "[resourceId('Microsoft.Resources/deployments', variables('databaseServerDeploymentName'))]",
+        "[resourceId('Microsoft.Resources/deployments', variables('vspAppServicePlanDeploymentName'))]"
       ],
       "properties": {
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",

--- a/azure/app/template.json
+++ b/azure/app/template.json
@@ -90,6 +90,9 @@
     "ROLLBAR_ENV": {
       "type": "string"
     },
+    "GOVUK_VERIFY_ENABLED": {
+      "type": "string"
+    },
     "VSP.VERIFY_ENVIRONMENT": {
       "type": "string"
     },
@@ -302,7 +305,8 @@
         "[resourceId('Microsoft.Resources/deployments', variables('appServicePlanDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('databaseDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('databaseServerDeploymentName'))]",
-        "[resourceId('Microsoft.Resources/deployments', variables('vspAppServicePlanDeploymentName'))]"
+        "[resourceId('Microsoft.Resources/deployments', variables('vspAppServicePlanDeploymentName'))]",
+        "[resourceId('Microsoft.Web/sites', variables('vspAppServiceName'))]"
       ],
       "properties": {
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
@@ -391,6 +395,14 @@
             {
               "name": "ROLLBAR_ENV",
               "value": "[parameters('ROLLBAR_ENV')]"
+            },
+            {
+              "name": "GOVUK_VERIFY_ENABLED",
+              "value": "[parameters('GOVUK_VERIFY_ENABLED')]"
+            },
+            {
+              "name": "GOVUK_VERIFY_VSP_HOST",
+              "value": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('vspAppServiceName'))).defaultHostName)]"
             }
           ]
         }

--- a/azure/app/template.json
+++ b/azure/app/template.json
@@ -250,6 +250,10 @@
               "value": "[parameters('VSP.VERIFY_ENVIRONMENT')]"
             },
             {
+              "name": "SERVICE_ENTITY_IDS",
+              "value": "[string(createArray(parameters('appServiceHostName')))]"
+            },
+            {
               "name": "SAML_SIGNING_KEY",
               "value": "[parameters('VSP.SAML_SIGNING_KEY')]"
             },

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -44,16 +44,19 @@ case $ENVIRONMENT_NAME in
     SUBSCRIPTION_ID="8655985a-2f87-44d7-a541-0be9a8c2779d"
     RESOURCE_GROUP_PREFIX="s118d01"
     DOCKER_IMAGE_TAG="development"
+    VSP_DOCKER_IMAGE_TAG="20190729.3"
     ;;
   "test")
     SUBSCRIPTION_ID="e9299169-9666-4f15-9da9-5332680145af"
     RESOURCE_GROUP_PREFIX="s118t01"
     DOCKER_IMAGE_TAG="test"
+    VSP_DOCKER_IMAGE_TAG="20190729.3"
     ;;
   "production")
     SUBSCRIPTION_ID="88bd392f-df19-458b-a100-22b4429060ed"
     RESOURCE_GROUP_PREFIX="s118p01"
     DOCKER_IMAGE_TAG="production"
+    VSP_DOCKER_IMAGE_TAG="20190729.3"
     ;;
   *)
     echo "Could not find an known environment with the name: $ENVIRONMENT_NAME"
@@ -164,6 +167,7 @@ ensure-resource-group-exists $APP_RESOURCE_GROUP_NAME
 echo "Rewriting app parameters file for $ENVIRONMENT_NAME..."
 sed \
     -e "s|\${keyVaultId}|$KEY_VAULT_ID|g" \
+    -e "s|\${vspDockerImageTag}|$VSP_DOCKER_IMAGE_TAG|g" \
     "$APP_PARAMETERS_TEMPLATE_FILE_PATH" \
   | ruby \
     -e "

--- a/bin/request-vsp-certs
+++ b/bin/request-vsp-certs
@@ -56,6 +56,33 @@ function fetch_or_generate_key_and_csr {
     KEY_EXISTED=1
   fi
 
+  if [ -f "$FILE_PREFIX.key.base64" ]; then
+    rm "$FILE_PREFIX.key.base64"
+  fi
+
+  echo "Attempting to fetch base64 encoded key..."
+
+  if ! az keyvault secret download \
+    --vault-name $KEY_VAULT_NAME \
+    --name "${FILE_PREFIX}KeyBase64" \
+    --file "$FILE_PREFIX.key.base64"
+  then
+    BASE64_KEY_EXISTED=
+
+    echo "Converting base64 encoded key..."
+    
+    sed \
+        -e "s|-----BEGIN PRIVATE KEY-----||g" \
+        -e "s|-----END PRIVATE KEY-----||g" \
+        "$FILE_PREFIX.key" \
+      | tr -d '\n' \
+      > "$FILE_PREFIX.key.base64"
+  else
+    echo "Base64 encoded key found."
+
+    BASE64_KEY_EXISTED=1
+  fi
+
   if [ -f "$FILE_PREFIX.csr" ]; then
     rm "$FILE_PREFIX.csr"
   fi
@@ -88,6 +115,13 @@ function store_key_and_csr_and_challenge_phrase {
       --vault-name $KEY_VAULT_NAME \
       --name "${FILE_PREFIX}Key" \
       --file "${FILE_PREFIX}.key"
+  fi
+
+  if ! [ "$KEY_EXISTED" ] || ! [ "$BASE64_KEY_EXISTED" ]; then
+    az keyvault secret set \
+      --vault-name $KEY_VAULT_NAME \
+      --name "${FILE_PREFIX}KeyBase64" \
+      --file "${FILE_PREFIX}.key.base64"
   fi
 
   if ! [ "$CSR_EXISTED" ]; then


### PR DESCRIPTION
This PR adds the config to set up a GOV.UK Verify VSP app service on our `development` infrastructure. The VSP Docker image is built, tagged and pushed when changes are made to the master branch on its repo: https://github.com/DFE-Digital/teacher-payments-service-verify

## Private keys

The private keys used by the VSP need to be in PKCS8 format and base64 encoded. We add a step to the script that requests certs to also save a base64 encoded version.

## Testing

We can use this VSP to test the Verify integration environment: https://www.docs.verify.service.gov.uk/test-in-integration/testing/set-up-tests
