### PR TITLE
Pluralize student_loan_start_date validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Restrict access to `/admin` by IP
+- Fix student_loan_start_date validation error message
 
 ## [Release 004] - 2019-09-04
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -82,7 +82,7 @@ class Claim < ApplicationRecord
   validates :has_student_loan, on: [:"student-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a student loan"}
   validates :student_loan_country, on: [:"student-loan-country"], presence: {message: "Select the country in which you first applied for your student loan"}
   validates :student_loan_courses, on: [:"student-loan-how-many-courses"], presence: {message: "Select the number of higher education courses you have studied"}
-  validates :student_loan_start_date, on: [:"student-loan-start-date"], presence: {message: "Select when the first year of your higher education course started"}
+  validates :student_loan_start_date, on: [:"student-loan-start-date"], presence: {message: ->(object, data) { I18n.t("validation_errors.student_loan_start_date.#{object.student_loan_courses}") }}
   validates :student_loan_plan, on: [:submit], presence: {message: "We have not been able determined your student loan repayment plan. Answer all questions about your student loan."}
 
   validates :email_address, on: [:"email-address", :submit], presence: {message: "Enter an email address"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,10 @@ en:
       male: "Male"
       female: "Female"
       dont_know: "Don’t know"
+  validation_errors:
+    student_loan_start_date:
+      one_course: "Select when the first year of your higher education course started"
+      two_or_more_courses: "Select when the first year of each of your higher education courses started"
   verified_fields:
     first_name: "first name"
     middle_name: "middle name"

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -181,9 +181,19 @@ RSpec.describe Claim, type: :model do
   end
 
   context "when saving in the “student-loan-start-date” validation context" do
-    it "validates the presence of the student_loan_how_many_courses" do
-      expect(build(:claim)).not_to be_valid(:"student-loan-start-date")
+    it "validates the presence of the student_loan_start_date" do
+      expect(build(:claim, student_loan_courses: :one_course)).not_to be_valid(:"student-loan-start-date")
       expect(build(:claim, student_loan_start_date: StudentLoans::BEFORE_1_SEPT_2012)).to be_valid(:"student-loan-start-date")
+    end
+
+    it "the validation error message is pluralized or not based on student_loan_how_many_courses" do
+      claim = build(:claim, student_loan_courses: :one_course)
+      claim.valid?(:"student-loan-start-date")
+      expect(claim.errors[:student_loan_start_date]).to eq [I18n.t("validation_errors.student_loan_start_date.#{claim.student_loan_courses}")]
+
+      claim = build(:claim, student_loan_courses: :two_or_more_courses)
+      claim.valid?(:"student-loan-start-date")
+      expect(claim.errors[:student_loan_start_date]).to eq [I18n.t("validation_errors.student_loan_start_date.#{claim.student_loan_courses}")]
     end
   end
 


### PR DESCRIPTION
The student_load_start_date is used in two contexts, when a user has
completed one course or has completed two or more courses. This should
be taken into account in the validation error message.

Used the locales file to provide two different validation errors.
Introduced question and validation_error keys to the
student_loan_start_date locale values which meant adjusting a few other
places those string are used.

The current value of student_loan_courses is used switch between them.

Updated an incorrect it block in claim_spec.rb.