### PR TITLE
Fix RestrictAdminByIpMiddleware allowing IPv6 addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix for allowing IPv6 addresses to visit the admin area
+
 ## [Release 006] - 2019-09-10
 
 - Add ability for service operators to download data for payroll

--- a/lib/restrict_admin_by_ip_middleware.rb
+++ b/lib/restrict_admin_by_ip_middleware.rb
@@ -25,7 +25,7 @@ class RestrictAdminByIpMiddleware
   end
 
   def allowed_ip?(req)
-    request_ip = req.ip.split(":").first
+    request_ip = req.ip.match?(Resolv::IPv6::Regex) ? req.ip : req.ip.split(":").first
     @allowed_ips.any? { |ip| ip.include?(request_ip) }
   end
 end

--- a/spec/lib/restrict_admin_by_ip_middleware_spec.rb
+++ b/spec/lib/restrict_admin_by_ip_middleware_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe RestrictAdminByIpMiddleware do
     expect(body).to eq ["Forbidden"]
   end
 
+  it "handles IPv6 addresses" do
+    unblessed_ipv6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+
+    code, _env, body = middleware.call(mock_request("/test", unblessed_ipv6))
+    expect(code).to eq 200
+    expect(body).to eq ["OK"]
+
+    code, _env, body = middleware.call(mock_request("/admin/something", unblessed_ipv6))
+    expect(code).to eq 403
+    expect(body).to eq ["Forbidden"]
+  end
+
   private
 
   def mock_request(url, remote_ip)


### PR DESCRIPTION
I noticed this when testing `/admin` locally, my IP address is `::1` which is the IPv6 equivalent for local host.

I'm not sure if IPv6 addresses can come through with ports attached, but this should fix it for the majority of cases anyway.