### PR TITLE
Don't raise on bullet warnings in test suite

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,7 +52,6 @@ Rails.application.configure do
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true
-    Bullet.raise = true
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "TslrClaim", association: :current_school
     Bullet.add_whitelist type: :n_plus_one_query, class_name: "School", association: :local_authority
   end


### PR DESCRIPTION
Instead we will warn and log in development mode.

This was causing us pain whilst working on the refactoring work to extract a separate model for eligibility criteria because it was raising circular warnings – if we didn't preload `eligibility: [:claim_school]`, etc when loading the claim in `current_claim`, it would complain that we
weren't eager-loading the associations, and if we did, it would complain that they were being eager-loaded but not used. This is because not all the pages where the `current_claim` is accessed also access the eligibility and/or the claim_school.

We could continue to add to the whitelist for these sorts of situations, but then bullet starts to lose its value as we'll essentially end up having to whitelist both n_plus_one_query and unused_eager_loading for pretty much every association on claim and eligibility.