### PR TITLE
Update accessiblity and T&Cs with support email

### DIFF
--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -47,13 +47,9 @@
     </h2>
 
     <p class="govuk-body">
-      If you need information on this website in a different format or cannot use the service:
+      If you need information on this website in a different format or cannot use the service,
+      contact us at <%= mail_to t("support_email_address"), t("support_email_address"), class: "govuk-link" %>.
     </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>email [XXXX]</li>
-      <li>call [XXXX]</li>
-    </ul>
 
     <p class="govuk-body">
       We’ll consider your request and get back to you in [XXXX] days.
@@ -65,7 +61,7 @@
 
     <p class="govuk-body">
       We’re always looking to improve the accessibility of this website. If you find any problems that aren’t listed on
-      this page or think we’re not meeting accessibility requirements, contact: [XXXX].
+      this page or think we’re not meeting accessibility requirements, contact: <%= mail_to t("support_email_address"), t("support_email_address"), class: "govuk-link" %>.
     </p>
 
     <h2 class="govuk-heading-l">

--- a/app/views/static_pages/terms_conditions.html.erb
+++ b/app/views/static_pages/terms_conditions.html.erb
@@ -40,8 +40,7 @@
     </p>
 
     <p class="govuk-body">
-      You can contact us using the following email address:
-      <a href="mailto: XXXX" class="govuk-link">XXXX</a>
+      You can contact us using the following email address: <%= mail_to t("support_email_address"), t("support_email_address"), class: "govuk-link" %>
     </p>
 
     <h3 class="govuk-heading-m">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
         employed_at_no_school: "You can only get this payment if you’re still working as a teacher"
         not_taught_eligible_subjects_enough: "You must have spent at least half your time teaching an eligible subject"
   service_name: "Claim additional payments for teaching"
+  support_email_address: "additionalteachingpayment@digital.education.gov.uk"
   questions:
     current_school: "Which school are you currently employed at?"
     address: "What is your address?"


### PR DESCRIPTION
We use the service-wide support email address on these pages as we can't know which particular policy the user will be interested in when viewing these pages.