### PR TITLE
Admin session timeout bug

### DIFF
--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -14,7 +14,7 @@ module Admin
 
     def callback
       if authorised?
-        session[:login] = auth_hash.fetch("info").to_h
+        session[:admin_auth] = auth_hash.fetch("info").to_h
         redirect_to admin_path
       else
         render "failure", status: :unauthorized

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -5,7 +5,7 @@ module Admin
     private
 
     def ensure_authenticated_user
-      redirect_to admin_sign_in_path unless signed_in?
+      redirect_to admin_sign_in_path unless admin_signed_in?
     end
   end
 end

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -12,14 +12,13 @@ module Admin
 
     def end_expired_sessions
       if admin_session_timed_out?
-        session.destroy
+        session.delete(:login)
         redirect_to admin_sign_in_path, notice: "Your session has timed out due to inactivity, please sign-in again"
       end
     end
 
     def admin_session_timed_out?
-      signed_in? && session.key?(:last_seen_at) &&
-        session[:last_seen_at] < TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
+      signed_in? && session[:last_seen_at] < TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
     end
   end
 end

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -1,24 +1,11 @@
 module Admin
   class BaseAdminController < ApplicationController
-    TIMEOUT_LENGTH_IN_MINUTES = 30
-
-    before_action :ensure_authenticated_user, :end_expired_sessions, :update_last_seen_at
+    before_action :ensure_authenticated_user
 
     private
 
     def ensure_authenticated_user
       redirect_to admin_sign_in_path unless signed_in?
-    end
-
-    def end_expired_sessions
-      if admin_session_timed_out?
-        session.delete(:login)
-        redirect_to admin_sign_in_path, notice: "Your session has timed out due to inactivity, please sign-in again"
-      end
-    end
-
-    def admin_session_timed_out?
-      signed_in? && session[:last_seen_at] < TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
   end
 
   def admin_signed_in?
-    session.key?(:login)
+    session.key?(:admin_auth)
   end
 
   def current_claim
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
 
   def end_expired_admin_sessions
     if admin_session_timed_out?
-      session.delete(:login)
+      session.delete(:admin_auth)
       flash[:notice] = "Your session has timed out due to inactivity, please sign-in again"
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
     if: -> { ENV.key?("BASIC_AUTH_USERNAME") },
   )
 
-  helper_method :signed_in?, :current_claim
+  helper_method :admin_signed_in?, :current_claim
   before_action :end_expired_admin_sessions
   before_action :end_expired_claim_sessions
   before_action :update_last_seen_at
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
     redirect_to root_url unless current_claim.present?
   end
 
-  def signed_in?
+  def admin_signed_in?
     session.key?(:login)
   end
 
@@ -45,7 +45,7 @@ class ApplicationController < ActionController::Base
   end
 
   def admin_session_timed_out?
-    signed_in? && session[:last_seen_at] < ADMIN_TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
+    admin_signed_in? && session[:last_seen_at] < ADMIN_TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
   end
 
   def end_expired_admin_sessions

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,14 +34,11 @@ class ApplicationController < ActionController::Base
   end
 
   def claim_session_timed_out?
-    session.key?(:claim_id) &&
-      session.key?(:last_seen_at) &&
-      session[:last_seen_at] < CLAIM_TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
+    session.key?(:claim_id) && session[:last_seen_at] < CLAIM_TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
   end
 
   def clear_claim_session
     session.delete(:claim_id)
-    session.delete(:last_seen_at)
     session.delete(:verify_request_id)
   end
 

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -3,7 +3,7 @@ class ClaimsController < ApplicationController
   TIMEOUT_WARNING_LENGTH_IN_MINUTES = 2
 
   before_action :send_unstarted_claiments_to_the_start, only: [:show, :update, :ineligible]
-  before_action :end_expired_sessions
+  before_action :end_expired_claim_sessions
   before_action :update_last_seen_at
   before_action :check_page_is_in_sequence, only: [:show, :update]
 
@@ -69,7 +69,7 @@ class ClaimsController < ApplicationController
     params[:slug].underscore
   end
 
-  def end_expired_sessions
+  def end_expired_claim_sessions
     if claim_session_timed_out?
       clear_claim_session
       redirect_to timeout_claim_path

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,10 +1,5 @@
 class ClaimsController < ApplicationController
-  TIMEOUT_LENGTH_IN_MINUTES = 30
-  TIMEOUT_WARNING_LENGTH_IN_MINUTES = 2
-
   before_action :send_unstarted_claiments_to_the_start, only: [:show, :update, :ineligible]
-  before_action :end_expired_claim_sessions
-  before_action :update_last_seen_at
   before_action :check_page_is_in_sequence, only: [:show, :update]
 
   after_action :clear_claim_session, if: :submission_complete?
@@ -67,25 +62,6 @@ class ClaimsController < ApplicationController
 
   def claim_page_template
     params[:slug].underscore
-  end
-
-  def end_expired_claim_sessions
-    if claim_session_timed_out?
-      clear_claim_session
-      redirect_to timeout_claim_path
-    end
-  end
-
-  def claim_session_timed_out?
-    session.key?(:claim_id) &&
-      session.key?(:last_seen_at) &&
-      session[:last_seen_at] < TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
-  end
-
-  def clear_claim_session
-    session.delete(:claim_id)
-    session.delete(:last_seen_at)
-    session.delete(:verify_request_id)
   end
 
   def check_page_is_in_sequence

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -4,11 +4,11 @@ module ClaimsHelper
   end
 
   def claim_timeout_in_minutes
-    ClaimsController::TIMEOUT_LENGTH_IN_MINUTES
+    ApplicationController::CLAIM_TIMEOUT_LENGTH_IN_MINUTES
   end
 
   def claim_timeout_warning_in_minutes
-    ClaimsController::TIMEOUT_WARNING_LENGTH_IN_MINUTES
+    ApplicationController::CLAIM_TIMEOUT_WARNING_LENGTH_IN_MINUTES
   end
 
   def eligibility_answers(eligibility)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,7 +50,7 @@
 
           <%= link_to t("student_loans.journey_name"), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
 
-          <% if signed_in? %>
+          <% if admin_signed_in? %>
           <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -102,7 +102,7 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">_dfe_teachers_payment_service_session</td>
           <td class="govuk-table__cell">Stores session data</td>
-          <td class="govuk-table__cell">After <%= ClaimsController::TIMEOUT_LENGTH_IN_MINUTES %> minutes</td>
+          <td class="govuk-table__cell">After <%= claim_timeout_in_minutes %> minutes</td>
         </tr>
       </tbody>
     </table>

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Admin", type: :request do
         get admin_path
 
         expect(response).to redirect_to(admin_sign_in_path)
-        expect(session[:login]).to be_nil
+        expect(session[:admin_auth]).to be_nil
       end
     end
 
@@ -24,14 +24,14 @@ RSpec.describe "Admin", type: :request do
 
           expect(response).to be_successful
           expect(response.body).to include("Admin")
-          expect(session[:login]).to eql({"email" => "test-dfe-sign-in@host.tld"})
+          expect(session[:admin_auth]).to eql({"email" => "test-dfe-sign-in@host.tld"})
         end
 
         context "and they sign out" do
           it "unsets the session" do
             delete admin_sign_out_path
 
-            expect(session[:login]).to be_nil
+            expect(session[:admin_auth]).to be_nil
           end
         end
       end
@@ -44,7 +44,7 @@ RSpec.describe "Admin", type: :request do
         end
 
         it "shows a not authorised page and doesn’t set a session" do
-          expect(session[:login]).to be_nil
+          expect(session[:admin_auth]).to be_nil
           expect(response.code).to eq("401")
           expect(response.body).to include("Not authorised")
         end
@@ -60,7 +60,7 @@ RSpec.describe "Admin", type: :request do
         post admin_dfe_sign_in_path
         follow_redirect!
 
-        expect(session[:login]).to be_nil
+        expect(session[:admin_auth]).to be_nil
         expect(response.body).to redirect_to(
           admin_auth_failure_path(message: :invalid_credentials, strategy: :dfe)
         )

--- a/spec/requests/admin_timeout_spec.rb
+++ b/spec/requests/admin_timeout_spec.rb
@@ -14,14 +14,13 @@ RSpec.describe "Admin session timing out", type: :request do
 
     it "clears the session and redirects to the login page" do
       expect(session[:login]).to eql({"email" => "test-dfe-sign-in@host.tld"})
-      expect(session[:last_seen_at]).not_to be_nil
 
       travel after_expiry do
         get admin_claims_path(format: :csv)
 
         expect(response).to redirect_to(admin_sign_in_path)
         expect(session[:login]).to be_nil
-        expect(session[:last_seen_at]).to be_nil
+
         follow_redirect!
         expect(response.body).to include("Your session has timed out due to inactivity")
       end
@@ -37,7 +36,6 @@ RSpec.describe "Admin session timing out", type: :request do
 
         expect(response.code).to eq("200")
         expect(session[:login]).to_not be_nil
-        expect(session[:last_seen_at]).to_not be_nil
       end
     end
   end

--- a/spec/requests/admin_timeout_spec.rb
+++ b/spec/requests/admin_timeout_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe "Admin session timing out", type: :request do
     let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
 
     it "clears the session and redirects to the login page" do
-      expect(session[:login]).to eql({"email" => "test-dfe-sign-in@host.tld"})
+      expect(session[:admin_auth]).to eql({"email" => "test-dfe-sign-in@host.tld"})
 
       travel after_expiry do
         get admin_claims_path(format: :csv)
 
         expect(response).to redirect_to(admin_sign_in_path)
-        expect(session[:login]).to be_nil
+        expect(session[:admin_auth]).to be_nil
 
         follow_redirect!
         expect(response.body).to include("Your session has timed out due to inactivity")
@@ -31,12 +31,12 @@ RSpec.describe "Admin session timing out", type: :request do
     let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
 
     it "still clears the admin session" do
-      expect(session[:login]).to eql({"email" => "test-dfe-sign-in@host.tld"})
+      expect(session[:admin_auth]).to eql({"email" => "test-dfe-sign-in@host.tld"})
 
       travel after_expiry do
         get root_path
 
-        expect(session[:login]).to be_nil
+        expect(session[:admin_auth]).to be_nil
         expect(response).to be_successful
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe "Admin session timing out", type: :request do
         get admin_claims_path(format: :csv)
 
         expect(response.code).to eq("200")
-        expect(session[:login]).to_not be_nil
+        expect(session[:admin_auth]).to_not be_nil
       end
     end
   end

--- a/spec/requests/admin_timeout_spec.rb
+++ b/spec/requests/admin_timeout_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin session timing out", type: :request do
-  let(:timeout_length_in_minutes) { Admin::BaseAdminController::TIMEOUT_LENGTH_IN_MINUTES }
+  let(:timeout_length_in_minutes) { ApplicationController::ADMIN_TIMEOUT_LENGTH_IN_MINUTES }
 
   before do
     stub_dfe_sign_in_with_role(Admin::AuthController::DFE_SIGN_IN_ADMIN_ROLE_CODE)
@@ -23,6 +23,21 @@ RSpec.describe "Admin session timing out", type: :request do
 
         follow_redirect!
         expect(response.body).to include("Your session has timed out due to inactivity")
+      end
+    end
+  end
+
+  context "user visits a non-admin page after the timeout period" do
+    let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
+
+    it "still clears the admin session" do
+      expect(session[:login]).to eql({"email" => "test-dfe-sign-in@host.tld"})
+
+      travel after_expiry do
+        get root_path
+
+        expect(session[:login]).to be_nil
+        expect(response).to be_successful
       end
     end
   end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe "Claims", type: :request do
 
       it "clears the claim from the session" do
         expect(session[:claim_id]).to be_nil
-        expect(session[:last_seen_at]).to be_nil
       end
     end
   end

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Claim session timing out", type: :request do
-  let(:timeout_length_in_minutes) { ClaimsController::TIMEOUT_LENGTH_IN_MINUTES }
+  let(:timeout_length_in_minutes) { ApplicationController::CLAIM_TIMEOUT_LENGTH_IN_MINUTES }
 
   context "no actions performed for more than the timeout period" do
     before do

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "Claim session timing out", type: :request do
 
     it "clears the session and redirects to the timeout page" do
       expect(session[:claim_id]).to eql current_claim.to_param
-      expect(session[:last_seen_at]).not_to be_nil
       expect(session[:verify_request_id]).not_to be_nil
 
       travel after_expiry do
@@ -22,7 +21,6 @@ RSpec.describe "Claim session timing out", type: :request do
 
         expect(response).to redirect_to(timeout_claim_path)
         expect(session[:claim_id]).to be_nil
-        expect(session[:last_seen_at]).to be_nil
         expect(session[:verify_request_id]).to be_nil
       end
     end
@@ -42,7 +40,6 @@ RSpec.describe "Claim session timing out", type: :request do
         put claim_path("qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "2014_2015"}}}
 
         expect(response).to redirect_to(claim_path("claim-school"))
-        expect(session[:last_seen_at]).not_to be_nil
         expect(session[:verify_request_id]).not_to be_nil
       end
     end


### PR DESCRIPTION
This fixes a bug where a admin users session wouldn't be correctly timed out, even after the timeout period had elapsed.

If a previously signed-in admin user visited a page outside of /admin after the timeout period had elapsed, their admin session wouldn't be cleared because that was only happening in controllers inheriting from `Admin::BaseAdminController`, but the `last_seen_at` timestamp would get updated, as that happens in `ApplicationController`. When they then visit /admin, their session will no longer be timed out because of the updated `last_seen_at`.

The fix is to check and reset the admin session on all controller actions, not just the admin ones.

This also does the same thing for the claims session so that a user's claim session will be reset regardless of whether they are visiting pages on /claim or not.