### PR TITLE
Remove linebreaks from email template

### DIFF
--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -1,8 +1,6 @@
 Dear <%= @claim.full_name %>,
 
-We‘ve received your claim to get back the student loan repayments you
-made through your wages at <%= @claim.eligibility.claim_school_name %>
-between 6 April 2018 and 5 April 2019.
+We‘ve received your claim to get back the student loan repayments you made through your wages at <%= @claim.eligibility.claim_school_name %> between 6 April 2018 and 5 April 2019.
 
 ^ Your reference number is <%= @claim.reference %>.
 
@@ -14,8 +12,7 @@ We’ll tell you if your claim was successful within XXXX.
 
 # Contact us
 
-Email studentloanteacherpayment@digital.education.gov.uk giving your
-reference number if you have any questions about your claim.
+Email studentloanteacherpayment@digital.education.gov.uk giving your reference number if you have any questions about your claim.
 
 Regards
 


### PR DESCRIPTION
The linebreaks get rendered as HTML `<br>` tags in the email body, which results in weird flow of text. Removing the linebreaks lets the text flow more naturally with the viewport of the mail client the email is being viewed in.

![Screenshot 2019-08-14 at 09 50 15](https://user-images.githubusercontent.com/3687/63008220-150d6e00-be7a-11e9-8960-17e4360f844e.png)
