### PR TITLE
Add production VSP configuration parameters

### DIFF
--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -158,10 +158,20 @@
       "value": "PRODUCTION"
     },
     "VSP.SAML_SIGNING_KEY": {
-      "value": ""
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsProdVspSamlSigning1KeyBase64"
+      }
     },
     "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
-      "value": ""
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsProdVspSamlEncryption1KeyBase64"
+      }
     }
   }
 }


### PR DESCRIPTION
So that we can get the production VSP up-and-running we need to configure several parameters used in the ARM templates.

We don't want to enable the feature flag just yet until we have a production VSP running and we can access the Verify production environment.