### PR TITLE
Drop redundant full_names column from claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Drop redundant full_name column from claims table
+
 ## [Release 010] - 2019-09-17
 
 - Fix deployment template conflict

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -25,7 +25,6 @@ class Claim < ApplicationRecord
     date_of_birth: true,
     eligibility_id: false,
     eligibility_type: false,
-    full_name: true,
     first_name: true,
     middle_name: true,
     surname: true,

--- a/db/data/20190829135327_backfill_first_middle_surnames.rb
+++ b/db/data/20190829135327_backfill_first_middle_surnames.rb
@@ -1,6 +1,6 @@
 class BackfillFirstMiddleSurnames < ActiveRecord::Migration[5.2]
   def up
-    claims_with_full_names.each do |claim|
+    claims_with_verify_info.each do |claim|
       parser = Claim::VerifyResponseParametersParser.new(claim.verify_response)
       claim.update!(
         first_name: parser.first_name,
@@ -11,7 +11,7 @@ class BackfillFirstMiddleSurnames < ActiveRecord::Migration[5.2]
   end
 
   def down
-    claims_with_full_names.update_all(
+    claims_with_verify_info.update_all(
       first_name: nil,
       middle_name: nil,
       surname: nil
@@ -20,7 +20,7 @@ class BackfillFirstMiddleSurnames < ActiveRecord::Migration[5.2]
 
   private
 
-  def claims_with_full_names
-    Claim.where.not(verify_response: nil).where.not(full_name: nil)
+  def claims_with_verify_info
+    Claim.where.not(verify_response: nil)
   end
 end

--- a/db/migrate/20190918142241_drop_redundant_full_name_column_from_claims.rb
+++ b/db/migrate/20190918142241_drop_redundant_full_name_column_from_claims.rb
@@ -1,0 +1,5 @@
+class DropRedundantFullNameColumnFromClaims < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :claims, :full_name, :string, limit: 200
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_06_082123) do
+ActiveRecord::Schema.define(version: 2019_09_18_142241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -19,7 +19,6 @@ ActiveRecord::Schema.define(version: 2019_09_06_082123) do
   create_table "claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "full_name", limit: 200
     t.string "address_line_1", limit: 100
     t.string "address_line_2", limit: 100
     t.string "address_line_3", limit: 100

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -427,7 +427,6 @@ RSpec.describe Claim, type: :model do
         :bank_sort_code,
         :bank_account_number,
         :date_of_birth,
-        :full_name,
         :first_name,
         :middle_name,
         :surname,


### PR DESCRIPTION
We split the claimants' names out to separate fields in Release 004,
making this field now redundant.

This also updates the data migration that performed the backfill so that
it won't error if it is run in future by a new developer joining the
team. There is probably an argument for simply deleting the data
migration, but given it's the only one we have it at the moment it might
be useful to keep it around to serve as a reference for future adding
future data migrations.