### PR TITLE
Add in text about how we use data with DQT and TPS

### DIFF
--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -103,9 +103,7 @@
 
     <p class="govuk-body">
       To process your claim we will compare the information you have provided with records kept on the Teachers
-      Pension Service and the Database of Qualified Teachers. This is so we can validate your claim, we will not allow
-      the Teachers Pension Service or the Database of Qualified Tachers acees to the information you have provided to
-      this service.
+      Pension Service and the Database of Qualified Teachers. This is so we can validate your claim.
     </p>
 
     <h2 class="govuk-heading-l">

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -98,6 +98,17 @@
     </ul>
 
     <h2 class="govuk-heading-l">
+      How we access your personal data
+    </h2>
+
+    <p class="govuk-body">
+      To process your claim we will compare the information you have provided with records kept on the Teachers
+      Pension Service and the Database of Qualified Teachers. This is so we can validate your claim, we will not allow
+      the Teachers Pension Service or the Database of Qualified Tachers acees to the information you have provided to
+      this service.
+    </p>
+
+    <h2 class="govuk-heading-l">
       How long we will keep your personal data
     </h2>
 


### PR DESCRIPTION
As we are accessing the Database of Qualified Teachers and the Teacher
Pension Service, need need to explain to users how this information will
be used and who will access it.