### PR TITLE
Do not log Verify responses in production

### DIFF
--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -11,7 +11,6 @@ module Verify
 
     def initialize(parameters)
       @parameters = parameters
-      Rollbar.debug("Verify::Response", parameters: parameters)
     end
 
     def self.translate(saml_response:, request_id:, level_of_assurance:)


### PR DESCRIPTION
Now that we have Verify running in production we do not want to log the responses in Rollbar anymore.