### PR TITLE
Allow overriding the Git commit hash via an environment variable

### DIFF
--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -103,7 +103,7 @@ while [ "$2" ]; do
   shift
 done
 
-GIT_COMMIT_HASH=$(git rev-parse --verify HEAD)
+GIT_COMMIT_HASH=${GIT_COMMIT_HASH:-$(git rev-parse --verify HEAD)}
 SCRIPT_PATH=$(cd "$(dirname "$0")" ; pwd -P)
 
 RESOURCE_LOCATION="West Europe"


### PR DESCRIPTION
Azure DevOps doesn't run the releases in a Git repository, so doesn't have access to Git operations. This allows it to use the build's source version to set an environment variable instead.