### PR TITLE
Add diagnostic logs to key vault

### DIFF
--- a/azure/resource_groups/secrets/template.json
+++ b/azure/resource_groups/secrets/template.json
@@ -8,12 +8,22 @@
     },
     "deliveryTeamUserGroupObjectId": {
       "type": "string"
+    },
+    "logRetentionInDays": {
+      "type": "int",
+      "defaultValue": 365,
+      "minValue": 0,
+      "maxValue": 365
     }
   },
   "variables": {
     "principal_Microsoft_Azure_App_Service": "a6621090-e704-45ec-b65f-50257f9d4dcd",
 
-    "keyVaultName": "[concat(parameters('resourceNamePrefix'), '-kv')]"
+    "keyVaultName": "[concat(parameters('resourceNamePrefix'), '-kv')]",
+
+    "keyVaultDiagnosticSettingName": "[concat(variables('keyVaultName'), '/Microsoft.Insights/service')]",
+
+    "storageAccountName": "[replace(concat(parameters('resourceNamePrefix'), 'storage'), '-', '')]"
   },
   "resources": [
     {
@@ -44,6 +54,43 @@
             "objectId": "[variables('principal_Microsoft_Azure_App_Service')]",
             "permissions": {
               "secrets": ["get"]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "2018-02-01",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "Storage",
+      "tags": {
+        "displayName": "[concat('Key Vault ', variables('keyVaultName'), ' diagnostics storage account')]"
+      },
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/providers/diagnosticsettings",
+      "name": "[variables('keyVaultDiagnosticSettingName')]",
+      "apiVersion": "2016-09-01",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+        "logs": [
+          {
+            "category": "AuditEvent",
+            "enabled": true,
+            "retentionPolicy": {
+              "enabled": true,
+              "days": "[parameters('logRetentionInDays')]"
             }
           }
         ]


### PR DESCRIPTION
This adds a diagnostic setting to our Keyvault, as well as a storage account where we can keep the logs (retained for a year by default)