### PR TITLE
Show how many claims are awaiting approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Show how many claims are awaiting approval
 - Show date of birth in a better place and format for claim checking
 - Show DfE number against school in approver view of claim
 - Drop redundant full_name column from claims table

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -104,7 +104,8 @@ class Claim < ApplicationRecord
   before_save :normalise_bank_account_number, if: :bank_account_number_changed?
   before_save :normalise_bank_sort_code, if: :bank_sort_code_changed?
 
-  scope :awaiting_approval, -> { where.not(submitted_at: nil).where(approved_at: nil) }
+  scope :submitted, -> { where.not(submitted_at: nil) }
+  scope :awaiting_approval, -> { submitted.where(approved_at: nil) }
   scope :approved, -> { where.not(approved_at: nil).where.not(approved_by: nil) }
 
   def submit!

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -6,6 +6,8 @@
 
     <% if @claims.any? %>
 
+      <h2 class="govuk-heading-m"><%= pluralize(@claims.count, "claim") %> awaiting approval</h2>
+
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
@@ -27,7 +29,7 @@
 
     <% else %>
 
-      <p class="govuk-body-l">There are currently no claims to approve.</p>
+      <h2 class="govuk-heading-m">There are currently no claims to approve.</h2>
 
     <% end %>
   </div>

--- a/app/views/admin/page/index.html.erb
+++ b/app/views/admin/page/index.html.erb
@@ -1,5 +1,7 @@
 <div class="govuk-grid-row">
+
   <div class="govuk-grid-column-two-thirds">
+
     <h1 class="govuk-heading-xl">
       Admin
     </h1>
@@ -13,4 +15,15 @@
     <% end %>
 
   </div>
+
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">Total claims received</h2>
+    <p class="govuk-body govuk-!-font-size-36"><%= Claim.submitted.count %></p>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m">Claims awaiting approval</h2>
+    <p class="govuk-body govuk-!-font-size-36"><%= Claim.awaiting_approval.count %></p>
+  </div>
+
 </div>

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature "Admin approves a claim" do
         click_on "Approve claims"
 
         expect(page).to have_content(claim_to_approve.reference)
+        expect(page).to have_content("5 claims awaiting approval")
 
         find("a[href='#{admin_claim_path(claim_to_approve)}']").click
         perform_enqueued_jobs { click_on "Approve" }


### PR DESCRIPTION
<!-- Do you need to update CHANGELOG.md? -->

This shows a service operator at a glance how many claims are awaiting approval, meaning they don't have to download a CSV and count rows in order to keep tabs on how many people have applied

![image](https://user-images.githubusercontent.com/109774/65259481-a2d51c80-dafc-11e9-98e5-2e93f2f92265.png)

![image](https://user-images.githubusercontent.com/109774/65246517-ad84b700-dae6-11e9-870f-0704d8841116.png)