### PR TITLE
Remove hint on ITT/QTS year

### DIFF
--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -8,9 +8,6 @@
           <h1 class="govuk-label-wrapper">
             <%= fields.label :qts_award_year, t("tslr.questions.qts_award_year"), {class: "govuk-label govuk-label--xl"} %>
           </h1>
-          <span id="claim_qts_award_year-hint" class="govuk-hint">
-            You are only eligible to claim back student loan repayments if you qualified on or after September 1st 2013.
-          </span>
 
           <%= errors_tag current_claim, :qts_award_year %>
           <div class="govuk-radios">


### PR DESCRIPTION
Originally this was a select with only eligible options so we needed
the hint to explain why their options were limited. Now that it has been
amended to radios and a path to fail has been added this hint text has
become very leading and it is no longer required.