### PR TITLE
Disable PR builds on Azure DevOps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,5 @@
+pr: none
+
 pool:
   vmImage: ubuntu-latest
 


### PR DESCRIPTION
We already build all branches, so building PRs means double building.