### PR TITLE
 Set up the more advanced unhandled exception handler on Application Insights

### DIFF
--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -4,5 +4,7 @@ if instrumentation_key.present?
   Rails.application.configure do
     buffer_size = 1
     config.middleware.use ApplicationInsights::Rack::TrackRequest, instrumentation_key, buffer_size
+
+    ApplicationInsights::UnhandledException.collect(app_insights_key)
   end
 end


### PR DESCRIPTION
This should give us more information about exceptions that occur. There is possibly some overlap here with Rollbar.