### PR TITLE
Fix admin IP restriction bug caused by port numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix admin IP restriction bug due to port numbers
 - Fix add clear and helpful page titles
 - Fix a bug displaying incorrect number of decimal places on monetary number
   form fields

--- a/lib/restrict_admin_by_ip_middleware.rb
+++ b/lib/restrict_admin_by_ip_middleware.rb
@@ -25,6 +25,7 @@ class RestrictAdminByIpMiddleware
   end
 
   def allowed_ip?(req)
-    @allowed_ips.any? { |ip| ip.include?(req.ip) }
+    request_ip = req.ip.split(":").first
+    @allowed_ips.any? { |ip| ip.include?(request_ip) }
   end
 end

--- a/spec/lib/restrict_admin_by_ip_middleware_spec.rb
+++ b/spec/lib/restrict_admin_by_ip_middleware_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe RestrictAdminByIpMiddleware do
     end
   end
 
+  it "handles IP addresses that arrive with a PORT number" do
+    unblessed_ip_with_port = "2.2.2.2:41234"
+
+    code, _env, body = middleware.call(mock_request("/test", unblessed_ip_with_port))
+    expect(code).to eq 200
+    expect(body).to eq ["OK"]
+
+    code, _env, body = middleware.call(mock_request("/admin/something", unblessed_ip_with_port))
+    expect(code).to eq 403
+    expect(body).to eq ["Forbidden"]
+  end
+
   private
 
   def mock_request(url, remote_ip)

--- a/spec/lib/restrict_admin_by_ip_middleware_spec.rb
+++ b/spec/lib/restrict_admin_by_ip_middleware_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+require "restrict_admin_by_ip_middleware"
+
+RSpec.describe RestrictAdminByIpMiddleware do
+  let(:middleware) { RestrictAdminByIpMiddleware.new(app, [blessed_ip]) }
+  let(:app) { ->(env) { [200, env, ["OK"]] } }
+  let(:blessed_ip) { "1.1.1.1" }
+
+  context "requests from an allowed IP address" do
+    it "passes through requests unchanged" do
+      code, _env, body = middleware.call(mock_request("/test", blessed_ip))
+      expect(code).to eq 200
+      expect(body).to eq ["OK"]
+    end
+  end
+
+  context "requests from an unrecognised IP address" do
+    let(:unblessed_ip) { "2.2.2.2" }
+
+    it "returns a 403 for anything below /admin" do
+      code, _env, body = middleware.call(mock_request("/admin", unblessed_ip))
+      expect(code).to eq 403
+      expect(body).to eq ["Forbidden"]
+
+      code, _env, body = middleware.call(mock_request("/admin/something", unblessed_ip))
+      expect(code).to eq 403
+      expect(body).to eq ["Forbidden"]
+    end
+
+    it "passes through non-admin requests" do
+      code, _env, body = middleware.call(mock_request("/test", unblessed_ip))
+      expect(code).to eq 200
+      expect(body).to eq ["OK"]
+
+      code, _env, body = middleware.call(mock_request("/administrators", unblessed_ip))
+      expect(code).to eq 200
+      expect(body).to eq ["OK"]
+    end
+  end
+
+  private
+
+  def mock_request(url, remote_ip)
+    Rack::MockRequest.env_for(url, {"REMOTE_ADDR" => remote_ip})
+  end
+end


### PR DESCRIPTION
Currently the admin IP restriction middleware is broken on Azure because the requests arrive with a port number in tow, which results in `IPAddr::InvalidAddressError` being raised
(see https://rollbar.com/dxw/teachers-payment-service/items/84/occurrences/95116428392/).