### PR TITLE
Update Slack script to send error if build fails

### DIFF
--- a/bin/slack-alert
+++ b/bin/slack-alert
@@ -4,9 +4,15 @@ ENVIRONMENT_NAME=$1
 BUILD_NUMBER=$2
 RELEASE_ID=$3
 WEBHOOK_URL=$4
+RESULT=$5
 
 RELEASE_URL="https://dev.azure.com/dfe-ssp/S118-Teacher-Payments-Service/_releaseProgress?_a=release-pipeline-progress&releaseId=$RELEASE_ID"
 
-MESSAGE=":ship: Build $BUILD_NUMBER is deployed to $ENVIRONMENT_NAME! $RELEASE_URL :rocket:"
+if [ "$RESULT" == "SUCCESS" ]; then
+  MESSAGE=":ship: Build $BUILD_NUMBER is deployed to $ENVIRONMENT_NAME! $RELEASE_URL :rocket:"
+else
+  MESSAGE=":warning: Build $BUILD_NUMBER has failed for $ENVIRONMENT_NAME. More info $RELEASE_URL"
+fi
+
 
 curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$MESSAGE\"}" "$WEBHOOK_URL"


### PR DESCRIPTION
This adds another option to add to the Slack script that sends an error if the build fails. The release pipeline will need to be changed before this is merged.