### PR TITLE
Migrate subjects and teaching time-related attributes to the Eligibility model

### DIFF
--- a/app/assets/javascripts/components/subjects_taught.js
+++ b/app/assets/javascripts/components/subjects_taught.js
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", function() {
   function toggleSubjectValues(event) {
     var el = event.target;
     var eligibleSubjectsClass = "subject";
-    var notTeachingSubjectsName = "tslr_claim[mostly_teaching_eligible_subjects]";
+    var notTeachingSubjectsName = "tslr_claim[eligibility_attributes][mostly_teaching_eligible_subjects]";
 
     if (!el) {
       return;

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -43,7 +43,7 @@ class PageSequence
 
   def slugs
     SLUGS.dup.tap do |sequence|
-      sequence.delete("current-school") if claim.employed_at_claim_school?
+      sequence.delete("current-school") if claim.eligibility.employed_at_claim_school?
       sequence.delete("student-loan-country") if claim.no_student_loan?
       sequence.delete("student-loan-how-many-courses") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
       sequence.delete("student-loan-start-date") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
@@ -52,7 +52,7 @@ class PageSequence
   end
 
   def next_slug
-    return "ineligible" if claim.ineligible?
+    return "ineligible" if claim.eligibility.ineligible?
     return "check-your-answers" if claim.submittable?
 
     slugs[current_slug_index + 1]

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -59,6 +59,8 @@ module StudentLoans
       ].find { |eligibility_check| send("#{eligibility_check}?") }
     end
 
+    private
+
     def ineligible_qts_award_year?
       awarded_qualified_status_before_2013?
     end
@@ -70,8 +72,6 @@ module StudentLoans
     def not_taught_eligible_subjects_enough?
       mostly_teaching_eligible_subjects == false
     end
-
-    private
 
     def one_subject_must_be_selected
       errors.add(:subjects_taught, "Choose a subject, or select “not applicable”") if subjects_taught.empty?

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -2,6 +2,14 @@
 
 module StudentLoans
   class Eligibility < ApplicationRecord
+    SUBJECT_ATTRIBUTES = [
+      :biology_taught,
+      :chemistry_taught,
+      :physics_taught,
+      :computer_science_taught,
+      :languages_taught,
+    ].freeze
+
     self.table_name = "student_loans_eligibilities"
 
     enum qts_award_year: {
@@ -28,12 +36,18 @@ module StudentLoans
     validates :claim_school, on: [:"claim-school", :submit], presence: {message: "Select a school from the list"}
     validates :employment_status, on: [:"still-teaching", :submit], presence: {message: "Choose the option that describes your current employment status"}
     validates :current_school, on: [:"current-school", :submit], presence: {message: "Select a school from the list"}
+    validate :one_subject_must_be_selected, on: [:"subjects-taught", :submit], unless: :not_taught_eligible_subjects_enough?
+    validates :mostly_teaching_eligible_subjects, on: [:"mostly-teaching-eligible-subjects", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
 
     delegate :name, to: :claim_school, prefix: true, allow_nil: true
     delegate :name, to: :current_school, prefix: true, allow_nil: true
 
+    def subjects_taught
+      SUBJECT_ATTRIBUTES.select { |attribute_name| public_send("#{attribute_name}?") }
+    end
+
     def ineligible?
-      ineligible_qts_award_year? || ineligible_claim_school? || employed_at_no_school?
+      ineligible_qts_award_year? || ineligible_claim_school? || employed_at_no_school? || not_taught_eligible_subjects_enough?
     end
 
     def ineligibility_reason
@@ -41,6 +55,7 @@ module StudentLoans
         :ineligible_qts_award_year,
         :ineligible_claim_school,
         :employed_at_no_school,
+        :not_taught_eligible_subjects_enough,
       ].find { |eligibility_check| send("#{eligibility_check}?") }
     end
 
@@ -50,6 +65,16 @@ module StudentLoans
 
     def ineligible_claim_school?
       claim_school.present? && !claim_school.eligible_for_tslr?
+    end
+
+    def not_taught_eligible_subjects_enough?
+      mostly_teaching_eligible_subjects == false
+    end
+
+    private
+
+    def one_subject_must_be_selected
+      errors.add(:subjects_taught, "Choose a subject, or select “not applicable”") if subjects_taught.empty?
     end
   end
 end

--- a/app/models/student_loans/permitted_parameters.rb
+++ b/app/models/student_loans/permitted_parameters.rb
@@ -1,7 +1,15 @@
 module StudentLoans
   class PermittedParameters
-    PARAMETERS = [
+    ELIGIBILITY_PARAMETERS = [
+      :qts_award_year,
+      :claim_school_id,
+      :employment_status,
+      :current_school_id,
       :mostly_teaching_eligible_subjects,
+      StudentLoans::Eligibility::SUBJECT_ATTRIBUTES,
+    ].flatten.freeze
+
+    PARAMETERS = [
       :full_name,
       :address_line_1,
       :address_line_2,
@@ -20,8 +28,7 @@ module StudentLoans
       :email_address,
       :bank_sort_code,
       :bank_account_number,
-      TslrClaim::SUBJECT_FIELDS,
-      eligibility_attributes: [:qts_award_year, :claim_school_id, :employment_status, :current_school_id],
+      eligibility_attributes: ELIGIBILITY_PARAMETERS,
     ].freeze
 
     attr_reader :claim

--- a/app/models/student_loans/permitted_parameters.rb
+++ b/app/models/student_loans/permitted_parameters.rb
@@ -1,7 +1,6 @@
 module StudentLoans
   class PermittedParameters
     PARAMETERS = [
-      :qts_award_year,
       :mostly_teaching_eligible_subjects,
       :full_name,
       :address_line_1,

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -20,14 +20,6 @@ class TslrClaim < ApplicationRecord
            :mostly_teaching_eligible_subjects?,
            to: :eligibility
 
-  # NOTE: Temporary delegation of eligibility methods
-  delegate :ineligible_qts_award_year?,
-           :ineligible_claim_school?,
-           :employed_at_claim_school?,
-           :employed_at_no_school?,
-           :not_taught_eligible_subjects_enough?,
-           to: :eligibility, allow_nil: nil
-
   # NOTE: Temporary delegation of left over methods
   delegate :claim_school_name, to: :eligibility
   delegate :current_school_name, to: :eligibility
@@ -115,19 +107,6 @@ class TslrClaim < ApplicationRecord
     valid?(:submit) && !submitted?
   end
 
-  def ineligible?
-    ineligible_qts_award_year? || ineligible_claim_school? || employed_at_no_school? || not_taught_eligible_subjects_enough?
-  end
-
-  def ineligibility_reason
-    [
-      :ineligible_qts_award_year,
-      :ineligible_claim_school,
-      :employed_at_no_school,
-      :not_taught_eligible_subjects_enough,
-    ].find { |eligibility_check| send("#{eligibility_check}?") }
-  end
-
   def address
     [address_line_1, address_line_2, address_line_3, address_line_4, postcode].reject(&:blank?).join(", ")
   end
@@ -201,6 +180,6 @@ class TslrClaim < ApplicationRecord
   end
 
   def claim_must_not_be_ineligible
-    errors.add(:base, ineligibility_reason) if ineligible?
+    errors.add(:base, eligibility.ineligibility_reason) if eligibility.ineligible?
   end
 end

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -5,7 +5,7 @@
     </h1>
 
     <p class="govuk-body">
-      <%= t("activerecord.errors.messages.#{current_claim.ineligibility_reason}") %>.
+      <%= t("activerecord.errors.messages.#{current_claim.eligibility.ineligibility_reason}") %>.
     </p>
 
     <p class="govuk-body">

--- a/app/views/claims/mostly_teaching_eligible_subjects.html.erb
+++ b/app/views/claims/mostly_teaching_eligible_subjects.html.erb
@@ -1,9 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { mostly_teaching_eligible_subjects: "tslr_claim_mostly_teaching_eligible_subjects_true"}) if current_claim.errors.any? %>
-      <%= form_for current_claim, url: claim_path do |form| %>
-        <%= form.hidden_field :mostly_teaching_eligible_subjects %>
-        <%= form_group_tag current_claim do %>
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { mostly_teaching_eligible_subjects: "tslr_claim_eligibility_attributes_mostly_teaching_eligible_subjects_true"}) if current_claim.errors.any? %>
+
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <%= form_group_tag current_claim do %>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+          <%= fields.hidden_field :mostly_teaching_eligible_subjects %>
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
@@ -19,17 +21,18 @@
             <%= errors_tag current_claim, :mostly_teaching_eligible_subjects %>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <%= form.radio_button(:mostly_teaching_eligible_subjects, true, class: "govuk-radios__input") %>
-                <%= form.label :mostly_teaching_eligible_subjects_true, "Yes", class: "govuk-label govuk-radios__label" %>
+                <%= fields.radio_button(:mostly_teaching_eligible_subjects, true, class: "govuk-radios__input") %>
+                <%= fields.label :mostly_teaching_eligible_subjects_true, "Yes", class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:mostly_teaching_eligible_subjects, false, class: "govuk-radios__input") %>
-                <%= form.label :mostly_teaching_eligible_subjects_false, "No", class: "govuk-label govuk-radios__label" %>
+                <%= fields.radio_button(:mostly_teaching_eligible_subjects, false, class: "govuk-radios__input") %>
+                <%= fields.label :mostly_teaching_eligible_subjects_false, "No", class: "govuk-label govuk-radios__label" %>
               </div>
             </div>
-        </fieldset>
+          </fieldset>
+        <% end %>
       <% end %>
-    <%= form.submit "Continue", class: "govuk-button" %>
+      <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/claims/subjects_taught.html.erb
+++ b/app/views/claims/subjects_taught.html.erb
@@ -1,30 +1,33 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
-        <fieldset class="govuk-fieldset" id="tslr_claim_subjects_taught">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading">
-              <%= t("tslr.questions.subjects_taught") %>
-            </h1>
-          </legend>
-          <div class="govuk-checkboxes">
-            <% TslrClaim::SUBJECT_FIELDS.each do |subject| -%>
-              <div class="govuk-checkboxes__item">
-                <%= form.hidden_field subject, value: false %>
-                <%= form.check_box subject, class: "govuk-checkboxes__input subject", id: "eligible_subjects_#{subject}"  %>
-                <%= form.label subject, t("tslr.questions.eligible_subjects.#{subject}"), class: "govuk-label govuk-checkboxes__label", for: "eligible_subjects_#{subject}"  %>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+          <fieldset class="govuk-fieldset" id="tslr_claim_subjects_taught">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("tslr.questions.subjects_taught") %>
+              </h1>
+            </legend>
+            <div class="govuk-checkboxes">
+              <% StudentLoans::Eligibility::SUBJECT_ATTRIBUTES.each do |subject| -%>
+                <div class="govuk-checkboxes__item">
+                  <%= fields.hidden_field subject, value: false %>
+                  <%= fields.check_box subject, class: "govuk-checkboxes__input subject", id: "eligible_subjects_#{subject}"  %>
+                  <%= fields.label subject, t("tslr.questions.eligible_subjects.#{subject}"), class: "govuk-label govuk-checkboxes__label", for: "eligible_subjects_#{subject}"  %>
+                </div>
+              <% end %>
+              <div class="govuk-radios__divider">or</div>
+              <div class="govuk-radios__item">
+                <%= fields.hidden_field :mostly_teaching_eligible_subjects, value: '' %>
+                <%= fields.radio_button(:mostly_teaching_eligible_subjects, false, class: "govuk-radios__input")  %>
+                <%= fields.label :mostly_teaching_eligible_subjects_false, t('tslr.questions.eligible_subjects.not_applicable'), class: "govuk-label govuk-radios__label" %>
               </div>
-            <% end %>
-            <div class="govuk-radios__divider">or</div>
-            <div class="govuk-radios__item">
-              <%= form.hidden_field :mostly_teaching_eligible_subjects, value: '' %>
-              <%= form.radio_button(:mostly_teaching_eligible_subjects, false, class: "govuk-radios__input")  %>
-              <%= form.label :mostly_teaching_eligible_subjects_false, t('tslr.questions.eligible_subjects.not_applicable'), class: "govuk-label govuk-radios__label" %>
             </div>
-          </div>
-        </fieldset>
+          </fieldset>
+        <% end %>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>

--- a/db/migrate/20190807103322_add_subjects_taught_attributes_to_student_loans_eligibilities.rb
+++ b/db/migrate/20190807103322_add_subjects_taught_attributes_to_student_loans_eligibilities.rb
@@ -1,0 +1,12 @@
+class AddSubjectsTaughtAttributesToStudentLoansEligibilities < ActiveRecord::Migration[5.2]
+  def change
+    change_table :student_loans_eligibilities do |t|
+      t.boolean :biology_taught
+      t.boolean :chemistry_taught
+      t.boolean :computer_science_taught
+      t.boolean :languages_taught
+      t.boolean :physics_taught
+      t.boolean :mostly_teaching_eligible_subjects
+    end
+  end
+end

--- a/db/migrate/20190807110948_remove_subjects_taught_attributes_from_tslr_claims.rb
+++ b/db/migrate/20190807110948_remove_subjects_taught_attributes_from_tslr_claims.rb
@@ -1,0 +1,12 @@
+class RemoveSubjectsTaughtAttributesFromTslrClaims < ActiveRecord::Migration[5.2]
+  def change
+    change_table :tslr_claims do |t|
+      t.remove :biology_taught
+      t.remove :chemistry_taught
+      t.remove :computer_science_taught
+      t.remove :languages_taught
+      t.remove :physics_taught
+      t.remove :mostly_teaching_eligible_subjects
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_06_133855) do
+ActiveRecord::Schema.define(version: 2019_08_07_110948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -71,6 +71,12 @@ ActiveRecord::Schema.define(version: 2019_08_06_133855) do
     t.uuid "claim_school_id"
     t.uuid "current_school_id"
     t.integer "employment_status"
+    t.boolean "biology_taught"
+    t.boolean "chemistry_taught"
+    t.boolean "computer_science_taught"
+    t.boolean "languages_taught"
+    t.boolean "physics_taught"
+    t.boolean "mostly_teaching_eligible_subjects"
     t.index ["claim_school_id"], name: "index_student_loans_eligibilities_on_claim_school_id"
     t.index ["current_school_id"], name: "index_student_loans_eligibilities_on_current_school_id"
   end
@@ -88,17 +94,11 @@ ActiveRecord::Schema.define(version: 2019_08_06_133855) do
     t.string "teacher_reference_number", limit: 11
     t.string "national_insurance_number", limit: 9
     t.string "email_address", limit: 256
-    t.boolean "mostly_teaching_eligible_subjects"
     t.string "bank_sort_code", limit: 6
     t.string "bank_account_number", limit: 8
     t.datetime "submitted_at"
     t.decimal "student_loan_repayment_amount", precision: 7, scale: 2
     t.string "reference", limit: 8
-    t.boolean "biology_taught", default: false
-    t.boolean "chemistry_taught", default: false
-    t.boolean "physics_taught", default: false
-    t.boolean "computer_science_taught", default: false
-    t.boolean "languages_taught", default: false
     t.boolean "has_student_loan"
     t.integer "student_loan_country"
     t.integer "student_loan_courses"

--- a/spec/factories/student_loans/eligibilities.rb
+++ b/spec/factories/student_loans/eligibilities.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
       claim_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
       employment_status { :claim_school }
       current_school { claim_school }
+      physics_taught { true }
+      mostly_teaching_eligible_subjects { true }
     end
   end
 end

--- a/spec/factories/student_loans/eligibilities.rb
+++ b/spec/factories/student_loans/eligibilities.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :student_loans_eligibility, class: "StudentLoans::Eligibility" do
-    trait :submittable do
+    trait :eligible do
       qts_award_year { "2013_2014" }
       claim_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
       employment_status { :claim_school }

--- a/spec/factories/student_loans/eligibilities.rb
+++ b/spec/factories/student_loans/eligibilities.rb
@@ -10,5 +10,10 @@ FactoryBot.define do
       physics_taught { true }
       mostly_teaching_eligible_subjects { true }
     end
+
+    trait :ineligible do
+      eligible
+      mostly_teaching_eligible_subjects { false }
+    end
   end
 end

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -29,5 +29,10 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
       reference { Reference.new.to_s }
     end
+
+    trait :ineligible do
+      submittable
+      association(:eligibility, factory: [:student_loans_eligibility, :ineligible])
+    end
   end
 end

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
       bank_sort_code { 123456 }
       bank_account_number { 12345678 }
 
-      association(:eligibility, factory: [:student_loans_eligibility, :submittable])
+      association(:eligibility, factory: [:student_loans_eligibility, :eligible])
       payroll_gender { :female }
     end
 

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -3,8 +3,6 @@ FactoryBot.define do
     association(:eligibility, factory: :student_loans_eligibility)
 
     trait :submittable do
-      physics_taught { true }
-      mostly_teaching_eligible_subjects { true }
       full_name { "Jo Bloggs" }
       address_line_1 { "1 Test Road" }
       address_line_3 { "Test Town" }

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Changing the answers on a submittable claim" do
   let(:claim) { TslrClaim.order(:created_at).last }
+  let(:eligibility) { claim.eligibility }
 
   before do
     answer_all_student_loans_claim_questions
@@ -42,9 +43,9 @@ RSpec.feature "Changing the answers on a submittable claim" do
       end
 
       scenario "Eligible subjects are set correctly" do
-        expect(claim.reload.physics_taught).to eq(false)
-        expect(claim.reload.biology_taught).to eq(true)
-        expect(claim.reload.chemistry_taught).to eq(true)
+        expect(eligibility.reload.physics_taught).to eq(false)
+        expect(eligibility.biology_taught).to eq(true)
+        expect(eligibility.chemistry_taught).to eq(true)
       end
 
       scenario "Teacher is redirected to ask if they were mostly teaching eligible subjects" do
@@ -63,7 +64,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
         end
 
         scenario "Sets mostly teaching eligible subjects correctly" do
-          expect(claim.reload.mostly_teaching_eligible_subjects).to eq(true)
+          expect(eligibility.reload.mostly_teaching_eligible_subjects).to eq(true)
         end
 
         scenario "Teacher is redirected to the check your answers page" do
@@ -79,7 +80,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
         end
 
         scenario "Sets mostly teaching eligible subjects correctly" do
-          expect(claim.reload.mostly_teaching_eligible_subjects).to eq(false)
+          expect(eligibility.reload.mostly_teaching_eligible_subjects).to eq(false)
         end
 
         scenario "Teacher is told they are not eligible" do
@@ -180,7 +181,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
   end
 
   scenario "going from same school to different school" do
-    claim.eligibility.update!(employment_status: "claim_school")
+    eligibility.update!(employment_status: "claim_school")
 
     find("a[href='#{claim_path("still-teaching")}']").click
 

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
     click_on "Continue"
 
-    expect(claim.reload.mostly_teaching_eligible_subjects).to eq(false)
+    expect(claim.reload.mostly_teaching_eligible_subjects?).to eq(false)
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text(I18n.t("activerecord.errors.messages.not_taught_eligible_subjects_enough"))
   end
@@ -80,7 +80,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     choose "No"
     click_on "Continue"
 
-    expect(claim.reload.mostly_teaching_eligible_subjects).to eq(false)
+    expect(claim.reload.mostly_teaching_eligible_subjects?).to eq(false)
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text(I18n.t("activerecord.errors.messages.not_taught_eligible_subjects_enough"))
   end

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
 
       choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
 
-      expect(page).to have_checked_field("tslr_claim_mostly_teaching_eligible_subjects_false", visible: false)
+      expect(page).to have_checked_field("tslr_claim_eligibility_attributes_mostly_teaching_eligible_subjects_false", visible: false)
 
       expect(page).to_not have_checked_field("eligible_subjects_biology_taught", visible: false)
       expect(page).to_not have_checked_field("eligible_subjects_physics_taught", visible: false)
@@ -30,12 +30,12 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
     scenario "checks not applicable and then chooses a subject" do
       choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
 
-      expect(page).to have_checked_field("tslr_claim_mostly_teaching_eligible_subjects_false", visible: false)
+      expect(page).to have_checked_field("tslr_claim_eligibility_attributes_mostly_teaching_eligible_subjects_false", visible: false)
 
       check "eligible_subjects_biology_taught"
 
       expect(page).to have_checked_field("eligible_subjects_biology_taught", visible: false)
-      expect(page).to_not have_checked_field("tslr_claim_mostly_teaching_eligible_subjects_false", visible: false)
+      expect(page).to_not have_checked_field("tslr_claim_eligibility_attributes_mostly_teaching_eligible_subjects_false", visible: false)
 
       click_on "Continue"
 

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     choose "Yes"
     click_on "Continue"
 
-    expect(claim.reload.mostly_teaching_eligible_subjects).to eq(true)
+    expect(claim.reload.mostly_teaching_eligible_subjects?).to eq(true)
 
     expect(page).to have_text("You are eligible to claim back student loan repayments")
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -4,12 +4,17 @@ describe ClaimsHelper do
   describe "#claim_answers" do
     it "returns an array of questions and answers for displaying to the user for review" do
       school = schools(:penistone_grammar_school)
-      claim = build(
-        :tslr_claim,
-        eligibility: build(:student_loans_eligibility, claim_school: school, current_school: school),
+      eligibility = build(
+        :student_loans_eligibility,
+        claim_school: school,
+        current_school: school,
         chemistry_taught: true,
         physics_taught: true,
         mostly_teaching_eligible_subjects: true,
+      )
+      claim = build(
+        :tslr_claim,
+        eligibility: eligibility,
         student_loan_repayment_amount: 1987.65,
         eligibility_attributes: {qts_award_year: "2013_2014"},
       )

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -158,35 +158,35 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
 
   context "when saving in the “submit” context" do
     it "is valid when all attributes are present" do
-      expect(build(:student_loans_eligibility, :submittable)).to be_valid(:submit)
+      expect(build(:student_loans_eligibility, :eligible)).to be_valid(:submit)
     end
 
     it "is not valid without a value for qts_award_year" do
-      expect(build(:student_loans_eligibility, :submittable, qts_award_year: nil)).not_to be_valid(:submit)
+      expect(build(:student_loans_eligibility, :eligible, qts_award_year: nil)).not_to be_valid(:submit)
 
       StudentLoans::Eligibility.qts_award_years.each_key do |academic_year|
-        expect(build(:student_loans_eligibility, :submittable, qts_award_year: academic_year)).to be_valid(:submit)
+        expect(build(:student_loans_eligibility, :eligible, qts_award_year: academic_year)).to be_valid(:submit)
       end
     end
 
     it "is not valid without a value for claim_school" do
-      expect(build(:student_loans_eligibility, :submittable, claim_school: nil)).not_to be_valid(:submit)
+      expect(build(:student_loans_eligibility, :eligible, claim_school: nil)).not_to be_valid(:submit)
     end
 
     it "is not valid without a value for employment_status" do
-      expect(build(:student_loans_eligibility, :submittable, employment_status: nil)).not_to be_valid(:submit)
+      expect(build(:student_loans_eligibility, :eligible, employment_status: nil)).not_to be_valid(:submit)
     end
 
     it "is not valid without a value for current_school" do
-      expect(build(:student_loans_eligibility, :submittable, current_school: nil)).not_to be_valid(:submit)
+      expect(build(:student_loans_eligibility, :eligible, current_school: nil)).not_to be_valid(:submit)
     end
 
     it "is not valid without at least one subject being taught selected" do
-      expect(build(:student_loans_eligibility, :submittable, physics_taught: nil)).not_to be_valid(:submit)
+      expect(build(:student_loans_eligibility, :eligible, physics_taught: nil)).not_to be_valid(:submit)
     end
 
     it "is not valid without a value for mostly_teaching_eligible_subjects" do
-      expect(build(:student_loans_eligibility, :submittable, mostly_teaching_eligible_subjects: nil)).not_to be_valid(:submit)
+      expect(build(:student_loans_eligibility, :eligible, mostly_teaching_eligible_subjects: nil)).not_to be_valid(:submit)
     end
   end
 end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -266,79 +266,6 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
-  describe "#ineligible?" do
-    subject { build(:tslr_claim, claim_attributes).ineligible? }
-
-    context "with an ineligible QTS award year" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, qts_award_year: "before_2013")} }
-      it { is_expected.to be true }
-    end
-
-    context "with an eligible QTS award year" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, qts_award_year: "2013_2014")} }
-      it { is_expected.to be false }
-    end
-
-    context "with no claim_school" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, claim_school: nil)} }
-      it { is_expected.to be false }
-    end
-
-    context "with an eligible claim school" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, claim_school: schools(:penistone_grammar_school))} }
-      it { is_expected.to be false }
-    end
-
-    context "with an ineligible claim_school" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, claim_school: schools(:hampstead_school))} }
-      it { is_expected.to be true }
-    end
-
-    context "when no longer teaching" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, employment_status: :no_school)} }
-      it { is_expected.to be true }
-    end
-
-    context "when taught less than half time in eligible subjects" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, mostly_teaching_eligible_subjects: false)} }
-      it { is_expected.to be true }
-    end
-
-    context "when taught at least half time in eligible subjects" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, mostly_teaching_eligible_subjects: true)} }
-      it { is_expected.to be false }
-    end
-  end
-
-  describe "#ineligibility_reason" do
-    subject { build(:tslr_claim, claim_attributes).ineligibility_reason }
-
-    context "with an ineligible qts_award_year" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, qts_award_year: "before_2013")} }
-      it { is_expected.to eql :ineligible_qts_award_year }
-    end
-
-    context "with an ineligible claim_school" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, claim_school: schools(:hampstead_school))} }
-      it { is_expected.to eql :ineligible_claim_school }
-    end
-
-    context "when no longer teaching" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, employment_status: :no_school)} }
-      it { is_expected.to eql :employed_at_no_school }
-    end
-
-    context "when taught less than half time in eligible subjects" do
-      let(:claim_attributes) { {eligibility: build(:student_loans_eligibility, mostly_teaching_eligible_subjects: false)} }
-      it { is_expected.to eql :not_taught_eligible_subjects_enough }
-    end
-
-    context "when not ineligible" do
-      let(:claim_attributes) { {} }
-      it { is_expected.to be_nil }
-    end
-  end
-
   describe "#student_loan_country" do
     it "captures the country the student loan was received in" do
       claim = build(:tslr_claim, student_loan_country: :england)
@@ -412,8 +339,7 @@ RSpec.describe TslrClaim, type: :model do
     end
 
     context "when the claim is ineligible" do
-      let(:ineligible_eligibility) { build(:student_loans_eligibility, :eligible, mostly_teaching_eligible_subjects: false) }
-      let(:tslr_claim) { create(:tslr_claim, :submittable, eligibility: ineligible_eligibility) }
+      let(:tslr_claim) { create(:tslr_claim, :ineligible) }
 
       before { tslr_claim.submit! }
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe TslrClaim, type: :model do
     end
 
     context "when the claim is ineligible" do
-      let(:ineligible_eligibility) { build(:student_loans_eligibility, :submittable, mostly_teaching_eligible_subjects: false) }
+      let(:ineligible_eligibility) { build(:student_loans_eligibility, :eligible, mostly_teaching_eligible_subjects: false) }
       let(:tslr_claim) { create(:tslr_claim, :submittable, eligibility: ineligible_eligibility) }
 
       before { tslr_claim.submit! }

--- a/spec/presenters/tslr_claim_csv_row_spec.rb
+++ b/spec/presenters/tslr_claim_csv_row_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe TslrClaimCsvRow do
 
   describe "to_s" do
     let(:date_of_birth) { "01/12/1980" }
-    let(:mostly_teaching_eligible_subjects) { "Yes" }
     let(:student_loan_repayment_amount) { "£1000.0" }
     let(:submitted_at) { "01/01/2019 13:00" }
     let(:row) { CSV.parse(subject.to_s).first }
@@ -14,10 +13,10 @@ RSpec.describe TslrClaimCsvRow do
     let(:claim) do
       build(:tslr_claim, :submittable,
         date_of_birth: Date.parse(date_of_birth),
-        mostly_teaching_eligible_subjects: mostly_teaching_eligible_subjects == "Yes",
         student_loan_repayment_amount: student_loan_repayment_amount.delete("£").to_i,
         student_loan_plan: StudentLoans::PLAN_2,
-        submitted_at: DateTime.parse(submitted_at))
+        submitted_at: DateTime.parse(submitted_at),
+        eligibility: build(:student_loans_eligibility, :eligible, mostly_teaching_eligible_subjects: true))
     end
 
     it "generates a csv row" do
@@ -40,7 +39,7 @@ RSpec.describe TslrClaimCsvRow do
         claim.national_insurance_number,
         StudentLoans::PLAN_2.humanize,
         "=\"#{claim.email_address}\"",
-        mostly_teaching_eligible_subjects,
+        "Yes",
         claim.bank_sort_code,
         claim.bank_account_number,
         student_loan_repayment_amount,

--- a/spec/presenters/tslr_claims_csv_spec.rb
+++ b/spec/presenters/tslr_claims_csv_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe TslrClaimsCsv do
         claim.national_insurance_number,
         claim.student_loan_plan.humanize,
         "=\"#{claim.email_address}\"",
-        claim.mostly_teaching_eligible_subjects ? "Yes" : "No",
+        claim.mostly_teaching_eligible_subjects? ? "Yes" : "No",
         claim.bank_sort_code,
         claim.bank_account_number,
         "£#{claim.student_loan_repayment_amount}",

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Claims", type: :request do
 
         claim = TslrClaim.order(:created_at).last
         claim.update_attributes(attributes_for(:tslr_claim, :submittable))
-        claim.eligibility.update_attributes(attributes_for(:student_loans_eligibility, :submittable))
+        claim.eligibility.update_attributes(attributes_for(:student_loans_eligibility, :eligible))
 
         claim.submit!
 
@@ -185,7 +185,7 @@ RSpec.describe "Claims", type: :request do
           before :each do
             # Make the claim submittable
             in_progress_claim.update!(attributes_for(:tslr_claim, :submittable))
-            in_progress_claim.eligibility.update!(attributes_for(:student_loans_eligibility, :submittable))
+            in_progress_claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible))
 
             perform_enqueued_jobs do
               put claim_path("check-your-answers")


### PR DESCRIPTION
This moves the attributes related to subjects and teaching time to the Eligibility model. These were the last attributes that determine eligibility, which means we can also now stop delegating the eligibility-related methods. There are still accessor methods being delegated that we'll want to remove, but that can be done as a separate step later.

Part of https://trello.com/c/9gpS69mI/536-separate-eligibility-data-modelling-from-claims-in-prep-for-mp