### PR TITLE
Stop old Azure URLs serving the site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Redirect requests from any domain other than the canonical one
 - Fix admin IP restriction bug due to port numbers
 - Fix add clear and helpful page titles
 - Fix a bug displaying incorrect number of decimal places on monetary number

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -295,6 +295,10 @@
                 "value": "[parameters('RAILS_SERVE_STATIC_FILES')]"
               },
               {
+                "name": "CANONICAL_HOSTNAME",
+                "value": "[if(parameters('useAppServiceHostName'), parameters('appServiceHostName'), '')]"
+              },
+              {
                 "name": "DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME",
                 "value": "[concat(parameters('databaseUsername'), '@', variables('databaseServerName'))]"
               },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,14 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that
+  # hostname, redirect us to the canonical hostname with the path and query string present
+  if ENV["CANONICAL_HOSTNAME"].present?
+    constraints(host: Regexp.new("^(?!#{Regexp.escape(ENV["CANONICAL_HOSTNAME"])})")) do
+      match "/(*path)" => redirect(host: ENV["CANONICAL_HOSTNAME"]), :via => [:all]
+    end
+  end
+
   root "static_pages#start_page"
 
   # setup a simple healthcheck endpoint for monitoring purposes

--- a/spec/requests/canonical_domain_redirect_spec.rb
+++ b/spec/requests/canonical_domain_redirect_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Canonical domain redirect", type: :request do
+  before(:all) do
+    ENV["CANONICAL_HOSTNAME"] = "http://teacherpayments.com"
+    Rails.application.reload_routes!
+  end
+
+  after(:all) do
+    ENV["CANONICAL_HOSTNAME"] = ""
+    Rails.application.reload_routes!
+  end
+
+  it "redirects to the canonical domain" do
+    expect(get("http://example.org/")).to redirect_to("http://teacherpayments.com/")
+    expect(response.status).to eq(301)
+  end
+
+  it "keeps the original path" do
+    expect(get("http://example.org/cookies")).to redirect_to("http://teacherpayments.com/cookies")
+    expect(response.status).to eq(301)
+  end
+
+  it "keeps query strings in place" do
+    expect(get("http://example.org/cookies?foo=bar")).to redirect_to("http://teacherpayments.com/cookies?foo=bar")
+    expect(response.status).to eq(301)
+  end
+end


### PR DESCRIPTION
This creates a new environment variable, called `CANONICAL_URL`, which is only set if we're using a hostname for that environment. If that variable is set in the app, then we have a rule in the routes that redirects us to the correct hostname, keeping the path and query string intact.

This should also help with #395 