### PR TITLE
Adjust ineligible screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
-- Verified middle names are now optional in Verify response
+- Update ineligibility page content for clarity
+- Ignore unverified middle names from Verify response
 - Report redacted GOV.UK Verify responses to help debug issues with our response
   handling
 - Add static error pages for 400, 500 and 422 errors

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -196,6 +196,6 @@ class Claim < ApplicationRecord
   end
 
   def claim_must_not_be_ineligible
-    errors.add(:base, eligibility.ineligibility_reason) if eligibility.ineligible?
+    errors.add(:base, "You’re not eligible for this payment") if eligibility.ineligible?
   end
 end

--- a/app/views/claims/_ineligibility_reason_employed_at_no_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_employed_at_no_school.html.erb
@@ -1,3 +1,3 @@
 <p class="govuk-body">
-  You can only get this payment if you’re still working as a teacher.
+  You can only get this payment if you’re still employed at a school.
 </p>

--- a/app/views/claims/_ineligibility_reason_employed_at_no_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_employed_at_no_school.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  You can only get this payment if you’re still working as a teacher.
+</p>

--- a/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -1,4 +1,5 @@
 <p class="govuk-body">
-  The school you were employed at is not eligible. You can only get this payment
-  if you were employed at an eligible school.
+  The school you were employed at between 6 April 2018 and 5 April 2019 is not
+  eligible. You can only get this payment if you were employed at an eligible
+  school.
 </p>

--- a/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -1,3 +1,4 @@
 <p class="govuk-body">
-  The school you were employed at is not eligible.
+  The school you were employed at is not eligible. You can only get this payment
+  if you were employed at an eligible school.
 </p>

--- a/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  The school you were employed at is not eligible.
+</p>

--- a/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -1,5 +1,5 @@
 <p class="govuk-body">
-  The school you were employed at between 6 April 2018 and 5 April 2019 is not
-  eligible. You can only get this payment if you were employed at an eligible
-  school.
+  <%= claim_school_name %>, where you were employed between 6 April 2018 and 5
+  April 2019, is not an eligible school. You can only get this payment if you
+  were employed at an eligible school.
 </p>

--- a/app/views/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -1,4 +1,4 @@
 <p class="govuk-body">
-  You are only eligible to claim back student loan repayments if you completed
-  your initial teacher training on or after September 1st 2013.
+  You can only get this payment if you completed your initial teacher training
+  on or after 1 September 2013.
 </p>

--- a/app/views/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -1,0 +1,4 @@
+<p class="govuk-body">
+  You are only eligible to claim back student loan repayments if you completed
+  your initial teacher training on or after September 1st 2013.
+</p>

--- a/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  You must have been teaching an eligible subject.
+</p>

--- a/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -1,3 +1,11 @@
 <p class="govuk-body">
-  You must have been teaching an eligible subject.
+  You can only get this payment if you taught at least one of:
 </p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>biology</li>
+  <li>chemistry</li>
+  <li>physics</li>
+  <li>computer science</li>
+  <li>languages (not including English)</li>
+</ul>

--- a/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -1,5 +1,6 @@
 <p class="govuk-body">
-  You can only get this payment if you taught at least one of:
+  You can only get this payment if you taught one or more of the following
+  subjects between 6 April 2018 and 5 April 2019:
 </p>
 
 <ul class="govuk-list govuk-list--bullet">

--- a/app/views/claims/_ineligibility_reason_not_taught_enough.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_enough.html.erb
@@ -1,4 +1,4 @@
 <p class="govuk-body">
-  You must not have spent more than half your working hours performing
-  leadership duties.
+  You can only get this payment if you spent less than half your working hours
+  performing leadership duties.
 </p>

--- a/app/views/claims/_ineligibility_reason_not_taught_enough.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_enough.html.erb
@@ -1,4 +1,4 @@
 <p class="govuk-body">
   You can only get this payment if you spent less than half your working hours
-  performing leadership duties.
+  performing leadership duties between 6 April 2018 and 5 April 2019.
 </p>

--- a/app/views/claims/_ineligibility_reason_not_taught_enough.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_enough.html.erb
@@ -1,0 +1,4 @@
+<p class="govuk-body">
+  You must not have spent more than half your working hours performing
+  leadership duties.
+</p>

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -4,7 +4,7 @@
       You’re not eligible for this payment
     </h1>
 
-    <%= render "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}" %>
+    <%= render partial: "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}", locals: { claim_school_name: current_claim.eligibility.claim_school_name } %>
 
     <p class="govuk-body">
       You can find more information on the <%= link_to "guidance for this service", tslr_guidance_url, class: 'govuk-link' %>.

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -4,9 +4,7 @@
       You’re not eligible for this payment
     </h1>
 
-    <p class="govuk-body">
-      <%= t("activerecord.errors.messages.#{current_claim.eligibility.ineligibility_reason}") %>.
-    </p>
+    <%= render "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}" %>
 
     <p class="govuk-body">
       You can find more information on the <%= link_to "guidance for this service", tslr_guidance_url, class: 'govuk-link' %>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,7 +88,7 @@ en:
         "2019_2020": "1 September 2019 to 31 August 2020"
       claim_school: "Which school were you employed at between 6 April 2018 and 5 April 2019?"
       employment_status: "Are you still employed to teach at a school in England?"
-      subjects_taught: "Did you teach any of the following subjects between 6 April 2018 and 5 April 2019?"
+      subjects_taught: "Did you teach any of these subjects between 6 April 2018 and 5 April 2019?"
       leadership_position: "Were you employed in a leadership position between 6 April 2018 and 5 April 2019?"
       mostly_performed_leadership_duties:
         "Were more than half your working hours spent on leadership duties betwen 6 April 2018 and 5 April 2019?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,15 +37,6 @@ en:
     currency:
       format:
         unit: "£"
-  activerecord:
-    errors:
-      messages:
-        ineligible_qts_award_year:
-          "You are only eligible to claim back student loan repayments if you completed your initial teacher training on or after September 1st 2013"
-        ineligible_claim_school: "The school you were employed at is not eligible"
-        employed_at_no_school: "You can only get this payment if you’re still working as a teacher"
-        not_taught_eligible_subjects: "You must have been teaching an eligible subject"
-        not_taught_enough: "You must not have spent more than half your working hours performing leadership duties"
   service_name: "Claim additional payments for teaching"
   support_email_address: "additionalteachingpayment@digital.education.gov.uk"
   questions:

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
         scenario "Teacher is told they are not eligible" do
           expect(page).to have_text("You’re not eligible")
-          expect(page).to have_text(I18n.t("activerecord.errors.messages.not_taught_enough"))
+          expect(page).to have_text("You must not have spent more than half your working hours performing leadership duties.")
         end
       end
     end

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
         scenario "Teacher is told they are not eligible" do
           expect(page).to have_text("You’re not eligible")
-          expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties.")
+          expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between 6 April 2018 and 5 April 2019.")
         end
       end
     end

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
         scenario "Teacher is told they are not eligible" do
           expect(page).to have_text("You’re not eligible")
-          expect(page).to have_text("You must not have spent more than half your working hours performing leadership duties.")
+          expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties.")
         end
       end
     end
@@ -207,7 +207,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
         scenario "Teacher is told they are not eligible" do
           expect(page).to have_text("You’re not eligible")
-          expect(page).to have_text("You can only get this payment if you’re still working as a teacher")
+          expect(page).to have_text("You can only get this payment if you’re still employed at a school.")
         end
       end
     end

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.qts_award_year).to eql("before_2013")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You are only eligible to claim back student loan repayments if you completed your initial teacher training on or after September 1st 2013.")
+    expect(page).to have_text("You can only get this payment if you completed your initial teacher training on or after 1 September 2013.")
   end
 
   scenario "now works for a different school" do
@@ -51,7 +51,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.employment_status).to eq("no_school")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you’re still working as a teacher.")
+    expect(page).to have_text("You can only get this payment if you’re still employed at a school.")
   end
 
   scenario "did not teach an eligible subject" do
@@ -65,7 +65,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.taught_eligible_subjects?).to eq(false)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You must have been teaching an eligible subject.")
+    expect(page).to have_text("You can only get this payment if you taught at least one of:")
   end
 
   scenario "was in a leadership position and performed leadership duties for more than half of their time" do
@@ -85,6 +85,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.mostly_performed_leadership_duties?).to eq(true)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You must not have spent more than half your working hours performing leadership duties.")
+    expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties.")
   end
 end

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.claim_school).to eq schools(:hampstead_school)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("The school you were employed at is not eligible.")
+    expect(page).to have_text("The school you were employed at between 6 April 2018 and 5 April 2019 is not eligible.")
   end
 
   scenario "no longer teaching" do
@@ -65,7 +65,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.taught_eligible_subjects?).to eq(false)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you taught at least one of:")
+    expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
   end
 
   scenario "was in a leadership position and performed leadership duties for more than half of their time" do
@@ -85,6 +85,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.mostly_performed_leadership_duties?).to eq(true)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties.")
+    expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between 6 April 2018 and 5 April 2019.")
   end
 end

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.qts_award_year).to eql("before_2013")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text(I18n.t("activerecord.errors.messages.ineligible_qts_award_year"))
+    expect(page).to have_text("You are only eligible to claim back student loan repayments if you completed your initial teacher training on or after September 1st 2013.")
   end
 
   scenario "now works for a different school" do
@@ -39,7 +39,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.claim_school).to eq schools(:hampstead_school)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text(I18n.t("activerecord.errors.messages.ineligible_claim_school"))
+    expect(page).to have_text("The school you were employed at is not eligible.")
   end
 
   scenario "no longer teaching" do
@@ -51,7 +51,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.employment_status).to eq("no_school")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text(I18n.t("activerecord.errors.messages.employed_at_no_school"))
+    expect(page).to have_text("You can only get this payment if you’re still working as a teacher.")
   end
 
   scenario "did not teach an eligible subject" do
@@ -65,7 +65,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.taught_eligible_subjects?).to eq(false)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text(I18n.t("activerecord.errors.messages.not_taught_eligible_subjects"))
+    expect(page).to have_text("You must have been teaching an eligible subject.")
   end
 
   scenario "was in a leadership position and performed leadership duties for more than half of their time" do
@@ -85,6 +85,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.mostly_performed_leadership_duties?).to eq(true)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text(I18n.t("activerecord.errors.messages.not_taught_enough"))
+    expect(page).to have_text("You must not have spent more than half your working hours performing leadership duties.")
   end
 end

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.claim_school).to eq schools(:hampstead_school)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("The school you were employed at between 6 April 2018 and 5 April 2019 is not eligible.")
+    expect(page).to have_text("Hampstead School, where you were employed between 6 April 2018 and 5 April 2019, is not an eligible school.")
   end
 
   scenario "no longer teaching" do

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You’re not eligible")
-      expect(page).to have_text("You can only get this payment if you taught at least one of:")
+      expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
     end
 
     scenario "checks not applicable and then chooses a subject" do
@@ -55,7 +55,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You’re not eligible")
-      expect(page).to have_text("You can only get this payment if you taught at least one of:")
+      expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
     end
 
     scenario "checks not applicable and then chooses a subject" do
@@ -65,7 +65,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You’re not eligible")
-      expect(page).to have_text("You can only get this payment if you taught at least one of:")
+      expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
     end
   end
 end

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You’re not eligible")
-      expect(page).to have_text(I18n.t("activerecord.errors.messages.not_taught_eligible_subjects"))
+      expect(page).to have_text("You must have been teaching an eligible subject.")
     end
 
     scenario "checks not applicable and then chooses a subject" do
@@ -55,7 +55,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You’re not eligible")
-      expect(page).to have_text(I18n.t("activerecord.errors.messages.not_taught_eligible_subjects"))
+      expect(page).to have_text("You must have been teaching an eligible subject.")
     end
 
     scenario "checks not applicable and then chooses a subject" do
@@ -65,7 +65,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You’re not eligible")
-      expect(page).to have_text(I18n.t("activerecord.errors.messages.not_taught_eligible_subjects"))
+      expect(page).to have_text("You must have been teaching an eligible subject.")
     end
   end
 end

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You’re not eligible")
-      expect(page).to have_text("You must have been teaching an eligible subject.")
+      expect(page).to have_text("You can only get this payment if you taught at least one of:")
     end
 
     scenario "checks not applicable and then chooses a subject" do
@@ -55,7 +55,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You’re not eligible")
-      expect(page).to have_text("You must have been teaching an eligible subject.")
+      expect(page).to have_text("You can only get this payment if you taught at least one of:")
     end
 
     scenario "checks not applicable and then chooses a subject" do
@@ -65,7 +65,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You’re not eligible")
-      expect(page).to have_text("You must have been teaching an eligible subject.")
+      expect(page).to have_text("You can only get this payment if you taught at least one of:")
     end
   end
 end

--- a/spec/lib/student_loans_spec.rb
+++ b/spec/lib/student_loans_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe StudentLoans do
       expect(StudentLoans.determine_plan(StudentLoans::ENGLAND, StudentLoans::BEFORE_1_SEPT_2012)).to eq StudentLoans::PLAN_1
     end
 
-    it "returns PLAN_2 when the course(s) started on or after 1 Semptember 2012" do
+    it "returns PLAN_2 when the course(s) started on or after 1 September 2012" do
       expect(StudentLoans.determine_plan(StudentLoans::ENGLAND, StudentLoans::ON_OR_AFTER_1_SEPT_2012)).to eq StudentLoans::PLAN_2
     end
 
-    it "returns PLAN_1_AND_2 when courses started both before and after 1st Semptember 2012" do
+    it "returns PLAN_1_AND_2 when courses started both before and after 1 September 2012" do
       expect(StudentLoans.determine_plan(StudentLoans::ENGLAND, StudentLoans::BEFORE_AND_AFTER_1_SEPT_2012)).to eq StudentLoans::PLAN_1_AND_2
     end
   end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Claim, type: :model do
       ineligible_claim.eligibility.mostly_performed_leadership_duties = true
 
       expect(ineligible_claim).not_to be_valid(:submit)
-      expect(ineligible_claim.errors[:base]).to include(I18n.t("activerecord.errors.messages.not_taught_enough"))
+      expect(ineligible_claim.errors.messages[:base]).to include("You’re not eligible for this payment")
     end
   end
 
@@ -322,7 +322,7 @@ RSpec.describe Claim, type: :model do
       end
 
       it "adds an error" do
-        expect(claim.errors.messages[:base]).to include(I18n.t("activerecord.errors.messages.not_taught_enough"))
+        expect(claim.errors.messages[:base]).to include("You’re not eligible for this payment")
       end
     end
 

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       expect(StudentLoans::Eligibility.new(qts_award_year: "before_2013").ineligibility_reason).to eq :ineligible_qts_award_year
       expect(StudentLoans::Eligibility.new(claim_school: schools(:hampstead_school)).ineligibility_reason).to eq :ineligible_claim_school
       expect(StudentLoans::Eligibility.new(employment_status: :no_school).ineligibility_reason).to eq :employed_at_no_school
+      expect(StudentLoans::Eligibility.new(taught_eligible_subjects: false).ineligibility_reason).to eq :not_taught_eligible_subjects
       expect(StudentLoans::Eligibility.new(mostly_performed_leadership_duties: true).ineligibility_reason).to eq :not_taught_enough
     end
   end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Claims", type: :request do
         get claim_path("ineligible")
 
         expect(response.body).to include("You’re not eligible")
-        expect(response.body).to include("You can only get this payment if you’re still working as a teacher")
+        expect(response.body).to include("You can only get this payment if you’re still employed at a school.")
       end
     end
 

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -77,14 +77,10 @@ RSpec.describe "Claims", type: :request do
       before { post claims_path }
 
       it "renders a static ineligibility page" do
-        get claim_path("ineligible")
-        expect(response.body).to include("You’re not eligible")
-      end
-
-      it "tailors the message to the claim" do
         Claim.order(:created_at).last.eligibility.update(employment_status: "no_school")
 
         get claim_path("ineligible")
+
         expect(response.body).to include("You’re not eligible")
         expect(response.body).to include("You can only get this payment if you’re still working as a teacher")
       end


### PR DESCRIPTION
They are now consitently worded and include the date range where appropriate. The subjects taught ineligibility is now more explicit about what the requirements are.