### PR TITLE
Conditionally get the thumbprint from deployment

### DIFF
--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -429,7 +429,7 @@
       ],
       "properties": {
         "sslState": "SniEnabled",
-        "thumbprint": "[reference(resourceId('Microsoft.Resources/deployments', variables('appServiceCertificateDeploymentName')), '2018-11-01').outputs.certificateThumbprint.value]"
+        "thumbprint": "[if(parameters('useAppServiceHostName'), reference(variables('appServiceCertificateDeploymentName'), '2018-11-01').outputs.certificateThumbprint.value, 'PLACEHOLDER')]"
       }
     },
     {


### PR DESCRIPTION
It seems that even though the deployment doesn't get run if `useAppServiceHostName` is false, Azure still attemptes to parse the template, and `appServiceCertificateDeploymentName` doesn't exist, so the deploy fails