### PR TITLE
Filter out or anonymise personally identifiable information

### DIFF
--- a/app/assets/javascripts/google_analytics.js
+++ b/app/assets/javascripts/google_analytics.js
@@ -4,4 +4,4 @@ function gtag() {
 }
 gtag("js", new Date());
 
-gtag("config", document.currentScript.getAttribute("data-ga-id"));
+gtag("config", document.currentScript.getAttribute("data-ga-id"), { anonymize_ip: true });

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -5,6 +5,34 @@ class Claim < ApplicationRecord
   NO_STUDENT_LOAN = "not_applicable"
   STUDENT_LOAN_PLAN_OPTIONS = StudentLoans::PLANS.dup << NO_STUDENT_LOAN
   ADDRESS_ATTRIBUTES = %w[address_line_1 address_line_2 address_line_3 address_line_4 postcode].freeze
+  FILTER_PARAMS = {
+    address_line_1: true,
+    address_line_2: true,
+    address_line_3: true,
+    address_line_4: true,
+    postcode: true,
+    payroll_gender: true,
+    teacher_reference_number: true,
+    national_insurance_number: true,
+    has_student_loan: false,
+    student_loan_country: false,
+    student_loan_courses: false,
+    student_loan_start_date: false,
+    email_address: true,
+    bank_sort_code: true,
+    bank_account_number: true,
+    created_at: false,
+    date_of_birth: true,
+    eligibility_id: false,
+    eligibility_type: false,
+    full_name: true,
+    id: false,
+    reference: false,
+    student_loan_plan: false,
+    submitted_at: false,
+    updated_at: false,
+    verified_fields: false,
+  }.freeze
 
   enum student_loan_country: StudentLoans::COUNTRIES
   enum student_loan_start_date: StudentLoans::COURSE_START_DATES
@@ -104,6 +132,10 @@ class Claim < ApplicationRecord
 
   def payroll_gender_verified?
     verified_fields.include?("payroll_gender")
+  end
+
+  def self.filtered_params
+    FILTER_PARAMS.select { |_, v| v }.keys
   end
 
   private

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,18 +3,5 @@
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [:password]
 
-# Personally identifiable information
-Rails.application.config.filter_parameters += [
-  :address_line_1,
-  :address_line_2,
-  :address_line_3,
-  :address_line_4,
-  :postcode,
-  :payroll_gender,
-  :teacher_reference_number,
-  :national_insurance_number,
-  :email_address,
-  :bank_sort_code,
-  :bank_account_number,
-  :SAMLResponse,
-]
+# Personally identifiable information in a claim
+Rails.application.config.filter_parameters += Claim.filtered_params

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,3 +2,19 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [:password]
+
+# Personally identifiable information
+Rails.application.config.filter_parameters += [
+  :address_line_1,
+  :address_line_2,
+  :address_line_3,
+  :address_line_4,
+  :postcode,
+  :payroll_gender,
+  :teacher_reference_number,
+  :national_insurance_number,
+  :email_address,
+  :bank_sort_code,
+  :bank_account_number,
+  :SAMLResponse,
+]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -5,3 +5,6 @@ Rails.application.config.filter_parameters += [:password]
 
 # Personally identifiable information in a claim
 Rails.application.config.filter_parameters += Claim.filtered_params
+
+# Sensitive parameter in Verify response
+Rails.application.config.filter_parameters += [:SAMLResponse]

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -7,6 +7,9 @@ Rollbar.configure do |config|
   # Disable Rollbar in "test" and "development" environments
   config.enabled = false if Rails.env.test? || Rails.env.development?
 
+  config.anonymize_user_ip = true
+  config.scrub_fields |= Rails.application.config.filter_parameters
+
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object"s `id`
   # method to fetch this property. To customize:

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -381,4 +381,30 @@ RSpec.describe Claim, type: :model do
       expect(Claim.new(verified_fields: ["address_line_1"]).payroll_gender_verified?).to eq false
     end
   end
+
+  describe ".filtered_params" do
+    it "returns a list of sensitive params to be filtered" do
+      expect(Claim.filtered_params).to match_array([
+        :address_line_1,
+        :address_line_2,
+        :address_line_3,
+        :address_line_4,
+        :postcode,
+        :payroll_gender,
+        :teacher_reference_number,
+        :national_insurance_number,
+        :email_address,
+        :bank_sort_code,
+        :bank_account_number,
+        :date_of_birth,
+        :full_name,
+      ])
+    end
+  end
+
+  describe "::FILTER_PARAMS" do
+    it "has a value for every claim attribute" do
+      expect(Claim::FILTER_PARAMS.keys).to match_array(Claim.new.attribute_names.map(&:to_sym))
+    end
+  end
 end


### PR DESCRIPTION
The disadvantage of maintaining a separate list of these fields in `filter_parameter_logging.rb` means we'll have to be vigilant with updating this list when new sensitive parameters get added. I considered extracting them out to a separate constant so they'd be more visible in our codebase but we'd have a similar problem of keeping it up-to-date.