### PR TITLE
The VSP Entity ID needs https to match the value on the Verify Hub

### DIFF
--- a/azure/app/template.json
+++ b/azure/app/template.json
@@ -254,7 +254,7 @@
             },
             {
               "name": "SERVICE_ENTITY_IDS",
-              "value": "[string(createArray(parameters('appServiceHostName')))]"
+              "value": "[string(createArray(concat('https://', parameters('appServiceHostName'))))]"
             },
             {
               "name": "SAML_SIGNING_KEY",

--- a/lib/verify/service_provider.rb
+++ b/lib/verify/service_provider.rb
@@ -76,7 +76,7 @@ module Verify
     end
 
     def uri_uses_ssl?(uri)
-      uri.port == 443
+      uri.default_port == 443
     end
   end
 end


### PR DESCRIPTION
If the value doesn't match the value on the hub we see a 500 error when making a POST to it.

Also changed the `uri_uses_ssl?` method to check for `default_port` instead of port.