### PR TITLE
A service operator is able to mark a claim as approved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog]
 
 ## [Release 004] - 2019-09-04
 
+- Allow service operators to approve claims
 - Fix claims export ordering
 - Store claimants' names as separate fields
 - Add ability to run data migrations

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -16,5 +16,9 @@ module Admin
     def service_operator_signed_in?
       admin_session.is_service_operator?
     end
+
+    def ensure_service_operator
+      render "admin/auth/failure", status: :unauthorized unless service_operator_signed_in?
+    end
   end
 end

--- a/app/controllers/admin/claim_approvals_controller.rb
+++ b/app/controllers/admin/claim_approvals_controller.rb
@@ -1,0 +1,9 @@
+class Admin::ClaimApprovalsController < Admin::BaseAdminController
+  before_action :ensure_service_operator
+
+  def create
+    @claim = Claim.find(params[:claim_id])
+    @claim.approve!(approved_by: admin_session.user_id)
+    redirect_to admin_claims_path, notice: "Claim has been approved successfully"
+  end
+end

--- a/app/controllers/admin/claim_approvals_controller.rb
+++ b/app/controllers/admin/claim_approvals_controller.rb
@@ -4,6 +4,7 @@ class Admin::ClaimApprovalsController < Admin::BaseAdminController
   def create
     @claim = Claim.find(params[:claim_id])
     if @claim.approve!(approved_by: admin_session.user_id)
+      ClaimMailer.approved(@claim).deliver_later
       redirect_to admin_claims_path, notice: "Claim has been approved successfully"
     else
       redirect_to admin_claim_path(@claim), notice: "Claim cannot be approved"

--- a/app/controllers/admin/claim_approvals_controller.rb
+++ b/app/controllers/admin/claim_approvals_controller.rb
@@ -3,7 +3,10 @@ class Admin::ClaimApprovalsController < Admin::BaseAdminController
 
   def create
     @claim = Claim.find(params[:claim_id])
-    @claim.approve!(approved_by: admin_session.user_id)
-    redirect_to admin_claims_path, notice: "Claim has been approved successfully"
+    if @claim.approve!(approved_by: admin_session.user_id)
+      redirect_to admin_claims_path, notice: "Claim has been approved successfully"
+    else
+      redirect_to admin_claim_path(@claim), notice: "Claim cannot be approved"
+    end
   end
 end

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -14,6 +14,12 @@ class Admin::ClaimsController < Admin::BaseAdminController
     @claim = Claim.find(params[:id])
   end
 
+  def approve
+    @claim = Claim.find(params[:id])
+    @claim.update(approved_at: DateTime.now)
+    redirect_to admin_claims_path, notice: "Claim has been approved successfully"
+  end
+
   private
 
   def ensure_service_operator

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -16,10 +16,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
 
   def approve
     @claim = Claim.find(params[:id])
-    @claim.update(
-      approved_at: Time.zone.now,
-      approved_by: admin_session.user_id
-    )
+    @claim.approve!(approved_by: admin_session.user_id)
     redirect_to admin_claims_path, notice: "Claim has been approved successfully"
   end
 

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -16,7 +16,10 @@ class Admin::ClaimsController < Admin::BaseAdminController
 
   def approve
     @claim = Claim.find(params[:id])
-    @claim.update(approved_at: DateTime.now)
+    @claim.update(
+      approved_at: Time.zone.now,
+      approved_by: admin_session.user_id
+    )
     redirect_to admin_claims_path, notice: "Claim has been approved successfully"
   end
 

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -10,6 +10,10 @@ class Admin::ClaimsController < Admin::BaseAdminController
     end
   end
 
+  def show
+    @claim = Claim.find(params[:id])
+  end
+
   private
 
   def ensure_service_operator

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -2,7 +2,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
   before_action :ensure_service_operator
 
   def index
-    @claims = Claim.includes(eligibility: [:claim_school, :current_school]).submitted.order(:submitted_at)
+    @claims = Claim.includes(eligibility: [:claim_school, :current_school]).awaiting_approval.order(:submitted_at)
 
     respond_to do |format|
       format.csv { send_file TslrClaimsCsv.new(@claims).file, type: "text/csv", filename: "claims.csv" }

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -2,11 +2,11 @@ class Admin::ClaimsController < Admin::BaseAdminController
   before_action :ensure_service_operator
 
   def index
-    claims = Claim.includes(eligibility: [:claim_school, :current_school]).submitted.order(:submitted_at)
-    csv = TslrClaimsCsv.new(claims)
+    @claims = Claim.includes(eligibility: [:claim_school, :current_school]).submitted.order(:submitted_at)
 
     respond_to do |format|
-      format.csv { send_file csv.file, type: "text/csv", filename: "claims.csv" }
+      format.csv { send_file TslrClaimsCsv.new(@claims).file, type: "text/csv", filename: "claims.csv" }
+      format.html
     end
   end
 

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -13,16 +13,4 @@ class Admin::ClaimsController < Admin::BaseAdminController
   def show
     @claim = Claim.find(params[:id])
   end
-
-  def approve
-    @claim = Claim.find(params[:id])
-    @claim.approve!(approved_by: admin_session.user_id)
-    redirect_to admin_claims_path, notice: "Claim has been approved successfully"
-  end
-
-  private
-
-  def ensure_service_operator
-    render "admin/auth/failure", status: :unauthorized unless service_operator_signed_in?
-  end
 end

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -1,0 +1,24 @@
+module Admin
+  module ClaimsHelper
+    include ::ClaimsHelper
+
+    def admin_eligibility_answers(eligibility)
+      [].tap do |a|
+        a << [t("student_loans.questions.admin.qts_award_year"), academic_years(eligibility.qts_award_year)]
+        a << [t("student_loans.questions.admin.claim_school"), eligibility.claim_school_name]
+        a << [t("questions.admin.current_school"), eligibility.current_school_name]
+        a << [t("student_loans.questions.admin.subjects_taught"), subject_list(eligibility.subjects_taught)]
+        a << [t("student_loans.questions.admin.had_leadership_position"), (eligibility.had_leadership_position? ? "Yes" : "No")]
+        a << [t("student_loans.questions.admin.mostly_performed_leadership_duties"), (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No")] if eligibility.had_leadership_position?
+      end
+    end
+
+    def admin_identity_answers(claim)
+      [
+        [t("questions.admin.teacher_reference_number"), claim.teacher_reference_number],
+        [t("questions.admin.national_insurance_number"), claim.national_insurance_number],
+        [t("questions.admin.email_address"), claim.email_address],
+      ]
+    end
+  end
+end

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -13,10 +13,13 @@ module Admin
       end
     end
 
-    def admin_identity_answers(claim)
+    def admin_personal_details(claim)
       [
         [t("questions.admin.teacher_reference_number"), claim.teacher_reference_number],
+        [t("verified_fields.full_name").capitalize, claim.full_name],
         [t("questions.admin.national_insurance_number"), claim.national_insurance_number],
+        [t("verified_fields.date_of_birth").capitalize, l(claim.date_of_birth)],
+        [t("verified_fields.address").capitalize, sanitize(claim.address("<br>").html_safe, tags: %w[br])],
         [t("questions.admin.email_address"), claim.email_address],
       ]
     end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -36,6 +36,7 @@ class Claim < ApplicationRecord
     updated_at: false,
     verified_fields: false,
     verify_response: true,
+    approved_at: false,
   }.freeze
 
   enum student_loan_country: StudentLoans::COUNTRIES

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -104,7 +104,7 @@ class Claim < ApplicationRecord
   before_save :normalise_bank_account_number, if: :bank_account_number_changed?
   before_save :normalise_bank_sort_code, if: :bank_sort_code_changed?
 
-  scope :submitted, -> { where.not(submitted_at: nil) }
+  scope :awaiting_approval, -> { where.not(submitted_at: nil).where(approved_at: nil) }
 
   def submit!
     if submittable?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -117,12 +117,27 @@ class Claim < ApplicationRecord
     end
   end
 
+  def approve!(approved_by:)
+    if approvable?
+      update(
+        approved_at: Time.zone.now,
+        approved_by: approved_by
+      )
+    else
+      false
+    end
+  end
+
   def submitted?
     submitted_at.present?
   end
 
   def submittable?
     valid?(:submit) && !submitted?
+  end
+
+  def approvable?
+    submitted? && approved_at.nil?
   end
 
   def address(seperator = ", ")

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -37,6 +37,7 @@ class Claim < ApplicationRecord
     verified_fields: false,
     verify_response: true,
     approved_at: false,
+    approved_by: false,
   }.freeze
 
   enum student_loan_country: StudentLoans::COUNTRIES

--- a/app/views/admin/claims/_answer_section.html.erb
+++ b/app/views/admin/claims/_answer_section.html.erb
@@ -1,0 +1,17 @@
+<h2 class="govuk-heading-m">
+  <%= heading %>
+</h2>
+
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <%- answers.each do |(label, answer)| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label %>
+      </dt>
+
+      <dd class="govuk-summary-list__value">
+        <%= answer %>
+      </dd>
+    </div>
+  <% end %>
+</dl>

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      Claims
+    </h1>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Reference</th>
+          <th scope="col" class="govuk-table__header">Applicant Name</th>
+          <th scope="col" class="govuk-table__header"></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @claims.each do |claim| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= claim.reference %></th>
+            <td class="govuk-table__cell"><%= claim.full_name %></td>
+            <td class="govuk-table__cell"><%= link_to 'View claim', admin_claim_path(claim), class: "govuk-link" %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -4,23 +4,31 @@
       Claims
     </h1>
 
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Reference</th>
-          <th scope="col" class="govuk-table__header">Applicant Name</th>
-          <th scope="col" class="govuk-table__header"></th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <% @claims.each do |claim| %>
+    <% if @claims.any? %>
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header"><%= claim.reference %></th>
-            <td class="govuk-table__cell"><%= claim.full_name %></td>
-            <td class="govuk-table__cell"><%= link_to 'View claim', admin_claim_path(claim), class: "govuk-link" %></td>
+            <th scope="col" class="govuk-table__header">Reference</th>
+            <th scope="col" class="govuk-table__header">Applicant Name</th>
+            <th scope="col" class="govuk-table__header"></th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @claims.each do |claim| %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header"><%= claim.reference %></th>
+              <td class="govuk-table__cell"><%= claim.full_name %></td>
+              <td class="govuk-table__cell"><%= link_to 'View claim', admin_claim_path(claim), class: "govuk-link" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+    <% else %>
+
+      <p class="govuk-body-l">There are currently no claims to approve.</p>
+
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Claim <%= @claim.reference %>
+    </h1>
+  </div>
+</div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -4,11 +4,9 @@
       Claim <%= @claim.reference %>
     </h1>
 
+    <%= render partial: "answer_section", locals: {heading: "Personal details", answers: admin_personal_details(@claim)} %>
+
     <%= render partial: "answer_section", locals: {heading: "Eligibility details", answers: admin_eligibility_answers(@claim.eligibility)} %>
-
-    <%= render partial: "answer_section", locals: {heading: "Personal details", answers: verify_answers(@claim)} %>
-
-    <%= render partial: "answer_section", locals: {heading: "Identity details", answers: admin_identity_answers(@claim)} %>
 
     <%= button_to "Approve",
                   admin_claim_approvals_path(@claim),

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -9,5 +9,11 @@
     <%= render partial: "answer_section", locals: {heading: "Personal details", answers: verify_answers(@claim)} %>
 
     <%= render partial: "answer_section", locals: {heading: "Identity details", answers: admin_identity_answers(@claim)} %>
+
+    <%= button_to "Approve",
+                  approve_admin_claim_path(@claim),
+                  method: :put,
+                  class: "govuk-button",
+                  data: { confirm: "Are you sure you want to approve this claim?" } %>
   </div>
 </div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -11,8 +11,8 @@
     <%= render partial: "answer_section", locals: {heading: "Identity details", answers: admin_identity_answers(@claim)} %>
 
     <%= button_to "Approve",
-                  approve_admin_claim_path(@claim),
-                  method: :put,
+                  admin_claim_approvals_path(@claim),
+                  method: :post,
                   class: "govuk-button",
                   data: { confirm: "Are you sure you want to approve this claim?" } %>
   </div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -3,5 +3,11 @@
     <h1 class="govuk-heading-xl">
       Claim <%= @claim.reference %>
     </h1>
+
+    <%= render partial: "answer_section", locals: {heading: "Eligibility details", answers: admin_eligibility_answers(@claim.eligibility)} %>
+
+    <%= render partial: "answer_section", locals: {heading: "Personal details", answers: verify_answers(@claim)} %>
+
+    <%= render partial: "answer_section", locals: {heading: "Identity details", answers: admin_identity_answers(@claim)} %>
   </div>
 </div>

--- a/app/views/admin/page/index.html.erb
+++ b/app/views/admin/page/index.html.erb
@@ -4,6 +4,12 @@
       Admin
     </h1>
 
-    <%= link_to 'Download claims', admin_claims_path(format: :csv), class: "govuk-button" if service_operator_signed_in? %>
+    <% if service_operator_signed_in? %>
+      <ul>
+        <li><%= link_to 'Approve claims', admin_claims_path, class: "govuk-link" %></li>
+        <li><%= link_to 'Download claims', admin_claims_path(format: :csv), class: "govuk-link" %></li>
+      </ul>
+    <% end %>
+
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,13 @@ en:
     email_address: "Email address"
     bank_details: "Enter bank account details"
     payroll_gender: "What gender does your school's payroll system associate with you?"
+    admin:
+      current_school: "Current school"
+      address: "Address"
+      teacher_reference_number: "Teacher reference number"
+      national_insurance_number: "National Insurance Number"
+      email_address: "Email address"
+      payroll_gender: "What gender does your school's payroll system associate with you?"
   answers:
     student_loan_start_date:
       one_course:
@@ -108,6 +115,12 @@ en:
       student_loan_amount:
         "Exactly how much student loan did you repay while you worked at %{claim_school_name} between 6 April 2018 and 5
         April 2019?"
+      admin:
+        qts_award_year: "Award year"
+        claim_school: "Claim school"
+        subjects_taught: "Subjects taught"
+        had_leadership_position: "Had leadership position?"
+        mostly_performed_leadership_duties: "Mostly performed leadership duties?"
     csv_headers:
       reference: "Reference"
       submitted_at: "Submitted at"
@@ -122,6 +135,7 @@ en:
       address_line_2: "Address 2"
       address_line_3: "Address 3"
       address_line_4: "Address 4"
+      address: "Address"
       postcode: "Postcode"
       date_of_birth: "Date of Birth"
       payroll_gender: "Payroll Gender"
@@ -135,6 +149,7 @@ en:
       computer_science_taught: "Computer Science Taught?"
       languages_taught: "Languages Taught?"
       physics_taught: "Physics Taught?"
+      subjects_taught: "Subjects Taught"
       mostly_performed_leadership_duties: "Mostly Performed Leadership Duties?"
       bank_sort_code: "Sort Code"
       bank_account_number: "Account Number"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
     date_of_birth: "date of birth"
     payroll_gender: "gender"
     address: "address"
+    full_name: "Full name"
   student_loans:
     journey_name: "Teachers: claim back your student loan repayments"
     support_email: "studentloanteacherpayment@digital.education.gov.uk"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,9 +60,7 @@ Rails.application.routes.draw do
     get "/auth/failure", to: "auth#failure"
 
     resources :claims, only: [:index, :show] do
-      member do
-        put :approve
-      end
+      resources :approvals, only: [:create], controller: "claim_approvals"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,10 @@ Rails.application.routes.draw do
     get "/auth/callback", to: "auth#callback"
     get "/auth/failure", to: "auth#failure"
 
-    resources :claims, only: [:index, :show]
+    resources :claims, only: [:index, :show] do
+      member do
+        put :approve
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,6 @@ Rails.application.routes.draw do
     get "/auth/callback", to: "auth#callback"
     get "/auth/failure", to: "auth#failure"
 
-    resources :claims, only: [:index]
+    resources :claims, only: [:index, :show]
   end
 end

--- a/db/migrate/20190905140712_add_approved_at_to_claim.rb
+++ b/db/migrate/20190905140712_add_approved_at_to_claim.rb
@@ -1,0 +1,5 @@
+class AddApprovedAtToClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :claims, :approved_at, :datetime
+  end
+end

--- a/db/migrate/20190906082123_add_approved_by_to_claim.rb
+++ b/db/migrate/20190906082123_add_approved_by_to_claim.rb
@@ -1,0 +1,5 @@
+class AddApprovedByToClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :claims, :approved_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_05_140712) do
+ActiveRecord::Schema.define(version: 2019_09_06_082123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2019_09_05_140712) do
     t.string "middle_name", limit: 100
     t.string "surname", limit: 100
     t.datetime "approved_at"
+    t.string "approved_by"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"
     t.index ["reference"], name: "index_claims_on_reference", unique: true
     t.index ["submitted_at"], name: "index_claims_on_submitted_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_29_145138) do
+ActiveRecord::Schema.define(version: 2019_09_05_140712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2019_08_29_145138) do
     t.string "first_name", limit: 100
     t.string "middle_name", limit: 100
     t.string "surname", limit: 100
+    t.datetime "approved_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"
     t.index ["reference"], name: "index_claims_on_reference", unique: true
     t.index ["submitted_at"], name: "index_claims_on_submitted_at"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -29,6 +29,12 @@ FactoryBot.define do
       reference { Reference.new.to_s }
     end
 
+    trait :approved do
+      submitted
+      approved_at { Time.zone.now }
+      approved_by { "12345" }
+    end
+
     trait :ineligible do
       submittable
       association(:eligibility, factory: [:student_loans_eligibility, :ineligible])

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Admin approves a claim" do
         expect(page).to have_content(claim_to_approve.reference)
 
         find("a[href='#{admin_claim_path(claim_to_approve)}']").click
-        click_on "Approve"
+        perform_enqueued_jobs { click_on "Approve" }
 
         claim_to_approve.reload
 
@@ -27,6 +27,17 @@ RSpec.feature "Admin approves a claim" do
 
         expect(page).to have_content("Claim has been approved successfully")
         expect(page).to_not have_content(claim_to_approve.reference)
+
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+
+        mail = ActionMailer::Base.deliveries.first
+
+        expect(mail.subject).to eq(
+          "Your claim to get your student loan repayments back has been approved, reference number: #{claim_to_approve.reference}"
+        )
+        expect(mail.body.raw_source).to match(
+          "Your claim to get your student loan repayments back has been approved"
+        )
       end
     end
   end

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -10,16 +10,19 @@ RSpec.feature "Admin approves a claim" do
 
     scenario "User can approve a claim" do
       freeze_time do
-        submitted_claims = create_list(:claim, 5, :submittable, submitted_at: DateTime.now)
+        submitted_claims = create_list(:claim, 5, :submitted, submitted_at: DateTime.now, approved_at: nil)
         claim_to_approve = submitted_claims.first
 
         visit admin_claims_path
+
+        expect(page).to have_content(claim_to_approve.reference)
 
         find("a[href='#{admin_claim_path(claim_to_approve)}']").click
         click_on "Approve"
 
         expect(claim_to_approve.reload.approved_at).to eq(DateTime.now)
         expect(page).to have_content("Claim has been approved successfully")
+        expect(page).to_not have_content(claim_to_approve.reference)
       end
     end
   end

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -10,10 +10,10 @@ RSpec.feature "Admin approves a claim" do
 
     scenario "User can approve a claim" do
       freeze_time do
-        submitted_claims = create_list(:claim, 5, :submitted, submitted_at: DateTime.now, approved_at: nil)
+        submitted_claims = create_list(:claim, 5, :submitted)
         claim_to_approve = submitted_claims.first
 
-        visit admin_claims_path
+        click_on "Approve claims"
 
         expect(page).to have_content(claim_to_approve.reference)
 
@@ -24,6 +24,23 @@ RSpec.feature "Admin approves a claim" do
         expect(page).to have_content("Claim has been approved successfully")
         expect(page).to_not have_content(claim_to_approve.reference)
       end
+    end
+  end
+
+  context "User is logged in as a support user" do
+    before do
+      stub_dfe_sign_in_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
+      visit admin_path
+      click_on "Sign in"
+    end
+
+    scenario "User cannot view claims to approve" do
+      expect(page).to_not have_link(nil, href: admin_claims_path)
+
+      visit admin_claims_path
+
+      expect(page.status_code).to eq(401)
+      expect(page).to have_content("Not authorised")
     end
   end
 end

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Admin approves a claim" do
   context "User is logged in as a service operator" do
     before do
-      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "12345")
       visit admin_path
       click_on "Sign in"
     end
@@ -20,7 +20,11 @@ RSpec.feature "Admin approves a claim" do
         find("a[href='#{admin_claim_path(claim_to_approve)}']").click
         click_on "Approve"
 
-        expect(claim_to_approve.reload.approved_at).to eq(DateTime.now)
+        claim_to_approve.reload
+
+        expect(claim_to_approve.approved_at).to eq(Time.zone.now)
+        expect(claim_to_approve.approved_by).to eq("12345")
+
         expect(page).to have_content("Claim has been approved successfully")
         expect(page).to_not have_content(claim_to_approve.reference)
       end

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "Admin approves a claim" do
+  context "User is logged in as a service operator" do
+    before do
+      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+      visit admin_path
+      click_on "Sign in"
+    end
+
+    scenario "User can approve a claim" do
+      freeze_time do
+        submitted_claims = create_list(:claim, 5, :submittable, submitted_at: DateTime.now)
+        claim_to_approve = submitted_claims.first
+
+        visit admin_claims_path
+
+        find("a[href='#{admin_claim_path(claim_to_approve)}']").click
+        click_on "Approve"
+
+        expect(claim_to_approve.reload.approved_at).to eq(DateTime.now)
+        expect(page).to have_content("Claim has been approved successfully")
+      end
+    end
+  end
+end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe Admin::ClaimsHelper do
+  let(:claim_school) { schools(:penistone_grammar_school) }
+  let(:current_school) { create(:school, :tslr_eligible) }
+
+  describe "eligibility_answers" do
+    let(:eligibility) do
+      build(
+        :student_loans_eligibility,
+        qts_award_year: "2013_2014",
+        claim_school: claim_school,
+        current_school: current_school,
+        chemistry_taught: true,
+        physics_taught: true,
+        had_leadership_position: true,
+        mostly_performed_leadership_duties: false,
+        student_loan_repayment_amount: 1987.65,
+      )
+    end
+
+    it "returns an array of questions and answers for displaying to approver" do
+      expected_answers = [
+        [I18n.t("student_loans.questions.admin.qts_award_year"), "1 September 2013 to 31 August 2014"],
+        [I18n.t("student_loans.questions.admin.claim_school"), claim_school.name],
+        [I18n.t("questions.admin.current_school"), current_school.name],
+        [I18n.t("student_loans.questions.admin.subjects_taught"), "Chemistry and Physics"],
+        [I18n.t("student_loans.questions.admin.had_leadership_position"), "Yes"],
+        [I18n.t("student_loans.questions.admin.mostly_performed_leadership_duties"), "No"],
+      ]
+
+      expect(helper.admin_eligibility_answers(eligibility)).to eq expected_answers
+    end
+
+    it "excludes questions skipped from the flow" do
+      eligibility.had_leadership_position = false
+      expect(helper.admin_eligibility_answers(eligibility)).to include([I18n.t("student_loans.questions.admin.had_leadership_position"), "No"])
+      expect(helper.admin_eligibility_answers(eligibility)).to_not include([I18n.t("student_loans.questions.admin.mostly_performed_leadership_duties"), "No"])
+    end
+  end
+
+  describe "identity_answers" do
+    let(:claim) do
+      build(
+        :claim,
+        teacher_reference_number: "1234567",
+        national_insurance_number: "QQ123456C",
+        email_address: "test@email.com"
+      )
+    end
+
+    it "includes an array of questions and answers" do
+      expected_answers = [
+        [I18n.t("questions.admin.teacher_reference_number"), "1234567"],
+        [I18n.t("questions.admin.national_insurance_number"), "QQ123456C"],
+        [I18n.t("questions.admin.email_address"), "test@email.com"],
+      ]
+
+      expect(helper.admin_identity_answers(claim)).to eq expected_answers
+    end
+  end
+end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -39,24 +39,34 @@ describe Admin::ClaimsHelper do
     end
   end
 
-  describe "identity_answers" do
+  describe "admin_personal_details" do
     let(:claim) do
       build(
         :claim,
+        first_name: "Bruce",
+        surname: "Wayne",
         teacher_reference_number: "1234567",
         national_insurance_number: "QQ123456C",
-        email_address: "test@email.com"
+        email_address: "test@email.com",
+        address_line_1: "Flat 1",
+        address_line_2: "1 Test Road",
+        address_line_3: "Test Town",
+        postcode: "AB1 2CD",
+        date_of_birth: Date.new(1901, 1, 1),
       )
     end
 
     it "includes an array of questions and answers" do
       expected_answers = [
         [I18n.t("questions.admin.teacher_reference_number"), "1234567"],
+        [I18n.t("verified_fields.full_name").capitalize, "Bruce Wayne"],
         [I18n.t("questions.admin.national_insurance_number"), "QQ123456C"],
+        [I18n.t("verified_fields.date_of_birth").capitalize, "1 January 1901"],
+        [I18n.t("verified_fields.address").capitalize, "Flat 1<br>1 Test Road<br>Test Town<br>AB1 2CD"],
         [I18n.t("questions.admin.email_address"), "test@email.com"],
       ]
 
-      expect(helper.admin_identity_answers(claim)).to eq expected_answers
+      expect(helper.admin_personal_details(claim)).to eq expected_answers
     end
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -441,4 +441,41 @@ RSpec.describe Claim, type: :model do
       expect(Claim::FILTER_PARAMS.keys).to match_array(Claim.new.attribute_names.map(&:to_sym))
     end
   end
+
+  describe "approvable?" do
+    it "returns false when it has not been submitted" do
+      claim = build(:claim)
+
+      expect(claim.approvable?).to eq false
+    end
+    it "returns true when it has been submitted and has not been approved" do
+      claim = build(:claim, :submitted)
+
+      expect(claim.approvable?).to eq true
+    end
+    it "returns false when it has been submitted and approved" do
+      claim = build(:claim, :approved)
+
+      expect(claim.approvable?).to eq false
+    end
+  end
+
+  describe "approve!" do
+    it "approves a claim" do
+      claim = create(:claim, :submitted)
+
+      freeze_time do
+        claim.approve!(approved_by: "12345")
+
+        expect(claim.approved_at).to eq(Time.zone.now)
+        expect(claim.approved_by).to eq("12345")
+      end
+    end
+
+    it "returns false when claim is not approvable" do
+      claim = create(:claim, :approved)
+
+      expect(claim.approve!(approved_by: "12345")).to eq(false)
+    end
+  end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -360,12 +360,13 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe "submitted" do
+  describe "awaiting_approval" do
     let!(:submitted_claims) { create_list(:claim, 5, :submitted) }
     let!(:unsubmitted_claims) { create_list(:claim, 2, :submittable) }
+    let!(:approved_claims) { create_list(:claim, 5, :submitted, approved_at: Time.zone.now) }
 
-    it "returns submitted claims" do
-      expect(subject.class.submitted).to match_array(submitted_claims)
+    it "returns submitted claims awaiting approval" do
+      expect(subject.class.awaiting_approval).to match_array(submitted_claims)
     end
   end
 

--- a/spec/requests/admin_claim_approvals_spec.rb
+++ b/spec/requests/admin_claim_approvals_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Admin claim approvals", type: :request do
+  context "when signed in as a service operator" do
+    before do
+      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+      post admin_dfe_sign_in_path
+      follow_redirect!
+    end
+
+    describe "claim_approvals#create" do
+      let(:claim) { create(:claim, :submitted) }
+
+      it "approves a claim" do
+        freeze_time do
+          post admin_claim_approvals_path(claim_id: claim.id)
+
+          claim.reload
+
+          expect(claim.approved_at).to eq(Time.zone.now)
+          expect(claim.approved_by).to eq("123")
+        end
+      end
+    end
+  end
+
+  context "when signed in as a support user" do
+    before do
+      stub_dfe_sign_in_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
+      post admin_dfe_sign_in_path
+      follow_redirect!
+    end
+
+    describe "claim_approvals#create" do
+      let(:claim) { create(:claim, :submitted) }
+
+      it "does not allow a claim to be approved" do
+        post admin_claim_approvals_path(claim_id: claim.id)
+
+        expect(response.code).to eq("401")
+      end
+    end
+  end
+end

--- a/spec/requests/admin_claim_approvals_spec.rb
+++ b/spec/requests/admin_claim_approvals_spec.rb
@@ -15,10 +15,26 @@ RSpec.describe "Admin claim approvals", type: :request do
         freeze_time do
           post admin_claim_approvals_path(claim_id: claim.id)
 
+          follow_redirect!
+
+          expect(response.body).to include("Claim has been approved successfully")
+
           claim.reload
 
           expect(claim.approved_at).to eq(Time.zone.now)
           expect(claim.approved_by).to eq("123")
+        end
+      end
+
+      context "when claim is unapprovable" do
+        let(:claim) { create(:claim, :approved) }
+
+        it "shows an error" do
+          post admin_claim_approvals_path(claim_id: claim.id)
+
+          follow_redirect!
+
+          expect(response.body).to include("Claim cannot be approved")
         end
       end
     end

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -7,6 +7,18 @@ RSpec.describe "Admin claims", type: :request do
     follow_redirect!
   end
 
+  describe "claims#index" do
+    let!(:claims) { create_list(:claim, 3, :submitted) }
+
+    it "lists all claims" do
+      get admin_claims_path
+
+      claims.each do |c|
+        expect(response.body).to include(c.reference)
+      end
+    end
+  end
+
   describe "claims#show" do
     let(:claim) { create(:claim, :submitted) }
 

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Admin claims", type: :request do
+  before do
+    stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    post admin_dfe_sign_in_path
+    follow_redirect!
+  end
+
+  describe "claims#show" do
+    let(:claim) { create(:claim, :submitted) }
+
+    it "returns a claim when one exists" do
+      get admin_claim_path(claim)
+
+      expect(response.body).to include(claim.reference)
+    end
+  end
+end


### PR DESCRIPTION
This is an MVP to allow logged in service operator can mark a claim as 'approved'. Users can view all claims awaiting approval, click a link to view the relevant information to allow a claim to be reviewed, and then click a button to approve.

![image](https://user-images.githubusercontent.com/109774/64355873-dcd0f980-cff9-11e9-9c25-5e228621b34c.png)

![image](https://user-images.githubusercontent.com/109774/64355985-07bb4d80-cffa-11e9-9578-e68f0d453081.png)

![image](https://user-images.githubusercontent.com/109774/64356008-10138880-cffa-11e9-9ecb-3ef398a7b59e.png)
