### PR TITLE
GOV.UK Verify support for EU citizens

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -184,6 +184,9 @@
         },
         "secretName": "TeacherPaymentsDevVspSamlEncryption2KeyBase64"
       }
+    },
+    "VSP.EUROPEAN_IDENTITY_ENABLED": {
+      "value": "true"
     }
   }
 }

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -175,6 +175,9 @@
         },
         "secretName": "TeacherPaymentsProdVspSamlEncryption1KeyBase64"
       }
+    },
+    "VSP.EUROPEAN_IDENTITY_ENABLED": {
+      "value": "false"
     }
   }
 }

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -506,6 +506,9 @@
           },
           "SAML_PRIMARY_ENCRYPTION_KEY": {
             "value": "[parameters('VSP.SAML_PRIMARY_ENCRYPTION_KEY')]"
+          },
+          "EUROPEAN_IDENTITY_ENABLED": {
+            "value": "[parameters('VSP.EUROPEAN_IDENTITY_ENABLED')]"
           }
         }
       }

--- a/azure/templates/vsp.json
+++ b/azure/templates/vsp.json
@@ -37,6 +37,9 @@
     },
     "SAML_PRIMARY_ENCRYPTION_KEY": {
       "type": "securestring"
+    },
+    "EUROPEAN_IDENTITY_ENABLED": {
+      "type": "string"
     }
   },
   "variables": {
@@ -101,6 +104,10 @@
             {
               "name": "SAML_PRIMARY_ENCRYPTION_KEY",
               "value": "[parameters('SAML_PRIMARY_ENCRYPTION_KEY')]"
+            },
+            {
+              "name": "EUROPEAN_IDENTITY_ENABLED",
+              "value": "[parameters('EUROPEAN_IDENTITY_ENABLED')]"
             }
           ],
           "copy": [

--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -42,6 +42,7 @@ module Verify
         address_line_1: address_line(1),
         address_line_2: address_line(2),
         address_line_3: address_line(3),
+        address_line_4: address_line(4),
         postcode: postcode,
         date_of_birth: attributes.fetch("datesOfBirth").first.fetch("value"),
         payroll_gender: gender,

--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -39,10 +39,10 @@ module Verify
     def identity_paramteters
       @identity_paramteters ||= {
         full_name: full_name,
-        address_line_1: address_lines[0],
-        address_line_2: address_lines[1],
-        address_line_3: address_lines[2],
-        postcode: address.fetch("postCode"),
+        address_line_1: address_line(1),
+        address_line_2: address_line(2),
+        address_line_3: address_line(3),
+        postcode: postcode,
         date_of_birth: attributes.fetch("datesOfBirth").first.fetch("value"),
         payroll_gender: gender,
       }
@@ -58,6 +58,18 @@ module Verify
 
     def address_lines
       @address_lines ||= address.fetch("lines")
+    end
+
+    def address_line(line)
+      address_lines[line - 1] unless address_missing?
+    end
+
+    def postcode
+      address.fetch("postCode") unless address_missing?
+    end
+
+    def address_missing?
+      address.nil?
     end
 
     def full_name

--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -69,7 +69,7 @@ module Verify
     end
 
     def most_recent_verified_value(attributes)
-      return if attributes.empty?
+      return if attributes.blank?
 
       attributes.sort_by { |attribute| attribute["from"].present? ? Date.strptime(attribute["from"], "%Y-%m-%d") : 0 }
         .reverse

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -30,9 +30,10 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
 
       @claim.reload
       expect(@claim.full_name).to eql("Isambard Kingdom Brunel")
-      expect(@claim.address_line_1).to eq("Verified Street")
-      expect(@claim.address_line_2).to eq("Verified Town")
-      expect(@claim.address_line_3).to eq("Verified County")
+      expect(@claim.address_line_1).to eq("Verified Building")
+      expect(@claim.address_line_2).to eq("Verified Street")
+      expect(@claim.address_line_3).to eq("Verified Town")
+      expect(@claim.address_line_4).to eq("Verified County")
       expect(@claim.postcode).to eq("M12 345")
       expect(@claim.date_of_birth).to eq(Date.new(1806, 4, 9))
       expect(@claim.payroll_gender).to eq("male")

--- a/spec/features/missing_verify_information_spec.rb
+++ b/spec/features/missing_verify_information_spec.rb
@@ -49,4 +49,56 @@ RSpec.feature "Missing information from GOV.UK Verify" do
 
     expect(page).to have_text("Claim submitted")
   end
+
+  scenario "Claimant is asked an address question when Verify doesn’t provide their address" do
+    claim = start_claim
+    choose_qts_year
+    choose_school schools(:penistone_grammar_school)
+    choose_still_teaching
+    check "Physics"
+    click_on "Continue"
+    choose "Yes"
+    click_on "Continue"
+
+    perform_verify_step("identity-verified-no-address")
+
+    expect(page).to have_text(I18n.t("questions.address"))
+    fill_in_address
+
+    expect(claim.reload.address_line_1).to eql("123 Main Street")
+    expect(claim.address_line_2).to eql("Downtown")
+    expect(claim.address_line_3).to eql("Twin Peaks")
+    expect(claim.address_line_4).to eql("Washington")
+    expect(claim.postcode).to eql("M1 7HL")
+
+    fill_in :claim_teacher_reference_number, with: "1234567"
+    click_on "Continue"
+
+    fill_in "National Insurance number", with: "QQ123456C"
+    click_on "Continue"
+
+    answer_student_loan_plan_questions
+
+    fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), with: "1100"
+    click_on "Continue"
+
+    fill_in I18n.t("questions.email_address"), with: "name@example.tld"
+    click_on "Continue"
+
+    fill_in "Sort code", with: "123456"
+    fill_in "Account number", with: "87654321"
+    click_on "Continue"
+
+    freeze_time do
+      perform_enqueued_jobs do
+        expect {
+          click_on "Confirm and send"
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+
+      expect(claim.reload.submitted_at).to eq(Time.zone.now)
+    end
+
+    expect(page).to have_text("Claim submitted")
+  end
 end

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -32,9 +32,10 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     perform_verify_step
 
     expect(claim.reload.full_name).to eql("Isambard Kingdom Brunel")
-    expect(claim.address_line_1).to eql("Verified Street")
-    expect(claim.address_line_2).to eql("Verified Town")
-    expect(claim.address_line_3).to eql("Verified County")
+    expect(claim.address_line_1).to eq("Verified Building")
+    expect(claim.address_line_2).to eq("Verified Street")
+    expect(claim.address_line_3).to eq("Verified Town")
+    expect(claim.address_line_4).to eq("Verified County")
     expect(claim.postcode).to eql("M12 345")
     expect(claim.date_of_birth).to eq(Date.new(1806, 4, 9))
     expect(claim.payroll_gender).to eq("male")

--- a/spec/fixtures/verify/identity-verified-no-address.json
+++ b/spec/fixtures/verify/identity-verified-no-address.json
@@ -1,0 +1,30 @@
+{
+  "scenario": "IDENTITY_VERIFIED",
+  "pid": "5989a87f344bb79ee8d0f0532c0f716deb4f8d71e906b87b346b649c4ceb20c5",
+  "levelOfAssurance": "LEVEL_2",
+  "attributes": {
+    "firstNames": [
+      {
+        "value": "Isambard",
+        "verified": true
+      }
+    ],
+    "middleNames": [],
+    "surnames": [
+      {
+        "value": "Brunel",
+        "verified": true
+      }
+    ],
+    "datesOfBirth": [
+      {
+        "value": "1806-04-09",
+        "verified": true
+      }
+    ],
+    "gender": {
+      "value": "FEMALE",
+      "verified": true
+    }
+  }
+}

--- a/spec/fixtures/verify/identity-verified.json
+++ b/spec/fixtures/verify/identity-verified.json
@@ -68,7 +68,7 @@
     "addresses": [
       {
         "value": {
-          "lines": ["Verified Street", "Verified Town", "Verified County"],
+          "lines": ["Verified Building", "Verified Street", "Verified Town", "Verified County"],
           "postCode": "M12 345"
         },
         "verified": true,

--- a/spec/lib/verify/response_spec.rb
+++ b/spec/lib/verify/response_spec.rb
@@ -29,9 +29,10 @@ RSpec.describe Verify::Response, type: :model do
 
     it "returns the expected verified parameters" do
       expect(subject.claim_parameters[:full_name]).to eq("Isambard Kingdom Brunel")
-      expect(subject.claim_parameters[:address_line_1]).to eq("Verified Street")
-      expect(subject.claim_parameters[:address_line_2]).to eq("Verified Town")
-      expect(subject.claim_parameters[:address_line_3]).to eq("Verified County")
+      expect(subject.claim_parameters[:address_line_1]).to eq("Verified Building")
+      expect(subject.claim_parameters[:address_line_2]).to eq("Verified Street")
+      expect(subject.claim_parameters[:address_line_3]).to eq("Verified Town")
+      expect(subject.claim_parameters[:address_line_4]).to eq("Verified County")
       expect(subject.claim_parameters[:postcode]).to eq("M12 345")
       expect(subject.claim_parameters[:date_of_birth]).to eq("1806-04-09")
       expect(subject.claim_parameters[:payroll_gender]).to eq(:male)
@@ -40,6 +41,7 @@ RSpec.describe Verify::Response, type: :model do
         :address_line_1,
         :address_line_2,
         :address_line_3,
+        :address_line_4,
         :postcode,
         :date_of_birth,
         :payroll_gender,

--- a/spec/lib/verify/response_spec.rb
+++ b/spec/lib/verify/response_spec.rb
@@ -81,6 +81,26 @@ RSpec.describe Verify::Response, type: :model do
         expect(subject.claim_parameters[:verified_fields]).to_not include(:payroll_gender)
       end
     end
+
+    context "when the address is missing (for EU citizens)" do
+      let(:response_filename) { "identity-verified-no-address.json" }
+
+      it "returns nil for address attributes" do
+        expect(subject.claim_parameters[:address_line_1]).to eq(nil)
+        expect(subject.claim_parameters[:address_line_2]).to eq(nil)
+        expect(subject.claim_parameters[:address_line_3]).to eq(nil)
+        expect(subject.claim_parameters[:postcode]).to eq(nil)
+      end
+
+      it "does not return any address attributes in the verified fields" do
+        expect(subject.claim_parameters[:verified_fields]).to_not include(
+          :address_line_1,
+          :address_line_2,
+          :address_line_3,
+          :postcode
+        )
+      end
+    end
   end
 
   context "with the minimum verified response" do

--- a/spec/requests/verify_authentications_spec.rb
+++ b/spec/requests/verify_authentications_spec.rb
@@ -43,9 +43,10 @@ RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :reque
           expect(response).to redirect_to(claim_path("verified"))
 
           expect(current_claim.full_name).to eq("Isambard Kingdom Brunel")
-          expect(current_claim.address_line_1).to eq("Verified Street")
-          expect(current_claim.address_line_2).to eq("Verified Town")
-          expect(current_claim.address_line_3).to eq("Verified County")
+          expect(current_claim.address_line_1).to eq("Verified Building")
+          expect(current_claim.address_line_2).to eq("Verified Street")
+          expect(current_claim.address_line_3).to eq("Verified Town")
+          expect(current_claim.address_line_4).to eq("Verified County")
           expect(current_claim.postcode).to eq("M12 345")
           expect(current_claim.date_of_birth).to eq(Date.new(1806, 4, 9))
           expect(current_claim.payroll_gender).to eq("male")
@@ -55,6 +56,7 @@ RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :reque
             "address_line_1",
             "address_line_2",
             "address_line_3",
+            "address_line_4",
             "postcode",
             "date_of_birth",
             "payroll_gender",


### PR DESCRIPTION
GOV.UK Verify returns a different set of data for EU citizens, which is missing their address. Therefor, for EU citizens to be able to use the service, we need to ask them to provide their address explicitly.

We also need to enable the eIDAS feature on our VSP.

See https://www.docs.verify.service.gov.uk/using-verify-data/data-from-verify/#european-identities-and-eidas

I also took the opportunity to add a feature spec for users being able to provide a payroll gender that got lost as part of some other refactoring work.