### PR TITLE
A user receives a notification when their claim is approved

### DIFF
--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -1,10 +1,22 @@
 class ClaimMailer < Mail::Notify::Mailer
   def submitted(claim)
+    view_mail_with_claim_and_subject(claim, "Your claim was received")
+  end
+
+  def approved(claim)
+    view_mail_with_claim_and_subject(claim, "Your claim to get your student loan repayments back has been approved, reference number: #{claim.reference}")
+  end
+
+  private
+
+  def view_mail_with_claim_and_subject(claim, subject)
     @claim = claim
+    @display_name = [claim.first_name, claim.surname].join(" ")
+
     view_mail(
       ENV["NOTIFY_TEMPLATE_ID"],
       to: @claim.email_address,
-      subject: "Your claim was received"
+      subject: subject
     )
   end
 end

--- a/app/views/claim_mailer/approved.text.erb
+++ b/app/views/claim_mailer/approved.text.erb
@@ -1,0 +1,9 @@
+Dear <%= @display_name %>,
+
+Your claim to get your student loan repayments back has been approved.
+
+We will now calculate your payment.
+
+We will email you confirming the amount when we are ready to make the payment.
+
+Email studentloanteacherpayment@digital.education.gov.uk giving your reference number: <%= @claim.reference %> if you have any questions.

--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @claim.full_name %>,
+Dear <%= @display_name %>,
 
 We've received your application to claim back your student loan repayments for the time you spent at <%= @claim.eligibility.claim_school.name %>.
 

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -16,4 +16,20 @@ RSpec.describe ClaimMailer, type: :mailer do
       expect(mail.body.encoded).to match("Your unique reference is #{claim.reference}. You will need this if you contact us about your claim.")
     end
   end
+
+  describe "#approved" do
+    let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
+    let(:mail) { ClaimMailer.approved(claim) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Your claim to get your student loan repayments back has been approved, reference number: #{claim.reference}")
+      expect(mail.to).to eq([claim.email_address])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Dear John Kennedy,")
+      expect(mail.body.encoded).to match("Your claim to get your student loan repayments back has been approved.")
+      expect(mail.body.encoded).to match("Email studentloanteacherpayment@digital.education.gov.uk giving your reference number: #{claim.reference} if you have any questions.")
+    end
+  end
 end


### PR DESCRIPTION
Once a users claim is approved we need to be notify them via email.
    
There is additional work to actually approve a claim happening
elsewhere this commit adds the email and method to send it:

```ruby
ClaimMailer.approved(claim).delviver_later
```

## Mockup

https://miro.com/app/board/o9J_kxelVYI=/?moveToWidget=3074457346829288666

## Screenshot

![Screenshot_2019-09-05 Your claim to get your student loan repayments back has been approved - meyric rawlings digital educa](https://user-images.githubusercontent.com/480578/64349172-5d89f880-cfee-11e9-9fb1-47b5ae82f1d7.png)
