### PR TITLE
Raise exception on missing translations in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   config.active_job.queue_adapter = :test
 


### PR DESCRIPTION
Now that we're using translations a lot and we've previously seen one go missing we should raise an exception so we know before it makes it in to production.