### PR TITLE
Use helpful and clear page titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix add clear and helpful page titles
 - Fix a bug displaying incorrect number of decimal places on monetary number
   form fields
 - Restrict access to `/admin` by IP

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 module ApplicationHelper
   def page_title(title)
-    content_for :page_title, title
+    content_for :page_title do
+      "#{title} – #{t("student_loans.journey_name")} – GOV.UK"
+    end
   end
 
   def claim_in_progress?

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.address")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.bank_details")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/claims/check_your_answers.html.erb
+++ b/app/views/claims/check_your_answers.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("Check your answers before sending your application") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("student_loans.questions.claim_school")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "school_search", question: t("student_loans.questions.claim_school"), school_param: :claim_school, school_id_param: :claim_school_id, school_search_value: current_claim.eligibility.claim_school_name %>

--- a/app/views/claims/confirmation.html.erb
+++ b/app/views/claims/confirmation.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("Claim submitted") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.current_school")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "school_search", question: t("questions.current_school"), school_param: :current_school, school_id_param: :current_school_id, school_search_value: current_claim.eligibility.current_school_name %>

--- a/app/views/claims/eligibility_confirmed.html.erb
+++ b/app/views/claims/eligibility_confirmed.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("You are eligible to claim back student loan repayments") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.email_address")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.payroll_gender")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { payroll_gender: "claim_payroll_gender_female" }) if current_claim.errors.any? %>

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("You’re not eligible for this payment") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/app/views/claims/information_provided.html.erb
+++ b/app/views/claims/information_provided.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("How we will use the information you provide") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/claims/leadership_position.html.erb
+++ b/app/views/claims/leadership_position.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("student_loans.questions.leadership_position")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.had_leadership_position": "claim_eligibility_attributes_had_leadership_position_true" }) if current_claim.errors.any? %>

--- a/app/views/claims/mostly_performed_leadership_duties.html.erb
+++ b/app/views/claims/mostly_performed_leadership_duties.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("student_loans.questions.mostly_performed_leadership_duties")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.mostly_performed_leadership_duties": "claim_eligibility_attributes_mostly_performed_leadership_duties_true"}) if current_claim.errors.any? %>

--- a/app/views/claims/national_insurance_number.html.erb
+++ b/app/views/claims/national_insurance_number.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.national_insurance_number")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("student_loans.questions.qts_award_year")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.qts_award_year": "claim_eligibility_attributes_qts_award_year_before_2013" }) if current_claim.errors.any? %>

--- a/app/views/claims/still_teaching.html.erb
+++ b/app/views/claims/still_teaching.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("student_loans.questions.employment_status")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.employment_status": "claim_eligibility_attributes_employment_status_claim_school" }) if current_claim.errors.any? %>

--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.has_student_loan")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { has_student_loan: "claim_has_student_loan_true" }) if current_claim.errors.any? %>

--- a/app/views/claims/student_loan_amount.html.erb
+++ b/app/views/claims/student_loan_amount.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("student_loans.questions.student_loan_amount")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>

--- a/app/views/claims/student_loan_country.html.erb
+++ b/app/views/claims/student_loan_country.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.student_loan_country")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { student_loan_country: "claim_student_loan_country_england" }) if current_claim.errors.any? %>

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.student_loan_how_many_courses")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { student_loan_courses: "claim_student_loan_courses_one_course" }) if current_claim.errors.any? %>

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.student_loan_start_date.#{current_claim.student_loan_courses}")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { student_loan_start_date: "claim_student_loan_start_date_before_first_september_2012" }) if current_claim.errors.any? %>

--- a/app/views/claims/subjects_taught.html.erb
+++ b/app/views/claims/subjects_taught.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("student_loans.questions.subjects_taught")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.subjects_taught": "eligible_subjects_biology_taught" }) if current_claim.errors.any? %>

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -1,3 +1,5 @@
+<%= page_title(t("questions.teacher_reference_number")) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>

--- a/app/views/claims/timeout.html.erb
+++ b/app/views/claims/timeout.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("Your session has ended due to inactivity") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/app/views/claims/verified.html.erb
+++ b/app/views/claims/verified.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("We have verified your identity") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template app-html-class">
   <head>
     <title>
-      <%= content_for(:page_title) || t("student_loans.journey_name") %>
+      <%= content_for(:page_title) || "#{t("student_loans.journey_name")} – GOV.UK" %>
     </title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -94,11 +94,6 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html" class="govuk-link">
-          2.4.2 – Page Titled
-        </a>
-      </li>
-      <li>
         <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/minimize-error-suggestions.html" class="govuk-link">
           3.3.3 – Error Suggestion
         </a>
@@ -118,9 +113,6 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        page titles do not follow accessibility guidelines
-      </li>
-      <li>
         some error messages are inconsistently formatted
       </li>
       <li>
@@ -129,16 +121,6 @@
     </ul>
 
     <h2 class="govuk-heading-l">Non compliance with the accessibility regulations</h2>
-
-    <p class="govuk-body">
-      Page titles are not clear and descriptive. They all have the same content.  This doesn’t meet WCAG 2.1 success
-      criterion 2.4.2 (page titled).
-    </p>
-
-    <p class="govuk-body">
-      We plan to amend the page titles by December 2020. When we create new pages we will be sure to use descriptive
-      page titles.
-    </p>
 
     <p class="govuk-body">
       Some error messages are inconsistently formatted. There is a list of all errors at the top of each page, but some
@@ -178,7 +160,7 @@
     </ul>
 
     <p class="govuk-body">
-      This statement was prepared on 31 July 2019. It was last updated on 5 September 2019.
+      This statement was prepared on 31 July 2019. It was last updated on 9 September 2019.
     </p>
 
   </div>

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("Accessibility statement for #{t("service_name")}") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/static_pages/contact_us.html.erb
+++ b/app/views/static_pages/contact_us.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("Contact us") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -1,4 +1,7 @@
+<%= page_title("Cookies") %>
+
 <div class="govuk-grid-row">
+
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("Privacy Notice: #{t("service_name")}") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/static_pages/terms_conditions.html.erb
+++ b/app/views/static_pages/terms_conditions.html.erb
@@ -1,3 +1,5 @@
+<%= page_title("Terms and Conditions") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 


### PR DESCRIPTION
Changed the `page_title` helper method to return the page title and the service name ('Teachers: claim back your student loan repayments') followed by 'GOV.UK'. If no page title is set, a sensible default is provided

Added page titles to every step in the user journey using either the question from the locales file or the title of the page in line with the decision we made on page titles.

Page titles are set in the view to couple the page titles to the presentation layer.