### PR TITLE
Temporarily log the Verify response in Rollbar

### DIFF
--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -11,6 +11,7 @@ module Verify
 
     def initialize(parameters)
       @parameters = parameters
+      Rollbar.debug("Verify::Response", parameters: parameters)
     end
 
     def self.translate(saml_response:, request_id:, level_of_assurance:)


### PR DESCRIPTION
Whilst we are debugging the Verify integration environment it would be helpful to know what the response from Verify looks like.

We should remove this logging before we integrate with the production VSP.