### PR TITLE
Cache Docker on CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@
 
 FROM ruby:2.6.2-alpine AS base
 
-RUN apk --no-cache add bash
-RUN apk --no-cache add postgresql-dev
-RUN apk --no-cache add tzdata
-RUN apk --no-cache add nodejs
+RUN apk add bash
+RUN apk add postgresql-dev
+RUN apk add tzdata
+RUN apk add nodejs
 
 ENV APP_HOME /app
 ENV DEPS_HOME /deps
@@ -24,9 +24,9 @@ FROM base AS dependencies
 
 RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
 
-RUN apk --no-cache add build-base
-RUN apk --no-cache add git
-RUN apk --no-cache add yarn
+RUN apk add build-base
+RUN apk add git
+RUN apk add yarn
 
 # Set up install environment
 RUN mkdir -p ${DEPS_HOME}
@@ -122,7 +122,7 @@ FROM web AS test
 
 RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
 
-RUN apk --no-cache add chromium chromium-chromedriver
+RUN apk add chromium chromium-chromedriver
 
 # Install ShellCheck
 COPY --from=shellcheck / /opt/shellcheck/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,6 @@ ENV NODE_ENV ${RAILS_ENV:-production}
 
 FROM base AS dependencies
 
-RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
-
 RUN apk add build-base
 RUN apk add git
 RUN apk add yarn
@@ -64,8 +62,6 @@ RUN if [ ${RAILS_ENV} = "production" ]; then \
 # ------------------------------------------------------------------------------
 
 FROM base AS web
-
-RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
 
 # Set up install environment
 RUN mkdir -p ${APP_HOME}
@@ -119,8 +115,6 @@ FROM koalaman/shellcheck:stable AS shellcheck
 # ------------------------------------------------------------------------------
 
 FROM web AS test
-
-RUN echo "Building with RAILS_ENV=${RAILS_ENV}, NODE_ENV=${NODE_ENV}"
 
 RUN apk add chromium chromium-chromedriver
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,15 +30,30 @@ steps:
     artifact: repository
     displayName: Publish repository as artifact
 
-  - script:
-      docker build --file=Dockerfile --tag=$(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber) --target=web .
-    displayName: Build web Docker image
-
   - script: docker login -u $(dockerId) -p $pass
     env:
       pass: $(dockerPassword)
     displayName: Login to DockerHub
+
+  - script: |
+      docker pull $(dockerRegistry)/$(dockerImageName):latest || true
+      docker build \
+        --file=Dockerfile \
+        --cache-from=$(dockerRegistry)/$(dockerImageName):latest \
+        --tag=$(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber) \
+        --target=web \
+        .
+    displayName: Build web Docker image using 'latest' as cache
+    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+  - script: |
+      docker build \
+        --file=Dockerfile \
+        --tag=$(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber) \
+        --target=web \
+        .
+    displayName: Build web Docker image without cache
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+
   - script: |
       docker tag $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber) $(dockerRegistry)/$(dockerImageName):latest
       docker push $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,35 +10,62 @@ variables:
   - group: docker-settings
 
 steps:
+  # Pin Ruby version
   - task: UseRubyVersion@0
     inputs:
       versionSpec: "2.6.2"
       addToPath: true
     displayName: Use Ruby 2.6.2
 
+  # Build and run tests
   - script: docker-compose -f docker-compose.test.yml build
     displayName: Build test Docker image
   - script: docker-compose -f docker-compose.test.yml run --rm test
     displayName: Run tests on Docker
 
+  # Clean up
   - script: |
       git reset --hard
       git clean -xdf
     displayName: Clean repository
 
+  # Publish
   - publish: $(System.DefaultWorkingDirectory)
     artifact: repository
     displayName: Publish repository as artifact
 
+  # Login to DockerHub
   - script: docker login -u $(dockerId) -p $pass
     env:
       pass: $(dockerPassword)
     displayName: Login to DockerHub
 
+  # Build web dependencies
+  - script: |
+      docker pull $(dockerRegistry)/$(dockerImageName):cache-web-dependencies || true
+      docker build \
+        --file=Dockerfile \
+        --cache-from=$(dockerRegistry)/$(dockerImageName):cache-web-dependencies \
+        --tag=local/dfe-teachers-payment-service:web-dependencies \
+        --target=dependencies \
+        .
+    displayName: Build web dependencies Docker image using 'cache-web-dependencies' as cache
+    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+  - script: |
+      docker build \
+        --file=Dockerfile \
+        --tag=local/dfe-teachers-payment-service:web-dependencies \
+        --target=dependencies \
+        .
+    displayName: Build web dependencies Docker image without cache
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+
+  # Build web
   - script: |
       docker pull $(dockerRegistry)/$(dockerImageName):latest || true
       docker build \
         --file=Dockerfile \
+        --cache-from=local/dfe-teachers-payment-service:web-dependencies \
         --cache-from=$(dockerRegistry)/$(dockerImageName):latest \
         --tag=$(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber) \
         --target=web \
@@ -48,12 +75,19 @@ steps:
   - script: |
       docker build \
         --file=Dockerfile \
+        --cache-from=local/dfe-teachers-payment-service:web-dependencies \
         --tag=$(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber) \
         --target=web \
         .
     displayName: Build web Docker image without cache
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
+  # Push web images
+  - script: |
+      docker tag local/dfe-teachers-payment-service:web-dependencies $(dockerRegistry)/$(dockerImageName):cache-web-dependencies
+      docker push $(dockerRegistry)/$(dockerImageName):cache-web-dependencies
+    displayName: Push web dependencies Docker image for caching
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
   - script: |
       docker tag $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber) $(dockerRegistry)/$(dockerImageName):latest
       docker push $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,10 +17,19 @@ steps:
       addToPath: true
     displayName: Use Ruby 2.6.2
 
+  # Login to DockerHub
+  - script: docker login -u $(dockerId) -p $pass
+    env:
+      pass: $(dockerPassword)
+    displayName: Login to DockerHub
+
   # Build and run tests
-  - script: docker-compose -f docker-compose.test.yml build
+  - script: |
+      docker pull $(dockerRegistry)/$(dockerImageName):cache-test-dependencies || true
+      docker pull $(dockerRegistry)/$(dockerImageName):cache-test || true
+      docker-compose --file=docker-compose.test.yml build
     displayName: Build test Docker image
-  - script: docker-compose -f docker-compose.test.yml run --rm test
+  - script: docker-compose --file=docker-compose.test.yml run --rm test
     displayName: Run tests on Docker
 
   # Clean up
@@ -33,12 +42,6 @@ steps:
   - publish: $(System.DefaultWorkingDirectory)
     artifact: repository
     displayName: Publish repository as artifact
-
-  # Login to DockerHub
-  - script: docker login -u $(dockerId) -p $pass
-    env:
-      pass: $(dockerPassword)
-    displayName: Login to DockerHub
 
   # Build web dependencies
   - script: |
@@ -80,6 +83,18 @@ steps:
         --target=web \
         .
     displayName: Build web Docker image without cache
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+
+  # Push test images
+  - script: |
+      docker tag local/dfe-teachers-payment-service:test-dependencies $(dockerRegistry)/$(dockerImageName):cache-test-dependencies
+      docker push $(dockerRegistry)/$(dockerImageName):cache-test-dependencies
+    displayName: Push test dependencies Docker image for caching
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+  - script: |
+      docker tag local/dfe-teachers-payment-service:test $(dockerRegistry)/$(dockerImageName):cache-test
+      docker push $(dockerRegistry)/$(dockerImageName):cache-test
+    displayName: Push test Docker image for caching
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
   # Push web images

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,7 @@ steps:
   - script: |
       docker pull $(dockerRegistry)/$(dockerImageName):cache-test-dependencies || true
       docker pull $(dockerRegistry)/$(dockerImageName):cache-test || true
+
       docker-compose --file=docker-compose.test.yml build
     displayName: Build test Docker image
   - script: docker-compose --file=docker-compose.test.yml run --rm test
@@ -46,6 +47,7 @@ steps:
   # Build web dependencies
   - script: |
       docker pull $(dockerRegistry)/$(dockerImageName):cache-web-dependencies || true
+
       docker build \
         --file=Dockerfile \
         --cache-from=$(dockerRegistry)/$(dockerImageName):cache-web-dependencies \
@@ -66,11 +68,12 @@ steps:
   # Build web
   - script: |
       docker pull $(dockerRegistry)/$(dockerImageName):latest || true
+
       docker build \
         --file=Dockerfile \
         --cache-from=local/dfe-teachers-payment-service:web-dependencies \
         --cache-from=$(dockerRegistry)/$(dockerImageName):latest \
-        --tag=$(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber) \
+        --tag=local/dfe-teachers-payment-service:web \
         --target=web \
         .
     displayName: Build web Docker image using 'latest' as cache
@@ -79,7 +82,7 @@ steps:
       docker build \
         --file=Dockerfile \
         --cache-from=local/dfe-teachers-payment-service:web-dependencies \
-        --tag=$(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber) \
+        --tag=local/dfe-teachers-payment-service:web \
         --target=web \
         .
     displayName: Build web Docker image without cache
@@ -88,11 +91,13 @@ steps:
   # Push test images
   - script: |
       docker tag local/dfe-teachers-payment-service:test-dependencies $(dockerRegistry)/$(dockerImageName):cache-test-dependencies
+
       docker push $(dockerRegistry)/$(dockerImageName):cache-test-dependencies
     displayName: Push test dependencies Docker image for caching
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
   - script: |
       docker tag local/dfe-teachers-payment-service:test $(dockerRegistry)/$(dockerImageName):cache-test
+
       docker push $(dockerRegistry)/$(dockerImageName):cache-test
     displayName: Push test Docker image for caching
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
@@ -100,11 +105,14 @@ steps:
   # Push web images
   - script: |
       docker tag local/dfe-teachers-payment-service:web-dependencies $(dockerRegistry)/$(dockerImageName):cache-web-dependencies
+
       docker push $(dockerRegistry)/$(dockerImageName):cache-web-dependencies
     displayName: Push web dependencies Docker image for caching
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
   - script: |
-      docker tag $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber) $(dockerRegistry)/$(dockerImageName):latest
+      docker tag local/dfe-teachers-payment-service:web $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber)
+      docker tag local/dfe-teachers-payment-service:web $(dockerRegistry)/$(dockerImageName):latest
+
       docker push $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber)
       docker push $(dockerRegistry)/$(dockerImageName):latest
     displayName: Push web Docker image

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,13 +1,27 @@
 version: "3.7"
 services:
+  dependencies:
+    build:
+      context: .
+      cache_from:
+        - dfedigital/teacher-payments-service:cache-test-dependencies
+      target: dependencies
+      args:
+        RAILS_ENV: test
+    image: local/dfe-teachers-payment-service:test-dependencies
+
   test:
     build:
       context: .
+      cache_from:
+        - local/dfe-teachers-payment-service:test-dependencies
+        - dfedigital/teacher-payments-service:cache-test
       target: test
       args:
         RAILS_ENV: test
     image: local/dfe-teachers-payment-service:test
     depends_on:
+      - dependencies
       - db
     environment:
       DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME: postgres


### PR DESCRIPTION
This involves pushing up 3 new Docker images with `master` builds:

- `cache-web-dependencies`: the `dependencies` image that's dropped from the final image
- `cache-test`: the `test` image built for running tests
- `cache-test-dependencies`: the `dependencies` image for those tests (with `RAILS_ENV=test`)

This is so we can use them as cache sources for builds. This change means all non-`master` builds should now reuse the Docker cache from the latest `master` build. `master` builds build from scratch to ensure we're running fresh images (probably not necessary, but it depends on how much you trust Docker and our use of it).

In order to get this to work locally, I needed to drop the `--no-cache` flag on the package installations. This results in slightly larger Docker images, which I think is ok.

**This isn't fully tested with actual images on Azure.** It was tested by running the commands locally using locally tagged images.