### PR TITLE
Have a support role within the app

### DIFF
--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -13,7 +13,7 @@ module Admin
     def callback
       admin_session = AdminSession.from_auth_hash(request.env.fetch("omniauth.auth"))
 
-      if admin_session.is_service_operator?
+      if admin_session.has_admin_access?
         session[:user_id] = admin_session.user_id
         session[:organisation_id] = admin_session.organisation_id
         redirect_to admin_path

--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -16,6 +16,7 @@ module Admin
       if admin_session.has_admin_access?
         session[:user_id] = admin_session.user_id
         session[:organisation_id] = admin_session.organisation_id
+        session[:role_codes] = admin_session.role_codes
         redirect_to admin_path
       else
         render "failure", status: :unauthorized

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class BaseAdminController < ApplicationController
     before_action :ensure_authenticated_user
+    helper_method :service_operator_signed_in?
 
     private
 

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -7,5 +7,13 @@ module Admin
     def ensure_authenticated_user
       redirect_to admin_sign_in_path unless admin_signed_in?
     end
+
+    def admin_session
+      @admin_session ||= AdminSession.new(session[:user_id], session[:organisation_id], session[:role_codes])
+    end
+
+    def service_operator_signed_in?
+      admin_session.is_service_operator?
+    end
   end
 end

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -1,4 +1,6 @@
 class Admin::ClaimsController < Admin::BaseAdminController
+  before_action :ensure_service_operator
+
   def index
     claims = Claim.includes(eligibility: [:claim_school, :current_school]).submitted.order(:submitted_at)
     csv = TslrClaimsCsv.new(claims)
@@ -6,5 +8,11 @@ class Admin::ClaimsController < Admin::BaseAdminController
     respond_to do |format|
       format.csv { send_file csv.file, type: "text/csv", filename: "claims.csv" }
     end
+  end
+
+  private
+
+  def ensure_service_operator
+    render "admin/auth/failure", status: :unauthorized unless service_operator_signed_in?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,6 +52,7 @@ class ApplicationController < ActionController::Base
     if admin_session_timed_out?
       session.delete(:user_id)
       session.delete(:organisation_id)
+      session.delete(:role_codes)
       flash[:notice] = "Your session has timed out due to inactivity, please sign-in again"
     end
   end

--- a/app/models/admin_session.rb
+++ b/app/models/admin_session.rb
@@ -2,8 +2,13 @@
 
 class AdminSession < DfeSignIn::AuthenticatedSession
   SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_access"
+  SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_support"
 
   def is_service_operator?
     role_codes.include?(SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+  end
+
+  def is_support_agent?
+    role_codes.include?(SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
   end
 end

--- a/app/models/admin_session.rb
+++ b/app/models/admin_session.rb
@@ -11,4 +11,8 @@ class AdminSession < DfeSignIn::AuthenticatedSession
   def is_support_agent?
     role_codes.include?(SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
   end
+
+  def has_admin_access?
+    is_service_operator? || is_support_agent?
+  end
 end

--- a/app/views/admin/page/index.html.erb
+++ b/app/views/admin/page/index.html.erb
@@ -4,6 +4,6 @@
       Admin
     </h1>
 
-    <%= link_to 'Download claims', admin_claims_path(format: :csv), class: "govuk-button" %>
+    <%= link_to 'Download claims', admin_claims_path(format: :csv), class: "govuk-button" if service_operator_signed_in? %>
   </div>
 </div>

--- a/spec/features/admin_csv_download_spec.rb
+++ b/spec/features/admin_csv_download_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Download CSV of claims" do
-  context "User is logged in" do
+  context "User is logged in as a service operator" do
     before do
       stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
       visit admin_path
@@ -18,6 +18,21 @@ RSpec.feature "Download CSV of claims" do
 
       csv = CSV.parse(body)
       expect(csv.count).to eq(submitted_claims.count + 1)
+    end
+  end
+
+  context "User is logged in as a support user" do
+    before do
+      stub_dfe_sign_in_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
+      visit admin_path
+      click_on "Sign in"
+    end
+
+    scenario "User cannot download a CSV" do
+      visit admin_claims_path(format: :csv)
+
+      expect(page.status_code).to eq(401)
+      expect(page).to have_content("Not authorised")
     end
   end
 

--- a/spec/features/admin_csv_download_spec.rb
+++ b/spec/features/admin_csv_download_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Download CSV of claims" do
       submitted_claims = create_list(:claim, 5, :submittable, submitted_at: DateTime.now)
       create_list(:claim, 2, :submittable)
 
+      expect(page).to have_link(nil, href: admin_claims_path(format: :csv))
       click_on "Download claims"
 
       expect(page.response_headers["Content-Type"]).to eq("text/csv")
@@ -29,6 +30,8 @@ RSpec.feature "Download CSV of claims" do
     end
 
     scenario "User cannot download a CSV" do
+      expect(page).to_not have_link(nil, href: admin_claims_path(format: :csv))
+
       visit admin_claims_path(format: :csv)
 
       expect(page.status_code).to eq(401)

--- a/spec/models/admin_session_spec.rb
+++ b/spec/models/admin_session_spec.rb
@@ -20,4 +20,29 @@ RSpec.describe AdminSession, type: :model do
       expect(admin_session.is_support_agent?).to eq false
     end
   end
+
+  describe "#has_admin_access?" do
+    it "returns true when user is a service operator" do
+      admin_session = AdminSession.new("user-id", "organisation-id", [AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
+      expect(admin_session.has_admin_access?).to eq true
+    end
+
+    it "returns true when user is a support user" do
+      admin_session = AdminSession.new("user-id", "organisation-id", [AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE])
+      expect(admin_session.has_admin_access?).to eq true
+    end
+
+    it "returns true when user has both roles" do
+      admin_session = AdminSession.new("user-id", "organisation-id", [
+        AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE,
+        AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE,
+      ])
+      expect(admin_session.has_admin_access?).to eq true
+    end
+
+    it "returns false when user does not have a valid role" do
+      admin_session = AdminSession.new("user-id", "organisation-id", ["other-role"])
+      expect(admin_session.has_admin_access?).to eq false
+    end
+  end
 end

--- a/spec/models/admin_session_spec.rb
+++ b/spec/models/admin_session_spec.rb
@@ -10,4 +10,14 @@ RSpec.describe AdminSession, type: :model do
       expect(admin_session.is_service_operator?).to eq false
     end
   end
+
+  describe "#is_support_agent?" do
+    it "returns true when the session has the right role" do
+      admin_session = AdminSession.new("user-id", "organisation-id", [AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE])
+      expect(admin_session.is_support_agent?).to eq true
+
+      admin_session = AdminSession.new("user-id", "organisation-id", ["other-role"])
+      expect(admin_session.is_support_agent?).to eq false
+    end
+  end
 end

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe "Admin", type: :request do
     end
 
     context "when the user is authenticated" do
-      context "when the user is authorised to access the service" do
-        let(:user_id) { "userid-345" }
-        let(:organisation_id) { "organisationid-6789" }
+      let(:user_id) { "userid-345" }
+      let(:organisation_id) { "organisationid-6789" }
 
+      context "when the user is a service operator" do
         before do
           stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user_id, organisation_id)
           post admin_dfe_sign_in_path
@@ -39,6 +39,23 @@ RSpec.describe "Admin", type: :request do
             expect(session[:user_id]).to be_nil
             expect(session[:organisation_id]).to be_nil
           end
+        end
+      end
+
+      context "when the user is a support user" do
+        before do
+          stub_dfe_sign_in_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, user_id, organisation_id)
+          post admin_dfe_sign_in_path
+          follow_redirect!
+        end
+
+        it "renders the admin page and sets a session" do
+          get admin_path
+
+          expect(response).to be_successful
+          expect(response.body).to include("Admin")
+          expect(session[:user_id]).to eq(user_id)
+          expect(session[:organisation_id]).to eq(organisation_id)
         end
       end
 

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Admin", type: :request do
         expect(response).to redirect_to(admin_sign_in_path)
         expect(session[:user_id]).to be_nil
         expect(session[:organisation_id]).to be_nil
+        expect(session[:role_codes]).to be_nil
       end
     end
 
@@ -30,6 +31,7 @@ RSpec.describe "Admin", type: :request do
           expect(response.body).to include("Admin")
           expect(session[:user_id]).to eq(user_id)
           expect(session[:organisation_id]).to eq(organisation_id)
+          expect(session[:role_codes]).to eq([AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
         end
 
         context "and they sign out" do
@@ -38,6 +40,7 @@ RSpec.describe "Admin", type: :request do
 
             expect(session[:user_id]).to be_nil
             expect(session[:organisation_id]).to be_nil
+            expect(session[:role_codes]).to be_nil
           end
         end
       end
@@ -56,6 +59,7 @@ RSpec.describe "Admin", type: :request do
           expect(response.body).to include("Admin")
           expect(session[:user_id]).to eq(user_id)
           expect(session[:organisation_id]).to eq(organisation_id)
+          expect(session[:role_codes]).to eq([AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE])
         end
       end
 
@@ -69,6 +73,7 @@ RSpec.describe "Admin", type: :request do
         it "shows a not authorised page and doesn’t set a session" do
           expect(session[:user_id]).to be_nil
           expect(session[:organisation_id]).to be_nil
+          expect(session[:role_codes]).to be_nil
 
           expect(response.code).to eq("401")
           expect(response.body).to include("Not authorised")
@@ -87,6 +92,7 @@ RSpec.describe "Admin", type: :request do
 
         expect(session[:user_id]).to be_nil
         expect(session[:organisation_id]).to be_nil
+        expect(session[:role_codes]).to be_nil
 
         expect(response.body).to redirect_to(
           admin_auth_failure_path(message: :invalid_credentials, strategy: :dfe)

--- a/spec/requests/admin_timeout_spec.rb
+++ b/spec/requests/admin_timeout_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Admin session timing out", type: :request do
     it "clears the session and redirects to the login page" do
       expect(session[:user_id]).to eq(user_id)
       expect(session[:organisation_id]).to eq(organisation_id)
+      expect(session[:role_codes]).to eq([AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
 
       travel after_expiry do
         get admin_claims_path(format: :csv)
@@ -24,6 +25,7 @@ RSpec.describe "Admin session timing out", type: :request do
         expect(response).to redirect_to(admin_sign_in_path)
         expect(session[:user_id]).to be_nil
         expect(session[:organisation_id]).to be_nil
+        expect(session[:role_codes]).to be_nil
 
         follow_redirect!
         expect(response.body).to include("Your session has timed out due to inactivity")
@@ -37,12 +39,15 @@ RSpec.describe "Admin session timing out", type: :request do
     it "still clears the admin session" do
       expect(session[:user_id]).to eq(user_id)
       expect(session[:organisation_id]).to eq(organisation_id)
+      expect(session[:role_codes]).to eq([AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
 
       travel after_expiry do
         get root_path
 
         expect(session[:user_id]).to be_nil
         expect(session[:organisation_id]).to be_nil
+        expect(session[:role_codes]).to be_nil
+
         expect(response).to be_successful
       end
     end
@@ -58,6 +63,7 @@ RSpec.describe "Admin session timing out", type: :request do
         expect(response.code).to eq("200")
         expect(session[:user_id]).to_not be_nil
         expect(session[:organisation_id]).to_not be_nil
+        expect(session[:role_codes]).to_not be_nil
       end
     end
   end


### PR DESCRIPTION
This builds on #307 and adds a support for a 'support' role in the app. If a user logs in to the admin section with a role of `teacher_payments_support`, then they are logged in, but cannot download the full CSV of claims