### PR TITLE
Move schools-related attributes to Eligibility

### DIFF
--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ClaimsController < Admin::BaseAdminController
   def index
-    claims = TslrClaim.includes(:claim_school, :current_school, :eligibility).submitted.order(:submitted_at)
+    claims = TslrClaim.includes(eligibility: [:claim_school, :current_school]).submitted.order(:submitted_at)
     csv = TslrClaimsCsv.new(claims)
 
     respond_to do |format|

--- a/app/models/student_loans/permitted_parameters.rb
+++ b/app/models/student_loans/permitted_parameters.rb
@@ -2,9 +2,6 @@ module StudentLoans
   class PermittedParameters
     PARAMETERS = [
       :qts_award_year,
-      :claim_school_id,
-      :employment_status,
-      :current_school_id,
       :mostly_teaching_eligible_subjects,
       :full_name,
       :address_line_1,
@@ -25,7 +22,7 @@ module StudentLoans
       :bank_sort_code,
       :bank_account_number,
       TslrClaim::SUBJECT_FIELDS,
-      eligibility_attributes: [:qts_award_year],
+      eligibility_attributes: [:qts_award_year, :claim_school_id, :employment_status, :current_school_id],
     ].freeze
 
     attr_reader :claim

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -2,10 +2,13 @@
 
   <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { school_search: "school_search" }) if current_claim.errors.any? %>
 
-  <%= form_for current_claim, url: claim_path, method: :get,  data: { "school-id-param": "tslr_claim_#{school_id_param}" }, html: { class: "school_search_form" } do |form| %>
+  <%= form_for current_claim, url: claim_path, method: :get,  data: { "school-id-param": "tslr_claim_eligibility_attributes_#{school_id_param}" }, html: { class: "school_search_form" } do |form| %>
     <%= hidden_field_tag :_method, "get", id: nil %>
     <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-    <%= form.hidden_field school_id_param %>
+
+    <%= form.fields_for :eligibility, include_id: false do |fields| %>
+      <%= fields.hidden_field school_id_param %>
+    <% end %>
 
     <%= form_group_tag current_claim, :school_search do %>
 
@@ -38,7 +41,7 @@
 
 <% else %>
 
-  <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { claim_school: "tslr_claim_#{school_id_param}_#{@schools.first.id}" }) if current_claim.errors.any?
+  <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { claim_school: "tslr_claim_eligibility_attributes_#{school_id_param}_#{@schools.first.id}" }) if current_claim.errors.any?
   %>
 
   <%= form_for current_claim, url: claim_path do |form| %>
@@ -60,12 +63,14 @@
         <%= errors_tag current_claim, :claim_school %>
 
         <div class="govuk-radios">
-          <%= form.collection_radio_buttons school_id_param, @schools, :id, :name do |b| %>
-            <div class="govuk-radios__item">
-              <%= b.radio_button class: "govuk-radios__input" %>
-              <%= b.label class: "govuk-label govuk-radios__label govuk-label--s" %>
-              <span class="govuk-hint govuk-radios__hint"><%= b.object.address %></span>
-            </div>
+          <%= form.fields_for :eligibility, include_id: false do |fields| %>
+            <%= fields.collection_radio_buttons school_id_param, @schools, :id, :name do |b| %>
+              <div class="govuk-radios__item">
+                <%= b.radio_button class: "govuk-radios__input" %>
+                <%= b.label class: "govuk-label govuk-radios__label govuk-label--s" %>
+                <span class="govuk-hint govuk-radios__hint"><%= b.object.address %></span>
+              </div>
+            <% end %>
           <% end %>
         </div>
 

--- a/app/views/claims/still_teaching.html.erb
+++ b/app/views/claims/still_teaching.html.erb
@@ -4,27 +4,29 @@
 
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading"><%= t("tslr.questions.employment_status") %></h1>
-          </legend>
-          <%= errors_tag current_claim, :employment_status %>
-          <div class="govuk-radios">
-            <%= form.hidden_field :employment_status %>
-            <div class="govuk-radios__item">
-              <%= form.radio_button(:employment_status, :claim_school, class: "govuk-radios__input") %>
-              <%= form.label :employment_status_claim_school, "Yes, at #{current_claim.claim_school_name}", class: "govuk-label govuk-radios__label" %>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading"><%= t("tslr.questions.employment_status") %></h1>
+            </legend>
+            <%= errors_tag current_claim, :employment_status %>
+            <div class="govuk-radios">
+              <%= fields.hidden_field :employment_status %>
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:employment_status, :claim_school, class: "govuk-radios__input") %>
+                <%= fields.label :employment_status_claim_school, "Yes, at #{current_claim.claim_school_name}", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:employment_status, :different_school, class: "govuk-radios__input") %>
+                <%= fields.label :employment_status_different_school, "Yes, at another school", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:employment_status, :no_school, class: "govuk-radios__input") %>
+                <%= fields.label :employment_status_no_school, "No", class: "govuk-label govuk-radios__label" %>
+              </div>
             </div>
-            <div class="govuk-radios__item">
-              <%= form.radio_button(:employment_status, :different_school, class: "govuk-radios__input") %>
-              <%= form.label :employment_status_different_school, "Yes, at another school", class: "govuk-label govuk-radios__label" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= form.radio_button(:employment_status, :no_school, class: "govuk-radios__input") %>
-              <%= form.label :employment_status_no_school, "No", class: "govuk-label govuk-radios__label" %>
-            </div>
-          </div>
-        </fieldset>
+          </fieldset>
+        <% end %>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,24 +3,24 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "4b211194d02b7ce69b81b6f7f9232bf911beaf094d9cb272098d62f31bc9f983",
+      "fingerprint": "12f068c7aa279eebbb0a080b73589aecb0ee9807916296213547e3fba1a770c5",
       "check_name": "SendFile",
       "message": "Model attribute used in file name",
       "file": "app/controllers/admin/claims_controller.rb",
       "line": 7,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(TslrClaimsCsv.new(TslrClaim.includes(:claim_school, :current_school, :eligibility).submitted.order(:submitted_at)).file, :type => \"text/csv\", :filename => \"claims.csv\")",
+      "code": "send_file(TslrClaimsCsv.new(TslrClaim.includes(:eligibility => ([:claim_school, :current_school])).submitted.order(:submitted_at)).file, :type => \"text/csv\", :filename => \"claims.csv\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "Admin::ClaimsController",
         "method": "index"
       },
-      "user_input": "TslrClaim.includes(:claim_school, :current_school, :eligibility).submitted",
+      "user_input": "TslrClaim.includes(:eligibility => ([:claim_school, :current_school])).submitted",
       "confidence": "Weak",
       "note": ""
     }
   ],
-  "updated": "2019-07-30 11:24:07 +0100",
+  "updated": "2019-08-07 11:22:21 +0100",
   "brakeman_version": "4.6.1"
 }

--- a/db/migrate/20190806101920_add_schools_attributes_to_student_loans_eligibilities.rb
+++ b/db/migrate/20190806101920_add_schools_attributes_to_student_loans_eligibilities.rb
@@ -1,0 +1,9 @@
+class AddSchoolsAttributesToStudentLoansEligibilities < ActiveRecord::Migration[5.2]
+  def change
+    change_table :student_loans_eligibilities do |t|
+      t.references :claim_school, type: :uuid, foreign_key: {to_table: :schools}
+      t.references :current_school, type: :uuid, foreign_key: {to_table: :schools}
+      t.integer :employment_status
+    end
+  end
+end

--- a/db/migrate/20190806133855_remove_school_attributes_from_tslr_claim.rb
+++ b/db/migrate/20190806133855_remove_school_attributes_from_tslr_claim.rb
@@ -1,0 +1,9 @@
+class RemoveSchoolAttributesFromTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    change_table :tslr_claims do |t|
+      t.remove :current_school_id
+      t.remove :claim_school_id
+      t.remove :employment_status
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_01_134306) do
+ActiveRecord::Schema.define(version: 2019_08_06_133855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -68,14 +68,16 @@ ActiveRecord::Schema.define(version: 2019_08_01_134306) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "qts_award_year"
+    t.uuid "claim_school_id"
+    t.uuid "current_school_id"
+    t.integer "employment_status"
+    t.index ["claim_school_id"], name: "index_student_loans_eligibilities_on_claim_school_id"
+    t.index ["current_school_id"], name: "index_student_loans_eligibilities_on_current_school_id"
   end
 
   create_table "tslr_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "claim_school_id"
-    t.integer "employment_status"
-    t.uuid "current_school_id"
     t.string "full_name", limit: 200
     t.string "address_line_1", limit: 100
     t.string "address_line_2", limit: 100
@@ -106,15 +108,12 @@ ActiveRecord::Schema.define(version: 2019_08_01_134306) do
     t.text "verified_fields", default: [], array: true
     t.string "eligibility_type"
     t.uuid "eligibility_id"
-    t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
-    t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["eligibility_type", "eligibility_id"], name: "index_tslr_claims_on_eligibility_type_and_eligibility_id"
-    t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"
     t.index ["reference"], name: "index_tslr_claims_on_reference", unique: true
     t.index ["submitted_at"], name: "index_tslr_claims_on_submitted_at"
   end
 
   add_foreign_key "schools", "local_authority_districts"
-  add_foreign_key "tslr_claims", "schools", column: "claim_school_id"
-  add_foreign_key "tslr_claims", "schools", column: "current_school_id"
+  add_foreign_key "student_loans_eligibilities", "schools", column: "claim_school_id"
+  add_foreign_key "student_loans_eligibilities", "schools", column: "current_school_id"
 end

--- a/spec/factories/student_loans/eligibilities.rb
+++ b/spec/factories/student_loans/eligibilities.rb
@@ -4,6 +4,9 @@ FactoryBot.define do
   factory :student_loans_eligibility, class: "StudentLoans::Eligibility" do
     trait :submittable do
       qts_award_year { "2013_2014" }
+      claim_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
+      employment_status { :claim_school }
+      current_school { claim_school }
     end
   end
 end

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -3,9 +3,6 @@ FactoryBot.define do
     association(:eligibility, factory: :student_loans_eligibility)
 
     trait :submittable do
-      claim_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
-      current_school { claim_school }
-      employment_status { :claim_school }
       physics_taught { true }
       mostly_teaching_eligible_subjects { true }
       full_name { "Jo Bloggs" }

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -180,7 +180,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
   end
 
   scenario "going from same school to different school" do
-    claim.update!(employment_status: "claim_school")
+    claim.eligibility.update!(employment_status: "claim_school")
 
     find("a[href='#{claim_path("still-teaching")}']").click
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -6,8 +6,7 @@ describe ClaimsHelper do
       school = schools(:penistone_grammar_school)
       claim = build(
         :tslr_claim,
-        claim_school: school,
-        current_school: school,
+        eligibility: build(:student_loans_eligibility, claim_school: school, current_school: school),
         chemistry_taught: true,
         physics_taught: true,
         mostly_teaching_eligible_subjects: true,

--- a/spec/models/claim_update_spec.rb
+++ b/spec/models/claim_update_spec.rb
@@ -81,9 +81,9 @@ RSpec.describe ClaimUpdate do
 
   describe "setting/resetting current_school based on the answer to employment_status" do
     context "when the update sets the employment_status to :claim_school" do
-      let(:claim) { create(:tslr_claim, claim_school: schools(:penistone_grammar_school)) }
+      let(:claim) { create(:tslr_claim, eligibility: build(:student_loans_eligibility, claim_school: schools(:penistone_grammar_school))) }
       let(:context) { "still-teaching" }
-      let(:params) { {employment_status: "claim_school"} }
+      let(:params) { {eligibility_attributes: {employment_status: "claim_school"}} }
 
       it "automatically sets current_school to match the claim_school" do
         expect(claim_update.perform).to be_truthy
@@ -93,21 +93,21 @@ RSpec.describe ClaimUpdate do
     end
 
     context "when the update changes employment_status to :different_school" do
-      let(:claim) { create(:tslr_claim, claim_school: schools(:penistone_grammar_school), employment_status: :claim_school, current_school: schools(:penistone_grammar_school)) }
+      let(:claim) { create(:tslr_claim, eligibility: build(:student_loans_eligibility, claim_school: schools(:penistone_grammar_school), employment_status: :claim_school, current_school: schools(:penistone_grammar_school))) }
       let(:context) { "still-teaching" }
-      let(:params) { {employment_status: "different_school"} }
+      let(:params) { {eligibility_attributes: {employment_status: "different_school"}} }
 
       it "resets the inferrred current_school to nil" do
         expect(claim_update.perform).to be_truthy
-        expect(claim.reload.employment_status).to eq "different_school"
+        expect(claim.reload.eligibility.employment_status).to eq "different_school"
         expect(claim.current_school).to be_nil
       end
     end
 
     context "when the update does not actually change the employment_status" do
-      let(:claim) { create(:tslr_claim, claim_school: schools(:penistone_grammar_school), employment_status: :different_school, current_school: schools(:hampstead_school)) }
+      let(:claim) { create(:tslr_claim, eligibility: build(:student_loans_eligibility, claim_school: schools(:penistone_grammar_school), employment_status: :different_school, current_school: schools(:hampstead_school))) }
       let(:context) { "still-teaching" }
-      let(:params) { {employment_status: claim.employment_status} }
+      let(:params) { {eligibility_attributes: {employment_status: claim.employment_status}} }
 
       it "does not reset the current_school" do
         expect(claim_update.perform).to be_truthy
@@ -118,11 +118,11 @@ RSpec.describe ClaimUpdate do
   end
 
   describe "setting/resetting employment_status when the claim_school changes" do
-    let(:claim) { create(:tslr_claim, claim_school: schools(:penistone_grammar_school), employment_status: :different_school, current_school: schools(:hampstead_school)) }
+    let(:claim) { create(:tslr_claim, eligibility: build(:student_loans_eligibility, claim_school: schools(:penistone_grammar_school), employment_status: :different_school, current_school: schools(:hampstead_school))) }
     let(:context) { "claim-school" }
 
     context "when the update changes the claim_school" do
-      let(:params) { {claim_school_id: schools(:hampstead_school).id} }
+      let(:params) { {eligibility_attributes: {claim_school_id: schools(:hampstead_school).id}} }
 
       it "resets the subsequent employment_status and current_school answers" do
         expect(claim_update.perform).to be_truthy
@@ -132,7 +132,7 @@ RSpec.describe ClaimUpdate do
     end
 
     context "when the update does not change the claim_school" do
-      let(:params) { {claim_school_id: claim.claim_school_id} }
+      let(:params) { {eligibility_attributes: {claim_school_id: claim.eligibility.claim_school_id}} }
 
       it "does not reset the subsequent employment_status and current_school answers" do
         expect(claim_update.perform).to be_truthy

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PageSequence do
 
   describe "#slugs" do
     it "excludes “current-school” when the claimant still works at the school they are claiming against" do
-      claim.employment_status = :claim_school
+      claim.eligibility.employment_status = :claim_school
       page_sequence = PageSequence.new(claim, "still-teaching")
 
       expect(page_sequence.slugs).not_to include("current-school")
@@ -62,7 +62,7 @@ RSpec.describe PageSequence do
     end
 
     context "with an ineligible claim" do
-      let(:claim) { build(:tslr_claim, employment_status: :no_school) }
+      let(:claim) { build(:tslr_claim, eligibility: build(:student_loans_eligibility, employment_status: :no_school)) }
 
       it "returns “ineligible” as the next slug" do
         expect(PageSequence.new(claim, "still-teaching").next_slug).to eq "ineligible"

--- a/spec/presenters/tslr_claim_csv_row_spec.rb
+++ b/spec/presenters/tslr_claim_csv_row_spec.rb
@@ -5,10 +5,7 @@ RSpec.describe TslrClaimCsvRow do
   let(:claim) { create(:tslr_claim) }
 
   describe "to_s" do
-    let(:claim_school) { "Claim School" }
-    let(:current_school) { "Current School" }
     let(:date_of_birth) { "01/12/1980" }
-    let(:employment_status) { "Different school" }
     let(:mostly_teaching_eligible_subjects) { "Yes" }
     let(:student_loan_repayment_amount) { "£1000.0" }
     let(:submitted_at) { "01/01/2019 13:00" }
@@ -16,9 +13,6 @@ RSpec.describe TslrClaimCsvRow do
 
     let(:claim) do
       create(:tslr_claim, :submittable,
-        claim_school: create(:school, name: claim_school),
-        current_school: create(:school, name: current_school),
-        employment_status: TslrClaim.employment_statuses[employment_status.parameterize.underscore],
         date_of_birth: Date.parse(date_of_birth),
         mostly_teaching_eligible_subjects: mostly_teaching_eligible_subjects == "Yes",
         student_loan_repayment_amount: student_loan_repayment_amount.delete("£").to_i,
@@ -31,9 +25,9 @@ RSpec.describe TslrClaimCsvRow do
         claim.reference,
         submitted_at,
         claim.qts_award_year,
-        claim_school,
-        employment_status,
-        current_school,
+        claim.eligibility.claim_school.name,
+        claim.eligibility.employment_status.humanize,
+        claim.eligibility.current_school.name,
         claim.full_name,
         claim.address_line_1,
         claim.address_line_2,

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Claims", type: :request do
       end
 
       it "tailors the message to the claim" do
-        TslrClaim.order(:created_at).last.update(employment_status: "no_school")
+        TslrClaim.order(:created_at).last.eligibility.update(employment_status: "no_school")
 
         get claim_path("ineligible")
         expect(response.body).to include("You’re not eligible")
@@ -149,7 +149,7 @@ RSpec.describe "Claims", type: :request do
 
       context "having searched for a school but not selected a school from the results on the claim-school page" do
         it "re-renders the school search results with an error message" do
-          put claim_path("claim-school"), params: {school_search: "peniston", tslr_claim: {claim_school_id: ""}}
+          put claim_path("claim-school"), params: {school_search: "peniston", tslr_claim: {eligibility_attributes: {claim_school_id: ""}}}
 
           expect(response).to be_successful
           expect(response.body).to include("There is a problem")
@@ -160,7 +160,7 @@ RSpec.describe "Claims", type: :request do
 
       context "when the update makes the claim ineligible" do
         it "redirects to the “ineligible” page" do
-          put claim_path("claim-school"), params: {tslr_claim: {claim_school_id: schools(:hampstead_school).to_param}}
+          put claim_path("claim-school"), params: {tslr_claim: {eligibility_attributes: {claim_school_id: schools(:hampstead_school).to_param}}}
 
           expect(response).to redirect_to(claim_path("ineligible"))
         end


### PR DESCRIPTION
This continues the work to separate the common claim-related data
(identity, payment, payroll, etc) from the policy-specific fields,
making it easier to support more than one type of policy (i.e. Maths &
Physics).

This commit focuses on the two schools associations and the closely
associated employment_status field. Because all three attributes are
closely related and interdependent they've had to be migrated at the
same time.

Note that no effort has been made to migrate the data from existing
claims as we're not yet live so any existing data can simply be deleted.
The best way to do this on the Azure environments is probably going to
be to drop the database and perform a release to force the rebuilding of
the database.

## Temporary fixes and future work

- As with the preceding work that moved qts_award_year, a bunch of
  attributes are temporarily being delegated from the claim model to the
  eligibility model to keep these changes as small and focused as
  possible. These will need removing before Maths & Physics can be
  introduced as at that point, the claim model will need to be entirely
  generic and not know anything about the policy-specific eligibility
  fields.
- The ClaimUpdate model has needed to be updated with knowledge specific
  both to the claim model and the eligibility model. The code doesn't
  look great at the moment, but we know it will need adjusting at the
  point the new policy is introduced, and that feels like a better point
  to figure out the best way to model the behaviour for adjusting
  in-progress claims (and their eligibility) and their dependent
  attributes
- Same goes for many of the specs; many have had to be updated with
  student loans-specific attributes and knowledge, in some cases
  coupling them to the specifics of student loans. As above, we'll be in
  a better place to try and untangle these at the point the new policy
  is introduced.

Part of https://trello.com/c/9gpS69mI/536-1-separate-an-eligibility-model-from-the-claim-model