### PR TITLE
Change loan amount hint

### DIFF
--- a/app/views/claims/student_loan_amount.html.erb
+++ b/app/views/claims/student_loan_amount.html.erb
@@ -10,7 +10,7 @@
             <%= fields.label :student_loan_repayment_amount, t("student_loans.questions.student_loan_amount", claim_school_name: current_claim.eligibility.claim_school_name), class: "govuk-label govuk-label--xl" %>
           </h1>
 
-          <span class="govuk-hint">If you do not know the amount, check your annual student loan statement, your P60 or contact the <a href="https://www.slc.co.uk/students-and-customers/contact-information-for-customers/loan-repayment-enquiries.aspx" class="govuk-link">student loans company</a>.</span>
+          <span class="govuk-hint">If you do not know the exact amount, check your P60, your annual student loan statement, or contact the <a href="https://www.slc.co.uk/students-and-customers/contact-information-for-customers/loan-repayment-enquiries.aspx" class="govuk-link">student loans company</a>.</span>
 
           <%= errors_tag current_claim, :student_loan_repayment_amount %>
 


### PR DESCRIPTION
Change hint to reference P60, annual statement then student loans
company so users will look for info in the way we want them to and not
guess last payslip contribution * 12