### PR TITLE
Recreate the Heroku start page within our app

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,7 @@
 class StaticPagesController < ApplicationController
+  def start_page
+  end
+
   def accessibility_statement
   end
 

--- a/app/views/static_pages/start_page.html.erb
+++ b/app/views/static_pages/start_page.html.erb
@@ -1,0 +1,36 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        <%= t('student_loans.journey_name') %>
+      </h1>
+
+      <p class="govuk-body">
+        Claim student loan repayments if you:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          teach biology, chemistry, physics, computer science or languages (not including English)
+          for over half your working hours, including your planning, preparation and assessment (PPA) time
+        </li>
+        <li>have been teaching for 1 to 5 years</li>
+        <li>teach in certain places - <a href="https://www.gov.uk/guidance/teachers-student-loan-reimbursement-guidance-for-teachers-and-schools#eligibility-criteria">check which places are eligible</a></li>
+        <li>received qualified teacher status in or after the 2013 to 2014 academic year</li>
+      </ul>
+
+      <h2 class="govuk-heading-m">Before you apply</h2>
+
+      <p class="govuk-body">You'll need:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the exact amount you have repaid – get this from your annual student loan statement, your P60 or by contacting the <a href="https://www.gov.uk/guidance/contact-slc-repayment-enquiries">student loans company</a></li>
+        <li>your National Insurance Number</li>
+        <li>your bank account details</li>
+        <li>your 7-digit teacher reference number – you can get this from your school, the certificate you got when you qualified, or from the <a href="https://www.gov.uk/guidance/individual-teacher-records-information-for-teachers#contact">teacher qualifications helpdesk</a></li>
+        <li>the date you completed your initial teacher training</li>
+        <li>sign in details for ‘Verify’ – the government’s secure way of proving who you are, if you do not have a Verify account, you’ll need your passport or photocard driving licence to sign up</li>
+      </ul>
+
+      <%= link_to "Start now", new_claim_path, class: "govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start", role: "button" %>
+    </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root "claims#new"
+  root "static_pages#start_page"
 
   # setup a simple healthcheck endpoint for monitoring purposes
   get "/healthcheck", to: proc { [200, {}, ["OK"]] }

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -28,6 +28,7 @@ module FeatureHelpers
 
   def start_claim
     visit root_path
+    click_on "Start now"
     click_on "Agree and continue"
     Claim.order(:created_at).last
   end


### PR DESCRIPTION
This replicates the start page on https://dfe-tslr-start-page.herokuapp.com/, and changes the root path to direct users to there by default. I'm not sure this is what we'll want to do long term (especially when we move to support Maths and Physics claims too), but it's enough for private beta.