### PR TITLE
Remove parameter on error check

### DIFF
--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -45,7 +45,7 @@
   %>
 
   <%= form_for current_claim, url: claim_path do |form| %>
-    <%= form_group_tag current_claim, school_param do %>
+    <%= form_group_tag current_claim do %>
       <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
 
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">


### PR DESCRIPTION
With the parameter on it appeared that the logic on the form group was
never getting triggered as it had returned a school and did not have an
error on that part. The error was because a user had not selected a
school from the radio.

Was
<img width="895" alt="Screenshot 2019-08-20 at 15 31 18" src="https://user-images.githubusercontent.com/13239597/63356406-9d4eb000-c35f-11e9-9089-4e339ace8450.png">


Now
<img width="938" alt="Screenshot 2019-08-20 at 15 30 26" src="https://user-images.githubusercontent.com/13239597/63356324-7ee8b480-c35f-11e9-9e9a-2491c31300e5.png">
