### PR TITLE
Changes to the claim data shown to service operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Show date of birth in a better place and format for claim checking
 - Show DfE number against school in approver view of claim
 - Drop redundant full_name column from claims table
 - Updated Accessibility statement to show current issues

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -17,8 +17,8 @@ module Admin
       [
         [t("questions.admin.teacher_reference_number"), claim.teacher_reference_number],
         [t("verified_fields.full_name").capitalize, claim.full_name],
+        [t("verified_fields.date_of_birth").capitalize, l(claim.date_of_birth, format: :day_month_year)],
         [t("questions.admin.national_insurance_number"), claim.national_insurance_number],
-        [t("verified_fields.date_of_birth").capitalize, l(claim.date_of_birth)],
         [t("verified_fields.address").capitalize, sanitize(claim.address("<br>").html_safe, tags: %w[br])],
         [t("questions.admin.email_address"), claim.email_address],
       ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
   date:
     formats:
       default: "%-d %B %Y"
+      day_month_year: "%d/%m/%Y"
   number:
     currency:
       format:

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -60,8 +60,8 @@ describe Admin::ClaimsHelper do
       expected_answers = [
         [I18n.t("questions.admin.teacher_reference_number"), "1234567"],
         [I18n.t("verified_fields.full_name").capitalize, "Bruce Wayne"],
+        [I18n.t("verified_fields.date_of_birth").capitalize, "01/01/1901"],
         [I18n.t("questions.admin.national_insurance_number"), "QQ123456C"],
-        [I18n.t("verified_fields.date_of_birth").capitalize, "1 January 1901"],
         [I18n.t("verified_fields.address").capitalize, "Flat 1<br>1 Test Road<br>Test Town<br>AB1 2CD"],
         [I18n.t("questions.admin.email_address"), "test@email.com"],
       ]


### PR DESCRIPTION
During a claim checking session we noticed that we were checking date of birth before national insurance number so it made sense to show that first. We also noticed that the date format in DQT and TPS is DD/MM/YYYY and claim checking could be eased by displaying the DOB in the same format.

# Before

![Screenshot_2019-09-19 Teachers claim back your student loan repayments – GOV UK(3)](https://user-images.githubusercontent.com/480578/65256364-520ef500-daf7-11e9-8f63-ac980d31de88.png)

# After

![Screenshot_2019-09-19 Teachers claim back your student loan repayments – GOV UK(2)](https://user-images.githubusercontent.com/480578/65256402-64892e80-daf7-11e9-879f-c7c2ab1bd6ce.png)
