### PR TITLE
Re organise locales

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -15,7 +15,7 @@ module ClaimsHelper
     [
       [t("student_loans.questions.qts_award_year"), academic_years(claim.qts_award_year), "qts-year"],
       [t("student_loans.questions.claim_school"), claim.claim_school_name, "claim-school"],
-      [t("student_loans.questions.current_school"), claim.current_school_name, "still-teaching"],
+      [t("questions.current_school"), claim.current_school_name, "still-teaching"],
       [t("student_loans.questions.subjects_taught"), subject_list(claim.subjects_taught), "subjects-taught"],
       [t("student_loans.questions.mostly_teaching_eligible_subjects", subjects: subject_list(claim.subjects_taught)), (claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"), "mostly-teaching-eligible-subjects"],
       [t("student_loans.questions.student_loan_amount", claim_school_name: claim.claim_school_name), number_to_currency(claim.student_loan_repayment_amount), "student-loan-amount"],
@@ -24,19 +24,19 @@ module ClaimsHelper
 
   def identity_answers(claim)
     [].tap do |a|
-      a << [t("student_loans.questions.address"), claim.address, "address"] unless claim.address_verified?
-      a << [t("student_loans.questions.payroll_gender"), t("student_loans.answers.payroll_gender.#{claim.payroll_gender}"), "gender"] unless claim.payroll_gender_verified?
-      a << [t("student_loans.questions.teacher_reference_number"), claim.teacher_reference_number, "teacher-reference-number"]
-      a << [t("student_loans.questions.national_insurance_number"), claim.national_insurance_number, "national-insurance-number"]
-      a << [t("student_loans.questions.email_address"), claim.email_address, "email-address"]
+      a << [t("questions.address"), claim.address, "address"] unless claim.address_verified?
+      a << [t("questions.payroll_gender"), t("answers.payroll_gender.#{claim.payroll_gender}"), "gender"] unless claim.payroll_gender_verified?
+      a << [t("questions.teacher_reference_number"), claim.teacher_reference_number, "teacher-reference-number"]
+      a << [t("questions.national_insurance_number"), claim.national_insurance_number, "national-insurance-number"]
+      a << [t("questions.email_address"), claim.email_address, "email-address"]
     end
   end
 
   def student_loan_answers(claim)
-    [[t("student_loans.questions.has_student_loan"), (claim.has_student_loan ? "Yes" : "No"), "student-loan"]].tap do |answers|
+    [[t("questions.has_student_loan"), (claim.has_student_loan ? "Yes" : "No"), "student-loan"]].tap do |answers|
       answers << [t("student_loans.questions.student_loan_country"), claim.student_loan_country.humanize, "student-loan-country"] if claim.student_loan_country.present?
-      answers << [t("student_loans.questions.student_loan_how_many_courses"), claim.student_loan_courses.humanize, "student-loan-how-many-courses"] if claim.student_loan_courses.present?
-      answers << [t("student_loans.questions.student_loan_start_date.#{claim.student_loan_courses}"), t("student_loans.answers.student_loan_start_date.#{claim.student_loan_courses}.#{claim.student_loan_start_date}"), "student-loan-start-date"] if claim.student_loan_courses.present?
+      answers << [t("questions.student_loan_how_many_courses"), claim.student_loan_courses.humanize, "student-loan-how-many-courses"] if claim.student_loan_courses.present?
+      answers << [t("questions.student_loan_start_date.#{claim.student_loan_courses}"), t("answers.student_loan_start_date.#{claim.student_loan_courses}.#{claim.student_loan_start_date}"), "student-loan-start-date"] if claim.student_loan_courses.present?
     end
   end
 

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -13,30 +13,30 @@ module ClaimsHelper
 
   def claim_answers(claim)
     [
-      [t("tslr.questions.qts_award_year"), academic_years(claim.qts_award_year), "qts-year"],
-      [t("tslr.questions.claim_school"), claim.claim_school_name, "claim-school"],
-      [t("tslr.questions.current_school"), claim.current_school_name, "still-teaching"],
-      [t("tslr.questions.subjects_taught"), subject_list(claim.subjects_taught), "subjects-taught"],
-      [t("tslr.questions.mostly_teaching_eligible_subjects", subjects: subject_list(claim.subjects_taught)), (claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"), "mostly-teaching-eligible-subjects"],
-      [t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), number_to_currency(claim.student_loan_repayment_amount), "student-loan-amount"],
+      [t("student_loans.questions.qts_award_year"), academic_years(claim.qts_award_year), "qts-year"],
+      [t("student_loans.questions.claim_school"), claim.claim_school_name, "claim-school"],
+      [t("student_loans.questions.current_school"), claim.current_school_name, "still-teaching"],
+      [t("student_loans.questions.subjects_taught"), subject_list(claim.subjects_taught), "subjects-taught"],
+      [t("student_loans.questions.mostly_teaching_eligible_subjects", subjects: subject_list(claim.subjects_taught)), (claim.mostly_teaching_eligible_subjects? ? "Yes" : "No"), "mostly-teaching-eligible-subjects"],
+      [t("student_loans.questions.student_loan_amount", claim_school_name: claim.claim_school_name), number_to_currency(claim.student_loan_repayment_amount), "student-loan-amount"],
     ]
   end
 
   def identity_answers(claim)
     [].tap do |a|
-      a << [t("tslr.questions.address"), claim.address, "address"] unless claim.address_verified?
-      a << [t("tslr.questions.payroll_gender"), t("tslr.answers.payroll_gender.#{claim.payroll_gender}"), "gender"] unless claim.payroll_gender_verified?
-      a << [t("tslr.questions.teacher_reference_number"), claim.teacher_reference_number, "teacher-reference-number"]
-      a << [t("tslr.questions.national_insurance_number"), claim.national_insurance_number, "national-insurance-number"]
-      a << [t("tslr.questions.email_address"), claim.email_address, "email-address"]
+      a << [t("student_loans.questions.address"), claim.address, "address"] unless claim.address_verified?
+      a << [t("student_loans.questions.payroll_gender"), t("student_loans.answers.payroll_gender.#{claim.payroll_gender}"), "gender"] unless claim.payroll_gender_verified?
+      a << [t("student_loans.questions.teacher_reference_number"), claim.teacher_reference_number, "teacher-reference-number"]
+      a << [t("student_loans.questions.national_insurance_number"), claim.national_insurance_number, "national-insurance-number"]
+      a << [t("student_loans.questions.email_address"), claim.email_address, "email-address"]
     end
   end
 
   def student_loan_answers(claim)
-    [[t("tslr.questions.has_student_loan"), (claim.has_student_loan ? "Yes" : "No"), "student-loan"]].tap do |answers|
-      answers << [t("tslr.questions.student_loan_country"), claim.student_loan_country.humanize, "student-loan-country"] if claim.student_loan_country.present?
-      answers << [t("tslr.questions.student_loan_how_many_courses"), claim.student_loan_courses.humanize, "student-loan-how-many-courses"] if claim.student_loan_courses.present?
-      answers << [t("tslr.questions.student_loan_start_date.#{claim.student_loan_courses}"), t("tslr.answers.student_loan_start_date.#{claim.student_loan_courses}.#{claim.student_loan_start_date}"), "student-loan-start-date"] if claim.student_loan_courses.present?
+    [[t("student_loans.questions.has_student_loan"), (claim.has_student_loan ? "Yes" : "No"), "student-loan"]].tap do |answers|
+      answers << [t("student_loans.questions.student_loan_country"), claim.student_loan_country.humanize, "student-loan-country"] if claim.student_loan_country.present?
+      answers << [t("student_loans.questions.student_loan_how_many_courses"), claim.student_loan_courses.humanize, "student-loan-how-many-courses"] if claim.student_loan_courses.present?
+      answers << [t("student_loans.questions.student_loan_start_date.#{claim.student_loan_courses}"), t("student_loans.answers.student_loan_start_date.#{claim.student_loan_courses}.#{claim.student_loan_start_date}"), "student-loan-start-date"] if claim.student_loan_courses.present?
     end
   end
 
@@ -49,7 +49,7 @@ module ClaimsHelper
 
   def subject_list(subjects)
     connector = " and "
-    translated_subjects = subjects.map { |subject| I18n.t("tslr.questions.eligible_subjects.#{subject}") }
+    translated_subjects = subjects.map { |subject| I18n.t("student_loans.questions.eligible_subjects.#{subject}") }
     translated_subjects.sort.to_sentence(
       last_word_connector: connector,
       two_words_connector: connector

--- a/app/presenters/tslr_claims_csv.rb
+++ b/app/presenters/tslr_claims_csv.rb
@@ -53,6 +53,6 @@ class TslrClaimsCsv
   end
 
   def header_string_for_field(header)
-    I18n.t("tslr.csv_headers.#{header}")
+    I18n.t("student_loans.csv_headers.#{header}")
   end
 end

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -6,7 +6,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading">
-            <%= t("student_loans.questions.address") %>
+            <%= t("questions.address") %>
           </h1>
         </legend>
 

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -6,7 +6,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading">
-            <%= t("tslr.questions.address") %>
+            <%= t("student_loans.questions.address") %>
           </h1>
         </legend>
 

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -7,7 +7,7 @@
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">
-              <%= t("student_loans.questions.bank_details") %>
+              <%= t("questions.bank_details") %>
             </h1>
           </legend>
 

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -7,7 +7,7 @@
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">
-              <%= t("tslr.questions.bank_details") %>
+              <%= t("student_loans.questions.bank_details") %>
             </h1>
           </legend>
 

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: "school_search", locals: {question: t("tslr.questions.claim_school"), school_id_param: :claim_school_id, school_search_value: current_claim.claim_school_name} %>
+    <%= render partial: "school_search", locals: {question: t("student_loans.questions.claim_school"), school_id_param: :claim_school_id, school_search_value: current_claim.claim_school_name} %>
   </div>
 </div>

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: "school_search", locals: {question: t("tslr.questions.current_school"), school_id_param: :current_school_id, school_search_value: current_claim.current_school_name} %>
+    <%= render partial: "school_search", locals: {question: t("student_loans.questions.current_school"), school_id_param: :current_school_id, school_search_value: current_claim.current_school_name} %>
   </div>
 </div>

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: "school_search", locals: {question: t("student_loans.questions.current_school"), school_id_param: :current_school_id, school_search_value: current_claim.current_school_name} %>
+    <%= render partial: "school_search", locals: {question: t("questions.current_school"), school_id_param: :current_school_id, school_search_value: current_claim.current_school_name} %>
   </div>
 </div>

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -5,7 +5,7 @@
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">
-          <%= form.label :email_address, t("tslr.questions.email_address"), class: "govuk-label govuk-label--xl"  %>
+          <%= form.label :email_address, t("student_loans.questions.email_address"), class: "govuk-label govuk-label--xl"  %>
         </h1>
 
         <span class="govuk-hint">We will only use your email address to update you about your claim. We recommend you use a personal email address.</span>

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -5,7 +5,7 @@
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">
-          <%= form.label :email_address, t("student_loans.questions.email_address"), class: "govuk-label govuk-label--xl"  %>
+          <%= form.label :email_address, t("questions.email_address"), class: "govuk-label govuk-label--xl"  %>
         </h1>
 
         <span class="govuk-hint">We will only use your email address to update you about your claim. We recommend you use a personal email address.</span>

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -4,7 +4,7 @@
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">
-          <%= form.label :payroll_gender, t("tslr.questions.payroll_gender"), {class: "govuk-label govuk-label--xl"} %>
+          <%= form.label :payroll_gender, t("student_loans.questions.payroll_gender"), {class: "govuk-label govuk-label--xl"} %>
         </h1>
 
         <span class="govuk-hint">

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -4,7 +4,7 @@
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">
-          <%= form.label :payroll_gender, t("student_loans.questions.payroll_gender"), {class: "govuk-label govuk-label--xl"} %>
+          <%= form.label :payroll_gender, t("questions.payroll_gender"), {class: "govuk-label govuk-label--xl"} %>
         </h1>
 
         <span class="govuk-hint">

--- a/app/views/claims/mostly_teaching_eligible_subjects.html.erb
+++ b/app/views/claims/mostly_teaching_eligible_subjects.html.erb
@@ -9,7 +9,7 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("tslr.questions.mostly_teaching_eligible_subjects", subjects: subject_list(current_claim.subjects_taught)) %>
+                <%= t("student_loans.questions.mostly_teaching_eligible_subjects", subjects: subject_list(current_claim.subjects_taught)) %>
               </h1>
             </legend>
             <p class="govuk-body">

--- a/app/views/claims/national_insurance_number.html.erb
+++ b/app/views/claims/national_insurance_number.html.erb
@@ -5,7 +5,7 @@
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">
-          <%= form.label :national_insurance_number, t("student_loans.questions.national_insurance_number"), {class: "govuk-label govuk-label--xl"}  %>
+          <%= form.label :national_insurance_number, t("questions.national_insurance_number"), {class: "govuk-label govuk-label--xl"}  %>
         </h1>
 
         <span class="govuk-hint">It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.</span>

--- a/app/views/claims/national_insurance_number.html.erb
+++ b/app/views/claims/national_insurance_number.html.erb
@@ -5,7 +5,7 @@
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">
-          <%= form.label :national_insurance_number, t("tslr.questions.national_insurance_number"), {class: "govuk-label govuk-label--xl"}  %>
+          <%= form.label :national_insurance_number, t("student_loans.questions.national_insurance_number"), {class: "govuk-label govuk-label--xl"}  %>
         </h1>
 
         <span class="govuk-hint">It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.</span>

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -6,7 +6,7 @@
       <%= form_group_tag current_claim do %>
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
           <h1 class="govuk-label-wrapper">
-            <%= fields.label :qts_award_year, t("tslr.questions.qts_award_year"), {class: "govuk-label govuk-label--xl"} %>
+            <%= fields.label :qts_award_year, t("student_loans.questions.qts_award_year"), {class: "govuk-label govuk-label--xl"} %>
           </h1>
 
           <%= errors_tag current_claim, :qts_award_year %>
@@ -15,7 +15,7 @@
             <% StudentLoans::Eligibility.qts_award_years.each_key do |option| %>
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:qts_award_year, option, class: "govuk-radios__input") %>
-                <%= fields.label "qts_award_year_#{option}", t("tslr.questions.qts_award_years.#{option}"), class: "govuk-label govuk-radios__label" %>
+                <%= fields.label "qts_award_year_#{option}", t("student_loans.questions.qts_award_years.#{option}"), class: "govuk-label govuk-radios__label" %>
               </div>
             <% end %>
           </div>

--- a/app/views/claims/still_teaching.html.erb
+++ b/app/views/claims/still_teaching.html.erb
@@ -7,7 +7,7 @@
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-              <h1 class="govuk-fieldset__heading"><%= t("tslr.questions.employment_status") %></h1>
+              <h1 class="govuk-fieldset__heading"><%= t("student_loans.questions.employment_status") %></h1>
             </legend>
             <%= errors_tag current_claim, :employment_status %>
             <div class="govuk-radios">

--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -8,7 +8,7 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("tslr.questions.has_student_loan") %>
+                <%= t("student_loans.questions.has_student_loan") %>
               </h1>
             </legend>
             <span class="govuk-hint">

--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -8,7 +8,7 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("student_loans.questions.has_student_loan") %>
+                <%= t("questions.has_student_loan") %>
               </h1>
             </legend>
             <span class="govuk-hint">

--- a/app/views/claims/student_loan_amount.html.erb
+++ b/app/views/claims/student_loan_amount.html.erb
@@ -7,7 +7,7 @@
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
 
           <h1 class="govuk-form-wrapper">
-            <%= fields.label :student_loan_repayment_amount, t("tslr.questions.student_loan_amount", claim_school_name: current_claim.claim_school_name), class: "govuk-label govuk-label--xl" %>
+            <%= fields.label :student_loan_repayment_amount, t("student_loans.questions.student_loan_amount", claim_school_name: current_claim.claim_school_name), class: "govuk-label govuk-label--xl" %>
           </h1>
 
           <span class="govuk-hint">If you do not know the amount, check your annual student loan statement, your P60 or contact the <a href="https://www.slc.co.uk/students-and-customers/contact-information-for-customers/loan-repayment-enquiries.aspx" class="govuk-link">student loans company</a>.</span>

--- a/app/views/claims/student_loan_country.html.erb
+++ b/app/views/claims/student_loan_country.html.erb
@@ -8,7 +8,7 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("tslr.questions.student_loan_country") %>
+                <%= t("student_loans.questions.student_loan_country") %>
               </h1>
             </legend>
 

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -8,7 +8,7 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("tslr.questions.student_loan_how_many_courses") %>
+                <%= t("student_loans.questions.student_loan_how_many_courses") %>
               </h1>
             </legend>
             <span class="govuk-hint">This includes university degrees, PGCE and Initial Teacher Training courses.</span>

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -8,7 +8,7 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("student_loans.questions.student_loan_how_many_courses") %>
+                <%= t("questions.student_loan_how_many_courses") %>
               </h1>
             </legend>
             <span class="govuk-hint">This includes university degrees, PGCE and Initial Teacher Training courses.</span>

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -8,7 +8,7 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("tslr.questions.student_loan_start_date.#{current_claim.student_loan_courses}") %>
+                <%= t("student_loans.questions.student_loan_start_date.#{current_claim.student_loan_courses}") %>
               </h1>
             </legend>
 
@@ -18,26 +18,26 @@
               <div class="govuk-radios">
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_before_first_september_2012, t("tslr.answers.student_loan_start_date.one_course.before_first_september_2012"), class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_before_first_september_2012, t("student_loans.answers.student_loan_start_date.one_course.before_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, t("tslr.answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, t("student_loans.answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
               </div>
             <% else %>
               <div class="govuk-radios">
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_before_first_september_2012, t("tslr.answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_before_first_september_2012, t("student_loans.answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_AND_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_some_before_some_after_first_september_2012, t("tslr.answers.student_loan_start_date.two_or_more_courses.some_before_some_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_some_before_some_after_first_september_2012, t("student_loans.answers.student_loan_start_date.two_or_more_courses.some_before_some_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, t("tslr.answers.student_loan_start_date.two_or_more_courses.on_or_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, t("student_loans.answers.student_loan_start_date.two_or_more_courses.on_or_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
               </div>
             <% end %>

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -8,7 +8,7 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("student_loans.questions.student_loan_start_date.#{current_claim.student_loan_courses}") %>
+                <%= t("questions.student_loan_start_date.#{current_claim.student_loan_courses}") %>
               </h1>
             </legend>
 
@@ -18,26 +18,26 @@
               <div class="govuk-radios">
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_before_first_september_2012, t("student_loans.answers.student_loan_start_date.one_course.before_first_september_2012"), class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_before_first_september_2012, t("answers.student_loan_start_date.one_course.before_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, t("student_loans.answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, t("answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
               </div>
             <% else %>
               <div class="govuk-radios">
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_before_first_september_2012, t("student_loans.answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_before_first_september_2012, t("answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::BEFORE_AND_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_some_before_some_after_first_september_2012, t("student_loans.answers.student_loan_start_date.two_or_more_courses.some_before_some_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_some_before_some_after_first_september_2012, t("answers.student_loan_start_date.two_or_more_courses.some_before_some_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
                 <div class="govuk-radios__item">
                   <%= form.radio_button(:student_loan_start_date, StudentLoans::ON_OR_AFTER_1_SEPT_2012, class: "govuk-radios__input")%>
-                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, t("student_loans.answers.student_loan_start_date.two_or_more_courses.on_or_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
+                  <%= form.label :student_loan_start_date_on_or_after_first_september_2012, t("answers.student_loan_start_date.two_or_more_courses.on_or_after_first_september_2012"), class: "govuk-label govuk-radios__label" %>
                 </div>
               </div>
             <% end %>

--- a/app/views/claims/subjects_taught.html.erb
+++ b/app/views/claims/subjects_taught.html.erb
@@ -8,7 +8,7 @@
           <fieldset class="govuk-fieldset" id="claim_subjects_taught">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("tslr.questions.subjects_taught") %>
+                <%= t("student_loans.questions.subjects_taught") %>
               </h1>
             </legend>
             <div class="govuk-checkboxes">
@@ -16,14 +16,14 @@
                 <div class="govuk-checkboxes__item">
                   <%= fields.hidden_field subject, value: false %>
                   <%= fields.check_box subject, class: "govuk-checkboxes__input subject", id: "eligible_subjects_#{subject}"  %>
-                  <%= fields.label subject, t("tslr.questions.eligible_subjects.#{subject}"), class: "govuk-label govuk-checkboxes__label", for: "eligible_subjects_#{subject}"  %>
+                  <%= fields.label subject, t("student_loans.questions.eligible_subjects.#{subject}"), class: "govuk-label govuk-checkboxes__label", for: "eligible_subjects_#{subject}"  %>
                 </div>
               <% end %>
               <div class="govuk-radios__divider">or</div>
               <div class="govuk-radios__item">
                 <%= fields.hidden_field :mostly_teaching_eligible_subjects, value: '' %>
                 <%= fields.radio_button(:mostly_teaching_eligible_subjects, false, class: "govuk-radios__input")  %>
-                <%= fields.label :mostly_teaching_eligible_subjects_false, t('tslr.questions.eligible_subjects.not_applicable'), class: "govuk-label govuk-radios__label" %>
+                <%= fields.label :mostly_teaching_eligible_subjects_false, t('student_loans.questions.eligible_subjects.not_applicable'), class: "govuk-label govuk-radios__label" %>
               </div>
             </div>
           </fieldset>

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -5,7 +5,7 @@
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">
-          <%= form.label :teacher_reference_number, t("student_loans.questions.teacher_reference_number"), class: "govuk-label govuk-label--xl" %>
+          <%= form.label :teacher_reference_number, t("questions.teacher_reference_number"), class: "govuk-label govuk-label--xl" %>
         </h1>
 
         <span class="govuk-hint">You can get this from your school, the certificate you got when you qualified as a teacher or from the <a href="https://www.gov.uk/guidance/individual-teacher-records-information-for-teachers#contact"  class="govuk-link">teacher qualifications helpdesk</a>.</span>

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -5,7 +5,7 @@
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
         <h1 class="govuk-label-wrapper">
-          <%= form.label :teacher_reference_number, t("tslr.questions.teacher_reference_number"), class: "govuk-label govuk-label--xl" %>
+          <%= form.label :teacher_reference_number, t("student_loans.questions.teacher_reference_number"), class: "govuk-label govuk-label--xl" %>
         </h1>
 
         <span class="govuk-hint">You can get this from your school, the certificate you got when you qualified as a teacher or from the <a href="https://www.gov.uk/guidance/individual-teacher-records-information-for-teachers#contact"  class="govuk-link">teacher qualifications helpdesk</a>.</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template app-html-class">
   <head>
     <title>
-      <%= content_for(:page_title) || t("tslr.journey_name") %>
+      <%= content_for(:page_title) || t("student_loans.journey_name") %>
     </title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -52,7 +52,7 @@
         </div>
         <div class="govuk-header__content">
 
-          <%= link_to t("tslr.journey_name"), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to t("student_loans.journey_name"), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
 
           <% if signed_in? %>
           <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
         employed_at_no_school: "You can only get this payment if you’re still working as a teacher"
         not_taught_eligible_subjects_enough: "You must have spent at least half your time teaching an eligible subject"
   service_name: "Claim additional payments for teaching"
-  tslr:
+  student_loans:
     journey_name: "Teachers: claim back your student loan repayments"
     questions:
       qts_award_year: "Which academic year did you complete your initial teacher training?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,38 +45,37 @@ en:
         employed_at_no_school: "You can only get this payment if you’re still working as a teacher"
         not_taught_eligible_subjects_enough: "You must have spent at least half your time teaching an eligible subject"
   service_name: "Claim additional payments for teaching"
+  questions:
+    current_school: "Which school are you currently employed at?"
+    address: "What is your address?"
+    teacher_reference_number: "What's your teacher reference number?"
+    national_insurance_number: "What's your National Insurance number?"
+    has_student_loan: "Are you still paying off your student loan?"
+    student_loan_country: "When you applied for your student loan where was your home address?"
+    student_loan_how_many_courses: "How many higher education courses have you studied?"
+    student_loan_start_date:
+      one_course: "When did the first year of your higher education course start?"
+      two_or_more_courses: "When did the first year of each higher education course start?"
+    email_address: "Email address"
+    bank_details: "Enter bank account details"
+    payroll_gender: "What gender does your school's payroll system associate with you?"
+  answers:
+    student_loan_start_date:
+      one_course:
+        before_first_september_2012: "Before 1 September 2012"
+        on_or_after_first_september_2012: "On or after 1 September 2012"
+      two_or_more_courses:
+        before_first_september_2012: "All my degree courses started before 1 September 2012"
+        some_before_some_after_first_september_2012: "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012"
+        on_or_after_first_september_2012: "All of my degree courses started after 1 September 2012"
+    payroll_gender:
+      male: "Male"
+      female: "Female"
+      dont_know: "Don’t know"
   student_loans:
     journey_name: "Teachers: claim back your student loan repayments"
     questions:
       qts_award_year: "Which academic year did you complete your initial teacher training?"
-      claim_school: "Which school were you employed at between 6 April 2018 and 5 April 2019?"
-      employment_status: "Are you still employed to teach at a school in England?"
-      current_school: "Which school are you currently employed at?"
-      subjects_taught: "Did you teach any of the following subjects between 6 April 2018 and 5 April 2019?"
-      mostly_teaching_eligible_subjects:
-        "Were half of your working hours spent teaching %{subjects} between 6 April 2018 and 5 April 2019?"
-      address: "What is your address?"
-      teacher_reference_number: "What's your teacher reference number?"
-      national_insurance_number: "What's your National Insurance number?"
-      has_student_loan: "Are you still paying off your student loan?"
-      student_loan_country: "When you applied for your student loan where was your home address?"
-      student_loan_how_many_courses: "How many higher education courses have you studied?"
-      student_loan_start_date:
-        one_course: "When did the first year of your higher education course start?"
-        two_or_more_courses: "When did the first year of each higher education course start?"
-      student_loan_amount:
-        "Exactly how much student loan did you repay while you worked at %{claim_school_name} between 6 April 2018 and 5
-        April 2019?"
-      email_address: "Email address"
-      bank_details: "Enter bank account details"
-      payroll_gender: "What gender does your school's payroll system associate with you?"
-      eligible_subjects:
-        biology_taught: "Biology"
-        chemistry_taught: "Chemistry"
-        physics_taught: "Physics"
-        computer_science_taught: "Computer Science"
-        languages_taught: "Languages"
-        not_applicable: "Not applicable, I didn't teach any of these subjects"
       qts_award_years:
         before_2013: "Before September 1 2013"
         "2013_2014": "September 1 2013 – August 31 2014"
@@ -86,19 +85,21 @@ en:
         "2017_2018": "September 1 2017 – August 31 2018"
         "2018_2019": "September 1 2018 – August 31 2019"
         "2019_2020": "September 1 2019 – August 31 2020"
-    answers:
-      student_loan_start_date:
-        one_course:
-          before_first_september_2012: "Before 1 September 2012"
-          on_or_after_first_september_2012: "On or after 1 September 2012"
-        two_or_more_courses:
-          before_first_september_2012: "All my degree courses started before 1 September 2012"
-          some_before_some_after_first_september_2012: "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012"
-          on_or_after_first_september_2012: "All of my degree courses started after 1 September 2012"
-      payroll_gender:
-        male: "Male"
-        female: "Female"
-        dont_know: "Don’t know"
+      claim_school: "Which school were you employed at between 6 April 2018 and 5 April 2019?"
+      employment_status: "Are you still employed to teach at a school in England?"
+      subjects_taught: "Did you teach any of the following subjects between 6 April 2018 and 5 April 2019?"
+      mostly_teaching_eligible_subjects:
+        "Were half of your working hours spent teaching %{subjects} between 6 April 2018 and 5 April 2019?"
+      eligible_subjects:
+        biology_taught: "Biology"
+        chemistry_taught: "Chemistry"
+        physics_taught: "Physics"
+        computer_science_taught: "Computer Science"
+        languages_taught: "Languages"
+        not_applicable: "Not applicable, I didn't teach any of these subjects"
+      student_loan_amount:
+        "Exactly how much student loan did you repay while you worked at %{claim_school_name} between 6 April 2018 and 5
+        April 2019?"
     csv_headers:
       reference: "Reference"
       submitted_at: "Submitted at"

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -240,7 +240,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     claim.update!(verified_fields: ["payroll_gender"])
     visit claim_path("check-your-answers")
 
-    expect(page).to_not have_content(I18n.t("student_loans.questions.payroll_gender"))
+    expect(page).to_not have_content(I18n.t("questions.payroll_gender"))
     expect(page).to_not have_selector(:css, "a[href='#{claim_path("gender")}']")
 
     expect {
@@ -252,7 +252,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     claim.update!(verified_fields: [])
     visit claim_path("check-your-answers")
 
-    expect(page).to have_content(I18n.t("student_loans.questions.payroll_gender"))
+    expect(page).to have_content(I18n.t("questions.payroll_gender"))
     expect(page).to have_selector(:css, "a[href='#{claim_path("gender")}']")
 
     find("a[href='#{claim_path("gender")}']").click

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -34,10 +34,10 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     context "Teacher changes their subjects" do
       before do
-        uncheck I18n.t("tslr.questions.eligible_subjects.physics_taught"), visible: false
+        uncheck I18n.t("student_loans.questions.eligible_subjects.physics_taught"), visible: false
 
-        check I18n.t("tslr.questions.eligible_subjects.biology_taught"), visible: false
-        check I18n.t("tslr.questions.eligible_subjects.chemistry_taught"), visible: false
+        check I18n.t("student_loans.questions.eligible_subjects.biology_taught"), visible: false
+        check I18n.t("student_loans.questions.eligible_subjects.chemistry_taught"), visible: false
 
         click_on "Continue"
       end
@@ -240,7 +240,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     claim.update!(verified_fields: ["payroll_gender"])
     visit claim_path("check-your-answers")
 
-    expect(page).to_not have_content(I18n.t("tslr.questions.payroll_gender"))
+    expect(page).to_not have_content(I18n.t("student_loans.questions.payroll_gender"))
     expect(page).to_not have_selector(:css, "a[href='#{claim_path("gender")}']")
 
     expect {
@@ -252,7 +252,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     claim.update!(verified_fields: [])
     visit claim_path("check-your-answers")
 
-    expect(page).to have_content(I18n.t("tslr.questions.payroll_gender"))
+    expect(page).to have_content(I18n.t("student_loans.questions.payroll_gender"))
     expect(page).to have_selector(:css, "a[href='#{claim_path("gender")}']")
 
     find("a[href='#{claim_path("gender")}']").click

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
       expect(page).to have_text("We have verified your identity")
       click_on "Continue"
 
-      expect(page).to have_text(I18n.t("student_loans.questions.teacher_reference_number"))
+      expect(page).to have_text(I18n.t("questions.teacher_reference_number"))
 
       @claim.reload
       expect(@claim.full_name).to eql("Isambard Kingdom Brunel")
@@ -48,7 +48,7 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
       expect(page).to have_text("We have verified your identity")
       click_on "Continue"
 
-      expect(page).to have_text(I18n.t("student_loans.questions.teacher_reference_number"))
+      expect(page).to have_text(I18n.t("questions.teacher_reference_number"))
 
       @claim.reload
       expect(@claim.full_name).to eql("Isambard Kingdom Brunel")

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
       expect(page).to have_text("We have verified your identity")
       click_on "Continue"
 
-      expect(page).to have_text(I18n.t("tslr.questions.teacher_reference_number"))
+      expect(page).to have_text(I18n.t("student_loans.questions.teacher_reference_number"))
 
       @claim.reload
       expect(@claim.full_name).to eql("Isambard Kingdom Brunel")
@@ -48,7 +48,7 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
       expect(page).to have_text("We have verified your identity")
       click_on "Continue"
 
-      expect(page).to have_text(I18n.t("tslr.questions.teacher_reference_number"))
+      expect(page).to have_text(I18n.t("student_loans.questions.teacher_reference_number"))
 
       @claim.reload
       expect(@claim.full_name).to eql("Isambard Kingdom Brunel")

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.current_school).to eql schools(:hampstead_school)
 
-    expect(page).to have_text(I18n.t("tslr.questions.subjects_taught"))
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
   end
 
   scenario "chooses an ineligible school" do
@@ -60,7 +60,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching
 
-    choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
+    choose I18n.t("student_loans.questions.eligible_subjects.not_applicable")
     click_on "Continue"
 
     expect(claim.reload.mostly_teaching_eligible_subjects?).to eq(false)

--- a/spec/features/missing_verify_information_spec.rb
+++ b/spec/features/missing_verify_information_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Missing information from GOV.UK Verify" do
 
     perform_verify_step("identity-verified-other-gender")
 
-    expect(page).to have_text(I18n.t("tslr.questions.payroll_gender"))
+    expect(page).to have_text(I18n.t("questions.payroll_gender"))
     choose "Female"
     click_on "Continue"
 
@@ -27,10 +27,10 @@ RSpec.feature "Missing information from GOV.UK Verify" do
 
     answer_student_loan_plan_questions
 
-    fill_in I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
+    fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
     click_on "Continue"
 
-    fill_in I18n.t("tslr.questions.email_address"), with: "name@example.tld"
+    fill_in I18n.t("questions.email_address"), with: "name@example.tld"
     click_on "Continue"
 
     fill_in "Sort code", with: "123456"

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     start_claim
     choose_qts_year
 
-    expect(page).to have_text(I18n.t("tslr.questions.claim_school"))
+    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
 
     fill_in :school_search, with: "Penistone"
@@ -53,7 +53,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
     click_button "Continue"
 
-    expect(page).to have_text(I18n.t("tslr.questions.employment_status"))
+    expect(page).to have_text(I18n.t("student_loans.questions.employment_status"))
   end
 
   scenario "Current school search with autocomplete", js: true do
@@ -62,7 +62,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching "Yes, at another school"
 
-    expect(page).to have_text(I18n.t("tslr.questions.current_school"))
+    expect(page).to have_text(I18n.t("student_loans.questions.current_school"))
     expect(page).to have_button("Search")
 
     fill_in :school_search, with: "Penistone"
@@ -72,14 +72,14 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
     click_button "Continue"
 
-    expect(page).to have_text(I18n.t("tslr.questions.subjects_taught"))
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
   end
 
   scenario "School search form still works like a normal form if submitted", js: true do
     start_claim
     choose_qts_year
 
-    expect(page).to have_text(I18n.t("tslr.questions.claim_school"))
+    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
 
     fill_in :school_search, with: "Penistone"
@@ -97,7 +97,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     start_claim
     choose_qts_year
 
-    expect(page).to have_text(I18n.t("tslr.questions.claim_school"))
+    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
 
     fill_in :school_search, with: "Penistone"

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching "Yes, at another school"
 
-    expect(page).to have_text(I18n.t("student_loans.questions.current_school"))
+    expect(page).to have_text(I18n.t("questions.current_school"))
     expect(page).to have_button("Search")
 
     fill_in :school_search, with: "Penistone"

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -3,25 +3,25 @@ require "rails_helper"
 RSpec.feature "Teacher Student Loan Repayments claims" do
   scenario "Teacher claims back student loan repayments" do
     claim = start_claim
-    expect(page).to have_text(I18n.t("tslr.questions.qts_award_year"))
+    expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
 
     choose_qts_year
     expect(claim.reload.qts_award_year).to eql("2014_2015")
-    expect(page).to have_text(I18n.t("tslr.questions.claim_school"))
+    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
 
     choose_school schools(:penistone_grammar_school)
     expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text(I18n.t("tslr.questions.employment_status"))
+    expect(page).to have_text(I18n.t("student_loans.questions.employment_status"))
 
     choose_still_teaching
     expect(claim.reload.employment_status).to eql("claim_school")
     expect(claim.current_school).to eql(schools(:penistone_grammar_school))
 
-    expect(page).to have_text(I18n.t("tslr.questions.subjects_taught"))
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
     check "Physics"
     click_on "Continue"
 
-    expect(page).to have_text(I18n.t("tslr.questions.mostly_teaching_eligible_subjects", subjects: "Physics"))
+    expect(page).to have_text(I18n.t("student_loans.questions.mostly_teaching_eligible_subjects", subjects: "Physics"))
     choose "Yes"
     click_on "Continue"
 
@@ -39,19 +39,19 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(claim.date_of_birth).to eq(Date.new(1806, 4, 9))
     expect(claim.payroll_gender).to eq("male")
 
-    expect(page).to have_text(I18n.t("tslr.questions.teacher_reference_number"))
+    expect(page).to have_text(I18n.t("student_loans.questions.teacher_reference_number"))
     fill_in :claim_teacher_reference_number, with: "1234567"
     click_on "Continue"
 
     expect(claim.reload.teacher_reference_number).to eql("1234567")
 
-    expect(page).to have_text(I18n.t("tslr.questions.national_insurance_number"))
+    expect(page).to have_text(I18n.t("student_loans.questions.national_insurance_number"))
     fill_in "National Insurance number", with: "QQ123456C"
     click_on "Continue"
 
     expect(claim.reload.national_insurance_number).to eq("QQ123456C")
 
-    expect(page).to have_text(I18n.t("tslr.questions.has_student_loan"))
+    expect(page).to have_text(I18n.t("student_loans.questions.has_student_loan"))
 
     answer_student_loan_plan_questions
 
@@ -61,20 +61,20 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(claim.student_loan_start_date).to eq(StudentLoans::BEFORE_1_SEPT_2012)
     expect(claim.student_loan_plan).to eq(StudentLoans::PLAN_1)
 
-    expect(page).to have_text(I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name))
-    fill_in I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
+    expect(page).to have_text(I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.claim_school_name))
+    fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
     click_on "Continue"
 
     expect(claim.reload.student_loan_repayment_amount).to eql(1100.00)
 
-    expect(page).to have_text(I18n.t("tslr.questions.email_address"))
+    expect(page).to have_text(I18n.t("student_loans.questions.email_address"))
     expect(page).to have_text("We will only use your email address to update you about your claim.")
-    fill_in I18n.t("tslr.questions.email_address"), with: "name@example.tld"
+    fill_in I18n.t("student_loans.questions.email_address"), with: "name@example.tld"
     click_on "Continue"
 
     expect(claim.reload.email_address).to eq("name@example.tld")
 
-    expect(page).to have_text(I18n.t("tslr.questions.bank_details"))
+    expect(page).to have_text(I18n.t("student_loans.questions.bank_details"))
     expect(page).to have_text("The account you want us to send your payment to.")
     fill_in "Sort code", with: "123456"
     fill_in "Account number", with: "87654321"

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -39,19 +39,19 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(claim.date_of_birth).to eq(Date.new(1806, 4, 9))
     expect(claim.payroll_gender).to eq("male")
 
-    expect(page).to have_text(I18n.t("student_loans.questions.teacher_reference_number"))
+    expect(page).to have_text(I18n.t("questions.teacher_reference_number"))
     fill_in :claim_teacher_reference_number, with: "1234567"
     click_on "Continue"
 
     expect(claim.reload.teacher_reference_number).to eql("1234567")
 
-    expect(page).to have_text(I18n.t("student_loans.questions.national_insurance_number"))
+    expect(page).to have_text(I18n.t("questions.national_insurance_number"))
     fill_in "National Insurance number", with: "QQ123456C"
     click_on "Continue"
 
     expect(claim.reload.national_insurance_number).to eq("QQ123456C")
 
-    expect(page).to have_text(I18n.t("student_loans.questions.has_student_loan"))
+    expect(page).to have_text(I18n.t("questions.has_student_loan"))
 
     answer_student_loan_plan_questions
 
@@ -67,14 +67,14 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.student_loan_repayment_amount).to eql(1100.00)
 
-    expect(page).to have_text(I18n.t("student_loans.questions.email_address"))
+    expect(page).to have_text(I18n.t("questions.email_address"))
     expect(page).to have_text("We will only use your email address to update you about your claim.")
-    fill_in I18n.t("student_loans.questions.email_address"), with: "name@example.tld"
+    fill_in I18n.t("questions.email_address"), with: "name@example.tld"
     click_on "Continue"
 
     expect(claim.reload.email_address).to eq("name@example.tld")
 
-    expect(page).to have_text(I18n.t("student_loans.questions.bank_details"))
+    expect(page).to have_text(I18n.t("questions.bank_details"))
     expect(page).to have_text("The account you want us to send your payment to.")
     fill_in "Sort code", with: "123456"
     fill_in "Account number", with: "87654321"

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       expect(page).to have_checked_field("eligible_subjects_biology_taught", visible: false)
       expect(page).to have_checked_field("eligible_subjects_physics_taught", visible: false)
 
-      choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
+      choose I18n.t("student_loans.questions.eligible_subjects.not_applicable")
 
       expect(page).to have_checked_field("claim_eligibility_attributes_mostly_teaching_eligible_subjects_false", visible: false)
 
@@ -28,7 +28,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
     end
 
     scenario "checks not applicable and then chooses a subject" do
-      choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
+      choose I18n.t("student_loans.questions.eligible_subjects.not_applicable")
 
       expect(page).to have_checked_field("claim_eligibility_attributes_mostly_teaching_eligible_subjects_false", visible: false)
 
@@ -39,7 +39,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
 
       click_on "Continue"
 
-      expect(page).to have_text(I18n.t("tslr.questions.mostly_teaching_eligible_subjects", subjects: "Biology"))
+      expect(page).to have_text(I18n.t("student_loans.questions.mostly_teaching_eligible_subjects", subjects: "Biology"))
     end
   end
 
@@ -48,7 +48,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       check "eligible_subjects_biology_taught"
       check "eligible_subjects_physics_taught"
 
-      choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
+      choose I18n.t("student_loans.questions.eligible_subjects.not_applicable")
       click_on "Continue"
 
       expect(page).to have_text("You’re not eligible")
@@ -56,7 +56,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
     end
 
     scenario "checks not applicable and then chooses a subject" do
-      choose I18n.t("tslr.questions.eligible_subjects.not_applicable")
+      choose I18n.t("student_loans.questions.eligible_subjects.not_applicable")
 
       check "eligible_subjects_biology_taught"
       click_on "Continue"

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -20,12 +20,12 @@ describe ClaimsHelper do
       )
 
       expected_answers = [
-        [I18n.t("tslr.questions.qts_award_year"), "September 1 2013 - August 31 2014", "qts-year"],
-        [I18n.t("tslr.questions.claim_school"), school.name, "claim-school"],
-        [I18n.t("tslr.questions.current_school"), school.name, "still-teaching"],
-        [I18n.t("tslr.questions.subjects_taught"), "Chemistry and Physics", "subjects-taught"],
-        [I18n.t("tslr.questions.mostly_teaching_eligible_subjects", subjects: "Chemistry and Physics"), "Yes", "mostly-teaching-eligible-subjects"],
-        [I18n.t("tslr.questions.student_loan_amount", claim_school_name: school.name), "£1,987.65", "student-loan-amount"],
+        [I18n.t("student_loans.questions.qts_award_year"), "September 1 2013 - August 31 2014", "qts-year"],
+        [I18n.t("student_loans.questions.claim_school"), school.name, "claim-school"],
+        [I18n.t("student_loans.questions.current_school"), school.name, "still-teaching"],
+        [I18n.t("student_loans.questions.subjects_taught"), "Chemistry and Physics", "subjects-taught"],
+        [I18n.t("student_loans.questions.mostly_teaching_eligible_subjects", subjects: "Chemistry and Physics"), "Yes", "mostly-teaching-eligible-subjects"],
+        [I18n.t("student_loans.questions.student_loan_amount", claim_school_name: school.name), "£1,987.65", "student-loan-amount"],
       ]
 
       expect(helper.claim_answers(claim)).to eq expected_answers
@@ -51,11 +51,11 @@ describe ClaimsHelper do
 
     it "returns an array of questions and answers for displaying to the user for review" do
       expected_answers = [
-        [I18n.t("tslr.questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
-        [I18n.t("tslr.questions.payroll_gender"), "Don’t know", "gender"],
-        [I18n.t("tslr.questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
-        [I18n.t("tslr.questions.national_insurance_number"), "QQ123456C", "national-insurance-number"],
-        [I18n.t("tslr.questions.email_address"), "test@email.com", "email-address"],
+        [I18n.t("student_loans.questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+        [I18n.t("student_loans.questions.payroll_gender"), "Don’t know", "gender"],
+        [I18n.t("student_loans.questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
+        [I18n.t("student_loans.questions.national_insurance_number"), "QQ123456C", "national-insurance-number"],
+        [I18n.t("student_loans.questions.email_address"), "test@email.com", "email-address"],
       ]
 
       expect(helper.identity_answers(claim)).to eq expected_answers
@@ -63,10 +63,10 @@ describe ClaimsHelper do
 
     it "excludes questions answered by verify" do
       claim.verified_fields = ["payroll_gender"]
-      expect(helper.identity_answers(claim)).to_not include([I18n.t("tslr.questions.payroll_gender"), "female", "gender"])
+      expect(helper.identity_answers(claim)).to_not include([I18n.t("student_loans.questions.payroll_gender"), "female", "gender"])
 
       claim.verified_fields = ["postcode"]
-      expect(helper.identity_answers(claim)).to_not include([I18n.t("tslr.questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"])
+      expect(helper.identity_answers(claim)).to_not include([I18n.t("student_loans.questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"])
     end
   end
 
@@ -94,10 +94,10 @@ describe ClaimsHelper do
       )
 
       expected_answers = [
-        [t("tslr.questions.has_student_loan"), "Yes", "student-loan"],
-        [t("tslr.questions.student_loan_country"), "England", "student-loan-country"],
-        [t("tslr.questions.student_loan_how_many_courses"), "One course", "student-loan-how-many-courses"],
-        [t("tslr.questions.student_loan_start_date.one_course"), t("tslr.answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), "student-loan-start-date"],
+        [t("student_loans.questions.has_student_loan"), "Yes", "student-loan"],
+        [t("student_loans.questions.student_loan_country"), "England", "student-loan-country"],
+        [t("student_loans.questions.student_loan_how_many_courses"), "One course", "student-loan-how-many-courses"],
+        [t("student_loans.questions.student_loan_start_date.one_course"), t("student_loans.answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), "student-loan-start-date"],
       ]
 
       expect(helper.student_loan_answers(claim)).to eq expected_answers
@@ -113,10 +113,10 @@ describe ClaimsHelper do
       )
 
       expected_answers = [
-        [t("tslr.questions.has_student_loan"), "Yes", "student-loan"],
-        [t("tslr.questions.student_loan_country"), "England", "student-loan-country"],
-        [t("tslr.questions.student_loan_how_many_courses"), "Two or more courses", "student-loan-how-many-courses"],
-        [t("tslr.questions.student_loan_start_date.two_or_more_courses"), t("tslr.answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), "student-loan-start-date"],
+        [t("student_loans.questions.has_student_loan"), "Yes", "student-loan"],
+        [t("student_loans.questions.student_loan_country"), "England", "student-loan-country"],
+        [t("student_loans.questions.student_loan_how_many_courses"), "Two or more courses", "student-loan-how-many-courses"],
+        [t("student_loans.questions.student_loan_start_date.two_or_more_courses"), t("student_loans.answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), "student-loan-start-date"],
       ]
 
       expect(helper.student_loan_answers(claim)).to eq expected_answers
@@ -126,8 +126,8 @@ describe ClaimsHelper do
       claim = build(:claim, has_student_loan: true, student_loan_country: StudentLoans::SCOTLAND)
 
       expected_answers = [
-        [t("tslr.questions.has_student_loan"), "Yes", "student-loan"],
-        [t("tslr.questions.student_loan_country"), "Scotland", "student-loan-country"],
+        [t("student_loans.questions.has_student_loan"), "Yes", "student-loan"],
+        [t("student_loans.questions.student_loan_country"), "Scotland", "student-loan-country"],
       ]
 
       expect(helper.student_loan_answers(claim)).to eq expected_answers

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -22,7 +22,7 @@ describe ClaimsHelper do
       expected_answers = [
         [I18n.t("student_loans.questions.qts_award_year"), "September 1 2013 - August 31 2014", "qts-year"],
         [I18n.t("student_loans.questions.claim_school"), school.name, "claim-school"],
-        [I18n.t("student_loans.questions.current_school"), school.name, "still-teaching"],
+        [I18n.t("questions.current_school"), school.name, "still-teaching"],
         [I18n.t("student_loans.questions.subjects_taught"), "Chemistry and Physics", "subjects-taught"],
         [I18n.t("student_loans.questions.mostly_teaching_eligible_subjects", subjects: "Chemistry and Physics"), "Yes", "mostly-teaching-eligible-subjects"],
         [I18n.t("student_loans.questions.student_loan_amount", claim_school_name: school.name), "£1,987.65", "student-loan-amount"],
@@ -51,11 +51,11 @@ describe ClaimsHelper do
 
     it "returns an array of questions and answers for displaying to the user for review" do
       expected_answers = [
-        [I18n.t("student_loans.questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
-        [I18n.t("student_loans.questions.payroll_gender"), "Don’t know", "gender"],
-        [I18n.t("student_loans.questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
-        [I18n.t("student_loans.questions.national_insurance_number"), "QQ123456C", "national-insurance-number"],
-        [I18n.t("student_loans.questions.email_address"), "test@email.com", "email-address"],
+        [I18n.t("questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+        [I18n.t("questions.payroll_gender"), "Don’t know", "gender"],
+        [I18n.t("questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
+        [I18n.t("questions.national_insurance_number"), "QQ123456C", "national-insurance-number"],
+        [I18n.t("questions.email_address"), "test@email.com", "email-address"],
       ]
 
       expect(helper.identity_answers(claim)).to eq expected_answers
@@ -63,10 +63,10 @@ describe ClaimsHelper do
 
     it "excludes questions answered by verify" do
       claim.verified_fields = ["payroll_gender"]
-      expect(helper.identity_answers(claim)).to_not include([I18n.t("student_loans.questions.payroll_gender"), "female", "gender"])
+      expect(helper.identity_answers(claim)).to_not include([I18n.t("questions.payroll_gender"), "female", "gender"])
 
       claim.verified_fields = ["postcode"]
-      expect(helper.identity_answers(claim)).to_not include([I18n.t("student_loans.questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"])
+      expect(helper.identity_answers(claim)).to_not include([I18n.t("questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"])
     end
   end
 
@@ -94,10 +94,10 @@ describe ClaimsHelper do
       )
 
       expected_answers = [
-        [t("student_loans.questions.has_student_loan"), "Yes", "student-loan"],
+        [t("questions.has_student_loan"), "Yes", "student-loan"],
         [t("student_loans.questions.student_loan_country"), "England", "student-loan-country"],
-        [t("student_loans.questions.student_loan_how_many_courses"), "One course", "student-loan-how-many-courses"],
-        [t("student_loans.questions.student_loan_start_date.one_course"), t("student_loans.answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), "student-loan-start-date"],
+        [t("questions.student_loan_how_many_courses"), "One course", "student-loan-how-many-courses"],
+        [t("questions.student_loan_start_date.one_course"), t("answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), "student-loan-start-date"],
       ]
 
       expect(helper.student_loan_answers(claim)).to eq expected_answers
@@ -113,10 +113,10 @@ describe ClaimsHelper do
       )
 
       expected_answers = [
-        [t("student_loans.questions.has_student_loan"), "Yes", "student-loan"],
+        [t("questions.has_student_loan"), "Yes", "student-loan"],
         [t("student_loans.questions.student_loan_country"), "England", "student-loan-country"],
-        [t("student_loans.questions.student_loan_how_many_courses"), "Two or more courses", "student-loan-how-many-courses"],
-        [t("student_loans.questions.student_loan_start_date.two_or_more_courses"), t("student_loans.answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), "student-loan-start-date"],
+        [t("questions.student_loan_how_many_courses"), "Two or more courses", "student-loan-how-many-courses"],
+        [t("questions.student_loan_start_date.two_or_more_courses"), t("answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), "student-loan-start-date"],
       ]
 
       expect(helper.student_loan_answers(claim)).to eq expected_answers
@@ -126,7 +126,7 @@ describe ClaimsHelper do
       claim = build(:claim, has_student_loan: true, student_loan_country: StudentLoans::SCOTLAND)
 
       expected_answers = [
-        [t("student_loans.questions.has_student_loan"), "Yes", "student-loan"],
+        [t("questions.has_student_loan"), "Yes", "student-loan"],
         [t("student_loans.questions.student_loan_country"), "Scotland", "student-loan-country"],
       ]
 

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Claims", type: :request do
 
       it "renders the requested page in the sequence" do
         get claim_path("qts-year")
-        expect(response.body).to include(I18n.t("tslr.questions.qts_award_year"))
+        expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
 
         get claim_path("claim-school")
         expect(response.body).to include("Which school were you employed at")

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -19,7 +19,7 @@ module FeatureHelpers
     answer_student_loan_plan_questions
     fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
     click_on "Continue"
-    fill_in I18n.t("student_loans.questions.email_address"), with: "name@example.tld"
+    fill_in I18n.t("questions.email_address"), with: "name@example.tld"
     click_on "Continue"
     fill_in "Sort code", with: "123456"
     fill_in "Account number", with: "87654321"
@@ -95,7 +95,7 @@ module FeatureHelpers
     click_on "Continue"
     choose("1")
     click_on "Continue"
-    choose I18n.t("student_loans.answers.student_loan_start_date.one_course.before_first_september_2012")
+    choose I18n.t("answers.student_loan_start_date.one_course.before_first_september_2012")
     click_on "Continue"
   end
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -17,9 +17,9 @@ module FeatureHelpers
     fill_in "National Insurance number", with: "QQ123456C"
     click_on "Continue"
     answer_student_loan_plan_questions
-    fill_in I18n.t("tslr.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
+    fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.claim_school_name), with: "1100"
     click_on "Continue"
-    fill_in I18n.t("tslr.questions.email_address"), with: "name@example.tld"
+    fill_in I18n.t("student_loans.questions.email_address"), with: "name@example.tld"
     click_on "Continue"
     fill_in "Sort code", with: "123456"
     fill_in "Account number", with: "87654321"
@@ -95,7 +95,7 @@ module FeatureHelpers
     click_on "Continue"
     choose("1")
     click_on "Continue"
-    choose I18n.t("tslr.answers.student_loan_start_date.one_course.before_first_september_2012")
+    choose I18n.t("student_loans.answers.student_loan_start_date.one_course.before_first_september_2012")
     click_on "Continue"
   end
 


### PR DESCRIPTION
Splits out the policy-specific questions and answers from the more general service-related ones, in preparation for introducing the Maths & Physics policy journey into the application.

The CSV headers ones still need untangling, but that's a bit more involved and probably best done when we actually introduce Maths & Physics claims.