### PR TITLE
Un-verified middle names are now ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Verified middle names are now optional in Verify response
 - Report redacted GOV.UK Verify responses to help debug issues with our response
   handling
 - Add static error pages for 400, 500 and 422 errors

--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -7,6 +7,7 @@ module Verify
   #   Verify::Response.translate(saml_response: "SOME SAML", request_id: "REQUEST_ID", level_of_assurance: "LEVEL_2")
   #
   class Response
+    class MissingResponseAttribute < StandardError; end
     attr_reader :parameters
 
     def initialize(parameters)
@@ -88,7 +89,7 @@ module Verify
       most_recent_verified_attribute = attributes.sort_by { |attribute| attribute["from"].present? ? Date.strptime(attribute["from"], "%Y-%m-%d") : 0 }
         .reverse
         .find { |attribute| attribute["verified"] }
-
+      raise MissingResponseAttribute, "No verified value found" if required && most_recent_verified_attribute.nil?
       required ? most_recent_verified_attribute.fetch("value") : most_recent_verified_attribute&.fetch("value")
     end
 

--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -76,19 +76,20 @@ module Verify
 
     def full_name
       first_name = most_recent_verified_value(attributes.fetch("firstNames"))
-      middle_name = most_recent_verified_value(attributes.fetch("middleNames"))
+      middle_name = most_recent_verified_value(attributes.fetch("middleNames"), required: false)
       surname = most_recent_verified_value(attributes.fetch("surnames"))
 
       [first_name, middle_name, surname].compact.join(" ")
     end
 
-    def most_recent_verified_value(attributes)
+    def most_recent_verified_value(attributes, required: true)
       return if attributes.blank?
 
-      attributes.sort_by { |attribute| attribute["from"].present? ? Date.strptime(attribute["from"], "%Y-%m-%d") : 0 }
+      most_recent_verified_attribute = attributes.sort_by { |attribute| attribute["from"].present? ? Date.strptime(attribute["from"], "%Y-%m-%d") : 0 }
         .reverse
         .find { |attribute| attribute["verified"] }
-        .fetch("value")
+
+      required ? most_recent_verified_attribute.fetch("value") : most_recent_verified_attribute&.fetch("value")
     end
 
     def gender

--- a/lib/verify/response.rb
+++ b/lib/verify/response.rb
@@ -56,7 +56,7 @@ module Verify
     end
 
     def address
-      @address ||= most_recent_verified_value(attributes.dig("addresses"))
+      @address ||= most_recent_verified_value("addresses", required: false)
     end
 
     def address_lines
@@ -76,20 +76,21 @@ module Verify
     end
 
     def full_name
-      first_name = most_recent_verified_value(attributes.fetch("firstNames"))
-      middle_name = most_recent_verified_value(attributes.fetch("middleNames"), required: false)
-      surname = most_recent_verified_value(attributes.fetch("surnames"))
+      first_name = most_recent_verified_value("firstNames")
+      middle_name = most_recent_verified_value("middleNames", required: false)
+      surname = most_recent_verified_value("surnames")
 
       [first_name, middle_name, surname].compact.join(" ")
     end
 
-    def most_recent_verified_value(attributes, required: true)
-      return if attributes.blank?
+    def most_recent_verified_value(attribute_name, required: true)
+      attrs = required ? attributes.fetch(attribute_name) : attributes.dig(attribute_name)
+      return if attrs.blank?
 
-      most_recent_verified_attribute = attributes.sort_by { |attribute| attribute["from"].present? ? Date.strptime(attribute["from"], "%Y-%m-%d") : 0 }
+      most_recent_verified_attribute = attrs.sort_by { |attribute| attribute["from"].present? ? Date.strptime(attribute["from"], "%Y-%m-%d") : 0 }
         .reverse
         .find { |attribute| attribute["verified"] }
-      raise MissingResponseAttribute, "No verified value found" if required && most_recent_verified_attribute.nil?
+      raise MissingResponseAttribute, "No verified value found for #{attribute_name}" if required && most_recent_verified_attribute.nil?
       required ? most_recent_verified_attribute.fetch("value") : most_recent_verified_attribute&.fetch("value")
     end
 

--- a/spec/fixtures/verify/identity-verified-unverified-lastname.json
+++ b/spec/fixtures/verify/identity-verified-unverified-lastname.json
@@ -1,0 +1,40 @@
+{
+  "scenario": "IDENTITY_VERIFIED",
+  "pid": "5989a87f344bb79ee8d0f0532c0f716deb4f8d71e906b87b346b649c4ceb20c5",
+  "levelOfAssurance": "LEVEL_2",
+  "attributes": {
+    "firstNames": [
+      {
+        "value": "Isambard",
+        "verified": true
+      }
+    ],
+    "middleNames": [
+      {
+        "value": "Kingdom",
+        "verified": false
+      }
+    ],
+    "surnames": [
+      {
+        "value": "Brunel",
+        "verified": false
+      }
+    ],
+    "datesOfBirth": [
+      {
+        "value": "1806-04-09",
+        "verified": true
+      }
+    ],
+    "addresses": [
+      {
+        "value": {
+          "lines": ["Verified Street", "Verified Town"],
+          "postCode": "M12 345"
+        },
+        "verified": true
+      }
+    ]
+  }
+}

--- a/spec/fixtures/verify/identity-verified-unverified-middlename.json
+++ b/spec/fixtures/verify/identity-verified-unverified-middlename.json
@@ -1,0 +1,40 @@
+{
+  "scenario": "IDENTITY_VERIFIED",
+  "pid": "5989a87f344bb79ee8d0f0532c0f716deb4f8d71e906b87b346b649c4ceb20c5",
+  "levelOfAssurance": "LEVEL_2",
+  "attributes": {
+    "firstNames": [
+      {
+        "value": "Isambard",
+        "verified": true
+      }
+    ],
+    "middleNames": [
+      {
+        "value": "Kingdom",
+        "verified": false
+      }
+    ],
+    "surnames": [
+      {
+        "value": "Brunel",
+        "verified": true
+      }
+    ],
+    "datesOfBirth": [
+      {
+        "value": "1806-04-09",
+        "verified": true
+      }
+    ],
+    "addresses": [
+      {
+        "value": {
+          "lines": ["Verified Street", "Verified Town"],
+          "postCode": "M12 345"
+        },
+        "verified": true
+      }
+    ]
+  }
+}

--- a/spec/lib/verify/response_spec.rb
+++ b/spec/lib/verify/response_spec.rb
@@ -112,6 +112,16 @@ RSpec.describe Verify::Response, type: :model do
         expect(subject.claim_parameters[:full_name]).to eq("Isambard Brunel")
       end
     end
+
+    context "when the last name isn't verified" do
+      let(:response_filename) { "identity-verified-unverified-lastname.json" }
+
+      it "raises an exception" do
+        expect { subject.claim_parameters[:full_name] }.to raise_exception(
+          Verify::Response::MissingResponseAttribute, "No verified value found"
+        )
+      end
+    end
   end
 
   context "with the minimum verified response" do

--- a/spec/lib/verify/response_spec.rb
+++ b/spec/lib/verify/response_spec.rb
@@ -104,6 +104,14 @@ RSpec.describe Verify::Response, type: :model do
         )
       end
     end
+
+    context "when the middle name isn't verified" do
+      let(:response_filename) { "identity-verified-unverified-middlename.json" }
+
+      it "returns the full name without the unverified middle name" do
+        expect(subject.claim_parameters[:full_name]).to eq("Isambard Brunel")
+      end
+    end
   end
 
   context "with the minimum verified response" do

--- a/spec/lib/verify/response_spec.rb
+++ b/spec/lib/verify/response_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Verify::Response, type: :model do
 
       it "raises an exception" do
         expect { subject.claim_parameters[:full_name] }.to raise_exception(
-          Verify::Response::MissingResponseAttribute, "No verified value found"
+          Verify::Response::MissingResponseAttribute, "No verified value found for surnames"
         )
       end
     end


### PR DESCRIPTION
We saw an error on production where a user returned from Verify with an unverified middle name causing an application error and they couldn't complete their journey.

Middle names are not essential to payroll so we can mark them as optional, if a non-verified value comes back we can ignore it.

https://rollbar.com/dxw/teachers-payment-service/items/69/