### PR TITLE
Log IP addresses in Application Insights

### DIFF
--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -1,3 +1,6 @@
+require_relative "../../lib/application_insights/enhance_request_data_with_client_ip.rb"
+require_relative "../../lib/application_insights/enhance_track_request_with_client_ip.rb"
+
 instrumentation_key = ENV["APPINSIGHTS_INSTRUMENTATIONKEY"]
 
 if instrumentation_key.present?

--- a/lib/application_insights/enhance_request_data_with_client_ip.rb
+++ b/lib/application_insights/enhance_request_data_with_client_ip.rb
@@ -1,0 +1,13 @@
+# Extensions to the [ApplicationInsights-Ruby gem](https://github.com/microsoft/ApplicationInsights-Ruby)
+# to add a client IP address to the payload of data sent to Application Insights
+module ApplicationInsights
+  module EnhanceRequestDataWithClientIp
+    # Adds the client IP address to the properties hash sent to Application Insights.
+    # This is stored in the customDimensions field in the requests table in Application Insights
+    def client_ip=(client_ip)
+      properties["clientIp"] = client_ip if client_ip.present?
+    end
+  end
+end
+
+ApplicationInsights::Channel::Contracts::RequestData.include ApplicationInsights::EnhanceRequestDataWithClientIp

--- a/lib/application_insights/enhance_track_request_with_client_ip.rb
+++ b/lib/application_insights/enhance_track_request_with_client_ip.rb
@@ -1,0 +1,21 @@
+# Extensions to the [ApplicationInsights-Ruby gem](https://github.com/microsoft/ApplicationInsights-Ruby)
+# to allow IP addresses to be sent and retrieved by Application Insights.
+module ApplicationInsights
+  module EnhanceTrackRequestWithClientIp
+    # Returns a hash of options to be passed to `request_data`. Overrides `options_hash`
+    # in the Application Insights gem to add the request IP to the hash
+    def options_hash(request)
+      super.merge(client_ip: request.ip)
+    end
+
+    # Returns the data to be sent to Application Insights. Overrides `request_data` in the
+    # Application Insights gem to add the client IP to the payload
+    def request_data(request_id, start_time, duration, status, success, options)
+      request_data = super
+      request_data.client_ip = options[:client_ip]
+      request_data
+    end
+  end
+end
+
+ApplicationInsights::Rack::TrackRequest.prepend ApplicationInsights::EnhanceTrackRequestWithClientIp

--- a/spec/requests/application_insights_spec.rb
+++ b/spec/requests/application_insights_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Application Insights", type: :request do
+  let(:app) { lambda { |env| [200, {"Content-Type" => "text/plain"}, ["OK"]] } }
+  let(:request) { Rack::MockRequest.new(subject) }
+  let(:send_interval) { 0.1 }
+  let(:ip) { "1.1.1.1" }
+
+  subject { ApplicationInsights::Rack::TrackRequest.new(app, "ABCDEFG", send_interval) }
+
+  it "sends the client IP along with the rest of the data" do
+    # Set up a stub for a request to Application Insights that includes the
+    # client IP. The request is gzipped, so requires us to expand the response
+    # and then check the contents of the json
+    stub = stub_request(:post, ApplicationInsights::Channel::AsynchronousSender::SERVICE_ENDPOINT_URI).with { |req|
+      body = Zlib::GzipReader.new(StringIO.new(req.body)).readlines
+      json = JSON.parse(body[0])
+      json[0]["data"]["baseData"]["properties"]["clientIp"] == ip
+    }
+    request.get("/", {"REMOTE_ADDR" => ip})
+    # The Application Insights requests are sent asynchronously, so we need to
+    # sleep for the value of `send_interval` (which is how often the logs are sent)
+    # before we check the stub has been requested, which will happen as soon as the
+    # `send_interval` has passed.
+    sleep(send_interval)
+    expect(stub).to have_been_requested.once
+  end
+end


### PR DESCRIPTION
The request IP gets sent to Application Insights, but not stored. This monkey patches the [Application Insights gem](https://github.com/microsoft/ApplicationInsights-Ruby) to add the request IP to the payload inside a custom properties hash, which allows us to store and query against IP addresses.
