### PR TITLE
Configure OmniAuth path_prefix so that failure path works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog]
   form fields
 - Restrict access to `/admin` by IP
 - Fix student_loan_start_date validation error message
+- Fix OmniAuth failure path
 
 ## [Release 004] - 2019-09-04
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,4 +1,7 @@
-OmniAuth.config.logger = Rails.logger
+OmniAuth.configure do |config|
+  config.logger = Rails.logger
+  config.path_prefix = "/admin/auth"
+end
 
 dfe_sign_in_issuer = ENV["DFE_SIGN_IN_ISSUER"]
 dfe_sign_in_redirect_base_url = ENV["DFE_SIGN_IN_REDIRECT_BASE_URL"]
@@ -13,7 +16,6 @@ options = {
   discovery: true,
   response_type: :code,
   scope: %i[openid email organisation],
-  path_prefix: "/admin/auth",
   callback_path: "/admin/auth/callback",
   client_options: {
     port: dfe_sign_in_issuer_uri&.port,

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,5 +1,4 @@
 OmniAuth.config.test_mode = true
-OmniAuth.config.path_prefix = "/admin/auth"
 OmniAuth.config.on_failure = proc { |env|
   OmniAuth::FailureEndpoint.new(env).redirect_to_failure
 }


### PR DESCRIPTION
Passing `path_prefix` as an option doesn't set it correctly, causing the failure path to have the "/admin" part missing. This means users who fail to authenticate themselves on DfE Sign In return to a 404 page.

By configuring OmniAuth's `path_prefix` we can ensure the correct failure path will be generated. We were (incorrectly) overriding this value in our spec helper, setting it globally means we don't have to do that any more.
