### PR TITLE
Set up healthcheck alerts

### DIFF
--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -141,6 +141,7 @@
     "applicationInsightsDeploymentName": "[concat(parameters('resourceNamePrefix'), '-application-insights')]",
     "appServiceCertificateDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app-service-certificate')]",
     "appServicePlanDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app-service-plan')]",
+    "appServiceWebTestDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app-service-web-test')]",
     "databaseServerFirewallRulesDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database-server-firewall-rules')]",
     "databaseServerDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database-server')]",
     "databaseDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database')]",
@@ -157,6 +158,8 @@
 
     "appServiceName": "[concat(parameters('resourceNamePrefix'), '-as')]",
     "appServiceRuntimeStack": "[concat('COMPOSE|', base64(parameters('appServiceDockerCompose')))]",
+
+    "appServiceWebTestName": "[concat(variables('appServiceName'), '-webtest')]",
 
     "vspAppServicePlanName": "[concat(parameters('resourceNamePrefix'), '-vsp-asp')]",
     "vspAppServiceName": "[concat(parameters('resourceNamePrefix'), '-vsp-as')]",
@@ -455,6 +458,32 @@
           },
           "serverName": {
             "value": "[variables('databaseServerName')]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "name": "[variables('appServiceWebTestDeploymentName')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'web_test.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "webTestName": {
+            "value": "[variables('appServiceWebTestName')]"
+          },
+          "appServiceHealthcheckUrl": {
+            "value": "[concat('https://', if(parameters('useAppServiceHostName'), parameters('appServiceHostName'), reference(resourceId('Microsoft.Web/sites', variables('appServiceName'))).defaultHostName), '/healthcheck')]"
+          },
+          "alertEmailAddress": {
+            "value": "[parameters('alertEmailAddress')]"
+          },
+          "applicationInsightsId": {
+            "value": "[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]"
           }
         }
       }

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -47,6 +47,10 @@
     "vspAppServiceDockerImage": {
       "type": "string"
     },
+    "vspAppServicePlanInstances": {
+      "type": "int",
+      "defaultValue": 2
+    },
     "vspAppServicePlanTier": {
       "type": "string",
       "defaultValue": "Standard"
@@ -54,10 +58,6 @@
     "vspAppServicePlanSize": {
       "type": "string",
       "defaultValue": "2"
-    },
-    "vspAppServicePlanInstances": {
-      "type": "int",
-      "defaultValue": 2
     },
     "verifyHubPossibleOutboundIpAddresses": {
       "type": "array"

--- a/azure/templates/web_test.json
+++ b/azure/templates/web_test.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "webTestName": {
+      "type": "string"
+    },
+    "appServiceHealthcheckUrl": {
+      "type": "string"
+    },
+    "alertEmailAddress": {
+      "type": "string"
+    },
+    "applicationInsightsId": {
+      "type": "string"
+    },
+    "webTestTimeoutInSeconds": {
+      "type": "int",
+      "defaultValue": 30
+    },
+    "webTestExpectedReturnCode": {
+      "type": "int",
+      "defaultValue": 200
+    },
+    "webTestLocations": {
+      "type": "array",
+      "defaultValue": [
+        { "Id": "us-il-ch1-azr" },
+        { "Id": "us-ca-sjc-azr" },
+        { "Id": "emea-fr-pra-edge" },
+        { "Id": "emea-nl-ams-azr" },
+        { "Id": "emea-gb-db3-azr" }
+      ]
+    },
+    "webTestAlertFailedLocationCount": {
+      "type": "int",
+      "defaultValue": 3
+    }
+  },
+  "variables": {
+    "webTestAlertName": "[concat(parameters('webTestName'), '-alert')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/webtests",
+      "apiVersion": "2015-05-01",
+      "name": "[parameters('webTestName')]",
+      "kind": "ping",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "[concat('hidden-link:', parameters('applicationInsightsId'))]": "Resource"
+      },
+      "properties": {
+        "Name": "[parameters('webTestName')]",
+        "Enabled": true,
+        "SyntheticMonitorId": "[parameters('webTestName')]",
+        "Frequency": 60,
+        "Timeout": "[parameters('webTestTimeoutInSeconds')]",
+        "Kind": "ping",
+        "Locations": "[parameters('webTestLocations')]",
+        "Configuration": {
+          "WebTest": "[concat('<WebTest Name=\"', parameters('webTestName'), '\" Enabled=\"True\" CssProjectStructure=\"\" CssIteration=\"\" Timeout=\"', parameters('webTestTimeoutInSeconds'), '\" WorkItemIds=\"\" xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\" Description=\"\" CredentialUserName=\"\" CredentialPassword=\"\" PreAuthenticate=\"True\" Proxy=\"default\" StopOnError=\"False\" RecordedResultFile=\"\" ResultsLocale=\"\"><Items><Request Method=\"GET\" Version=\"1.1\" Url=\"', parameters('appServiceHealthcheckUrl'), '\" ThinkTime=\"0\" Timeout=\"', parameters('webTestTimeoutInSeconds'), '\" ParseDependentRequests=\"True\" FollowRedirects=\"True\" RecordResult=\"True\" Cache=\"False\" ResponseTimeGoal=\"0\" Encoding=\"utf-8\" ExpectedHttpStatusCode=\"', parameters('webTestExpectedReturnCode'), '\" ExpectedResponseUrl=\"\" ReportingName=\"\" IgnoreHttpStatusCode=\"False\" /></Items></WebTest>')]"
+        }
+      }
+    },
+    {
+      "type": "microsoft.insights/alertrules",
+      "apiVersion": "2016-03-01",
+      "name": "[variables('webTestAlertName')]",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "[concat('hidden-link:', parameters('applicationInsightsId'))]": "Resource",
+        "[concat('hidden-link:', resourceId('Microsoft.Insights/webtests', parameters('webTestName')))]": "Resource"
+      },
+      "dependsOn": ["[resourceId('Microsoft.Insights/webtests', parameters('webTestName'))]"],
+      "properties": {
+        "name": "[variables('webTestAlertName')]",
+        "isEnabled": true,
+        "condition": {
+          "odata.type": "Microsoft.Azure.Management.Insights.Models.LocationThresholdRuleCondition",
+          "dataSource": {
+            "odata.type": "Microsoft.Azure.Management.Insights.Models.RuleMetricDataSource",
+            "resourceUri": "[resourceId('Microsoft.Insights/webtests', parameters('webTestName'))]",
+            "metricName": "GSMT_AvRaW"
+          },
+          "windowSize": "PT5M",
+          "failedLocationCount": "[parameters('webTestAlertFailedLocationCount')]"
+        },
+        "actions": [
+          {
+            "odata.type": "Microsoft.Azure.Management.Insights.Models.RuleEmailAction",
+            "customEmails": ["[parameters('alertEmailAddress')]"],
+            "sendToServiceOwners": false
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This GETs /healthcheck from 6 regions and fails if at least 3 of those regions return anything other than a 200 response within 30 seconds.

It lives in `app`, despite being an alert, because it needs to be in the same resource group as the Application Insights resource, and the web app service depends on that.

Inline XML is less than ideal, but we need to modify it at runtime making it difficult to pull out into a file.