### PR TITLE
Fix busted link to release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Development is automatically built and deployed when commits are pushed to
 
 ### Production
 
-The release process for Production is documented in [`docs/release-process.md`]
+The release process for Production is documented in [`docs/release-process.md`](docs/release-process.md)
 
 ## Service architecture
 


### PR DESCRIPTION
The link in the Readme doesn't work