### PR TITLE
Create a staging slot to deploy to for zero-downtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog]
 - Add contact us page
 - Fix an error in the claim CSV where the current school was displaying
   incorrectly
+- Switch to using deployment slots for "zero-downtime" deployment
 
 ## [Release 002] - 2019-08-22
 

--- a/azure/templates/app.json
+++ b/azure/templates/app.json
@@ -59,7 +59,9 @@
     "appServiceLogsDeploymentName": "[concat(deployment().name, '-app-service-logs')]",
     "appServicePlanDeploymentName": "[concat(deployment().name, '-app-service-plan')]",
 
-    "hasCustomHostName": "[greater(length(parameters('appServiceHostName')), 0)]"
+    "hasCustomHostName": "[greater(length(parameters('appServiceHostName')), 0)]",
+
+    "appServiceHostNameBindingsName": "[concat(parameters('appServiceName'), '/', if(variables('hasCustomHostName'), parameters('appServiceHostName'), 'PLACEHOLDER'))]"
   },
   "resources": [
     {
@@ -140,7 +142,7 @@
       "condition": "[variables('hasCustomHostName')]",
       "type": "Microsoft.Web/sites/hostNameBindings",
       "apiVersion": "2018-11-01",
-      "name": "[concat(parameters('appServiceName'), '/', if(variables('hasCustomHostName'), parameters('appServiceHostName'), 'PLACEHOLDER'))]",
+      "name": "[variables('appServiceHostNameBindingsName')]",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', variables('appServiceCertificateDeploymentName'))]",

--- a/azure/templates/app.json
+++ b/azure/templates/app.json
@@ -61,6 +61,7 @@
 
     "hasCustomHostName": "[greater(length(parameters('appServiceHostName')), 0)]",
 
+    "appServiceStagingSlotName": "[concat(parameters('appServiceName'), '/staging')]",
     "appServiceHostNameBindingsName": "[concat(parameters('appServiceName'), '/', if(variables('hasCustomHostName'), parameters('appServiceHostName'), 'PLACEHOLDER'))]"
   },
   "resources": [
@@ -133,6 +134,22 @@
         "httpsOnly": true,
         "siteConfig": {
           "alwaysOn": "[parameters('appServiceAlwaysOn')]",
+          "linuxFxVersion": "[parameters('appServiceRuntimeStack')]",
+          "appSettings": "[parameters('appServiceEnvironmentVariables')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/slots",
+      "apiVersion": "2018-11-01",
+      "name": "[variables('appServiceStagingSlotName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": ["[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"],
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
+        "httpsOnly": true,
+        "siteConfig": {
+          "alwaysOn": false,
           "linuxFxVersion": "[parameters('appServiceRuntimeStack')]",
           "appSettings": "[parameters('appServiceEnvironmentVariables')]"
         }

--- a/bin/swap-slots
+++ b/bin/swap-slots
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+ENVIRONMENT_NAME=$1
+
+case $ENVIRONMENT_NAME in
+  "development")
+    SUBSCRIPTION_ID="8655985a-2f87-44d7-a541-0be9a8c2779d"
+    RESOURCE_GROUP="s118d01-app"
+    ;;
+  "production")
+    SUBSCRIPTION_ID="88bd392f-df19-458b-a100-22b4429060ed"
+    RESOURCE_GROUP="s118p01-app"
+    ;;
+  *)
+    echo "Could not find an known environment with the name: $ENVIRONMENT_NAME"
+    exit 1
+    ;;
+esac
+
+while [ "$2" ]; do
+  case $2 in
+    "--tmp-app")
+      RESOURCE_GROUP="$RESOURCE_GROUP-tmp"
+      ;;
+    *)
+      echo "Unexpected argument: $2"
+      exit 1
+      ;;
+  esac
+
+  shift
+done
+
+APP_NAME="$RESOURCE_GROUP-as"
+
+echo "Restarting staging slot for $RESOURCE_GROUP"
+az webapp restart --name "$APP_NAME" --resource-group "$RESOURCE_GROUP" --slot staging --subscription="$SUBSCRIPTION_ID"
+echo "Swapping staging slot to production for $RESOURCE_GROUP"
+az webapp deployment slot swap --name "$APP_NAME" --slot staging --resource-group "$RESOURCE_GROUP" --subscription="$SUBSCRIPTION_ID"


### PR DESCRIPTION
The runtime stack is still declared for the "production" slot so an incomplete deployment followed by a service restart doesn't take the service down. If not specified, the fact that we do a `Complete` deployment would mean that the configuration would be cleared when deploying, making the app fragile to a restart.

The app service doesn't change which version it's running unless it's restarted.

This situation might be improved by setting the main slot to use the currently live version explicitly, so configuration would match what's already live, though this wouldn't stop environment variable changes getting deployed. We could do this by querying the Azure API. I don't believe this is a good idea, however. It's better to deploy a complete configuration of the newest version accidentally than to deploy mixed configuration.

**BEFORE MERGE: This requires changing _both_ Azure DevOps deployment to (re)start the staging slot (possibly unnecessary, but it feels more reliable to be explicit), then swap staging to production.** It looks like you can type into the slot name, so this _can_ be done before merge, even though the slot doesn't exist. I **highly** recommend we set up production at the same time as we set up development, because release configuration gets attached to releases, so you can't easily change it after the development release occurs.

Additional reading:
- https://blogs.msdn.microsoft.com/mvpawardprogram/2017/05/16/deploy-app-azure-app-service/
- https://ruslany.net/2015/09/how-to-warm-up-azure-web-app-during-deployment-slots-swap/