### PR TITLE
Add a basic cookie banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ To enable Google Analytics set the following environment variable:
 GOOGLE_ANALYTICS_ID=<UA PROPERTY>
 ```
 
+### Storing non-essential cookies
+
+Non-essential cookies should not be stored without the user's consent. If the
+user has given consent, we record it in a cookie called `accept_cookies`.
+
+In JavaScript before setting a cookie, you can check the user's consent by using
+the function: `TeacherPayments.cookies.checkNonEssentialCookiesAccepted()`
+
 ### Running `CronJob`s
 
 To schedule recurring jobs, run the following:

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require govuk_frontend_rails
 //= require a11y-dialog/a11y-dialog.min.js
 //= require accessible-autocomplete/dist/accessible-autocomplete.min.js
+//= require cookie_functions.js
 //= require_tree .
 //= stub js_check.js
 //= stub google_analytics.js

--- a/app/assets/javascripts/components/cookie_banner.js
+++ b/app/assets/javascripts/components/cookie_banner.js
@@ -1,28 +1,15 @@
 "use strict";
 
 document.addEventListener("DOMContentLoaded", function() {
-  var cookiePolicyName = "accept_cookie_policy";
-  var acceptCookies = getCookie(cookiePolicyName);
   var cookieBanner = document.querySelector("#global-cookie-message");
   var acceptButton = document.querySelector("#accept-cookies");
 
-  if (!acceptCookies) {
-    cookieBanner.style.display = "block";
+  if (!TeacherPayments.cookies.checkNonEssentialCookiesAccepted()) {
+    cookieBanner.classList.add("govuk-cookie-banner--visible");
   }
 
   acceptButton.onclick = function() {
-    setCookie(cookiePolicyName, 1, 365);
-    cookieBanner.style.display = "none";
+    TeacherPayments.cookies.acceptNonEssentialCookies();
+    cookieBanner.classList.remove("govuk-cookie-banner--visible");
   };
-
-  function getCookie(name) {
-    var v = document.cookie.match("(^|;) ?" + name + "=([^;]*)(;|$)");
-    return v ? v[2] : null;
-  }
-
-  function setCookie(name, value, days) {
-    var date = new Date();
-    date.setTime(date.getTime() + 24 * 60 * 60 * 1000 * days);
-    document.cookie = name + "=" + value + ";path=/;expires=" + date.toGMTString();
-  }
 });

--- a/app/assets/javascripts/components/cookie_banner.js
+++ b/app/assets/javascripts/components/cookie_banner.js
@@ -1,0 +1,28 @@
+"use strict";
+
+document.addEventListener("DOMContentLoaded", function() {
+  var cookiePolicyName = "accept_cookie_policy";
+  var acceptCookies = getCookie(cookiePolicyName);
+  var cookieBanner = document.querySelector("#global-cookie-message");
+  var acceptButton = document.querySelector("#accept-cookies");
+
+  if (!acceptCookies) {
+    cookieBanner.style.display = "block";
+  }
+
+  acceptButton.onclick = function() {
+    setCookie(cookiePolicyName, 1, 365);
+    cookieBanner.style.display = "none";
+  };
+
+  function getCookie(name) {
+    var v = document.cookie.match("(^|;) ?" + name + "=([^;]*)(;|$)");
+    return v ? v[2] : null;
+  }
+
+  function setCookie(name, value, days) {
+    var date = new Date();
+    date.setTime(date.getTime() + 24 * 60 * 60 * 1000 * days);
+    document.cookie = name + "=" + value + ";path=/;expires=" + date.toGMTString();
+  }
+});

--- a/app/assets/javascripts/cookie_functions.js
+++ b/app/assets/javascripts/cookie_functions.js
@@ -1,0 +1,20 @@
+window.TeacherPayments = window.TeacherPayments || {};
+
+window.TeacherPayments.cookies = {
+  acceptCookieName: "accept_cookies",
+  checkNonEssentialCookiesAccepted: function() {
+    return this._get(this.acceptCookieName);
+  },
+  acceptNonEssentialCookies: function() {
+    this._set(this.acceptCookieName, 1, 90);
+  },
+  _set: function(name, value, days) {
+    var date = new Date();
+    date.setTime(date.getTime() + 24 * 60 * 60 * 1000 * days);
+    document.cookie = name + "=" + value + ";path=/;expires=" + date.toGMTString();
+  },
+  _get: function(name) {
+    var v = document.cookie.match("(^|;) ?" + name + "=([^;]*)(;|$)");
+    return v ? v[2] : null;
+  }
+};

--- a/app/assets/javascripts/google_analytics.js
+++ b/app/assets/javascripts/google_analytics.js
@@ -1,7 +1,14 @@
-window.dataLayer = window.dataLayer || [];
-function gtag() {
-  dataLayer.push(arguments);
-}
-gtag("js", new Date());
+var currentScript = document.currentScript;
 
-gtag("config", document.currentScript.getAttribute("data-ga-id"), { anonymize_ip: true });
+document.addEventListener("DOMContentLoaded", function() {
+  if (!window.TeacherPayments.cookies.checkNonEssentialCookiesAccepted()) {
+    return;
+  }
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag("js", new Date());
+
+  gtag("config", currentScript.getAttribute("data-ga-id"), { anonymize_ip: true });
+});

--- a/app/assets/stylesheets/components/cookie_banner.scss
+++ b/app/assets/stylesheets/components/cookie_banner.scss
@@ -17,7 +17,7 @@ $govuk-cookie-banner-text-green: #00823b;
 
 .govuk-cookie-banner {
   @include govuk-font(19);
-  padding: govuk-spacing(4) 0;
+  padding: govuk-spacing(4) 0 govuk-spacing(2) 0;
   background-color: $govuk-cookie-banner-background;
   border: 2px solid govuk-colour("black");
 
@@ -30,7 +30,7 @@ $govuk-cookie-banner-text-green: #00823b;
   display: inline-block;
   margin: govuk-spacing(0);
   padding-right: govuk-spacing(4);
-  padding-bottom: govuk-spacing(0);
+  padding-bottom: govuk-spacing(2);
   color: $govuk-cookie-banner-text-green;
 }
 
@@ -45,7 +45,7 @@ $govuk-cookie-banner-text-green: #00823b;
 
   .govuk-button--secondary {
     padding: 8px 10px;
-    margin-bottom: 0;
+    margin-bottom: govuk-spacing(2);
     border-color: $govuk-cookie-banner-text-green;
     color: $govuk-cookie-banner-text-green;
     background-color: govuk-colour("white");

--- a/app/assets/stylesheets/components/cookie_banner.scss
+++ b/app/assets/stylesheets/components/cookie_banner.scss
@@ -9,16 +9,16 @@ $govuk-cookie-banner-text-green: #00823b;
 
 .govuk-cookie-banner {
   @include govuk-font(19);
-  padding: govuk-spacing(2) 0;
+  padding: govuk-spacing(4) 0;
   background-color: $govuk-cookie-banner-background;
   border: 2px solid govuk-colour("black");
 }
 
 .govuk-cookie-banner__message {
   display: inline-block;
-  margin-top: govuk-spacing(2);
+  margin: govuk-spacing(0);
   padding-right: govuk-spacing(4);
-  padding-bottom: govuk-spacing(2);
+  padding-bottom: govuk-spacing(0);
   color: $govuk-cookie-banner-text-green;
 }
 
@@ -29,9 +29,11 @@ $govuk-cookie-banner-text-green: #00823b;
     display: inline-block;
   }
 
+  vertical-align: super;
+
   .govuk-button--secondary {
     padding: 8px 10px;
-    margin-bottom: govuk-spacing(2);
+    margin-bottom: 0;
     border-color: $govuk-cookie-banner-text-green;
     color: $govuk-cookie-banner-text-green;
     background-color: govuk-colour("white");

--- a/app/assets/stylesheets/components/cookie_banner.scss
+++ b/app/assets/stylesheets/components/cookie_banner.scss
@@ -5,6 +5,14 @@ $govuk-cookie-banner-text-green: #00823b;
 
 .js-enabled .govuk-cookie-banner {
   display: none;
+
+  &.govuk-cookie-banner--visible {
+    display: block;
+  }
+
+  #accept-cookies {
+    display: inline-block;
+  }
 }
 
 .govuk-cookie-banner {
@@ -12,6 +20,10 @@ $govuk-cookie-banner-text-green: #00823b;
   padding: govuk-spacing(4) 0;
   background-color: $govuk-cookie-banner-background;
   border: 2px solid govuk-colour("black");
+
+  #accept-cookies {
+    display: none;
+  }
 }
 
 .govuk-cookie-banner__message {

--- a/app/assets/stylesheets/components/cookie_banner.scss
+++ b/app/assets/stylesheets/components/cookie_banner.scss
@@ -1,0 +1,40 @@
+@import "govuk-frontend-rails";
+
+$govuk-cookie-banner-background: govuk-colour("white");
+$govuk-cookie-banner-text-green: #00823b;
+
+.js-enabled .govuk-cookie-banner {
+  display: none;
+}
+
+.govuk-cookie-banner {
+  @include govuk-font(19);
+  padding: govuk-spacing(2) 0;
+  background-color: $govuk-cookie-banner-background;
+  border: 2px solid govuk-colour("black");
+}
+
+.govuk-cookie-banner__message {
+  display: inline-block;
+  margin-top: govuk-spacing(2);
+  padding-right: govuk-spacing(4);
+  padding-bottom: govuk-spacing(2);
+  color: $govuk-cookie-banner-text-green;
+}
+
+.govuk-cookie-banner__buttons {
+  @include govuk-clearfix;
+
+  @include govuk-media-query($from: desktop) {
+    display: inline-block;
+  }
+
+  .govuk-button--secondary {
+    padding: 8px 10px;
+    margin-bottom: govuk-spacing(2);
+    border-color: $govuk-cookie-banner-text-green;
+    color: $govuk-cookie-banner-text-green;
+    background-color: govuk-colour("white");
+    box-shadow: none;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,16 @@
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
+    <div id="global-cookie-message" class="govuk-cookie-banner" role="region" aria-label="cookie banner">
+      <div class="govuk-width-container">
+        <p class="govuk-cookie-banner__message">This service uses cookies to make the site simpler.</p>
+        <div class="govuk-cookie-banner__buttons">
+          <button class="govuk-button govuk-button--secondary" type="submit" id="accept-cookies">Accept cookies</button>
+          <%= link_to('Cookie information', cookies_path, class: "govuk-button govuk-button--secondary ") %>
+        </div>
+      </div>
+    </div>
+
     <header class="govuk-header " role="banner" data-module="header">
       <div class="govuk-header__container govuk-width-container">
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
 
     <div id="global-cookie-message" class="govuk-cookie-banner" role="region" aria-label="cookie banner">
       <div class="govuk-width-container">
-        <p class="govuk-cookie-banner__message">This service uses cookies to make the site simpler.</p>
+        <p class="govuk-cookie-banner__message"><%= t("service_name") %> uses cookies to make the site simpler.</p>
         <div class="govuk-cookie-banner__buttons">
           <button class="govuk-button govuk-button--secondary" type="submit" id="accept-cookies">Accept cookies</button>
           <%= link_to('Cookie information', cookies_path, class: "govuk-button govuk-button--secondary ") %>

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -77,6 +77,12 @@
           <td class="govuk-table__cell">This helps us count how many people visit <%= t("service_name") %> by tracking if you’ve visited before</td>
           <td class="govuk-table__cell">After 24 hours</td>
         </tr>
+        <tr>
+          <tr class="govuk-table__row">
+          <td class="govuk-table__cell">_gat_gtag_[ua-code]</td>
+          <td class="govuk-table__cell">This is used by Google Analytics to limit the amount of requests they receive</td>
+          <td class="govuk-table__cell">After 1 minute</td>
+        </tr>
       </tbody>
     </table>
 

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -16,7 +16,7 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>track your progress and record your answers as you complete a claim</li>
       <li>measure how you use this service so it can be updated and improved based on your needs</li>
-      <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
+      <li>remember your cookie consent so that we don’t ask you again</li>
     </ul>
 
     <div class="panel panel-border-wide">
@@ -104,7 +104,7 @@
     </h2>
 
     <p class="govuk-body">
-      A cookie is set to record your session activity.
+      A cookie is set to record your session activity. This is essential to the function of the service.
     </p>
 
     <table class="govuk-table mb1">
@@ -123,12 +123,12 @@
     </table>
 
     <h2 class="govuk-heading-l">
-      Our introductory message
+      Cookie consent
     </h2>
 
     <p class="govuk-body">
-      You may see a pop-up welcome message when you first visit <%= t("service_name") %>.
-      We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.
+      You will see a pop-up cookie consent message when you visit <%= t("service_name") %>.
+      If you give us consent to, we'll store a cookie so that your computer knows you’ve consented to non-essential cookies and don't ask you again.
     </p>
 
     <table class="govuk-table mb1">
@@ -139,9 +139,9 @@
       </thead>
       <tbody>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">XXXX</td>
-          <td class="govuk-table__cell">Saves a message to let us know that you have seen our cookie message</td>
-          <td class="govuk-table__cell">After 1 month</td>
+          <td class="govuk-table__cell">accept_cookies</td>
+          <td class="govuk-table__cell">Saves a message to let us know that you have accepted non-essential cookies</td>
+          <td class="govuk-table__cell">After 90 days</td>
         </tr>
       </tbody>
     </table>

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -79,7 +79,7 @@
         </tr>
         <tr>
           <tr class="govuk-table__row">
-          <td class="govuk-table__cell">_gat_gtag_[ua-code]</td>
+          <td class="govuk-table__cell">_gat_gtag_<%= ENV["GOOGLE_ANALYTICS_ID"]&.underscore %></td>
           <td class="govuk-table__cell">This is used by Google Analytics to limit the amount of requests they receive</td>
           <td class="govuk-table__cell">After 1 minute</td>
         </tr>


### PR DESCRIPTION
The styles are mostly copied from the "govuk_publishing_components" which GOV.UK uses as there's no official pattern in the Design System for it.

It will always show until the user clicks 'accept cookies'. No non-essential cookies should be loaded unless the user has clicked accept.

Google Analytics is considered non-essential so it won't start tracking until the page after they click "Accept cookies" on, this might skew our analytics slightly and we might want to tweak this/add events at a later date.

By default the cookie banner will always show to users without JavaScript, but won't have the accept button.

https://ico.org.uk/about-the-ico/news-and-events/news-and-blogs/2019/07/blog-cookies-what-does-good-look-like/

## Screenshot

<img width="1178" alt="Screenshot 2019-08-20 at 14 33 27" src="https://user-images.githubusercontent.com/2804149/63351640-83a96a80-c357-11e9-8ad9-f6c1b6986058.png">

