### PR TITLE
Set up redundancy and resource levels on infrastructure

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -17,6 +17,9 @@
     "appServicePlanInstances": {
       "value": 1
     },
+    "vspAppServicePlanInstances": {
+      "value": 1
+    },
     "vspAppServiceDockerImage": {
       "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
     },

--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -14,6 +14,9 @@
     "appServiceAlwaysOn": {
       "value": false
     },
+    "appServicePlanInstances": {
+      "value": 1
+    },
     "vspAppServiceDockerImage": {
       "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
     },

--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -23,6 +23,9 @@
     "vspAppServicePlanInstances": {
       "value": 1
     },
+    "vspAppServicePlanSize": {
+      "value": "1"
+    },
     "vspAppServiceDockerImage": {
       "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
     },

--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -17,6 +17,9 @@
     "appServicePlanInstances": {
       "value": 1
     },
+    "appServicePlanSize": {
+      "value": "1"
+    },
     "vspAppServicePlanInstances": {
       "value": 1
     },

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -14,6 +14,9 @@
     "appServicePlanSize": {
       "value": "3"
     },
+    "vspAppServicePlanSize": {
+      "value": "3"
+    },
     "vspAppServiceDockerImage": {
       "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
     },

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -11,6 +11,9 @@
     "appServiceCertificateSecretName": {
       "value": "sslCertificate-additional-teaching-payment-education-gov-uk"
     },
+    "appServicePlanSize": {
+      "value": "3"
+    },
     "vspAppServiceDockerImage": {
       "value": "dfedigital/teacher-payments-service-verify:${vspDockerImageTag}"
     },

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -44,12 +44,20 @@
       "type": "string",
       "defaultValue": "1"
     },
+    "vspAppServiceDockerImage": {
+      "type": "string"
+    },
+    "vspAppServicePlanTier": {
+      "type": "string",
+      "defaultValue": "Standard"
+    },
+    "vspAppServicePlanSize": {
+      "type": "string",
+      "defaultValue": "2"
+    },
     "vspAppServicePlanInstances": {
       "type": "int",
       "defaultValue": 2
-    },
-    "vspAppServiceDockerImage": {
-      "type": "string"
     },
     "verifyHubPossibleOutboundIpAddresses": {
       "type": "array"
@@ -484,6 +492,12 @@
           },
           "appServicePlanInstances": {
             "value": "[parameters('vspAppServicePlanInstances')]"
+          },
+          "appServicePlanTier": {
+            "value": "[parameters('vspAppServicePlanTier')]"
+          },
+          "appServicePlanSize": {
+            "value": "[parameters('vspAppServicePlanSize')]"
           },
           "appServiceAllowedIpAddresses": {
             "value": "[union(split(reference(resourceId('Microsoft.Web/sites', variables('appServiceName'))).possibleOutboundIpAddresses, ','), parameters('verifyHubPossibleOutboundIpAddresses'))]"

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -32,6 +32,10 @@
       "type": "bool",
       "defaultValue": true
     },
+    "appServicePlanInstances": {
+      "type": "int",
+      "defaultValue": 2
+    },
     "vspAppServiceDockerImage": {
       "type": "string"
     },
@@ -243,6 +247,9 @@
         "parameters": {
           "appServicePlanName": {
             "value": "[variables('appServicePlanName')]"
+          },
+          "appServicePlanInstances": {
+            "value": "[parameters('appServicePlanInstances')]"
           }
         }
       }

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -36,6 +36,10 @@
       "type": "int",
       "defaultValue": 2
     },
+    "vspAppServicePlanInstances": {
+      "type": "int",
+      "defaultValue": 2
+    },
     "vspAppServiceDockerImage": {
       "type": "string"
     },
@@ -463,6 +467,9 @@
           },
           "appServiceAlwaysOn": {
             "value": "[parameters('appServiceAlwaysOn')]"
+          },
+          "appServicePlanInstances": {
+            "value": "[parameters('vspAppServicePlanInstances')]"
           },
           "appServiceAllowedIpAddresses": {
             "value": "[union(split(reference(resourceId('Microsoft.Web/sites', variables('appServiceName'))).possibleOutboundIpAddresses, ','), parameters('verifyHubPossibleOutboundIpAddresses'))]"

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -36,6 +36,14 @@
       "type": "int",
       "defaultValue": 2
     },
+    "appServicePlanTier": {
+      "type": "string",
+      "defaultValue": "Standard"
+    },
+    "appServicePlanSize": {
+      "type": "string",
+      "defaultValue": "1"
+    },
     "vspAppServicePlanInstances": {
       "type": "int",
       "defaultValue": 2
@@ -254,6 +262,12 @@
           },
           "appServicePlanInstances": {
             "value": "[parameters('appServicePlanInstances')]"
+          },
+          "appServicePlanTier": {
+            "value": "[parameters('appServicePlanTier')]"
+          },
+          "appServicePlanSize": {
+            "value": "[parameters('appServicePlanSize')]"
           }
         }
       }

--- a/azure/templates/vsp.json
+++ b/azure/templates/vsp.json
@@ -14,6 +14,9 @@
     "appServiceAlwaysOn": {
       "type": "bool"
     },
+    "appServicePlanInstances": {
+      "type": "int"
+    },
     "appServiceAllowedIpAddresses": {
       "type": "array"
     },
@@ -49,6 +52,9 @@
         "parameters": {
           "appServicePlanName": {
             "value": "[parameters('appServicePlanName')]"
+          },
+          "appServicePlanInstances": {
+            "value": "[parameters('appServicePlanInstances')]"
           }
         }
       }

--- a/azure/templates/vsp.json
+++ b/azure/templates/vsp.json
@@ -17,6 +17,12 @@
     "appServicePlanInstances": {
       "type": "int"
     },
+    "appServicePlanTier": {
+      "type": "string"
+    },
+    "appServicePlanSize": {
+      "type": "string"
+    },
     "appServiceAllowedIpAddresses": {
       "type": "array"
     },
@@ -55,6 +61,12 @@
           },
           "appServicePlanInstances": {
             "value": "[parameters('appServicePlanInstances')]"
+          },
+          "appServicePlanTier": {
+            "value": "[parameters('appServicePlanTier')]"
+          },
+          "appServicePlanSize": {
+            "value": "[parameters('appServicePlanSize')]"
           }
         }
       }


### PR DESCRIPTION
This allows us to explicitly set the number of instances we're running in a service plan. There is the option to do autoscaling, but this gives us redundancy if one instance was to fall over.