### PR TITLE
Output formatted payroll_gender

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -27,7 +27,7 @@ module ClaimsHelper
       a << [t("tslr.questions.full_name"), claim.full_name, "full-name"]
       a << [t("tslr.questions.address"), claim.address, "address"]
       a << [t("tslr.questions.date_of_birth"), l(claim.date_of_birth), "date-of-birth"]
-      a << [t("tslr.questions.payroll_gender"), claim.payroll_gender, "gender"] unless claim.verified_fields.include?("payroll_gender")
+      a << [t("tslr.questions.payroll_gender"), t("tslr.answers.payroll_gender.#{claim.payroll_gender}"), "gender"] unless claim.verified_fields.include?("payroll_gender")
       a << [t("tslr.questions.teacher_reference_number"), claim.teacher_reference_number, "teacher-reference-number"]
       a << [t("tslr.questions.national_insurance_number"), claim.national_insurance_number, "national-insurance-number"]
       a << [t("tslr.questions.email_address"), claim.email_address, "email-address"]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,10 @@ en:
           before_first_september_2012: "All my degree courses started before 1 September 2012"
           some_before_some_after_first_september_2012: "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012"
           on_or_after_first_september_2012: "All of my degree courses started after 1 September 2012"
+      payroll_gender:
+        male: "Male"
+        female: "Female"
+        dont_know: "Don’t know"
     csv_headers:
       reference: "Reference"
       submitted_at: "Submitted at"

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -40,7 +40,7 @@ describe ClaimsHelper do
         teacher_reference_number: "1234567",
         national_insurance_number: "QQ123456C",
         email_address: "test@email.com",
-        payroll_gender: :female
+        payroll_gender: :dont_know
       )
     end
 
@@ -49,7 +49,7 @@ describe ClaimsHelper do
         [I18n.t("tslr.questions.full_name"), "Jo Bloggs", "full-name"],
         [I18n.t("tslr.questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
         [I18n.t("tslr.questions.date_of_birth"), I18n.l(20.years.ago.to_date), "date-of-birth"],
-        [I18n.t("tslr.questions.payroll_gender"), "female", "gender"],
+        [I18n.t("tslr.questions.payroll_gender"), "Don’t know", "gender"],
         [I18n.t("tslr.questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
         [I18n.t("tslr.questions.national_insurance_number"), "QQ123456C", "national-insurance-number"],
         [I18n.t("tslr.questions.email_address"), "test@email.com", "email-address"],


### PR DESCRIPTION
When shown, the payroll_gender attribute should be formatted and not an
internal representation.

![image](https://user-images.githubusercontent.com/480578/62641749-36330380-b93c-11e9-8bd4-f9e9a7a04385.png)
