### PR TITLE
Fix Verify responses without "from" fields throwing an exception

### DIFF
--- a/spec/fixtures/verify/identity-verified-without-some-dates.json
+++ b/spec/fixtures/verify/identity-verified-without-some-dates.json
@@ -1,0 +1,67 @@
+{
+  "scenario": "IDENTITY_VERIFIED",
+  "pid": "5989a87f344bb79ee8d0f0532c0f716deb4f8d71e906b87b346b649c4ceb20c5",
+  "levelOfAssurance": "LEVEL_2",
+  "attributes": {
+    "firstNames": [
+      {
+        "value": "Isambard",
+        "verified": true
+      },
+      {
+        "value": "Thomas",
+        "verified": true,
+        "from": "2015-03-01",
+        "to": "2019-06-25"
+      }
+    ],
+    "middleNames": [
+      {
+        "value": "K.",
+        "verified": true,
+        "from": "2019-06-24",
+        "to": "2019-06-25"
+      },
+      {
+        "value": "Kingdom",
+        "verified": true
+      }
+    ],
+    "surnames": [
+      {
+        "value": "Telford",
+        "verified": true,
+        "from": "2015-03-01",
+        "to": "2019-06-24"
+      },
+      {
+        "value": "Brunel",
+        "verified": true
+      }
+    ],
+    "datesOfBirth": [
+      {
+        "value": "1806-04-09",
+        "verified": true
+      }
+    ],
+    "addresses": [
+      {
+        "value": {
+          "lines": ["Verified Street", "Verified Town"],
+          "postCode": "M12 345"
+        },
+        "verified": true,
+        "from": "2019-06-22",
+        "to": "2019-06-25"
+      },
+      {
+        "value": {
+          "lines": ["Unverified Street", "Unverified Town", "Unverified County"],
+          "postCode": "M67 890"
+        },
+        "verified": false
+      }
+    ]
+  }
+}

--- a/spec/lib/verify/response_spec.rb
+++ b/spec/lib/verify/response_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Verify::Response, type: :model do
   subject { Verify::Response.new(response) }
-  let(:response) { JSON.parse File.read(Rails.root.join("spec", "fixtures", "verify", response_filename)) }
+  let(:response) { JSON.parse(File.read(Rails.root.join("spec", "fixtures", "verify", response_filename))) }
 
   describe ".translate" do
     let(:saml_response) { example_vsp_translate_request_payload.fetch("samlResponse") }
@@ -133,6 +133,25 @@ RSpec.describe Verify::Response, type: :model do
 
     it "returns the expected verified parameters" do
       expect(subject.claim_parameters[:full_name]).to eq("Isambard Brunel")
+      expect(subject.claim_parameters[:gender]).to be_nil
+      expect(subject.claim_parameters[:address_line_1]).to eq("Verified Street")
+      expect(subject.claim_parameters[:address_line_2]).to eq("Verified Town")
+      expect(subject.claim_parameters[:address_line_3]).to be_nil
+      expect(subject.claim_parameters[:postcode]).to eq("M12 345")
+      expect(subject.claim_parameters[:date_of_birth]).to eq("1806-04-09")
+    end
+  end
+
+  context "with date ranges missing from some verified response" do
+    let(:response_filename) { "identity-verified-without-some-dates.json" }
+
+    it "is verified" do
+      expect(subject.verified?).to eq(true)
+    end
+
+    it "returns the expected verified parameters" do
+      expect(subject.claim_parameters[:full_name]).to eq("Isambard Kingdom Brunel")
+      expect(subject.claim_parameters[:gender]).to be_nil
       expect(subject.claim_parameters[:address_line_1]).to eq("Verified Street")
       expect(subject.claim_parameters[:address_line_2]).to eq("Verified Town")
       expect(subject.claim_parameters[:address_line_3]).to be_nil

--- a/spec/lib/verify/response_spec.rb
+++ b/spec/lib/verify/response_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Verify::Response, type: :model do
 
       it "raises an exception" do
         expect { subject.claim_parameters[:full_name] }.to raise_exception(
-          Verify::Response::MissingResponseAttribute, "No verified value found for surnames"
+          Verify::Response::MissingResponseAttribute, "No verified values found for surnames"
         )
       end
     end


### PR DESCRIPTION
If it exists, we assume the first attribute without "from" is always the most recent. We also assume that there will only be one, though the code will probably function fine if there are more than one.