### PR TITLE
Store the entire GOV.UK Verify response to aid debugging during early beta

### DIFF
--- a/app/controllers/verify/authentications_controller.rb
+++ b/app/controllers/verify/authentications_controller.rb
@@ -23,6 +23,7 @@ module Verify
         current_claim.update!(@response.claim_parameters)
         redirect_to claim_url("verified")
       else
+        current_claim.update!(verify_response: @response.parameters)
         redirect_to verify_path_for_response_scenario(@response.scenario)
       end
     end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -32,6 +32,7 @@ class Claim < ApplicationRecord
     submitted_at: false,
     updated_at: false,
     verified_fields: false,
+    verify_response: true,
   }.freeze
 
   enum student_loan_country: StudentLoans::COUNTRIES

--- a/db/migrate/20190815151449_add_verify_response_to_claim.rb
+++ b/db/migrate/20190815151449_add_verify_response_to_claim.rb
@@ -1,0 +1,5 @@
+class AddVerifyResponseToClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :claims, :verify_response, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_08_153656) do
+ActiveRecord::Schema.define(version: 2019_08_15_151449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 2019_08_08_153656) do
     t.text "verified_fields", default: [], array: true
     t.string "eligibility_type"
     t.uuid "eligibility_id"
+    t.json "verify_response"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"
     t.index ["reference"], name: "index_claims_on_reference", unique: true
     t.index ["submitted_at"], name: "index_claims_on_submitted_at"

--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -26,7 +26,8 @@ module Verify
       return {} unless verified?
 
       identity_paramteters.merge(
-        verified_fields: verified_fields
+        verified_fields: verified_fields,
+        verify_response: parameters
       )
     end
 

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -37,6 +37,7 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
       expect(@claim.postcode).to eq("M12 345")
       expect(@claim.date_of_birth).to eq(Date.new(1806, 4, 9))
       expect(@claim.payroll_gender).to eq("male")
+      expect(@claim.verify_response).to eq(parsed_vsp_translated_response("identity-verified"))
     end
 
     scenario "successful verification with JavaScript disabled" do

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -68,6 +68,9 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
       click_on "Perform identity check"
 
       expect(page).to have_text("you did not complete the process")
+
+      @claim.reload
+      expect(@claim.verify_response).to eq(parsed_vsp_translated_response("no-authentication"))
     end
   end
 
@@ -82,6 +85,9 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
       click_on "Perform identity check"
 
       expect(page).to have_text("the company you chose does not have enough information about you")
+
+      @claim.reload
+      expect(@claim.verify_response).to eq(parsed_vsp_translated_response("authentication-failed"))
     end
   end
 end

--- a/spec/lib/verify/response_spec.rb
+++ b/spec/lib/verify/response_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Verify::Response, type: :model do
         :date_of_birth,
         :payroll_gender,
       ])
+      expect(subject.claim_parameters[:verify_response]).to eq(response)
     end
 
     context "when the gender from Verify is female" do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -398,6 +398,7 @@ RSpec.describe Claim, type: :model do
         :bank_account_number,
         :date_of_birth,
         :full_name,
+        :verify_response,
       ])
     end
   end

--- a/spec/support/verify_helpers.rb
+++ b/spec/support/verify_helpers.rb
@@ -36,3 +36,7 @@ end
 def stubbed_vsp_translated_response(type)
   File.read(Rails.root.join("spec", "fixtures", "verify", "#{type}.json"))
 end
+
+def parsed_vsp_translated_response(type)
+  JSON.parse(stubbed_vsp_translated_response(type))
+end


### PR DESCRIPTION
This adds an additional JSON column to the Claims table where the entirity of the Verify response is called, regardless of if it's a succcessful verification or not. How we actually access this data (given we don't have SSH access) is a different matter