### PR TITLE
Fixed bug with non JS search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- fixed a bug where the no JS school contact was not selectable
 - fixed a bug in the GOVUK logotype svg src url
 - Improve layout of closed schools in search results
 - Add contact us page

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -67,17 +67,21 @@
             <%= fields.collection_radio_buttons school_id_param, @schools, :id, :name do |b| %>
               <div class="govuk-radios__item">
                 <%= b.radio_button class: "govuk-radios__input" %>
-                <div class="school-search__suggestion">
-                  <div class"school-search__suggestion-main-section>
-                    <%= b.label class: "govuk-label govuk-radios__label govuk-label--s" %>
-                    <span class="govuk-hint govuk-radios__hint"><%= b.object.address %></span>
-                  </div>
-                  <% unless b.object.close_date.blank? %>
-                    <div class="school-search__closed-status">
-                      <span class="govuk-hint govuk-radios__hint govuk-!-margin-bottom-1">Closed on <%= l(b.object.close_date) %></span>
+                <%= b.label class: "govuk-radios__label govuk-label--s govuk-radios__label govuk-!-padding-0" do %>
+                  <div class="school-search__suggestion">
+                    <div class"school-search__suggestion-main-section>
+                      <div class="govuk-label govuk-radios__label govuk-label--s">
+                        <%= b.text %>
+                      </div>
+                      <span class="govuk-hint govuk-radios__hint"><%= b.object.address %></span>
                     </div>
-                  <% end %>
-                </div>
+                    <% unless b.object.close_date.blank? %>
+                      <div class="school-search__closed-status">
+                        <span class="govuk-hint govuk-radios__hint govuk-!-margin-bottom-1">Closed on <%= l(b.object.close_date) %></span>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
               </div>
             <% end %>
           <% end %>


### PR DESCRIPTION
The radio's label was not the next element so it made the radio
unselectable. Moved the label to the correct postition and split the
label to wrap the school contents.