### PR TITLE
Report redacted GOV.UK Verify responses using Rollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Report redacted GOV.UK Verify responses to help debug issues with our response
+  handling
 - Add static error pages for 400, 500 and 422 errors
 
 ## [Release 001] - 2019-08-21

--- a/lib/verify.rb
+++ b/lib/verify.rb
@@ -19,5 +19,6 @@ end
 
 require_relative "verify/service_provider"
 require_relative "verify/authentication_request"
+require_relative "verify/redacted_response"
 require_relative "verify/response"
 require_relative "verify/response_error"

--- a/lib/verify/redacted_response.rb
+++ b/lib/verify/redacted_response.rb
@@ -1,0 +1,42 @@
+module Verify
+  # Used to report a response from Verify without revealing any Personally
+  # Identifiable Information by replacing any string "values" with the "X"
+  # character. For example:
+  #
+  #   Verify::RedactedResponse.new({"value" => "Secret"}).parameters
+  #   => {"value" => "XXXXXX"}
+  #
+  class RedactedResponse
+    KEYS_TO_REDACT = %w[value postCode].freeze
+
+    attr_reader :parameters
+
+    def initialize(parameters)
+      @parameters = redact_values(parameters.deep_dup)
+    end
+
+    private
+
+    def redact_values(input)
+      if input.is_a?(String)
+        redact_string(input)
+      else
+        input.tap do |hash_to_redact|
+          hash_to_redact.each do |key, value|
+            if value.is_a?(Hash)
+              hash_to_redact[key] = redact_values(value)
+            elsif value.is_a?(Array)
+              hash_to_redact[key].each_with_index { |nested_value, nested_key| hash_to_redact[key][nested_key] = redact_values(nested_value) }
+            elsif value.is_a?(String) && KEYS_TO_REDACT.include?(key)
+              hash_to_redact[key] = redact_string(value)
+            end
+          end
+        end
+      end
+    end
+
+    def redact_string(string)
+      "X" * string.length
+    end
+  end
+end

--- a/spec/lib/verify/redacted_response_spec.rb
+++ b/spec/lib/verify/redacted_response_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe Verify::RedactedResponse do
+  it "redacts 'value' keys" do
+    input = {"value" => "SECRET", "another-key" => "NOT SECRET"}
+    expected_output = {"value" => "XXXXXX", "another-key" => "NOT SECRET"}
+
+    expect(Verify::RedactedResponse.new(input).parameters).to eq expected_output
+  end
+
+  it "handles nested hashes" do
+    input = {"attributes" => {"value" => "SECRET", "another-key" => "NOT SECRET"}}
+    expected_output = {"attributes" => {"value" => "XXXXXX", "another-key" => "NOT SECRET"}}
+
+    expect(Verify::RedactedResponse.new(input).parameters).to eq expected_output
+  end
+
+  it "handles values that are arrays" do
+    input = {"firstNames" => [{"value" => "Bob", "verified" => true}, {"value" => "Booker", "verified" => true}]}
+    expected_output = {"firstNames" => [{"value" => "XXX", "verified" => true}, {"value" => "XXXXXX", "verified" => true}]}
+
+    expect(Verify::RedactedResponse.new(input).parameters).to eq expected_output
+  end
+
+  it "handles the sort of responses we get back from GOV.UK Verify" do
+    input = parsed_vsp_translated_response("identity-verified")
+    expected_output = {
+      "scenario" => "IDENTITY_VERIFIED",
+      "pid" => "5989a87f344bb79ee8d0f0532c0f716deb4f8d71e906b87b346b649c4ceb20c5",
+      "levelOfAssurance" => "LEVEL_2",
+      "attributes" => {
+        "firstNames" => [
+          {"value" => "XXXXXXXX", "verified" => true, "from" => "2019-06-25", "to" => "2019-06-30"},
+          {"value" => "XXXXXX", "verified" => true, "from" => "2015-03-01", "to" => "2019-06-25"},
+          {"value" => "XXX", "verified" => false, "from" => "2019-06-30"},
+        ],
+        "middleNames" => [
+          {"value" => "XXXXXXX", "verified" => true, "from" => "2019-06-25", "to" => "2019-06-25"},
+          {"value" => "XX", "verified" => false, "from" => "2019-06-25"},
+        ],
+        "surnames" => [
+          {"value" => "XXXXXXX", "verified" => true, "from" => "2015-03-01", "to" => "2019-06-24"},
+          {"value" => "XXXXXX", "verified" => true, "from" => "2019-06-25", "to" => "2019-06-25"},
+          {"value" => "", "verified" => false, "from" => "2019-06-25"},
+        ],
+        "datesOfBirth" => [{"value" => "XXXXXXXXXX", "verified" => true, "from" => "1806-04-09"}],
+        "gender" => {"value" => "XXXX", "verified" => true},
+        "addresses" => [
+          {
+            "value" => {
+              "lines" => ["XXXXXXXXXXXXXXXXX", "XXXXXXXXXXXXXXX", "XXXXXXXXXXXXX", "XXXXXXXXXXXXXXX"],
+              "postCode" => "XXXXXXX",
+            },
+            "verified" => true,
+            "from" => "2019-06-25",
+            "to" => "2019-06-25",
+          },
+          {
+            "value" => {
+              "lines" => ["XXXXXXXXXXXXXXXXX", "XXXXXXXXXXXXXXX", "XXXXXXXXXXXXXXXXX"],
+              "postCode" => "XXXXXXX",
+            },
+            "verified" => false,
+            "from" => "2019-06-25",
+          },
+        ],
+      },
+    }
+
+    expect(Verify::RedactedResponse.new(input).parameters).to eq expected_output
+  end
+
+  it "doesn't modify the original input" do
+    input = parsed_vsp_translated_response("identity-verified")
+    Verify::RedactedResponse.new(input).parameters
+
+    expect(input).to eq parsed_vsp_translated_response("identity-verified")
+  end
+end


### PR DESCRIPTION
This will aid in debugging situations where there is a problem handling the response from GOV.UK Verify.