### PR TITLE
Adjust escaping of formula-triggering characters

### DIFF
--- a/app/presenters/tslr_claim_csv_row.rb
+++ b/app/presenters/tslr_claim_csv_row.rb
@@ -1,5 +1,6 @@
 require "delegate"
 require "csv"
+require "excel_utils"
 
 class TslrClaimCsvRow < SimpleDelegator
   def to_s
@@ -8,17 +9,10 @@ class TslrClaimCsvRow < SimpleDelegator
 
   private
 
-  DANGEROUS_STRINGS = [
-    "-",
-    "+",
-    "=",
-    "@",
-  ].freeze
-
   def data
     TslrClaimsCsv::FIELDS.map do |f|
       field = send(f)
-      sanitize_field(field)
+      ExcelUtils.escape_formulas(field)
     end
   end
 
@@ -56,13 +50,6 @@ class TslrClaimCsvRow < SimpleDelegator
 
   def submitted_at
     model.submitted_at.strftime("%d/%m/%Y %H:%M")
-  end
-
-  def sanitize_field(field)
-    return field if field.blank?
-
-    field = "=\"#{field}\"" if DANGEROUS_STRINGS.any? { |string| field.include?(string) }
-    field
   end
 
   def model

--- a/lib/excel_utils.rb
+++ b/lib/excel_utils.rb
@@ -1,0 +1,13 @@
+module ExcelUtils
+  FORMULA_TRIGGERS = %w[- + = @].freeze
+
+  # Escapes potentially formula-triggering characters from the front of the
+  # string, i.e. +,-,=,@
+  def self.escape_formulas(string)
+    if ExcelUtils::FORMULA_TRIGGERS.include?(string&.chr)
+      "\\" + string
+    else
+      string
+    end
+  end
+end

--- a/spec/lib/excel_utils_spec.rb
+++ b/spec/lib/excel_utils_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+require "excel_utils"
+
+RSpec.describe ExcelUtils do
+  describe "escape_formulas" do
+    it "escapes formula-triggering characters at the beginning of a string" do
+      expect(ExcelUtils.escape_formulas("=1+2")).to eq '\=1+2'
+      expect(ExcelUtils.escape_formulas("@reference")).to eq '\@reference'
+      expect(ExcelUtils.escape_formulas("-12 + 13")).to eq '\-12 + 13'
+      expect(ExcelUtils.escape_formulas("+12 + 13")).to eq '\+12 + 13'
+    end
+
+    it "doesn't escape non-formula-triggering characters" do
+      expect(ExcelUtils.escape_formulas("1 Buckingham Palace")).to eq "1 Buckingham Palace"
+    end
+
+    it "doesn't escape characters in the body of a string" do
+      expect(ExcelUtils.escape_formulas("some+address@email.com")).to eq "some+address@email.com"
+      expect(ExcelUtils.escape_formulas('\a-url?')).to eq '\a-url?'
+    end
+  end
+end

--- a/spec/presenters/tslr_claim_csv_row_spec.rb
+++ b/spec/presenters/tslr_claim_csv_row_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe TslrClaimCsvRow do
         claim.teacher_reference_number,
         claim.national_insurance_number,
         StudentLoans::PLAN_2.humanize,
-        "=\"#{claim.email_address}\"",
+        claim.email_address,
         "Yes",
         claim.bank_sort_code,
         claim.bank_account_number,
@@ -46,25 +46,9 @@ RSpec.describe TslrClaimCsvRow do
     end
 
     it "escapes fields with strings that could be dangerous in Microsoft Excel and friends" do
-      claim.address_line_1 = "equals=sign"
-      claim.address_line_2 = "minus-sign"
-      claim.address_line_3 = "plus+sign"
-      claim.address_line_4 = "at@symbol"
-      claim.postcode = "=SUM(A1, A2)"
-      claim.email_address = "valid=email@domain.tld"
+      claim.address_line_1 = "=ActiveCell.Row-1,14"
 
-      expect(row[TslrClaimsCsv::FIELDS.index(:address_line_1)]).to eq("=\"#{claim.address_line_1}\"")
-      expect(row[TslrClaimsCsv::FIELDS.index(:address_line_2)]).to eq("=\"#{claim.address_line_2}\"")
-      expect(row[TslrClaimsCsv::FIELDS.index(:address_line_3)]).to eq("=\"#{claim.address_line_3}\"")
-      expect(row[TslrClaimsCsv::FIELDS.index(:address_line_4)]).to eq("=\"#{claim.address_line_4}\"")
-      expect(row[TslrClaimsCsv::FIELDS.index(:postcode)]).to eq("=\"#{claim.postcode}\"")
-      expect(row[TslrClaimsCsv::FIELDS.index(:email_address)]).to eq("=\"#{claim.email_address}\"")
-    end
-
-    it "escaped fields are properly quoted when converted to CSV" do
-      claim.postcode = "=SUM(A1, A2)"
-
-      expect(CSV.generate_line(row)).to include('"=""' + claim.postcode + '"""')
+      expect(row[TslrClaimsCsv::FIELDS.index(:address_line_1)]).to eq("\\#{claim.address_line_1}")
     end
   end
 end

--- a/spec/presenters/tslr_claims_csv_spec.rb
+++ b/spec/presenters/tslr_claims_csv_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe TslrClaimsCsv do
         claim.teacher_reference_number,
         claim.national_insurance_number,
         claim.student_loan_plan.humanize,
-        "=\"#{claim.email_address}\"",
+        claim.email_address,
         eligibility.mostly_teaching_eligible_subjects? ? "Yes" : "No",
         claim.bank_sort_code,
         claim.bank_account_number,

--- a/test.csv
+++ b/test.csv
@@ -1,0 +1,2 @@
+one,two,three
+\=something,foo,bar


### PR DESCRIPTION
Just wrapping the entire value in ="STRING_HERE" is not going to prevent
a formula triggering, for example a value of test"+SUM(A1- A2)+" would
get escaped to ="test"+SUM(A1- A2)+"", which would still attempt to
evaluate the entered info as a formula.

Instead we escape the first character if it is one of the known
formula-triggering characters. This may result in operability issues
further down the line, but these will be easy to deal with by the human
operator that will be working with the files. The excess of backslashes
in the gsub is the only way to add the '\\' escape character and match
substitution character '\0'.

See http://georgemauer.net/2017/10/07/csv-injection.html for more
details of how opening CSV files with Excel can result in formula
injection.