### PR TITLE
Remove reference to storing partial IP addresses

### DIFF
--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -89,11 +89,6 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        for security purposes: collecting part of the IP addresses of people visiting the <%= t("service_name") %>
-        website (for example, if we were receiving continuous direct denial of service attacks from an IP address range
-        then we could block it)
-      </li>
-      <li>
         to enable users to use the service and receive updates
       </li>
     </ul>


### PR DESCRIPTION
We don't store any IP addresses at all, currently.