### PR TITLE
Simplify student loan plan gate question

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,7 +58,7 @@ en:
       address: "What is your address?"
       teacher_reference_number: "What's your teacher reference number?"
       national_insurance_number: "What's your National Insurance number?"
-      has_student_loan: "Have you ever taken out a student loan and not paid it off yet?"
+      has_student_loan: "Are you still paying off your student loan?"
       student_loan_country: "When you applied for your student loan where was your home address?"
       student_loan_how_many_courses: "How many higher education courses have you studied?"
       student_loan_start_date:


### PR DESCRIPTION
We ask this question to determine whether we need to know the student
loan repayment plan the claimant is on so we can cover the recoveries
due for their claim. It makes no sense to ask them if they have ever
taken out a student loan at this stage, as if they hadn't they
wouldn't be eligible to actually claim back student loan repayments!

Separate work might follow to add an additional "Have you ever taken
out a student?" question earlier in the journey to tell those that might
be claiming even though they've never had one that they aren't eligible.