### PR TITLE
Fix email field validation error messages

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -83,7 +83,7 @@ class TslrClaim < ApplicationRecord
   validates :email_address,             on: [:"email-address", :submit], presence: {message: "Enter an email address"}
   validates :email_address,             format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email address in the correct format, like name@example.com"},
                                         length: {maximum: 256, message: "Email address must be 256 characters or less"},
-                                        allow_nil: true
+                                        allow_blank: true
 
   validates :bank_sort_code,            on: [:"bank-details", :submit], presence: {message: "Enter a sort code"}
   validates :bank_account_number,       on: [:"bank-details", :submit], presence: {message: "Enter an account number"}

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe TslrClaim, type: :model do
     it "validates that the value is in the correct format" do
       expect(build(:tslr_claim, email_address: "notan email@address.com")).not_to be_valid
       expect(build(:tslr_claim, email_address: "name@example.com")).to be_valid
+      expect(build(:tslr_claim, email_address: "")).to be_valid
     end
 
     it "checks that the email address in not longer than 256 characters" do


### PR DESCRIPTION
If the user submits the email field with no value both the presence and
the format validation is triggered.

Switching the format validation to allow_blank stops this behaviour and
shows the appropriate message.

https://trello.com/c/YBl0fxWQ