### PR TITLE
Change how we show academic years

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -60,7 +60,8 @@ module ClaimsHelper
     return unless year_range.present?
 
     start_year, end_year = year_range.split("_")
-
-    "September 1 #{start_year} - August 31 #{end_year}"
+    start_date = Date.new(start_year.to_i, 9, 1)
+    end_date = Date.new(end_year.to_i, 8, 31)
+    "#{l(start_date)} to #{l(end_date)}"
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@
 en:
   date:
     formats:
-      default: "%d %B %Y"
+      default: "%-d %B %Y"
   number:
     currency:
       format:
@@ -78,14 +78,14 @@ en:
     questions:
       qts_award_year: "Which academic year did you complete your initial teacher training?"
       qts_award_years:
-        before_2013: "Before September 1 2013"
-        "2013_2014": "September 1 2013 – August 31 2014"
-        "2014_2015": "September 1 2014 – August 31 2015"
-        "2015_2016": "September 1 2015 – August 31 2016"
-        "2016_2017": "September 1 2016 – August 31 2017"
-        "2017_2018": "September 1 2017 – August 31 2018"
-        "2018_2019": "September 1 2018 – August 31 2019"
-        "2019_2020": "September 1 2019 – August 31 2020"
+        before_2013: "Before 1 September 2013"
+        "2013_2014": "1 September 2013 to 31 August 2014"
+        "2014_2015": "1 September 2014 to 31 August 2015"
+        "2015_2016": "1 September 2015 to 31 August 2016"
+        "2016_2017": "1 September 2016 to 31 August 2017"
+        "2017_2018": "1 September 2017 to 31 August 2018"
+        "2018_2019": "1 September 2018 to 31 August 2019"
+        "2019_2020": "1 September 2019 to 31 August 2020"
       claim_school: "Which school were you employed at between 6 April 2018 and 5 April 2019?"
       employment_status: "Are you still employed to teach at a school in England?"
       subjects_taught: "Did you teach any of the following subjects between 6 April 2018 and 5 April 2019?"

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   scenario "qualified before the first eligible year" do
     claim = start_claim
 
-    choose "Before September 1 2013"
+    choose "Before 1 September 2013"
     click_on "Continue"
 
     expect(claim.eligibility.reload.qts_award_year).to eql("before_2013")

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -16,7 +16,7 @@ describe ClaimsHelper do
       )
 
       expected_answers = [
-        [I18n.t("student_loans.questions.qts_award_year"), "September 1 2013 - August 31 2014", "qts-year"],
+        [I18n.t("student_loans.questions.qts_award_year"), "1 September 2013 to 31 August 2014", "qts-year"],
         [I18n.t("student_loans.questions.claim_school"), school.name, "claim-school"],
         [I18n.t("questions.current_school"), school.name, "still-teaching"],
         [I18n.t("student_loans.questions.subjects_taught"), "Chemistry and Physics", "subjects-taught"],
@@ -152,7 +152,7 @@ describe ClaimsHelper do
 
   describe "#academic_years" do
     it "returns a string showing the date range for the academic year based on the qts_award_year input" do
-      expect(helper.academic_years("2012_2013")).to eq "September 1 2012 - August 31 2013"
+      expect(helper.academic_years("2012_2013")).to eq "1 September 2012 to 31 August 2013"
     end
 
     it "doesn't fall over if the qts_award_year has not been set yet" do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -32,7 +32,7 @@ module FeatureHelpers
     Claim.order(:created_at).last
   end
 
-  def choose_qts_year(year = "September 1 2014 – August 31 2015")
+  def choose_qts_year(year = "1 September 2014 to 31 August 2015")
     choose year
     click_on "Continue"
   end


### PR DESCRIPTION
Because screen readers don't read out "-" as a word we should say
e.g. September 1 2013 to August 31 2014