### PR TITLE
Parsing no major html markup code errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix html validation issues with qts year and address views
+
 ## [Release 005] - 2019-09-10
 
 - Redirect requests from any domain other than the canonical one

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -44,8 +44,7 @@
             County
           <% end %>
           <%= errors_tag current_claim, :address_line_4 %>
-          <%= form.text_field :address_line_4, autocomplete: "region",
-            class: "govuk-input govuk-!-width-two-thirds" %>
+          <%= form.text_field :address_line_4, class: "govuk-input govuk-!-width-two-thirds" %>
         <% end %>
 
         <%= form_group_tag current_claim, :postcode do %>

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -6,23 +6,28 @@
 
     <%= form_for current_claim, url: claim_path do |form| %>
       <%= form_group_tag current_claim do %>
-        <%= form.fields_for :eligibility, include_id: false do |fields| %>
-          <h1 class="govuk-label-wrapper">
-            <%= fields.label :qts_award_year, t("student_loans.questions.qts_award_year"), {class: "govuk-label govuk-label--xl"} %>
-          </h1>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              <%= t("student_loans.questions.qts_award_year") %>
+            </h1>
+          </legend>
 
-          <%= errors_tag current_claim.eligibility, :qts_award_year %>
+          <%= form.fields_for :eligibility, include_id: false do |fields| %>
+            <%= errors_tag current_claim.eligibility, :qts_award_year %>
 
-          <div class="govuk-radios">
-            <%= fields.hidden_field :qts_award_year %>
-            <% StudentLoans::Eligibility.qts_award_years.each_key do |option| %>
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:qts_award_year, option, class: "govuk-radios__input") %>
-                <%= fields.label "qts_award_year_#{option}", t("student_loans.questions.qts_award_years.#{option}"), class: "govuk-label govuk-radios__label" %>
-              </div>
-            <% end %>
-          </div>
-        <% end %>
+            <div class="govuk-radios">
+              <%= fields.hidden_field :qts_award_year %>
+              <% StudentLoans::Eligibility.qts_award_years.each_key do |option| %>
+                <div class="govuk-radios__item">
+                  <%= fields.radio_button(:qts_award_year, option, class: "govuk-radios__input") %>
+                  <%= fields.label "qts_award_year_#{option}", t("student_loans.questions.qts_award_years.#{option}"), class: "govuk-label govuk-radios__label" %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+
+        </fieldset>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -98,11 +98,6 @@
           3.3.3 – Error Suggestion
         </a>
       </li>
-      <li>
-        <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-parses.html" class="govuk-link">
-          4.1.1 – Parsing
-        </a>
-      </li>
     </ul>
 
     <h2 class="govuk-heading-l">Non accessible content</h2>
@@ -114,9 +109,6 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>
         some error messages are inconsistently formatted
-      </li>
-      <li>
-        auto complete for address may not function correctly
       </li>
     </ul>
 
@@ -131,16 +123,6 @@
     <p class="govuk-body">
       We plan to amend the error messages by December 2020. When we create new pages we will make sure to use
       consistently formatted error messages.
-    </p>
-
-    <p class="govuk-body">
-      Some pages return errors when parsed through a html validator. Although the pages should display correctly they
-      may have invalid html. This doesn’t meet WCAG 2.1 success criterion 4.1.1 (parsing).
-    </p>
-
-    <p class="govuk-body">
-      We plan to amend the pages to ensure they are valid html by December 2020. When we create new pages we will make
-      sure they validate.
     </p>
 
     <h2 class="govuk-heading-l">How we tested this website</h2>


### PR DESCRIPTION
For 'Which academic year did you complete your initial teacher training?'

This question originally used a select field that was later replaced with a
set of radio buttons. Radio buttons should be marked-up with `<fieldset>`
and `<legend>` rather than a `<label>` so the html parser error is resolved.

For the address question:

- 'region' is not valid `autocomplete` value, use 'address-level-1' 
see below
- Town or city is the second most specific after County so is
'address-level-2'

See guidance:

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values