### PR TITLE
Add the icon to the start button

### DIFF
--- a/app/views/static_pages/start_page.html.erb
+++ b/app/views/static_pages/start_page.html.erb
@@ -31,6 +31,11 @@
         <li>sign in details for ‘Verify’ – the government’s secure way of proving who you are, if you do not have a Verify account, you’ll need your passport or photocard driving licence to sign up</li>
       </ul>
 
-      <%= button_to "Start now", claims_path, method: :post, class: "govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start", role: "button" %>
+      <%= button_to claims_path, method: :post, class: "govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start", role: "button" do %>
+        Start now
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+        </svg>
+      <% end %>
     </div>
 </div>


### PR DESCRIPTION
The GOV.UK v3.0.0 start button requires an in-line svg to render the
chevron icon.

<!-- Do you need to update CHANGELOG.md? -->
