### PR TITLE
Tighten Content-Security-Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,12 +5,12 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self, :https
+  policy.default_src :self
   policy.font_src :self, :https, :data
   policy.img_src :self, :https, :data
   policy.object_src :none
-  policy.script_src :self, :https
-  policy.style_src :self, :https
+  policy.script_src :self, "https://*.google-analytics.com", "https://www.googletagmanager.com"
+  policy.style_src :self
 
   # Specify URI for violation reports
   # policy.report_uri "/csp-violation-report-endpoint"


### PR DESCRIPTION
Only allow whitelisted JavaScript and CSS, which at the moment means anything from our domain, plus JavaScript from the Google Analytics and Tag Manager domains.