### PR TITLE
Revert "Bump omniauth_openid_connect from 0.3.1 to 0.3.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
-    json-jwt (1.10.2)
+    json-jwt (1.10.1)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
@@ -144,11 +144,11 @@ GEM
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
-    omniauth_openid_connect (0.3.2)
+    omniauth_openid_connect (0.3.1)
       addressable (~> 2.5)
-      omniauth (~> 1.9)
+      omniauth (~> 1.3)
       openid_connect (~> 1.1)
-    openid_connect (1.1.8)
+    openid_connect (1.1.7)
       activemodel
       attr_required (>= 1.0.0)
       json-jwt (>= 1.5.0)


### PR DESCRIPTION
This reverts commit a3aa62f879f17e4f3b8c0297768bd5d4c9cc0326.

The update broke our integration with DfE Signin. We've not got the time to investigate the source of the issue, but the error can be seen here: https://rollbar.com/dxw/teachers-payment-service/items/30/.