### PR TITLE
Extend timeout length when coming back from Verify

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
     if: -> { ENV.key?("BASIC_AUTH_USERNAME") },
   )
 
-  helper_method :admin_signed_in?, :current_claim
+  helper_method :admin_signed_in?, :current_claim, :claim_timeout_in_minutes, :claim_timeout_warning_in_minutes
   before_action :end_expired_admin_sessions
   before_action :end_expired_claim_sessions
   before_action :update_last_seen_at
@@ -28,6 +28,14 @@ class ApplicationController < ActionController::Base
     @current_claim ||= Claim.find(session[:claim_id]) if session.key?(:claim_id)
   end
 
+  def claim_timeout_in_minutes
+    self.class::CLAIM_TIMEOUT_LENGTH_IN_MINUTES
+  end
+
+  def claim_timeout_warning_in_minutes
+    self.class::CLAIM_TIMEOUT_WARNING_LENGTH_IN_MINUTES
+  end
+
   def end_expired_claim_sessions
     if claim_session_timed_out?
       clear_claim_session
@@ -36,7 +44,7 @@ class ApplicationController < ActionController::Base
   end
 
   def claim_session_timed_out?
-    session.key?(:claim_id) && session[:last_seen_at] < CLAIM_TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
+    session.key?(:claim_id) && session[:last_seen_at] < claim_timeout_in_minutes.minutes.ago
   end
 
   def clear_claim_session

--- a/app/controllers/verify/authentications_controller.rb
+++ b/app/controllers/verify/authentications_controller.rb
@@ -1,5 +1,7 @@
 module Verify
   class AuthenticationsController < ApplicationController
+    CLAIM_TIMEOUT_LENGTH_IN_MINUTES = 90
+
     before_action :send_unstarted_claiments_to_the_start
     before_action :update_last_seen_at
     skip_before_action :verify_authenticity_token, only: [:create]

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -3,14 +3,6 @@ module ClaimsHelper
     "https://www.gov.uk/guidance/teachers-student-loan-reimbursement-guidance-for-teachers-and-schools"
   end
 
-  def claim_timeout_in_minutes
-    ApplicationController::CLAIM_TIMEOUT_LENGTH_IN_MINUTES
-  end
-
-  def claim_timeout_warning_in_minutes
-    ApplicationController::CLAIM_TIMEOUT_WARNING_LENGTH_IN_MINUTES
-  end
-
   def verified_fields(claim)
     fields = []
     fields << I18n.t("verified_fields.full_name") if claim.verified_fields.include?("full_name")

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -100,4 +100,20 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
       expect(@claim.verify_response).to eq(parsed_vsp_translated_response("authentication-failed"))
     end
   end
+
+  context "user takes a particularly long time to get through verify" do
+    before do
+      stub_vsp_translate_response_request
+    end
+
+    scenario "Does not time the user out", js: true do
+      click_on "Continue"
+
+      travel 80.minutes do
+        click_on "Perform identity check"
+        expect(page).to_not have_text("Your session has ended due to inactivity")
+        expect(page).to have_text("This is your full name, address, date of birth, and gender from your digital identity")
+      end
+    end
+  end
 end

--- a/spec/features/timeout_spec.rb
+++ b/spec/features/timeout_spec.rb
@@ -4,8 +4,8 @@ RSpec.feature "Teacher Student Loan Repayments claims", js: true do
   let(:one_second_in_minutes) { 1 / 60.to_f }
 
   before do
-    allow_any_instance_of(ClaimsHelper).to receive(:claim_timeout_in_minutes) { one_second_in_minutes }
-    allow_any_instance_of(ClaimsHelper).to receive(:claim_timeout_warning_in_minutes) { one_second_in_minutes }
+    allow_any_instance_of(ApplicationController).to receive(:claim_timeout_in_minutes) { one_second_in_minutes }
+    allow_any_instance_of(ApplicationController).to receive(:claim_timeout_warning_in_minutes) { one_second_in_minutes }
     start_claim
   end
 


### PR DESCRIPTION
As a user can potentially take a long time to authenticate with Verify, we've seen users sessions getting timed out when they return to the app. This extends the timeout period to 90 minutes on Verify-related pages, giving the user a bit more time to complete their actions.