### PR TITLE
Change focus element on inputs for contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix accessibility issue where there is insufficient contrast on UI elements
+
 ## [Release 005] - 2019-09-10
 
 - Redirect requests from any domain other than the canonical one

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
+$govuk-focus-colour: #e67300;
+
 @import "govuk-frontend-rails";
 @import "accessible-autocomplete/src/autocomplete";
 

--- a/app/assets/stylesheets/components/accessible_autocomplete_tweaks.scss
+++ b/app/assets/stylesheets/components/accessible_autocomplete_tweaks.scss
@@ -12,4 +12,7 @@
       }
     }
   }
+  .autocomplete__input--focused {
+    outline: 3px solid #e67300;
+  }
 }


### PR DESCRIPTION
Updating the GDS kit replaced the orange border on the inputs with a
yellow one. This made the contrast worse since the update.

I've had to pick a darker orange colour for the border on focus so we
meet AA standards.

GDS thickens the border when an input has focus, but I'm not sure if that will be sufficient to pass.

### Before
![Screenshot 2019-09-10 at 11 20 53](https://user-images.githubusercontent.com/13239597/64606483-45372680-d3be-11e9-89bb-f63a783f0b0b.png)

### After
![Screenshot 2019-09-10 at 11 20 13](https://user-images.githubusercontent.com/13239597/64606499-4b2d0780-d3be-11e9-9eff-cca69867493b.png)

