### PR TITLE
 Allow the minimum set of verified data from Verify

### DIFF
--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -66,11 +66,12 @@ module Verify
       middle_name = most_recent_verified_value(attributes.fetch("middleNames"))
       surname = most_recent_verified_value(attributes.fetch("surnames"))
 
-      [first_name, middle_name, surname].join(" ")
+      [first_name, middle_name, surname].compact.join(" ")
     end
 
     def most_recent_verified_value(attributes)
-      attributes.sort_by { |attribute| Date.strptime(attribute["to"], "%Y-%m-%d") }
+      return if attributes.empty?
+      attributes.sort_by { |attribute| attribute["to"].present? ? Date.strptime(attribute["to"], "%Y-%m-%d") : 0 }
         .reverse
         .find { |attribute| attribute["verified"] }
         .fetch("value")

--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -71,7 +71,8 @@ module Verify
 
     def most_recent_verified_value(attributes)
       return if attributes.empty?
-      attributes.sort_by { |attribute| attribute["to"].present? ? Date.strptime(attribute["to"], "%Y-%m-%d") : 0 }
+
+      attributes.sort_by { |attribute| attribute["from"].present? ? Date.strptime(attribute["from"], "%Y-%m-%d") : 0 }
         .reverse
         .find { |attribute| attribute["verified"] }
         .fetch("value")

--- a/spec/fixtures/verify/identity-verified-minimum.json
+++ b/spec/fixtures/verify/identity-verified-minimum.json
@@ -1,0 +1,35 @@
+{
+  "scenario": "IDENTITY_VERIFIED",
+  "pid": "5989a87f344bb79ee8d0f0532c0f716deb4f8d71e906b87b346b649c4ceb20c5",
+  "levelOfAssurance": "LEVEL_2",
+  "attributes": {
+    "firstNames": [
+      {
+        "value": "Isambard",
+        "verified": true
+      }
+    ],
+    "middleNames": [],
+    "surnames": [
+      {
+        "value": "Brunel",
+        "verified": true
+      }
+    ],
+    "datesOfBirth": [
+      {
+        "value": "1806-04-09",
+        "verified": true
+      }
+    ],
+    "addresses": [
+      {
+        "value": {
+          "lines": ["Verified Street", "Verified Town"],
+          "postCode": "M12 345"
+        },
+        "verified": true
+      }
+    ]
+  }
+}

--- a/spec/fixtures/verify/identity-verified.json
+++ b/spec/fixtures/verify/identity-verified.json
@@ -19,8 +19,7 @@
       {
         "value": "Sam",
         "verified": false,
-        "from": "2019-06-30",
-        "to": "2019-07-09"
+        "from": "2019-06-30"
       }
     ],
     "middleNames": [
@@ -33,8 +32,7 @@
       {
         "value": "K.",
         "verified": false,
-        "from": "2019-06-25",
-        "to": "2019-07-09"
+        "from": "2019-06-25"
       }
     ],
     "surnames": [
@@ -53,16 +51,14 @@
       {
         "value": "",
         "verified": false,
-        "from": "2019-06-25",
-        "to": "2019-07-09"
+        "from": "2019-06-25"
       }
     ],
     "datesOfBirth": [
       {
         "value": "1806-04-09",
         "verified": true,
-        "from": "1806-04-09",
-        "to": "1806-04-09"
+        "from": "1806-04-09"
       }
     ],
     "gender": {
@@ -85,8 +81,7 @@
           "postCode": "L12 345"
         },
         "verified": false,
-        "from": "2019-06-25",
-        "to": "2019-07-25"
+        "from": "2019-06-25"
       }
     ]
   }

--- a/spec/lib/verify/response_spec.rb
+++ b/spec/lib/verify/response_spec.rb
@@ -83,6 +83,23 @@ RSpec.describe Verify::Response, type: :model do
     end
   end
 
+  context "with the minimum verified response" do
+    let(:response_filename) { "identity-verified-minimum.json" }
+
+    it "is verified" do
+      expect(subject.verified?).to eq(true)
+    end
+
+    it "returns the expected verified parameters" do
+      expect(subject.claim_parameters[:full_name]).to eq("Isambard Brunel")
+      expect(subject.claim_parameters[:address_line_1]).to eq("Verified Street")
+      expect(subject.claim_parameters[:address_line_2]).to eq("Verified Town")
+      expect(subject.claim_parameters[:address_line_3]).to be_nil
+      expect(subject.claim_parameters[:postcode]).to eq("M12 345")
+      expect(subject.claim_parameters[:date_of_birth]).to eq("1806-04-09")
+    end
+  end
+
   context "with a cancelled response" do
     let(:response_filename) { "no-authentication.json" }
 


### PR DESCRIPTION
We now know more about the data attributes that are returned from Verify. This PR should allow us to have a "minimum viable Verify user" complete the journey with us.

- If the user's details haven't changed then we don't get any `to` or `from` dates
- If the user's details have changed they get a `to` and `from` date except the current value which doesn't have a `to` date
- If a user has no middle name it will be returned as an empty array