### PR TITLE
Have a support role within the app

### DIFF
--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -1,8 +1,5 @@
 module Admin
   class AuthController < BaseAdminController
-    DFE_SIGN_IN_ADMIN_ROLE_CODE = "teacher_payments_access"
-    DFE_SIGN_IN_SUPPORT_ROLE_CODE = "teacher_payments_support"
-
     skip_before_action :ensure_authenticated_user
 
     def sign_in

--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -26,11 +26,15 @@ module Admin
 
     private
 
-    def authorised?
-      DfeSignIn::UserAccess.new(
+    def role_codes
+      @role_codes ||= DfeSignIn::UserAccess.new(
         user_id: user_id,
         organisation_id: organisation_id
-      ).has_role?(DFE_SIGN_IN_ADMIN_ROLE_CODE)
+      ).role_codes
+    end
+
+    def authorised?
+      ([DFE_SIGN_IN_ADMIN_ROLE_CODE] & role_codes).present?
     end
 
     def auth_hash

--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class AuthController < BaseAdminController
     DFE_SIGN_IN_ADMIN_ROLE_CODE = "teacher_payments_access"
+    DFE_SIGN_IN_SUPPORT_ROLE_CODE = "teacher_payments_support"
 
     skip_before_action :ensure_authenticated_user
 
@@ -14,6 +15,7 @@ module Admin
 
     def callback
       if authorised?
+        session[:role_codes] = role_codes
         session[:admin_auth] = auth_hash.fetch("info").to_h
         redirect_to admin_path
       else
@@ -34,7 +36,11 @@ module Admin
     end
 
     def authorised?
-      ([DFE_SIGN_IN_ADMIN_ROLE_CODE] & role_codes).present?
+      (valid_roles & role_codes).present?
+    end
+
+    def valid_roles
+      [DFE_SIGN_IN_ADMIN_ROLE_CODE, DFE_SIGN_IN_SUPPORT_ROLE_CODE]
     end
 
     def auth_hash

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -1,8 +1,24 @@
 module Admin
   class BaseAdminController < ApplicationController
+    DFE_SIGN_IN_ADMIN_ROLE_CODE = "teacher_payments_access"
+    DFE_SIGN_IN_SUPPORT_ROLE_CODE = "teacher_payments_support"
+
     before_action :ensure_authenticated_user
+    helper_method :is_admin_user?, :is_support_user?
+
+    def is_admin_user?
+      is_user_of_type?(DFE_SIGN_IN_ADMIN_ROLE_CODE)
+    end
+
+    def is_support_user?
+      is_user_of_type?(DFE_SIGN_IN_SUPPORT_ROLE_CODE)
+    end
 
     private
+
+    def is_user_of_type?(type)
+      session[:role_codes].include?(type)
+    end
 
     def ensure_authenticated_user
       redirect_to admin_sign_in_path unless admin_signed_in?

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -1,4 +1,6 @@
 class Admin::ClaimsController < Admin::BaseAdminController
+  before_action :ensure_admin_user
+
   def index
     claims = Claim.includes(eligibility: [:claim_school, :current_school]).submitted.order(:submitted_at)
     csv = TslrClaimsCsv.new(claims)
@@ -6,5 +8,11 @@ class Admin::ClaimsController < Admin::BaseAdminController
     respond_to do |format|
       format.csv { send_file csv.file, type: "text/csv", filename: "claims.csv" }
     end
+  end
+
+  private
+
+  def ensure_admin_user
+    redirect_to admin_path unless is_admin_user?
   end
 end

--- a/app/views/admin/page/index.html.erb
+++ b/app/views/admin/page/index.html.erb
@@ -4,6 +4,6 @@
       Admin
     </h1>
 
-    <%= link_to 'Download claims', admin_claims_path(format: :csv), class: "govuk-button" %>
+    <%= link_to 'Download claims', admin_claims_path(format: :csv), class: "govuk-button" if is_admin_user? %>
   </div>
 </div>

--- a/lib/dfe_sign_in/user_access.rb
+++ b/lib/dfe_sign_in/user_access.rb
@@ -10,8 +10,8 @@ module DfeSignIn
       self.user_id = user_id
     end
 
-    def has_role?(role_code)
-      role_codes.include?(role_code)
+    def role_codes
+      @role_codes ||= body["roles"].map { |r| r["code"] }
     end
 
     private
@@ -30,10 +30,6 @@ module DfeSignIn
 
         JSON.parse(response.body)
       end
-    end
-
-    def role_codes
-      body["roles"].map { |r| r["code"] }
     end
 
     def uri

--- a/spec/features/admin_csv_download_spec.rb
+++ b/spec/features/admin_csv_download_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Download CSV of claims" do
-  context "User is logged in" do
+  context "User is logged in as an admin user" do
     before do
       stub_dfe_sign_in_with_role(Admin::AuthController::DFE_SIGN_IN_ADMIN_ROLE_CODE)
       visit admin_path
@@ -18,6 +18,24 @@ RSpec.feature "Download CSV of claims" do
 
       csv = CSV.parse(body)
       expect(csv.count).to eq(submitted_claims.count + 1)
+    end
+  end
+
+  context "User is logged in as a support user" do
+    before do
+      stub_dfe_sign_in_with_role(Admin::AuthController::DFE_SIGN_IN_SUPPORT_ROLE_CODE)
+      visit admin_path
+      click_on "Sign in"
+    end
+
+    scenario "User cannot see a link to download claims" do
+      expect(page).to_not have_content("Download claims")
+    end
+
+    scenario "User cannot download CSV directly" do
+      visit admin_claims_path(format: :csv)
+
+      expect(page).to have_current_path(admin_path)
     end
   end
 

--- a/spec/features/admin_sessions_spec.rb
+++ b/spec/features/admin_sessions_spec.rb
@@ -1,22 +1,45 @@
 require "rails_helper"
 
 RSpec.feature "Admin sessions" do
-  before do
-    stub_dfe_sign_in_with_role(Admin::AuthController::DFE_SIGN_IN_ADMIN_ROLE_CODE)
+  context "when the user is an admin" do
+    before do
+      stub_dfe_sign_in_with_role(Admin::AuthController::DFE_SIGN_IN_ADMIN_ROLE_CODE)
+    end
+
+    scenario "Redirected to admin page after signing in" do
+      visit admin_path
+      click_on "Sign in"
+
+      expect(page).to have_content("Admin")
+    end
+
+    scenario "Signing out" do
+      visit admin_path
+      click_on "Sign in"
+
+      click_on "Sign out"
+      expect(page).to have_content("You've been signed out")
+    end
   end
 
-  scenario "Redirected to admin page after signing in" do
-    visit admin_path
-    click_on "Sign in"
+  context "when the user is a support user" do
+    before do
+      stub_dfe_sign_in_with_role(Admin::AuthController::DFE_SIGN_IN_SUPPORT_ROLE_CODE)
+    end
 
-    expect(page).to have_content("Admin")
-  end
+    scenario "Redirected to admin page after signing in" do
+      visit admin_path
+      click_on "Sign in"
 
-  scenario "Signing out" do
-    visit admin_path
-    click_on "Sign in"
+      expect(page).to have_content("Admin")
+    end
 
-    click_on "Sign out"
-    expect(page).to have_content("You've been signed out")
+    scenario "Signing out" do
+      visit admin_path
+      click_on "Sign in"
+
+      click_on "Sign out"
+      expect(page).to have_content("You've been signed out")
+    end
   end
 end

--- a/spec/lib/dfe_sign_in/user_access_spec.rb
+++ b/spec/lib/dfe_sign_in/user_access_spec.rb
@@ -10,24 +10,14 @@ RSpec.describe DfeSignIn::UserAccess do
       .to_return(body: response.to_json, status: status)
   end
 
-  context "with a valid response" do
-    let(:status) { 200 }
+  describe "role_codes" do
+    let(:role_ids) { subject.role_codes }
     let(:response) do
       {
         "userId" => "999",
         "serviceId" => "123",
         "organisationId" => "456",
-        "roles" => [
-          {
-            "id" => "role-id",
-            "name" => "My role",
-            "code" => "my_role",
-            "numericId" => "9999",
-            "status" => {
-              "id" => 1,
-            },
-          },
-        ],
+        "roles" => roles,
         "identifiers" => [
           {
             "key" => "identifier-key",
@@ -37,28 +27,63 @@ RSpec.describe DfeSignIn::UserAccess do
       }
     end
 
-    describe "has_role?" do
-      let(:has_role?) { subject.has_role?(role) }
-
-      context "when a role exists" do
-        let(:role) { "my_role" }
-        it { expect(has_role?).to eq(true) }
+    context "with a valid response" do
+      let(:status) { 200 }
+      let(:roles) do
+        [
+          {
+            "id" => "role-id",
+            "name" => "My role",
+            "code" => "my_role",
+            "numericId" => "9999",
+            "status" => {
+              "id" => 1,
+            },
+          },
+        ]
       end
 
-      context "when a role does not exist" do
-        let(:role) { "other_role" }
-        it { expect(has_role?).to eq(false) }
+      it "returns the role code" do
+        expect(role_ids).to eq(["my_role"])
       end
     end
-  end
 
-  context "with an invalid response" do
-    let(:status) { 500 }
-    let(:response) { {"error": "An error occurred"} }
+    context "with multiple roles" do
+      let(:status) { 200 }
+      let(:roles) do
+        [
+          {
+            "id" => "role-id",
+            "name" => "My role",
+            "code" => "my_role",
+            "numericId" => "9999",
+            "status" => {
+              "id" => 1,
+            },
+          },
+          {
+            "id" => "another-role",
+            "name" => "Another role",
+            "code" => "another_role",
+            "numericId" => "1234",
+            "status" => {
+              "id" => 5,
+            },
+          },
+        ]
+      end
 
-    describe "has_role?" do
+      it "returns both role codes" do
+        expect(role_ids).to eq(["my_role", "another_role"])
+      end
+    end
+
+    context "with an invalid response" do
+      let(:status) { 500 }
+      let(:response) { {"error": "An error occurred"} }
+
       it "raises an error" do
-        expect { subject.has_role?("my_role") }.to raise_error(
+        expect { role_ids }.to raise_error(
           DfeSignIn::ExternalServerError, "500: {\"error\":\"An error occurred\"}"
         )
       end


### PR DESCRIPTION
This adds a support for a support role in the app. If a user logs in to the admin section with a role of `teacher_payments_support`, then they are logged in, but cannot download the full CSV of claims