### PR TITLE
Fix display of current school in CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog]
 - fixed a bug in the GOVUK logotype svg src url
 - Improve layout of closed schools in search results
 - Add contact us page
+- Fix an error in the claim CSV where the current school was displaying
+  incorrectly
 
 ## [Release 002] - 2019-08-22
 

--- a/app/presenters/tslr_claim_csv_row.rb
+++ b/app/presenters/tslr_claim_csv_row.rb
@@ -25,7 +25,7 @@ class TslrClaimCsvRow < SimpleDelegator
   end
 
   def current_school_name
-    model.eligibility.claim_school_name
+    model.eligibility.current_school_name
   end
 
   def employment_status

--- a/spec/presenters/tslr_claim_csv_row_spec.rb
+++ b/spec/presenters/tslr_claim_csv_row_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe TslrClaimCsvRow do
         submitted_at: DateTime.parse(submitted_at),
         eligibility: build(:student_loans_eligibility, :eligible,
           had_leadership_position: true,
+          employment_status: :different_school,
+          current_school: School.find(ActiveRecord::FixtureSet.identify(:hampstead_school, :uuid)),
           mostly_performed_leadership_duties: false))
     end
     let(:eligibility) { claim.eligibility }


### PR DESCRIPTION
The `Current School` CSV field was erroneously displaying the Claim School