### PR TITLE
Add student loan plan and amount to approver view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add student loan plan and amount to approver view of a claim
 - Link to Get Information About Schools from the admin view of a claim
 - Monitor VSP availability
 - Use slots to make VSP deployment zero-downtime

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -24,6 +24,13 @@ module Admin
       ]
     end
 
+    def admin_student_loan_details(claim)
+      [
+        [t("student_loans.csv_headers.student_loan_repayment_amount"), number_to_currency(claim.eligibility.student_loan_repayment_amount)],
+        [t("student_loans.csv_headers.student_loan_repayment_plan"), claim.student_loan_plan&.humanize],
+      ]
+    end
+
     def link_to_school(school)
       url = "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{school.urn}"
       link_to(school.name, url, class: "govuk-link")

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -8,6 +8,8 @@
 
     <%= render partial: "answer_section", locals: {heading: "Eligibility details", answers: admin_eligibility_answers(@claim.eligibility)} %>
 
+    <%= render partial: "answer_section", locals: {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
+
     <%= button_to "Approve",
                   admin_claim_approvals_path(@claim),
                   method: :post,

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -69,4 +69,21 @@ describe Admin::ClaimsHelper do
       expect(helper.admin_personal_details(claim)).to eq expected_answers
     end
   end
+
+  describe "admin_student_loan_details" do
+    let(:claim) do
+      build(
+        :claim,
+        student_loan_plan: :plan_1,
+        eligibility: build(:student_loans_eligibility, student_loan_repayment_amount: 1234),
+      )
+    end
+
+    it "includes an array of questions and answers" do
+      expect(helper.admin_student_loan_details(claim)).to eq([
+        [I18n.t("student_loans.csv_headers.student_loan_repayment_amount"), "£1,234.00"],
+        [I18n.t("student_loans.csv_headers.student_loan_repayment_plan"), "Plan 1"],
+      ])
+    end
+  end
 end


### PR DESCRIPTION
This should make it easier for an approver to see all the information they need to approve a claim without having to download the CSV

![image](https://user-images.githubusercontent.com/109774/65028683-550db800-d934-11e9-888b-9f4ed193aeb3.png)
