### PR TITLE
Turn off autocomplete on sensitive inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Turned off autocomplete setting on National Insurance number and bank inputs
 - Prefix titles with an error notification if an error is present
 - Fix html validation issues with qts year and address views
 

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -23,6 +23,7 @@
             <%= errors_tag current_claim, :bank_sort_code %>
             <%= form.text_field :bank_sort_code,
               class: css_classes_for_input(current_claim, :bank_sort_code, "govuk-!-width-one-quarter"),
+              autocomplete: "off",
               "aria-describedby" => "sort-code-hint" %>
           <% end %>
 
@@ -32,6 +33,7 @@
             <%= errors_tag current_claim, :bank_account_number %>
             <%= form.text_field :bank_account_number,
               class: css_classes_for_input(current_claim, :bank_account_number, "govuk-input--width-20"),
+              autocomplete: "off",
               "aria-describedby" => "account-number-hint" %>
           <% end %>
         </fieldset>

--- a/app/views/claims/national_insurance_number.html.erb
+++ b/app/views/claims/national_insurance_number.html.erb
@@ -14,7 +14,12 @@
 
         <%= errors_tag current_claim, :national_insurance_number %>
 
-        <%= form.text_field :national_insurance_number, spellcheck: "false", :minlength => 9, class: css_classes_for_input(current_claim, :national_insurance_number, 'govuk-input--width-10') %>
+        <%= form.text_field :national_insurance_number,
+              spellcheck: "false",
+              autocomplete: "off",
+              minlength: 9,
+              class: css_classes_for_input(current_claim, :national_insurance_number, 'govuk-input--width-10')
+        %>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>


### PR DESCRIPTION
It is something that is unique to each person and is often used in identity theft. It looks like people can unknowingly submit 'autocompleted' data on malicious websites/websites that accidentally
use malicious npm packages: https://medium.com/@bramus/stealing-usernames-passwords-and-other-personal-data-via-browsers-and-npm-packages-30938725ebc8

However by turning it off, we'll be breaking this WCAG 2.1 criteria: https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html

Some more detail: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

Also: https://www.owasp.org/index.php/Top_10_2013-A6-Sensitive_Data_Exposure