### PR TITLE
Add empty secondary VSP encryption key parameter

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -208,6 +208,9 @@
         "secretName": "TeacherPaymentsDevVspSamlEncryption2KeyBase64"
       }
     },
+    "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
+      "value": ""
+    },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "value": "true"
     }

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -187,6 +187,9 @@
         "secretName": "TeacherPaymentsProdVspSamlEncryption1KeyBase64"
       }
     },
+    "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
+      "value": ""
+    },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "value": "true"
     }

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -159,6 +159,9 @@
     "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
       "type": "securestring"
     },
+    "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
+      "type": "securestring"
+    },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "type": "string"
     }
@@ -519,6 +522,10 @@
               {
                 "name": "SAML_PRIMARY_ENCRYPTION_KEY",
                 "value": "[parameters('VSP.SAML_PRIMARY_ENCRYPTION_KEY')]"
+              },
+              {
+                "name": "SAML_SECONDARY_ENCRYPTION_KEY",
+                "value": "[parameters('VSP.SAML_SECONDARY_ENCRYPTION_KEY')]"
               },
               {
                 "name": "EUROPEAN_IDENTITY_ENABLED",


### PR DESCRIPTION
During key rotation on the VSP the secondary key is the new,
incoming key and once the old cert is removed at the GOV.UK Verify hub
the new key becomes the primary.

Have a empty string as the secondary key in the template files to make
this explicit.

<!-- Do you need to update CHANGELOG.md? -->
