### PR TITLE
Don't validate address line 3 presence

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -57,10 +57,7 @@ class TslrClaim < ApplicationRecord
 
   validates :address_line_1,                    on: [:address, :submit], presence: {message: "Enter your building and street address"}
   validates :address_line_1,                    length: {maximum: 100, message: "Address lines must be 100 characters or less"}
-
   validates :address_line_2,                    length: {maximum: 100, message: "Address lines must be 100 characters or less"}
-
-  validates :address_line_3,                    on: [:address, :submit], presence: {message: "Enter your town or city"}
   validates :address_line_3,                    length: {maximum: 100, message: "Address lines must be 100 characters or less"}
 
   validates :postcode,                          on: [:address, :submit], presence: {message: "Enter your postcode"}

--- a/spec/factories/tslr_claims.rb
+++ b/spec/factories/tslr_claims.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
       mostly_teaching_eligible_subjects { true }
       full_name { "Jo Bloggs" }
       address_line_1 { "1 Test Road" }
-      address_line_3 { "Test Town" }
       postcode { "AB1 2CD" }
       date_of_birth { 20.years.ago.to_date }
       teacher_reference_number { "1234567" }

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -156,10 +156,10 @@ RSpec.describe TslrClaim, type: :model do
   end
 
   context "when saving in the “address” validation context" do
-    it "validates the presence of address_line_1, address_line_3 (i.e. the town or city), and postcode" do
+    it "validates the presence of address_line_1 and postcode" do
       expect(build(:tslr_claim)).not_to be_valid(:address)
 
-      valid_address_attributes = {address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "12345"}
+      valid_address_attributes = {address_line_1: "123 Main Street", postcode: "12345"}
       expect(build(:tslr_claim, valid_address_attributes)).to be_valid(:address)
     end
   end


### PR DESCRIPTION
We can't expect Verify to always return three lines of address.