### PR TITLE
Increase contrast on hint text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Increase contrast on hint text to AAA standard
 - Turned off autocomplete setting on National Insurance number and bank inputs
 - Prefix titles with an error notification if an error is present
 - Fix html validation issues with qts year and address views

--- a/app/assets/stylesheets/components/gds_kit_tweaks.scss
+++ b/app/assets/stylesheets/components/gds_kit_tweaks.scss
@@ -1,0 +1,3 @@
+.govuk-hint {
+  color: #52575b;
+}


### PR DESCRIPTION
Dyslexic user couldn't see the hint text. I've changed the colour to be
AAA accessible for the font size.

### Before

![Screenshot 2019-09-10 at 12 02 51](https://user-images.githubusercontent.com/13239597/64609037-e70d4200-d3c3-11e9-951c-32b85acdf4af.png)

### After

![Screenshot 2019-09-10 at 12 03 00](https://user-images.githubusercontent.com/13239597/64609038-e8d70580-d3c3-11e9-8785-9e16185a9c7f.png)

