### PR TITLE
Make it so current school doesn't support closed schools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Exclude closed schools from current school search
+
 ## [Release 009] - 2019-09-17
 
 - Add student loan plan and amount to approver view of a claim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Make closed schools ineligibile for current school
 - Exclude closed schools from current school search
 
 ## [Release 009] - 2019-09-17

--- a/app/assets/javascripts/components/school_search.js.erb
+++ b/app/assets/javascripts/components/school_search.js.erb
@@ -19,6 +19,8 @@ document.addEventListener("DOMContentLoaded", function() {
     return;
   }
 
+  var excludeClosedSchools = form.getAttribute("data-exclude-closed") || false;
+
   var methodInput = form.querySelector('input[name="_method"]');
   var formSubmit = form.querySelector('input[type="submit"]');
 
@@ -66,7 +68,7 @@ document.addEventListener("DOMContentLoaded", function() {
       Rails.ajax({
         type: "post",
         url: "<%= Rails.application.routes.url_helpers.school_search_index_path %>",
-        data: "query=" + query,
+        data: "query=" + query + "&exclude_closed=" + excludeClosedSchools.toString(),
         success: handleResponse,
         error: handleResponse
       });
@@ -95,7 +97,8 @@ document.addEventListener("DOMContentLoaded", function() {
 
         if (school.closeDate) {
           suggestion +=
-            '<div class="school-search__closed-status"><span class="govuk-hint govuk-!-margin-bottom-1">' +
+            '<div class="school-search__closed-status">' +
+            '<span class="govuk-hint govuk-!-margin-bottom-1">' +
             "Closed on<br>" +
             school.closeDate +
             "</span>" +

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -46,7 +46,8 @@ class ClaimsController < ApplicationController
   end
 
   def search_schools
-    @schools = School.search(params[:school_search])
+    schools = ActiveModel::Type::Boolean.new.cast(params[:exclude_closed]) ? School.open : School
+    @schools = schools.search(params[:school_search])
   rescue ArgumentError => e
     raise unless e.message == School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR
 

--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -12,8 +12,10 @@ class SchoolSearchController < ApplicationController
       return
     end
 
+    schools = ActiveModel::Type::Boolean.new.cast(params[:exclude_closed]) ? School.open : School
+
     begin
-      @schools = School.search(params[:query])
+      @schools = schools.search(params[:query])
     rescue ArgumentError => e
       raise unless e.message == School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -97,6 +97,9 @@ class School < ApplicationRecord
   enum school_type_group: SCHOOL_TYPE_GROUPS
   enum school_type: SCHOOL_TYPES
 
+  scope :open, -> { where(close_date: nil) }
+  scope :closed, -> { where.not(close_date: nil) }
+
   def self.search(search_term)
     raise ArgumentError, SEARCH_NOT_ENOUGH_CHARACTERS_ERROR if search_term.length < 4
 

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -57,6 +57,7 @@ module StudentLoans
       ineligible_qts_award_year? ||
         ineligible_claim_school? ||
         employed_at_no_school? ||
+        current_school_closed? ||
         not_taught_eligible_subjects? ||
         not_taught_enough?
     end
@@ -66,6 +67,7 @@ module StudentLoans
         :ineligible_qts_award_year,
         :ineligible_claim_school,
         :employed_at_no_school,
+        :current_school_closed,
         :not_taught_eligible_subjects,
         :not_taught_enough,
       ].find { |eligibility_check| send("#{eligibility_check}?") }
@@ -91,6 +93,10 @@ module StudentLoans
 
     def one_subject_must_be_selected
       errors.add(:subjects_taught, "Choose a subject, or select No") if subjects_taught.empty?
+    end
+
+    def current_school_closed?
+      current_school.present? && !current_school.open?
     end
   end
 end

--- a/app/views/claims/_ineligibility_reason_current_school_closed.html.erb
+++ b/app/views/claims/_ineligibility_reason_current_school_closed.html.erb
@@ -1,0 +1,4 @@
+<p class="govuk-body">
+  <%= claim_school_name %> is closed. You can only get this payment if you’re
+  still employed at a school.
+</p>

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -79,7 +79,7 @@
                 <%= b.radio_button class: "govuk-radios__input" %>
                 <%= b.label class: "govuk-radios__label govuk-label--s govuk-radios__label govuk-!-padding-0" do %>
                   <div class="school-search__suggestion">
-                    <div class"school-search__suggestion-main-section>
+                    <div class="school-search__suggestion-main-section">
                       <div class="govuk-label govuk-radios__label govuk-label--s">
                         <%= b.text %>
                       </div>

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -2,7 +2,15 @@
 
   <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { school_search: "school_search" }) if current_claim.errors.any? %>
 
-  <%= form_for current_claim, url: claim_path, method: :get,  data: { "school-id-param": "claim_eligibility_attributes_#{school_id_param}" }, html: { class: "school_search_form" } do |form| %>
+  <%= form_for current_claim,
+               url: claim_path,
+               method: :get,
+               data: {
+                 "school-id-param": "claim_eligibility_attributes_#{school_id_param}",
+                 "exclude-closed": exclude_closed
+               },
+               html: { class: "school_search_form" } do |form|
+  %>
     <%= hidden_field_tag :_method, "get", id: nil %>
     <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
 
@@ -11,6 +19,8 @@
     <% end %>
 
     <%= form_group_tag current_claim, :school_search do %>
+
+      <%= hidden_field_tag :exclude_closed, exclude_closed, id: nil %>
 
       <h1 class="govuk-label-wrapper">
         <%= label_tag :school_search, question, class: "govuk-label govuk-label--xl" %>
@@ -21,7 +31,7 @@
           <strong>No results match that search term. Try again.</strong>
         </p>
       <% else %>
-        <span id="school-search-hint" class="govuk-hint">
+        <span class="govuk-hint">
           Enter the school name. Use at least four characters.
         </span>
       <% end %>
@@ -75,7 +85,7 @@
                       </div>
                       <span class="govuk-hint govuk-radios__hint"><%= b.object.address %></span>
                     </div>
-                    <% unless b.object.close_date.blank? %>
+                    <% if b.object.close_date.present? %>
                       <div class="school-search__closed-status">
                         <span class="govuk-hint govuk-radios__hint govuk-!-margin-bottom-1">Closed on <%= l(b.object.close_date) %></span>
                       </div>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -2,6 +2,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "school_search", question: t("student_loans.questions.claim_school"), school_param: :claim_school, school_id_param: :claim_school_id, school_search_value: current_claim.eligibility.claim_school_name %>
+    <%= render "school_search",
+               question: t("student_loans.questions.claim_school"),
+               school_param: :claim_school,
+               school_id_param: :claim_school_id,
+               school_search_value: current_claim.eligibility.claim_school_name,
+               exclude_closed: false
+    %>
   </div>
 </div>

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -2,6 +2,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "school_search", question: t("questions.current_school"), school_param: :current_school, school_id_param: :current_school_id, school_search_value: current_claim.eligibility.current_school_name %>
+    <%= render "school_search",
+               question: t("questions.current_school"),
+               school_param: :current_school,
+               school_id_param: :current_school_id,
+               school_search_value: current_claim.eligibility.current_school_name,
+               exclude_closed: true
+    %>
   </div>
 </div>

--- a/app/views/claims/still_teaching.html.erb
+++ b/app/views/claims/still_teaching.html.erb
@@ -16,19 +16,35 @@
             <%= errors_tag current_claim.eligibility, :employment_status %>
 
             <div class="govuk-radios">
+
               <%= fields.hidden_field :employment_status %>
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:employment_status, :claim_school, class: "govuk-radios__input") %>
-                <%= fields.label :employment_status_claim_school, "Yes, at #{current_claim.eligibility.claim_school_name}", class: "govuk-label govuk-radios__label" %>
-              </div>
-              <div class="govuk-radios__item">
-                <%= fields.radio_button(:employment_status, :different_school, class: "govuk-radios__input") %>
-                <%= fields.label :employment_status_different_school, "Yes, at another school", class: "govuk-label govuk-radios__label" %>
-              </div>
+
+              <% if current_claim.eligibility.claim_school.open? %>
+
+                <div class="govuk-radios__item">
+                  <%= fields.radio_button(:employment_status, :claim_school, class: "govuk-radios__input") %>
+                  <%= fields.label :employment_status_claim_school, "Yes, at #{current_claim.eligibility.claim_school_name}", class: "govuk-label govuk-radios__label" %>
+                </div>
+
+                <div class="govuk-radios__item">
+                  <%= fields.radio_button(:employment_status, :different_school, class: "govuk-radios__input") %>
+                  <%= fields.label :employment_status_different_school, "Yes, at another school", class: "govuk-label govuk-radios__label" %>
+                </div>
+
+              <% else %>
+
+                <div class="govuk-radios__item">
+                  <%= fields.radio_button(:employment_status, :different_school, class: "govuk-radios__input") %>
+                  <%= fields.label :employment_status_different_school, "Yes", class: "govuk-label govuk-radios__label" %>
+                </div>
+
+              <% end %>
+
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:employment_status, :no_school, class: "govuk-radios__input") %>
                 <%= fields.label :employment_status_no_school, "No", class: "govuk-label govuk-radios__label" %>
               </div>
+
             </div>
 
           </fieldset>

--- a/app/views/school_search/create.json.jbuilder
+++ b/app/views/school_search/create.json.jbuilder
@@ -4,7 +4,7 @@ if @schools.present?
       json.id school.id
       json.name school.name
       json.address school.address
-      json.closeDate l(school.close_date) unless school.close_date.blank?
+      json.closeDate l(school.close_date) if school.close_date.present?
     end
   end
 end

--- a/spec/features/current_school_with_closed_claim_school_spec.rb
+++ b/spec/features/current_school_with_closed_claim_school_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.feature "Current school with closed claim school" do
+  let(:claim_school) { schools(:the_samuel_lister_academy) }
+
+  scenario "Still teaching only has two options" do
+    start_claim
+    choose_qts_year
+    choose_school claim_school
+
+    expect(page).to have_text("Yes")
+    expect(page).to have_text("No")
+    expect(page).not_to have_text("Yes, at #{claim_school.name}")
+    expect(page).not_to have_text("Yes, at another school")
+  end
+
+  scenario "Choosing yes to still teaching prompts to search for a school" do
+    claim = start_claim
+    choose_qts_year
+    choose_school claim_school
+
+    choose_still_teaching "Yes"
+
+    expect(claim.eligibility.employment_status).to eq("different_school")
+    expect(page).to have_text(I18n.t("questions.current_school"))
+    expect(page).to have_button("Search")
+  end
+end

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -54,17 +54,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     expect(page).to have_text("You can only get this payment if you’re still employed at a school.")
   end
 
-  scenario "current school is closed" do
-    claim = start_claim
-    choose_qts_year
-    choose_school schools(:the_samuel_lister_academy)
-
-    choose_still_teaching "Yes, at The Samuel Lister Academy"
-
-    expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("The Samuel Lister Academy is closed. You can only get this payment if you’re still employed at a school.")
-  end
-
   scenario "did not teach an eligible subject" do
     claim = start_claim
     choose_qts_year

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -54,6 +54,17 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     expect(page).to have_text("You can only get this payment if you’re still employed at a school.")
   end
 
+  scenario "current school is closed" do
+    claim = start_claim
+    choose_qts_year
+    choose_school schools(:the_samuel_lister_academy)
+
+    choose_still_teaching "Yes, at The Samuel Lister Academy"
+
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("The Samuel Lister Academy is closed. You can only get this payment if you’re still employed at a school.")
+  end
+
   scenario "did not teach an eligible subject" do
     claim = start_claim
     choose_qts_year

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -123,10 +123,10 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
 
-    fill_in :school_search, with: "Creaton"
+    fill_in :school_search, with: "Lister"
     click_button "Search"
 
-    expect(page).to have_text(schools(:great_creaton_primary_school).name)
+    expect(page).to have_text(schools(:the_samuel_lister_academy).name)
   end
 
   scenario "Current school search excludes closed schools" do
@@ -138,10 +138,10 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     expect(page).to have_text(I18n.t("questions.current_school"))
     expect(page).to have_button("Search")
 
-    fill_in :school_search, with: "Creaton"
+    fill_in :school_search, with: "Lister"
     click_button "Search"
 
-    expect(page).not_to have_text(schools(:great_creaton_primary_school).name)
+    expect(page).not_to have_text(schools(:the_samuel_lister_academy).name)
   end
 
   scenario "Claim school search with autocomplete includes closed schools", js: true do
@@ -151,8 +151,8 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
 
-    fill_in :school_search, with: "Creaton"
-    expect(page).to have_text(schools(:great_creaton_primary_school).name)
+    fill_in :school_search, with: "Lister"
+    expect(page).to have_text(schools(:the_samuel_lister_academy).name)
   end
 
   scenario "Current school search with autocomplete excludes closed schools", js: true do
@@ -164,7 +164,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     expect(page).to have_text(I18n.t("questions.current_school"))
     expect(page).to have_button("Search")
 
-    fill_in :school_search, with: "Creaton"
-    expect(page).not_to have_text(schools(:great_creaton_primary_school).name)
+    fill_in :school_search, with: "Lister"
+    expect(page).not_to have_text(schools(:the_samuel_lister_academy).name)
   end
 end

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -115,4 +115,56 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     expect(page).to have_text("Select your school from the search results.")
     expect(page).to have_text(schools(:hampstead_school).name)
   end
+
+  scenario "Claim school search includes closed schools" do
+    start_claim
+    choose_qts_year
+
+    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
+    expect(page).to have_button("Search")
+
+    fill_in :school_search, with: "Creaton"
+    click_button "Search"
+
+    expect(page).to have_text(schools(:great_creaton_primary_school).name)
+  end
+
+  scenario "Current school search excludes closed schools" do
+    start_claim
+    choose_qts_year
+    choose_school schools(:penistone_grammar_school)
+    choose_still_teaching "Yes, at another school"
+
+    expect(page).to have_text(I18n.t("questions.current_school"))
+    expect(page).to have_button("Search")
+
+    fill_in :school_search, with: "Creaton"
+    click_button "Search"
+
+    expect(page).not_to have_text(schools(:great_creaton_primary_school).name)
+  end
+
+  scenario "Claim school search with autocomplete includes closed schools", js: true do
+    start_claim
+    choose_qts_year
+
+    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
+    expect(page).to have_button("Search")
+
+    fill_in :school_search, with: "Creaton"
+    expect(page).to have_text(schools(:great_creaton_primary_school).name)
+  end
+
+  scenario "Current school search with autocomplete excludes closed schools", js: true do
+    start_claim
+    choose_qts_year
+    choose_school schools(:penistone_grammar_school)
+    choose_still_teaching "Yes, at another school"
+
+    expect(page).to have_text(I18n.t("questions.current_school"))
+    expect(page).to have_button("Search")
+
+    fill_in :school_search, with: "Creaton"
+    expect(page).not_to have_text(schools(:great_creaton_primary_school).name)
+  end
 end

--- a/spec/fixtures/local_authorities.yml
+++ b/spec/fixtures/local_authorities.yml
@@ -2,6 +2,10 @@
 barnsley:
   code: 370
   name: Barnsley
+bradford:
+  code: 380
+  name: Bradford
+
 # Student loans and Maths and Physics Ineligible
 camden:
   code: 202

--- a/spec/fixtures/schools.yml
+++ b/spec/fixtures/schools.yml
@@ -1,4 +1,5 @@
 # Student loans and Maths and Physics Eligible
+
 penistone_grammar_school:
   name: Penistone Grammar School
   urn: 1234
@@ -13,7 +14,24 @@ penistone_grammar_school:
   county: South Yorkshire
   postcode: S36 7BX
 
+## Closed schools
+
+the_samuel_lister_academy:
+  name: The Samuel Lister Academy
+  urn: 137576
+  phase: secondary
+  close_date: 2018-06-30
+  school_type_group: academies
+  school_type: academy_sponsor_led
+  local_authority: bradford
+  local_authority_district: bradford
+  street: Cottingley New Road
+  town: Bingley
+  county: West Yorkshire
+  postcode: BD16 1TZ
+
 # Student loans and Maths and Physics Ineligible
+
 hampstead_school:
   name: Hampstead School
   urn: 4567
@@ -26,18 +44,3 @@ hampstead_school:
   locality: Hampstead
   town: London
   postcode: NW2 3RT
-
-## Closed school
-great_creaton_primary_school:
-  name: Great Creaton Primary School
-  urn: 121820
-  phase: primary
-  close_date: 2018-12-31
-  school_type_group: la_maintained
-  school_type: community_school
-  local_authority: northamptonshire
-  local_authority_district: daventry
-  street: Welford Road
-  locality: Creaton
-  town: Northampton
-  postcode: NN6 8NH

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       expect(StudentLoans::Eligibility.new(qts_award_year: "before_2013").ineligibility_reason).to eq :ineligible_qts_award_year
       expect(StudentLoans::Eligibility.new(claim_school: schools(:hampstead_school)).ineligibility_reason).to eq :ineligible_claim_school
       expect(StudentLoans::Eligibility.new(employment_status: :no_school).ineligibility_reason).to eq :employed_at_no_school
+      expect(StudentLoans::Eligibility.new(current_school: schools(:the_samuel_lister_academy)).ineligibility_reason).to eq :current_school_closed
       expect(StudentLoans::Eligibility.new(taught_eligible_subjects: false).ineligibility_reason).to eq :not_taught_eligible_subjects
       expect(StudentLoans::Eligibility.new(mostly_performed_leadership_duties: true).ineligibility_reason).to eq :not_taught_enough
     end

--- a/spec/requests/school_search_spec.rb
+++ b/spec/requests/school_search_spec.rb
@@ -28,27 +28,27 @@ RSpec.describe "School search", type: :request do
     end
 
     it "includes closed schools by default" do
-      post school_search_index_path, params: {query: "Great Creaton Primary School"}
+      post school_search_index_path, params: {query: "The Samuel Lister Academy"}
 
-      expect(response.body).to include(schools(:great_creaton_primary_school).name)
+      expect(response.body).to include(schools(:the_samuel_lister_academy).name)
     end
 
     it "includes the close date when the school is closed" do
-      post school_search_index_path, params: {query: "Great Creaton Primary School"}
+      post school_search_index_path, params: {query: "The Samuel Lister Academy"}
 
-      expect(response.body).to include(schools(:great_creaton_primary_school).close_date.strftime("%-d %B %Y"))
+      expect(response.body).to include(schools(:the_samuel_lister_academy).close_date.strftime("%-d %B %Y"))
     end
 
     it "includes closed schools when requested" do
-      post school_search_index_path, params: {query: "Great Creaton Primary School", exclude_closed: false}
+      post school_search_index_path, params: {query: "The Samuel Lister Academy", exclude_closed: false}
 
-      expect(response.body).to include(schools(:great_creaton_primary_school).name)
+      expect(response.body).to include(schools(:the_samuel_lister_academy).name)
     end
 
     it "excludes closed schools when requested" do
-      post school_search_index_path, params: {query: "Great Creaton Primary School", exclude_closed: true}
+      post school_search_index_path, params: {query: "The Samuel Lister Academy", exclude_closed: true}
 
-      expect(response.body).not_to include(schools(:great_creaton_primary_school).name)
+      expect(response.body).not_to include(schools(:the_samuel_lister_academy).name)
     end
   end
 end

--- a/spec/requests/school_search_spec.rb
+++ b/spec/requests/school_search_spec.rb
@@ -11,13 +11,7 @@ RSpec.describe "School search", type: :request do
       expect(response.body).not_to include(schools(:hampstead_school).name)
     end
 
-    it "includes the close date when the school is closed" do
-      post school_search_index_path, params: {query: "Great Creaton Primary School"}
-
-      expect(response.body).to include(schools(:great_creaton_primary_school).close_date.strftime("%-d %B %Y"))
-    end
-
-    it "returns an error if the query parameter is more than three characters" do
+    it "returns an error if the query parameter is less than four characters" do
       post school_search_index_path, params: {query: "Pen"}
 
       expect(response.status).to eq(400)
@@ -31,6 +25,30 @@ RSpec.describe "School search", type: :request do
       expect(response.status).to eq(400)
       expect(response.body).to include({errors: ["Expected required parameter 'query' to be set"]}.to_json)
       expect(response.body).not_to include(schools(:penistone_grammar_school).name)
+    end
+
+    it "includes closed schools by default" do
+      post school_search_index_path, params: {query: "Great Creaton Primary School"}
+
+      expect(response.body).to include(schools(:great_creaton_primary_school).name)
+    end
+
+    it "includes the close date when the school is closed" do
+      post school_search_index_path, params: {query: "Great Creaton Primary School"}
+
+      expect(response.body).to include(schools(:great_creaton_primary_school).close_date.strftime("%-d %B %Y"))
+    end
+
+    it "includes closed schools when requested" do
+      post school_search_index_path, params: {query: "Great Creaton Primary School", exclude_closed: false}
+
+      expect(response.body).to include(schools(:great_creaton_primary_school).name)
+    end
+
+    it "excludes closed schools when requested" do
+      post school_search_index_path, params: {query: "Great Creaton Primary School", exclude_closed: true}
+
+      expect(response.body).not_to include(schools(:great_creaton_primary_school).name)
     end
   end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -41,7 +41,7 @@ module FeatureHelpers
   end
 
   def choose_school(school)
-    fill_in :school_search, with: school.name.split(" ").first
+    fill_in :school_search, with: school.name.sub("The ", "").split(" ").first
     click_on "Search"
 
     choose school.name


### PR DESCRIPTION
This does 3 things:
- Excludes closed schools from the current school search
- Removes the option to pick the claim school as the current school if it's closed
- Adds an ineligibility screen for if a user somehow selects a closed school as their current school (e.g. by manually setting query parameters)
