### PR TITLE
Stop leaking dates of birth in govuk verify responses inferrable from from fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- redact all from dates in Verify response
 - fixed a bug where the no JS school contact was not selectable
 - fixed a bug in the GOVUK logotype svg src url
 - Improve layout of closed schools in search results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- stop user IP address appearing in Rollbar
 - redact all from dates in Verify response
 - fixed a bug where the no JS school contact was not selectable
 - fixed a bug in the GOVUK logotype svg src url

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -7,7 +7,9 @@ Rollbar.configure do |config|
   # Disable Rollbar in "test" and "development" environments
   config.enabled = false if Rails.env.test? || Rails.env.development?
 
-  config.anonymize_user_ip = true
+  # removing personally identifiable information
+  config.collect_user_ip = false
+  config.scrub_headers |= ["X-Client-Ip", "Client-Ip"]
   config.scrub_fields |= Rails.application.config.filter_parameters
 
   # By default, Rollbar will try to call the `current_user` controller method

--- a/lib/verify/redacted_response.rb
+++ b/lib/verify/redacted_response.rb
@@ -7,7 +7,7 @@ module Verify
   #   => {"value" => "XXXXXX"}
   #
   class RedactedResponse
-    KEYS_TO_REDACT = %w[value postCode].freeze
+    KEYS_TO_REDACT = %w[value postCode from].freeze
 
     attr_reader :parameters
 

--- a/spec/lib/verify/redacted_response_spec.rb
+++ b/spec/lib/verify/redacted_response_spec.rb
@@ -30,20 +30,20 @@ RSpec.describe Verify::RedactedResponse do
       "levelOfAssurance" => "LEVEL_2",
       "attributes" => {
         "firstNames" => [
-          {"value" => "XXXXXXXX", "verified" => true, "from" => "2019-06-25", "to" => "2019-06-30"},
-          {"value" => "XXXXXX", "verified" => true, "from" => "2015-03-01", "to" => "2019-06-25"},
-          {"value" => "XXX", "verified" => false, "from" => "2019-06-30"},
+          {"value" => "XXXXXXXX", "verified" => true, "from" => "XXXXXXXXXX", "to" => "2019-06-30"},
+          {"value" => "XXXXXX", "verified" => true, "from" => "XXXXXXXXXX", "to" => "2019-06-25"},
+          {"value" => "XXX", "verified" => false, "from" => "XXXXXXXXXX"},
         ],
         "middleNames" => [
-          {"value" => "XXXXXXX", "verified" => true, "from" => "2019-06-25", "to" => "2019-06-25"},
-          {"value" => "XX", "verified" => false, "from" => "2019-06-25"},
+          {"value" => "XXXXXXX", "verified" => true, "from" => "XXXXXXXXXX", "to" => "2019-06-25"},
+          {"value" => "XX", "verified" => false, "from" => "XXXXXXXXXX"},
         ],
         "surnames" => [
-          {"value" => "XXXXXXX", "verified" => true, "from" => "2015-03-01", "to" => "2019-06-24"},
-          {"value" => "XXXXXX", "verified" => true, "from" => "2019-06-25", "to" => "2019-06-25"},
-          {"value" => "", "verified" => false, "from" => "2019-06-25"},
+          {"value" => "XXXXXXX", "verified" => true, "from" => "XXXXXXXXXX", "to" => "2019-06-24"},
+          {"value" => "XXXXXX", "verified" => true, "from" => "XXXXXXXXXX", "to" => "2019-06-25"},
+          {"value" => "", "verified" => false, "from" => "XXXXXXXXXX"},
         ],
-        "datesOfBirth" => [{"value" => "XXXXXXXXXX", "verified" => true, "from" => "1806-04-09"}],
+        "datesOfBirth" => [{"value" => "XXXXXXXXXX", "verified" => true, "from" => "XXXXXXXXXX"}],
         "gender" => {"value" => "XXXX", "verified" => true},
         "addresses" => [
           {
@@ -52,7 +52,7 @@ RSpec.describe Verify::RedactedResponse do
               "postCode" => "XXXXXXX",
             },
             "verified" => true,
-            "from" => "2019-06-25",
+            "from" => "XXXXXXXXXX",
             "to" => "2019-06-25",
           },
           {
@@ -61,7 +61,7 @@ RSpec.describe Verify::RedactedResponse do
               "postCode" => "XXXXXXX",
             },
             "verified" => false,
-            "from" => "2019-06-25",
+            "from" => "XXXXXXXXXX",
           },
         ],
       },


### PR DESCRIPTION
There are two goals here:

1. Redact the from date in the Verify response
2. Ensure the users IP Address is not passed from Rails to Rollbar

Redacting the entire from date was the simplest option at this point, we will continue to monitor the service and if we need to redact only part of the date we can come back to this.

Rails sends a couple of headers and we have expicitly set the Rollbar gem not to send the client IP.

You can test this in Rollbar by removing `|| Rails.env.development?` from the rollbar config and adding the `ROLLBAR_ACCESS_TOKEN` to your `env.development` –  you can get the token from Rollbar, after which there should be no evidence of the IP in Rollbar occurances.

## Important

Once this change is deployed to production we must delete all prioir occorances in Rollbar where the from date could be used to infer a users DOB.
