### PR TITLE
Update privacy notice to include IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Update privacy notice to include the collection of IP address
+
 ## [Release 009] - 2019-09-17
 
 - Add student loan plan and amount to approver view of a claim

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -48,6 +48,7 @@
         your email address if you include it with feedback to us on the service or agree to be contacted for user research
         purposes
       </li>
+      <li>your Internet Protocol (IP) address</li>
     </ul>
 
     <h2 class="govuk-heading-l">


### PR DESCRIPTION
We are now sending the client IP address to Application Insights so we
state that in the notice.

I've tried to copy the GOV.UK use of IP address in their privacy notice, 
I am no expert in this so we may want other eyes on the content?

![Screenshot_2019-09-17 Privacy Notice Claim additional payments for teaching - Teachers claim back your student loan repayme](https://user-images.githubusercontent.com/480578/65047845-0d4e5700-d95b-11e9-8489-77fb5cee16b7.png)