### PR TITLE
Fix incorrectly named variable

### DIFF
--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -5,6 +5,6 @@ if instrumentation_key.present?
     buffer_size = 1
     config.middleware.use ApplicationInsights::Rack::TrackRequest, instrumentation_key, buffer_size
 
-    ApplicationInsights::UnhandledException.collect(app_insights_key)
+    ApplicationInsights::UnhandledException.collect(instrumentation_key)
   end
 end


### PR DESCRIPTION
#293 has introduced an error in dev, because the `instrumentation_key` was incorrectly named (my bad, should've spotted that) and the container can't start correctly.