### PR TITLE
Sanitize dangerous fields in CSV output

### DIFF
--- a/app/presenters/tslr_claim_csv_row.rb
+++ b/app/presenters/tslr_claim_csv_row.rb
@@ -8,8 +8,18 @@ class TslrClaimCsvRow < SimpleDelegator
 
   private
 
+  DANGEROUS_STRINGS = [
+    "-",
+    "+",
+    "=",
+    "@",
+  ].freeze
+
   def data
-    TslrClaimsCsv::FIELDS.map { |f| send(f) }
+    TslrClaimsCsv::FIELDS.map do |f|
+      field = send(f)
+      sanitize_field(field)
+    end
   end
 
   def employment_status
@@ -34,6 +44,13 @@ class TslrClaimCsvRow < SimpleDelegator
 
   def submitted_at
     model.submitted_at.strftime("%d/%m/%Y %H:%M")
+  end
+
+  def sanitize_field(field)
+    return field if field.blank?
+
+    field = "=\"#{field}\"" if DANGEROUS_STRINGS.any? { |string| field.include?(string) }
+    field
   end
 
   def model

--- a/spec/presenters/tslr_claim_csv_row_spec.rb
+++ b/spec/presenters/tslr_claim_csv_row_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe TslrClaimCsvRow do
   subject { described_class.new(claim) }
-  let(:claim) { create(:tslr_claim) }
+  let(:claim) { build(:tslr_claim) }
 
   describe "to_s" do
     let(:date_of_birth) { "01/12/1980" }
@@ -12,7 +12,7 @@ RSpec.describe TslrClaimCsvRow do
     let(:row) { CSV.parse(subject.to_s).first }
 
     let(:claim) do
-      create(:tslr_claim, :submittable,
+      build(:tslr_claim, :submittable,
         date_of_birth: Date.parse(date_of_birth),
         mostly_teaching_eligible_subjects: mostly_teaching_eligible_subjects == "Yes",
         student_loan_repayment_amount: student_loan_repayment_amount.delete("£").to_i,
@@ -38,13 +38,35 @@ RSpec.describe TslrClaimCsvRow do
         claim.payroll_gender,
         claim.teacher_reference_number,
         claim.national_insurance_number,
-        "Plan 2",
-        claim.email_address,
+        StudentLoans::PLAN_2.humanize,
+        "=\"#{claim.email_address}\"",
         mostly_teaching_eligible_subjects,
         claim.bank_sort_code,
         claim.bank_account_number,
         student_loan_repayment_amount,
       ])
+    end
+
+    it "escapes fields with strings that could be dangerous in Microsoft Excel and friends" do
+      claim.address_line_1 = "equals=sign"
+      claim.address_line_2 = "minus-sign"
+      claim.address_line_3 = "plus+sign"
+      claim.address_line_4 = "at@symbol"
+      claim.postcode = "=SUM(A1, A2)"
+      claim.email_address = "valid=email@domain.tld"
+
+      expect(row[TslrClaimsCsv::FIELDS.index(:address_line_1)]).to eq("=\"#{claim.address_line_1}\"")
+      expect(row[TslrClaimsCsv::FIELDS.index(:address_line_2)]).to eq("=\"#{claim.address_line_2}\"")
+      expect(row[TslrClaimsCsv::FIELDS.index(:address_line_3)]).to eq("=\"#{claim.address_line_3}\"")
+      expect(row[TslrClaimsCsv::FIELDS.index(:address_line_4)]).to eq("=\"#{claim.address_line_4}\"")
+      expect(row[TslrClaimsCsv::FIELDS.index(:postcode)]).to eq("=\"#{claim.postcode}\"")
+      expect(row[TslrClaimsCsv::FIELDS.index(:email_address)]).to eq("=\"#{claim.email_address}\"")
+    end
+
+    it "escaped fields are properly quoted when converted to CSV" do
+      claim.postcode = "=SUM(A1, A2)"
+
+      expect(CSV.generate_line(row)).to include('"=""' + claim.postcode + '"""')
     end
   end
 end

--- a/spec/presenters/tslr_claims_csv_spec.rb
+++ b/spec/presenters/tslr_claims_csv_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe TslrClaimsCsv do
         claim.teacher_reference_number,
         claim.national_insurance_number,
         claim.student_loan_plan.humanize,
-        claim.email_address,
+        "=\"#{claim.email_address}\"",
         claim.mostly_teaching_eligible_subjects ? "Yes" : "No",
         claim.bank_sort_code,
         claim.bank_account_number,


### PR DESCRIPTION
"-", "+", "=", and "@" all have special meaning in Excel. Wrapping strings that contain them in `="<field>"` tells Excel to treat the field as a string, and to not execute any formulae.

When exported to a CSV, we end up with field that look like: `"=""=SUM(A1, A2)"""`, which works as expected.