### PR TITLE
Set up Application Insights

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ FROM base AS dependencies
 RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
 
 RUN apk --no-cache add build-base
+RUN apk --no-cache add git
 RUN apk --no-cache add yarn
 
 # Set up install environment

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem "bootsnap", ">= 1.1.0", require: false
 # Allows generation of a JWT token to interact with the DfE Login API
 gem "jwt"
 
+# Send app telemetry to Azure Application Insights
+gem "application_insights"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem "bootsnap", ">= 1.1.0", require: false
 gem "jwt"
 
 # Send app telemetry to Azure Application Insights
-gem "application_insights"
+gem "application_insights", git: "https://github.com/microsoft/ApplicationInsights-Ruby.git", ref: "5db6b4ad65262d23f26b678143a4a1fd7939e5c2"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/microsoft/ApplicationInsights-Ruby.git
+  revision: 5db6b4ad65262d23f26b678143a4a1fd7939e5c2
+  ref: 5db6b4ad65262d23f26b678143a4a1fd7939e5c2
+  specs:
+    application_insights (0.5.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -45,7 +52,6 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     aes_key_wrap (1.0.1)
-    application_insights (0.5.6)
     arel (9.0.0)
     ast (2.4.0)
     attr_required (1.0.1)
@@ -312,7 +318,7 @@ PLATFORMS
   x86_64-darwin-18
 
 DEPENDENCIES
-  application_insights
+  application_insights!
   bootsnap (>= 1.1.0)
   brakeman
   bullet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     aes_key_wrap (1.0.1)
+    application_insights (0.5.6)
     arel (9.0.0)
     ast (2.4.0)
     attr_required (1.0.1)
@@ -311,6 +312,7 @@ PLATFORMS
   x86_64-darwin-18
 
 DEPENDENCIES
+  application_insights
   bootsnap (>= 1.1.0)
   brakeman
   bullet

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -113,6 +113,7 @@
     "batPlatformDeploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
     "deploymentUrlBase": "[concat('https://raw.githubusercontent.com/DFE-Digital/dfe-teachers-payment-service/', parameters('gitCommitHash'), '/azure/templates/')]",
 
+    "applicationInsightsDeploymentName": "[concat(parameters('resourceNamePrefix'), '-application-insights')]",
     "appServiceCertificateDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app-service-certificate')]",
     "appServicePlanDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app-service-plan')]",
     "databaseServerFirewallRulesDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database-server-firewall-rules')]",
@@ -124,6 +125,8 @@
     "storageAccountName": "[replace(concat(parameters('resourceNamePrefix'), 'storage'), '-', '')]",
 
     "databaseServerName": "[concat(parameters('resourceNamePrefix'), '-db')]",
+
+    "applicationInsightsName": "[concat(parameters('resourceNamePrefix'), '-ai')]",
 
     "appServicePlanName": "[concat(parameters('resourceNamePrefix'), '-asp')]",
 
@@ -205,6 +208,26 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "name": "[variables('applicationInsightsDeploymentName')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('batPlatformDeploymentUrlBase'), 'application-insights.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appInsightsName": {
+            "value": "[variables('applicationInsightsName')]"
+          },
+          "attachedService": {
+            "value": "[variables('appServiceName')]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
       "apiVersion": "2017-05-10",
       "name": "[variables('appServicePlanDeploymentName')]",
       "properties": {
@@ -253,6 +276,7 @@
       "kind": "app,linux,container",
       "location": "[resourceGroup().location]",
       "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', variables('applicationInsightsDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('appServiceCertificateDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('appServicePlanDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('databaseDeploymentName'))]",
@@ -289,6 +313,10 @@
             {
               "name": "DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_NAME",
               "value": "[parameters('databaseName')]"
+            },
+            {
+              "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('applicationInsightsDeploymentName'))).outputs.instrumentationKey.value]"
             },
             {
               "name": "SECRET_KEY_BASE",

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -247,6 +247,7 @@
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2017-05-10",
       "name": "[variables('appServiceCertificateDeploymentName')]",
+      "dependsOn": ["[resourceId('Microsoft.Resources/deployments', variables('appServicePlanDeploymentName'))]"],
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -277,7 +278,6 @@
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', variables('applicationInsightsDeploymentName'))]",
-        "[resourceId('Microsoft.Resources/deployments', variables('appServiceCertificateDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('appServicePlanDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('databaseDeploymentName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('databaseServerDeploymentName'))]"
@@ -391,7 +391,10 @@
       "apiVersion": "2018-11-01",
       "name": "[concat(variables('appServiceName'), '/', parameters('appServiceHostName'))]",
       "location": "[resourceGroup().location]",
-      "dependsOn": ["[resourceId('Microsoft.Web/sites', variables('appServiceName'))]"],
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', variables('appServiceCertificateDeploymentName'))]",
+        "[resourceId('Microsoft.Web/sites', variables('appServiceName'))]"
+      ],
       "properties": {
         "sslState": "SniEnabled",
         "thumbprint": "[reference(resourceId('Microsoft.Resources/deployments', variables('appServiceCertificateDeploymentName')), '2018-11-01').outputs.certificateThumbprint.value]"

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -21,6 +21,10 @@
     "appServiceHostName": {
       "type": "string"
     },
+    "useAppServiceHostName": {
+      "type": "bool",
+      "defaultValue": true
+    },
     "appServiceCertificateSecretName": {
       "type": "string"
     },
@@ -244,6 +248,7 @@
       }
     },
     {
+      "condition": "[parameters('useAppServiceHostName')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2017-05-10",
       "name": "[variables('appServiceCertificateDeploymentName')]",
@@ -387,6 +392,7 @@
       }
     },
     {
+      "condition": "[parameters('useAppServiceHostName')]",
       "type": "Microsoft.Web/sites/hostNameBindings",
       "apiVersion": "2018-11-01",
       "name": "[concat(variables('appServiceName'), '/', parameters('appServiceHostName'))]",
@@ -458,7 +464,7 @@
             "value": "[parameters('VSP.VERIFY_ENVIRONMENT')]"
           },
           "SERVICE_ENTITY_IDS": {
-            "value": "[string(createArray(concat('https://', parameters('appServiceHostName'))))]"
+            "value": "[string(createArray(concat('https://', if(parameters('useAppServiceHostName'), parameters('appServiceHostName'), reference(resourceId('Microsoft.Web/sites', variables('appServiceName'))).defaultHostName))))]"
           },
           "SAML_SIGNING_KEY": {
             "value": "[parameters('VSP.SAML_SIGNING_KEY')]"

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -70,6 +70,7 @@ ALERTS_DEPLOYMENT_NAME=$ALERTS_RESOURCE_GROUP_NAME
 LOGIN_TO_AZURE=1
 CONFIRM_BEFORE_DEPLOY=1
 DEPLOY_ALERTS=1
+EXTRA_APP_DEPLOYMENT_OPTIONS=()
 
 while [ "$2" ]; do
   case $2 in
@@ -89,6 +90,7 @@ while [ "$2" ]; do
     "--tmp-app")
       APP_RESOURCE_GROUP_NAME="$APP_RESOURCE_GROUP_NAME-tmp"
       APP_DEPLOYMENT_NAME="$APP_DEPLOYMENT_NAME-tmp"
+      EXTRA_APP_DEPLOYMENT_OPTIONS+=(--parameters "useAppServiceHostName=false")
       ;;
     "--tmp-alerts")
       ALERTS_RESOURCE_GROUP_NAME="$ALERTS_RESOURCE_GROUP_NAME-tmp"
@@ -200,6 +202,7 @@ APP_DEPLOYMENT_RESULT=$(
         "$SECRETS_DEPLOYMENT_RESULT" \
         "['keyVaultName']"
     )" \
+    "${EXTRA_APP_DEPLOYMENT_OPTIONS[@]}" \
     --mode Complete \
     --verbose
 )

--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -1,0 +1,8 @@
+instrumentation_key = ENV["APPINSIGHTS_INSTRUMENTATIONKEY"]
+
+if instrumentation_key.present?
+  Rails.application.configure do
+    buffer_size = 1
+    config.middleware.use ApplicationInsights::Rack::TrackRequest, instrumentation_key, buffer_size
+  end
+end


### PR DESCRIPTION
We should see request logging show up once it's deployed. This doesn't do any more than that on the AI front.

This also fixes the deployment of the tmp resource groups. You aren't allowed to have more than one app service with a given host name, so we disable deployment of the hostname parts when deploying a tmp app. The dependency graph was also missing some explicit dependencies that blocked a fresh deployment.