### PR TITLE
Play GOV.UK Verify response data back to the user

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -23,6 +23,15 @@ module ClaimsHelper
     end
   end
 
+  def verify_answers(claim)
+    [].tap do |a|
+      a << ["Full name", claim.full_name]
+      a << ["Address", claim.address] if claim.address_verified?
+      a << ["Date of birth", l(claim.date_of_birth)]
+      a << ["Gender", t("answers.payroll_gender.#{claim.payroll_gender}")] if claim.payroll_gender_verified?
+    end
+  end
+
   def identity_answers(claim)
     [].tap do |a|
       a << [t("questions.address"), claim.address, "address"] unless claim.address_verified?

--- a/app/views/claims/_check_your_answers_section.html.erb
+++ b/app/views/claims/_check_your_answers_section.html.erb
@@ -14,7 +14,7 @@
       </dd>
 
       <dd class="govuk-summary-list__actions">
-        <%= link_to 'Change', claim_path(slug), class: 'govuk-link' %>
+        <%= link_to('Change', claim_path(slug), class: 'govuk-link') unless slug.nil? %>
       </dd>
     </div>
   <% end %>

--- a/app/views/claims/check_your_answers.html.erb
+++ b/app/views/claims/check_your_answers.html.erb
@@ -8,6 +8,8 @@
 
     <%= render partial: "check_your_answers_section", locals: {heading: "Claim details", answers: eligibility_answers(current_claim.eligibility)} %>
 
+    <%= render partial: "check_your_answers_section", locals: {heading: "GOV.UK Verify details", answers: verify_answers(current_claim)} %>
+
     <%= render partial: "check_your_answers_section", locals: {heading: "Identity details", answers: identity_answers(current_claim)} %>
 
     <%= render partial: "check_your_answers_section", locals: {heading: "Student loan details", answers: student_loan_answers(current_claim)} %>

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -38,6 +38,55 @@ describe ClaimsHelper do
     end
   end
 
+  describe "#verify_answers" do
+    let(:claim) do
+      build(
+        :claim,
+        full_name: "Jo Bloggs",
+        address_line_1: "Flat 1",
+        address_line_2: "1 Test Road",
+        address_line_3: "Test Town",
+        postcode: "AB1 2CD",
+        date_of_birth: Date.new(1901, 1, 1),
+        teacher_reference_number: "1234567",
+        national_insurance_number: "QQ123456C",
+        email_address: "test@email.com",
+        payroll_gender: :female,
+        verified_fields: [
+          "full_name",
+          "address_line_1",
+          "address_line_2",
+          "address_line_3",
+          "postcode",
+          "date_of_birth",
+          "payroll_gender",
+        ]
+      )
+    end
+
+    it "returns an array of questions and answers for displaying to the user for review" do
+      expected_answers = [
+        ["Full name", "Jo Bloggs"],
+        ["Address", "Flat 1, 1 Test Road, Test Town, AB1 2CD"],
+        ["Date of birth", "1 January 1901"],
+        ["Gender", "Female"],
+      ]
+
+      expect(helper.verify_answers(claim)).to eq expected_answers
+    end
+
+    it "excludes questions not answered by verify" do
+      claim.verified_fields = []
+
+      expected_answers = [
+        ["Full name", "Jo Bloggs"],
+        ["Date of birth", "1 January 1901"],
+      ]
+
+      expect(helper.verify_answers(claim)).to eq expected_answers
+    end
+  end
+
   describe "#identity_answers" do
     let(:claim) do
       build(
@@ -68,11 +117,15 @@ describe ClaimsHelper do
     end
 
     it "excludes questions answered by verify" do
-      claim.verified_fields = ["payroll_gender"]
-      expect(helper.identity_answers(claim)).to_not include([I18n.t("questions.payroll_gender"), "female", "gender"])
+      claim.verified_fields = ["payroll_gender", "postcode"]
 
-      claim.verified_fields = ["postcode"]
-      expect(helper.identity_answers(claim)).to_not include([I18n.t("questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"])
+      expected_answers = [
+        [I18n.t("questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
+        [I18n.t("questions.national_insurance_number"), "QQ123456C", "national-insurance-number"],
+        [I18n.t("questions.email_address"), "test@email.com", "email-address"],
+      ]
+
+      expect(helper.identity_answers(claim)).to eq expected_answers
     end
   end
 


### PR DESCRIPTION
They need to see what data we're using before they can make an informed decision about whether or not they submit the claim.

![image](https://user-images.githubusercontent.com/1027364/63283965-7c785300-c2aa-11e9-8fae-1170175a6b4b.png)
