### PR TITLE
A service operator can easily check employment details in Hartlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Show DfE number against school in approver view of claim
 - Drop redundant full_name column from claims table
 
 ## [Release 010] - 2019-09-17

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -5,8 +5,8 @@ module Admin
     def admin_eligibility_answers(eligibility)
       [].tap do |a|
         a << [t("student_loans.questions.admin.qts_award_year"), academic_years(eligibility.qts_award_year)]
-        a << [t("student_loans.questions.admin.claim_school"), link_to_school(eligibility.claim_school)]
-        a << [t("questions.admin.current_school"), link_to_school(eligibility.current_school)]
+        a << [t("student_loans.questions.admin.claim_school"), display_school(eligibility.claim_school)]
+        a << [t("questions.admin.current_school"), display_school(eligibility.current_school)]
         a << [t("student_loans.questions.admin.subjects_taught"), subject_list(eligibility.subjects_taught)]
         a << [t("student_loans.questions.admin.had_leadership_position"), (eligibility.had_leadership_position? ? "Yes" : "No")]
         a << [t("student_loans.questions.admin.mostly_performed_leadership_duties"), (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No")] if eligibility.had_leadership_position?
@@ -34,6 +34,14 @@ module Admin
     def link_to_school(school)
       url = "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{school.urn}"
       link_to(school.name, url, class: "govuk-link")
+    end
+
+    def display_school(school)
+      html = [
+        link_to_school(school),
+        tag.span("(#{school.dfe_number})", class: "govuk-body-s"),
+      ].join(" ").html_safe
+      sanitize(html, tags: %w[span a], attributes: %w[href class])
     end
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -129,4 +129,11 @@ class School < ApplicationRecord
   def open?
     close_date.nil?
   end
+
+  def dfe_number
+    [
+      local_authority.code,
+      establishment_number,
+    ].join("/")
+  end
 end

--- a/app/models/school_data_importer.rb
+++ b/app/models/school_data_importer.rb
@@ -44,6 +44,7 @@ class SchoolDataImporter
     school.local_authority = local_authority
     school.local_authority_district = local_authority_district
     school.close_date = row.fetch("CloseDate")
+    school.establishment_number = row.fetch("EstablishmentNumber")
     school
   end
 

--- a/db/migrate/20190917100131_add_establishment_number_to_schools.rb
+++ b/db/migrate/20190917100131_add_establishment_number_to_schools.rb
@@ -1,0 +1,5 @@
+class AddEstablishmentNumberToSchools < ActiveRecord::Migration[5.2]
+  def change
+    add_column :schools, :establishment_number, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 2019_09_18_142241) do
     t.datetime "updated_at", null: false
     t.uuid "local_authority_district_id"
     t.date "close_date"
+    t.integer "establishment_number"
     t.index ["local_authority_district_id"], name: "index_schools_on_local_authority_district_id"
     t.index ["local_authority_id"], name: "index_schools_on_local_authority_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -22,8 +22,8 @@ describe Admin::ClaimsHelper do
     it "returns an array of questions and answers for displaying to approver" do
       expected_answers = [
         [I18n.t("student_loans.questions.admin.qts_award_year"), "1 September 2013 to 31 August 2014"],
-        [I18n.t("student_loans.questions.admin.claim_school"), "<a class=\"govuk-link\" href=\"https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{claim_school.urn}\">#{claim_school.name}</a>"],
-        [I18n.t("questions.admin.current_school"), "<a class=\"govuk-link\" href=\"https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{current_school.urn}\">#{current_school.name}</a>"],
+        [I18n.t("student_loans.questions.admin.claim_school"), helper.display_school(claim_school)],
+        [I18n.t("questions.admin.current_school"), helper.display_school(current_school)],
         [I18n.t("student_loans.questions.admin.subjects_taught"), "Chemistry and Physics"],
         [I18n.t("student_loans.questions.admin.had_leadership_position"), "Yes"],
         [I18n.t("student_loans.questions.admin.mostly_performed_leadership_duties"), "No"],
@@ -84,6 +84,23 @@ describe Admin::ClaimsHelper do
         [I18n.t("student_loans.csv_headers.student_loan_repayment_amount"), "£1,234.00"],
         [I18n.t("student_loans.csv_headers.student_loan_repayment_plan"), "Plan 1"],
       ])
+    end
+  end
+
+  describe "display_school" do
+    let(:school) do
+      build(:school,
+        name: "Bash Street School",
+        urn: "1234",
+        establishment_number: 4567,
+        local_authority: build(:local_authority, code: 123))
+    end
+
+    it "shows a school with a link and the DfE number" do
+      gias_url = "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{school.urn}"
+      expect(helper.display_school(school)).to eq(
+        "<a class=\"govuk-link\" href=\"#{gias_url}\">#{school.name}</a> <span class=\"govuk-body-s\">(#{school.dfe_number})</span>"
+      )
     end
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -47,4 +47,18 @@ RSpec.describe School, type: :model do
       expect(school.address).to eql("10 The Street, Town, County, PC1 4TE")
     end
   end
+
+  describe "dfe_number" do
+    let(:school) do
+      build(:school,
+        name: "Bash Street School",
+        urn: "1234",
+        establishment_number: 4567,
+        local_authority: build(:local_authority, code: 123))
+    end
+
+    it "returns a combination of local authority code and establishment number" do
+      expect(school.dfe_number).to eq("123/4567")
+    end
+  end
 end

--- a/spec/services/school_data_importer_spec.rb
+++ b/spec/services/school_data_importer_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe SchoolDataImporter do
         expect(imported_school.local_authority_district.code).to eql("E08000016")
         expect(imported_school.local_authority_district.name).to eql("Barnsley")
         expect(imported_school.close_date).to be_nil
+        expect(imported_school.establishment_number).to eq(4027)
       end
 
       it "imports a closed school with the date it closed" do


### PR DESCRIPTION
This adds a new column to schools to store the DfE number in the database (which is fetched when the nightly import runs), and show the DfE number in brackets against both the claim and the current school, to make it easier when checking a school against a record in Hartlink. 

![image](https://user-images.githubusercontent.com/109774/65048807-a336b180-d95c-11e9-8d5b-690dca576789.png)

