### PR TITLE
Be explicit about pushing the release tag

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -47,7 +47,7 @@ the format `release-xxx` (zero-padded again) and push it to GitHub:
 
 ```
 git tag release-xxx merge-commit-for-release
-git push origin release-xxx
+git push origin refs/tags/release-xxx
 ```
 
 ## 4. Trigger a production release in Azure DevOps


### PR DESCRIPTION
We're already using the ref `release-xxx` for the branch name so doing a push will result in an error `src refspec matches more than one`.