### PR TITLE
Add a Slack alert script to be run in Azure DevOps

### DIFF
--- a/bin/slack-alert
+++ b/bin/slack-alert
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ENVIRONMENT_NAME=$1
+BUILD_NUMBER=$2
+RELEASE_ID=$3
+WEBHOOK_URL=$4
+
+RELEASE_URL="https://dev.azure.com/dfe-ssp/S118-Teacher-Payments-Service/_releaseProgress?_a=release-pipeline-progress&releaseId=$RELEASE_ID"
+
+MESSAGE=":ship: Build $BUILD_NUMBER is deployed to $ENVIRONMENT_NAME! $RELEASE_URL :rocket:"
+
+curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$MESSAGE\"}" "$WEBHOOK_URL"


### PR DESCRIPTION
This adds a quick Bash script that we can use in Azure DevOps at the end of a pipeline to alert the `#twd_payments_devs` channel that a deploy has happened. 

Once this has merged, we'll need to add the following command to a bash script at the end of both pipelines:

```bash
$(System.DefaultWorkingDirectory)/Build/repository/bin/slack-alert
```

And the following arguments

```bash
$(Environment.Name) $(Release.Artifacts.Build.BuildNumber) $(Build.BuildId) {SLACK_WEBHOOK_URL)
```