### PR TITLE
Format student loan amount to two decimal places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix a bug displaying incorrect number of decimal places on monetary number
+  form fields
 - Restrict access to `/admin` by IP
 
 ## [Release 004] - 2019-09-04

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,10 @@ module ApplicationHelper
   def claim_in_progress?
     session.key?(:claim_id)
   end
+
+  def currency_value_for_number_field(value)
+    return if value.nil?
+
+    number_to_currency(value, delimiter: "", unit: "")
+  end
 end

--- a/app/views/claims/student_loan_amount.html.erb
+++ b/app/views/claims/student_loan_amount.html.erb
@@ -16,7 +16,15 @@
 
           <div class="govuk-currency-input">
             <span class="govuk-currency-input__unit">&pound;</span>
-            <%= fields.number_field :student_loan_repayment_amount, class: css_classes_for_input(current_claim, :student_loan_repayment_amount, "govuk-currency-input__input govuk-input--width-5"), step: 'any', min: 0, max: 99999 %>
+            <%= fields.number_field(
+                  :student_loan_repayment_amount,
+                  class: css_classes_for_input(current_claim, :student_loan_repayment_amount, "govuk-currency-input__input govuk-input--width-5"),
+                  step: 'any',
+                  min: 0,
+                  max: 99999,
+                  value: currency_value_for_number_field(fields.object.student_loan_repayment_amount),
+                )
+            %>
           </div>
         <% end %>
       <% end %>

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -305,4 +305,20 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     expect(claim.reload.payroll_gender).to eq("dont_know")
   end
+
+  context "when changing the student loan repayment amount" do
+    scenario "user can change answer and it preserves two decimal places" do
+      claim.eligibility.update!(student_loan_repayment_amount: 100.1)
+      visit claim_path("check-your-answers")
+
+      expect(page).to have_content("£100.10")
+      find("a[href='#{claim_path("student-loan-amount")}']").click
+
+      expect(find("#claim_eligibility_attributes_student_loan_repayment_amount").value).to eq("100.10")
+      fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), with: "150.20"
+      click_on "Continue"
+
+      expect(page).to have_content("£150.20")
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe ApplicationHelper do
+  describe "#currency_value_for_number_field" do
+    let(:value) { 1000.1 }
+
+    it "formats the number to two decimal places and is suitable for a number_field" do
+      expect(helper.currency_value_for_number_field(value)).to eql("1000.10")
+    end
+
+    context "when no value exists" do
+      let(:value) { nil }
+
+      it "does no formatting and just returns nil" do
+        expect(helper.currency_value_for_number_field(value)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce a new `currency_value_for_number_field` helper that will take a number, convert it in to a currency value (with two decimal places) but not include a pound sign or commas, suitable for a number_field.