### PR TITLE
Use each instead of find_each in claims export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix claims export ordering
 - Store claimants' names as separate fields
 - Add ability to run data migrations
 - Add data migration to back fill claimant's full name, middle name and surname

--- a/app/presenters/tslr_claims_csv.rb
+++ b/app/presenters/tslr_claims_csv.rb
@@ -43,7 +43,7 @@ class TslrClaimsCsv
   def file
     Tempfile.new.tap do |file|
       file.write(header_row)
-      claims.find_each do |claim|
+      claims.each do |claim|
         file.write(TslrClaimCsvRow.new(claim).to_s)
       end
       file.rewind


### PR DESCRIPTION
Active Record's find_each cannot be ordered and the claims export must
be ordered.

The claim export is a temporary measure for private beta only so we
are not worried about the load on the service that switching to each
will incur as the number of cliams is limited.

Details about find_each in the Rails docs:

https://edgeguides.rubyonrails.org/active_record_querying.html#retrieving-multiple-objects-in-batches

## wot no test!? :O
I decided not to add a test as I wasn't sure creating a whole bunch of claims 
in the DB and slowing the test suite outweighed knowing that this tiny change is right.

Could I have done something smarter for a test? Thoughts/suggestions please?