### PR TITLE
Prefer dev.azure.com URLs

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -55,7 +55,8 @@ git push origin refs/tags/release-xxx
 Once the build has passed for the newly tagged commit, you can deploy to
 production as follows:
 
-- Log in to this project on [Azure DevOps](https://dfe-ssp.visualstudio.com/)
+- Log in to this project on
+  [Azure DevOps](https://dev.azure.com/dfe-ssp/S118-Teacher-Payments-Service).
 - Navigate to Pipelines > Builds.
 - Find the build you want to release and note its build number (for example,
   `20190717.2`). You can filter by branch using the filter / funnel icon in the


### PR DESCRIPTION
*.visualstudio.com is deprecated, and some features only work from dev.azure.com URLs.