### PR TITLE
Enable strict content security policy

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,3 +15,4 @@
 //= require a11y-dialog/a11y-dialog.min.js
 //= require accessible-autocomplete/dist/accessible-autocomplete.min.js
 //= require_tree .
+//= stub js_check.js

--- a/app/assets/javascripts/js_check.js
+++ b/app/assets/javascripts/js_check.js
@@ -1,0 +1,1 @@
+document.body.className = document.body.className ? document.body.className + " js-enabled" : "js-enabled";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,11 +22,7 @@
   </head>
 
   <body class="govuk-template__body app-body-class">
-
-    <script>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-
-    </script>
+    <%= javascript_include_tag 'js_check' %>
 
     <%= render partial: "timeout_dialog" %>
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,4 +12,4 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-Rails.application.config.assets.precompile += %w[accessible-autocomplete/src/autocomplete.css]
+Rails.application.config.assets.precompile += %w[js_check.js accessible-autocomplete/src/autocomplete.css]

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,17 +4,17 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src :self, :https, :data
+  policy.img_src :self, :https, :data
+  policy.object_src :none
+  policy.script_src :self, :https
+  policy.style_src :self, :https
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator =


### PR DESCRIPTION
We only allow scripts, images and styles served over https and from our own domain. This will need updating as and when we add third-party scripts, for example Google Analytics.