### PR TITLE
School search form field without descriptive label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix school search autocomplete missing label tag
+
 ## [Release 005] - 2019-09-10
 
 - Redirect requests from any domain other than the canonical one

--- a/app/assets/stylesheets/components/accessible_autocomplete_tweaks.scss
+++ b/app/assets/stylesheets/components/accessible_autocomplete_tweaks.scss
@@ -1,5 +1,12 @@
 @import "govuk-frontend-rails";
 
+.autocomplete__input:focus {
+  // standard focus state from govuk frontend input component
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+}
+
 .autocomplete__wrapper {
   .autocomplete__menu {
     .autocomplete__option {


### PR DESCRIPTION
The school search autocomplete had no `<label>` which casued accessibilty issues.

This PR also adds the new GOVUK Frontend v3 focus style to the autocomplete input.

This issue was raised specifically around the JAWS screen reader so it would be great to test it with that.