### PR TITLE
Add in text to assist JAWS users

### DIFF
--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -12,7 +12,10 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>zoom in up to 300&#37; without the text spilling off the screen</li>
-      <li>navigate most of the website using just a keyboard</li>
+      <li>
+        navigate most of the website using just a keyboard (please note if you are using JAWS you may need to tab into
+        text boxes to enter your answer)
+      </li>
       <li>navigate most of the website using speech recognition software</li>
       <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and
       VoiceOver)</li>
@@ -173,7 +176,7 @@
     </ul>
 
     <p class="govuk-body">
-      This statement was prepared on 31 July 2019. It was last updated on 20 August 2019.
+      This statement was prepared on 31 July 2019. It was last updated on 5 September 2019.
     </p>
 
   </div>


### PR DESCRIPTION
Currently on an older version of JAWS and Windows 7 if you use a JAWS
shortcut it thinks you are in the school search input but you are not.

The text added is to explain to users how to sidestep this issue.