### PR TITLE
Order tests randomly

### DIFF
--- a/spec/features/timeout_spec.rb
+++ b/spec/features/timeout_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 RSpec.feature "Teacher Student Loan Repayments claims", js: true do
   let(:one_second_in_minutes) { 1 / 60.to_f }
+  let(:two_seconds_in_minutes) { 2 / 60.to_f }
 
   before do
-    allow_any_instance_of(ApplicationController).to receive(:claim_timeout_in_minutes) { one_second_in_minutes }
+    allow_any_instance_of(ApplicationController).to receive(:claim_timeout_in_minutes) { two_seconds_in_minutes }
     allow_any_instance_of(ApplicationController).to receive(:claim_timeout_warning_in_minutes) { one_second_in_minutes }
     start_claim
   end
@@ -15,6 +16,7 @@ RSpec.feature "Teacher Student Loan Repayments claims", js: true do
   end
 
   scenario "Claimants can refresh their session" do
+    expect(page).to have_content("Your session will expire in #{one_second_in_minutes} minutes")
     expect_any_instance_of(ClaimsController).to receive(:update_last_seen_at)
     click_on "Continue session"
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,6 +68,7 @@ RSpec.configure do |config|
 
   config.before :each do
     clear_enqueued_jobs
+    ActionMailer::Base.deliveries.clear
     OmniAuth.config.mock_auth[:dfe] = nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,12 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
@@ -83,12 +89,6 @@ RSpec.configure do |config|
   #   # end of the spec run, to help surface which specs are running
   #   # particularly slow.
   #   config.profile_examples = 10
-  #
-  #   # Run specs in random order to surface order dependencies. If you find an
-  #   # order dependency and want to debug it, you can fix the order by providing
-  #   # the seed, which is printed after each run.
-  #   #     --seed 1234
-  #   config.order = :random
   #
   #   # Seed global randomization in this process using the `--seed` CLI option.
   #   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
We've been running tests in the order they're defined in. This could potentially cause some issues where tests defined further down could rely invisibly on some state that gets defined before that test gets run. This sets the order to random, so every time the test suite gets run, the tests are run in a different order each time.
