### PR TITLE
A service operator is able to mark a claim as being investigated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Service operators can reject a claim
 - Show DfE number against school in approver view of claim
 - Drop redundant full_name column from claims table
 - Updated Accessibility statement to show current issues

--- a/app/controllers/admin/claim_escalations_controller.rb
+++ b/app/controllers/admin/claim_escalations_controller.rb
@@ -1,0 +1,22 @@
+class Admin::ClaimEscalationsController < Admin::BaseAdminController
+  before_action :ensure_service_operator, :fetch_claim
+
+  def new
+    @claim.notes.build
+  end
+
+  def create
+    if @claim.escalate!(escalated_by: admin_session.user_id)
+      @claim.notes.create!(created_by: admin_session.user_id, body: params[:claim][:note][:body])
+      redirect_to admin_claims_path, notice: "Claim has been escalated successfully"
+    else
+      redirect_to admin_claim_path(@claim), notice: "Claim cannot be escalated"
+    end
+  end
+
+  private
+
+  def fetch_claim
+    @claim = Claim.find(params[:claim_id])
+  end
+end

--- a/app/controllers/admin/claim_rejections_controller.rb
+++ b/app/controllers/admin/claim_rejections_controller.rb
@@ -1,8 +1,13 @@
 class Admin::ClaimRejectionsController < Admin::BaseAdminController
   before_action :ensure_service_operator, :fetch_claim
 
+  def new
+    @claim.notes.build
+  end
+
   def create
     if @claim.reject!(rejected_by: admin_session.user_id)
+      @claim.notes.create!(created_by: admin_session.user_id, body: params[:claim][:note][:body])
       ClaimMailer.rejected(@claim).deliver_later
       redirect_to admin_claims_path, notice: "Claim has been rejected successfully"
     else

--- a/app/controllers/admin/claim_rejections_controller.rb
+++ b/app/controllers/admin/claim_rejections_controller.rb
@@ -3,6 +3,7 @@ class Admin::ClaimRejectionsController < Admin::BaseAdminController
 
   def create
     if @claim.reject!(rejected_by: admin_session.user_id)
+      ClaimMailer.rejected(@claim).deliver_later
       redirect_to admin_claims_path, notice: "Claim has been rejected successfully"
     else
       redirect_to admin_claim_path(@claim), notice: "Claim cannot be rejected"

--- a/app/controllers/admin/claim_rejections_controller.rb
+++ b/app/controllers/admin/claim_rejections_controller.rb
@@ -1,0 +1,17 @@
+class Admin::ClaimRejectionsController < Admin::BaseAdminController
+  before_action :ensure_service_operator, :fetch_claim
+
+  def create
+    if @claim.reject!(rejected_by: admin_session.user_id)
+      redirect_to admin_claims_path, notice: "Claim has been rejected successfully"
+    else
+      redirect_to admin_claim_path(@claim), notice: "Claim cannot be rejected"
+    end
+  end
+
+  private
+
+  def fetch_claim
+    @claim = Claim.find(params[:claim_id])
+  end
+end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -7,6 +7,10 @@ class ClaimMailer < Mail::Notify::Mailer
     view_mail_with_claim_and_subject(claim, "Your claim to get your student loan repayments back has been approved, reference number: #{claim.reference}")
   end
 
+  def rejected(claim)
+    view_mail_with_claim_and_subject(claim, "Your claim to get your student loan repayments back has been rejected, reference number: #{claim.reference}")
+  end
+
   private
 
   def view_mail_with_claim_and_subject(claim, subject)

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -49,6 +49,8 @@ class Claim < ApplicationRecord
   belongs_to :eligibility, polymorphic: true
   accepts_nested_attributes_for :eligibility, update_only: true
 
+  has_many :notes, dependent: :destroy
+
   enum payroll_gender: {
     dont_know: 0,
     female: 1,

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -145,6 +145,17 @@ class Claim < ApplicationRecord
     end
   end
 
+  def escalate!(escalated_by:)
+    if needs_checking?
+      update(
+        escalated_at: Time.zone.now,
+        escalated_by: escalated_by
+      )
+    else
+      false
+    end
+  end
+
   def submitted?
     submitted_at.present?
   end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -134,7 +134,7 @@ class Claim < ApplicationRecord
     if needs_checking?
       update(
         rejected_at: Time.zone.now,
-        rejected_by: rejected_by
+        rejected_by: rejected_by,
       )
     else
       false

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -39,6 +39,8 @@ class Claim < ApplicationRecord
     approved_by: false,
     rejected_at: false,
     rejected_by: false,
+    escalated_at: false,
+    escalated_by: false,
   }.freeze
 
   enum student_loan_country: StudentLoans::COUNTRIES

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -37,6 +37,8 @@ class Claim < ApplicationRecord
     verify_response: true,
     approved_at: false,
     approved_by: false,
+    rejected_at: false,
+    rejected_by: false,
   }.freeze
 
   enum student_loan_country: StudentLoans::COUNTRIES
@@ -118,10 +120,21 @@ class Claim < ApplicationRecord
   end
 
   def approve!(approved_by:)
-    if approvable?
+    if needs_checking?
       update(
         approved_at: Time.zone.now,
         approved_by: approved_by
+      )
+    else
+      false
+    end
+  end
+
+  def reject!(rejected_by:)
+    if needs_checking?
+      update(
+        rejected_at: Time.zone.now,
+        rejected_by: rejected_by
       )
     else
       false
@@ -136,8 +149,8 @@ class Claim < ApplicationRecord
     valid?(:submit) && !submitted?
   end
 
-  def approvable?
-    submitted? && approved_at.nil?
+  def needs_checking?
+    submitted? && approved_at.nil? && rejected_at.nil?
   end
 
   def address(seperator = ", ")

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,5 @@
+class Note < ApplicationRecord
+  belongs_to :claim
+
+  validates :body, :created_by, presence: true
+end

--- a/app/views/admin/claim_escalations/new.html.erb
+++ b/app/views/admin/claim_escalations/new.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Escalate claim <%= @claim.reference %>
+    </h1>
+
+    <%= form_for @claim, url: admin_claim_escalations_path(@claim), method: :post do |form| %>
+      <%= form.fields_for @claim.notes.first do |note_fields| %>
+        <%= note_fields.label :body, "Escalation note", class: "govuk-label" %>
+        <span class="govuk-hint">This will be recorded against the claim but not sent to the user.</span>
+        <%= note_fields.text_area :body, class: "govuk-textarea" %>
+      <% end %>
+
+      <%= form.submit "Escalate claim", class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/claim_rejections/new.html.erb
+++ b/app/views/admin/claim_rejections/new.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Reject claim <%= @claim.reference %>
+    </h1>
+
+    <%= form_for @claim, url: admin_claim_rejections_path(@claim), method: :post do |form| %>
+      <%= form.fields_for @claim.notes.first do |note_fields| %>
+        <%= note_fields.label :body, "Rejection note", class: "govuk-label govuk-radios__label" %>
+        <span class="govuk-hint">This will be recorded against the claim but not sent to the user.</span>
+        <%= note_fields.text_area :body, class: "govuk-textarea" %>
+      <% end %>
+
+      <%= form.submit "Reject claim", class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -13,10 +13,10 @@
     <%= button_to "Approve",
                   admin_claim_approvals_path(@claim),
                   class: "govuk-button",
-                  data: { confirm: "Are you sure you want to approve this claim?" } %>
+                  data: { confirm: "Are you sure you want to approve this claim?", module: "govuk-button" } %>
 
     <%= button_to "Reject", admin_claim_rejections_path(@claim),
                   class: "govuk-button govuk-button--warning",
-                  data: { confirm: "Are you sure you want to reject this claim?" } %>
+                  data: { confirm: "Are you sure you want to reject this claim?", module: "govuk-button" } %>
   </div>
 </div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -16,5 +16,7 @@
                   data: { confirm: "Are you sure you want to approve this claim?", module: "govuk-button" } %>
 
     <%= link_to "Reject", new_admin_claim_rejection_path(@claim), class: "govuk-link" %>
+
+    <%= link_to "Escalate", new_admin_claim_escalation_path(@claim), class: "govuk-link" %>
   </div>
 </div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -15,8 +15,6 @@
                   class: "govuk-button",
                   data: { confirm: "Are you sure you want to approve this claim?", module: "govuk-button" } %>
 
-    <%= button_to "Reject", admin_claim_rejections_path(@claim),
-                  class: "govuk-button govuk-button--warning",
-                  data: { confirm: "Are you sure you want to reject this claim?", module: "govuk-button" } %>
+    <%= link_to "Reject", new_admin_claim_rejection_path(@claim), class: "govuk-link" %>
   </div>
 </div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -12,8 +12,11 @@
 
     <%= button_to "Approve",
                   admin_claim_approvals_path(@claim),
-                  method: :post,
                   class: "govuk-button",
                   data: { confirm: "Are you sure you want to approve this claim?" } %>
+
+    <%= button_to "Reject", admin_claim_rejections_path(@claim),
+                  class: "govuk-button govuk-button--warning",
+                  data: { confirm: "Are you sure you want to reject this claim?" } %>
   </div>
 </div>

--- a/app/views/admin/page/index.html.erb
+++ b/app/views/admin/page/index.html.erb
@@ -6,7 +6,7 @@
 
     <% if service_operator_signed_in? %>
       <ul>
-        <li><%= link_to 'Approve claims', admin_claims_path, class: "govuk-link" %></li>
+        <li><%= link_to 'Manage claims', admin_claims_path, class: "govuk-link" %></li>
         <li><%= link_to 'Download claims', admin_claims_path(format: :csv), class: "govuk-link" %></li>
         <li><%= link_to 'Download payroll data', payroll_admin_claims_path(format: :csv), class: "govuk-link" %></li>
       </ul>

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -1,0 +1,14 @@
+Dear <%= @display_name %>,
+
+
+Unfortunately your claim to get your student loan payments back has been denied.
+
+# Appeals process and support
+
+If you feel that we have made a mistake in the processing of your application or something is incorrect please email studentloanteacherpayment@digital.education.gov.uk giving your reference number: <%= @claim.reference %> if you have any questions about your claim.
+
+Regards,
+
+The claim additional payments for teaching team.
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
     resources :claims, only: [:index, :show] do
       get "payroll", on: :collection
       resources :approvals, only: [:create], controller: "claim_approvals"
-      resources :rejections, only: [:create], controller: "claim_rejections"
+      resources :rejections, only: [:new, :create], controller: "claim_rejections"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
     resources :claims, only: [:index, :show] do
       get "payroll", on: :collection
       resources :approvals, only: [:create], controller: "claim_approvals"
+      resources :rejections, only: [:create], controller: "claim_rejections"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
       get "payroll", on: :collection
       resources :approvals, only: [:create], controller: "claim_approvals"
       resources :rejections, only: [:new, :create], controller: "claim_rejections"
+      resources :escalations, only: [:new, :create], controller: "claim_escalations"
     end
   end
 end

--- a/db/migrate/20190917144556_add_rejections_to_claims.rb
+++ b/db/migrate/20190917144556_add_rejections_to_claims.rb
@@ -1,0 +1,6 @@
+class AddRejectionsToClaims < ActiveRecord::Migration[5.2]
+  def change
+    add_column :claims, :rejected_at, :datetime
+    add_column :claims, :rejected_by, :string
+  end
+end

--- a/db/migrate/20190919110103_create_notes.rb
+++ b/db/migrate/20190919110103_create_notes.rb
@@ -1,0 +1,10 @@
+class CreateNotes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :notes, id: :uuid do |t|
+      t.references :claim, index: true, type: :uuid
+      t.string :created_by
+      t.text :body
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190919133826_add_escalation_fields_to_claims.rb
+++ b/db/migrate/20190919133826_add_escalation_fields_to_claims.rb
@@ -1,0 +1,6 @@
+class AddEscalationFieldsToClaims < ActiveRecord::Migration[5.2]
+  def change
+    add_column :claims, :escalated_at, :datetime
+    add_column :claims, :escalated_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_18_142241) do
+ActiveRecord::Schema.define(version: 2019_09_19_110103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -83,6 +83,15 @@ ActiveRecord::Schema.define(version: 2019_09_18_142241) do
     t.string "name"
     t.string "code"
     t.index ["code"], name: "index_local_authority_districts_on_code", unique: true
+  end
+
+  create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "claim_id"
+    t.string "created_by"
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["claim_id"], name: "index_notes_on_claim_id"
   end
 
   create_table "schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_19_110103) do
+ActiveRecord::Schema.define(version: 2019_09_19_133826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -49,6 +49,8 @@ ActiveRecord::Schema.define(version: 2019_09_19_110103) do
     t.string "approved_by"
     t.datetime "rejected_at"
     t.string "rejected_by"
+    t.datetime "escalated_at"
+    t.string "escalated_by"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"
     t.index ["reference"], name: "index_claims_on_reference", unique: true
     t.index ["submitted_at"], name: "index_claims_on_submitted_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,6 +47,8 @@ ActiveRecord::Schema.define(version: 2019_09_18_142241) do
     t.string "surname", limit: 100
     t.datetime "approved_at"
     t.string "approved_by"
+    t.datetime "rejected_at"
+    t.string "rejected_by"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"
     t.index ["reference"], name: "index_claims_on_reference", unique: true
     t.index ["submitted_at"], name: "index_claims_on_submitted_at"

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Admin approves a claim" do
         submitted_claims = create_list(:claim, 5, :submitted)
         claim_to_approve = submitted_claims.first
 
-        click_on "Approve claims"
+        click_on "Manage claims"
 
         expect(page).to have_content(claim_to_approve.reference)
 

--- a/spec/features/admin_claim_escalate_spec.rb
+++ b/spec/features/admin_claim_escalate_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.feature "Admin escalates a claim" do
+  context "User is logged in as a service operator" do
+    before do
+      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "12345")
+      visit admin_path
+      click_on "Sign in"
+    end
+
+    scenario "User can escalate a claim" do
+      freeze_time do
+        submitted_claims = create_list(:claim, 5, :submitted)
+        claim_to_escalate = submitted_claims.first
+
+        click_on "Manage claims"
+
+        expect(page).to have_content(claim_to_escalate.reference)
+
+        find("a[href='#{admin_claim_path(claim_to_escalate)}']").click
+        click_on "Escalate"
+
+        fill_in "Escalation note", with: "Hmmm. Not sure about this"
+        click_on "Escalate"
+
+        claim_to_escalate.reload
+
+        expect(claim_to_escalate.escalated_at).to eq(Time.zone.now)
+        expect(claim_to_escalate.escalated_by).to eq("12345")
+
+        escalation_note = claim_to_escalate.notes.last
+        expect(escalation_note.body).to eq("Hmmm. Not sure about this")
+        expect(escalation_note.created_by).to eq("12345")
+
+        expect(page).to have_content("Claim has been escalated successfully")
+      end
+    end
+  end
+end

--- a/spec/features/admin_claim_reject_spec.rb
+++ b/spec/features/admin_claim_reject_spec.rb
@@ -18,7 +18,8 @@ RSpec.feature "Rejecting a claim" do
         expect(page).to have_content(claim_to_reject.reference)
 
         find("a[href='#{admin_claim_path(claim_to_reject)}']").click
-        click_on "Reject"
+
+        perform_enqueued_jobs { click_on "Reject" }
 
         expect(page).to have_content("Claim has been rejected successfully")
 
@@ -26,6 +27,15 @@ RSpec.feature "Rejecting a claim" do
 
         expect(claim_to_reject.rejected_at).to eq(Time.zone.now)
         expect(claim_to_reject.rejected_by).to eq("12345")
+
+        mail = ActionMailer::Base.deliveries.last
+
+        expect(mail.subject).to eq(
+          "Your claim to get your student loan repayments back has been rejected, reference number: #{claim_to_reject.reference}"
+        )
+        expect(mail.body.raw_source).to match(
+          "Unfortunately your claim to get your student loan payments back has been denied."
+        )
       end
     end
   end

--- a/spec/features/admin_claim_reject_spec.rb
+++ b/spec/features/admin_claim_reject_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.feature "Rejecting a claim" do
+  context "when the user is signed in as a service operator" do
+    before do
+      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "12345")
+      visit admin_path
+      click_on "Sign in"
+    end
+
+    scenario "they can reject a claim" do
+      freeze_time do
+        submitted_claims = create_list(:claim, 5, :submitted)
+        claim_to_reject = submitted_claims.first
+
+        click_on "Manage claims"
+
+        expect(page).to have_content(claim_to_reject.reference)
+
+        find("a[href='#{admin_claim_path(claim_to_reject)}']").click
+        click_on "Reject"
+
+        expect(page).to have_content("Claim has been rejected successfully")
+
+        claim_to_reject.reload
+
+        expect(claim_to_reject.rejected_at).to eq(Time.zone.now)
+        expect(claim_to_reject.rejected_by).to eq("12345")
+      end
+    end
+  end
+end

--- a/spec/features/admin_claim_reject_spec.rb
+++ b/spec/features/admin_claim_reject_spec.rb
@@ -19,6 +19,10 @@ RSpec.feature "Rejecting a claim" do
 
         find("a[href='#{admin_claim_path(claim_to_reject)}']").click
 
+        click_on "Reject"
+
+        fill_in "Rejection note", with: "Looks dodgy to me."
+
         perform_enqueued_jobs { click_on "Reject" }
 
         expect(page).to have_content("Claim has been rejected successfully")
@@ -28,8 +32,11 @@ RSpec.feature "Rejecting a claim" do
         expect(claim_to_reject.rejected_at).to eq(Time.zone.now)
         expect(claim_to_reject.rejected_by).to eq("12345")
 
-        mail = ActionMailer::Base.deliveries.last
+        rejection_note = claim_to_reject.notes.last
+        expect(rejection_note.body).to eq("Looks dodgy to me.")
+        expect(rejection_note.created_by).to eq("12345")
 
+        mail = ActionMailer::Base.deliveries.last
         expect(mail.subject).to eq(
           "Your claim to get your student loan repayments back has been rejected, reference number: #{claim_to_reject.reference}"
         )

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -32,4 +32,20 @@ RSpec.describe ClaimMailer, type: :mailer do
       expect(mail.body.encoded).to match("Email studentloanteacherpayment@digital.education.gov.uk giving your reference number: #{claim.reference} if you have any questions.")
     end
   end
+
+  describe "#rejected" do
+    let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
+    let(:mail) { ClaimMailer.rejected(claim) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Your claim to get your student loan repayments back has been rejected, reference number: #{claim.reference}")
+      expect(mail.to).to eq([claim.email_address])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Dear John Kennedy,")
+      expect(mail.body.encoded).to match("Unfortunately your claim to get your student loan payments back has been denied.")
+      expect(mail.body.encoded).to match("If you feel that we have made a mistake in the processing of your application or something is incorrect please email studentloanteacherpayment@digital.education.gov.uk giving your reference number: #{claim.reference} if you have any questions about your claim.")
+    end
+  end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -509,4 +509,26 @@ RSpec.describe Claim, type: :model do
       expect(claim.rejected_by).to eq(nil)
     end
   end
+
+  describe "escalate!" do
+    it "escalates a claim" do
+      claim = create(:claim, :submitted)
+
+      freeze_time do
+        claim.escalate!(escalated_by: "12345")
+
+        expect(claim.escalated_at).to eq(Time.zone.now)
+        expect(claim.escalated_by).to eq("12345")
+      end
+    end
+
+    it "returns false when claim is not checkable" do
+      claim = create(:claim, :approved)
+      result = claim.escalate!(escalated_by: "12345")
+
+      expect(result).to eq(false)
+      expect(claim.escalated_at).to eq(nil)
+      expect(claim.escalated_by).to eq(nil)
+    end
+  end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -502,8 +502,11 @@ RSpec.describe Claim, type: :model do
 
     it "returns false when claim is not checkable" do
       claim = create(:claim, :approved)
+      result = claim.reject!(rejected_by: "12345")
 
-      expect(claim.reject!(rejected_by: "12345")).to eq(false)
+      expect(result).to eq(false)
+      expect(claim.rejected_at).to eq(nil)
+      expect(claim.rejected_by).to eq(nil)
     end
   end
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,4 @@
+require "rails_helper"
+
+RSpec.describe Note, type: :model do
+end

--- a/spec/requests/admin_claim_escalation_spec.rb
+++ b/spec/requests/admin_claim_escalation_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "Admin claim escalations", type: :request do
+  context "when signed in as a service operator" do
+    before do
+      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+      post admin_dfe_sign_in_path
+      follow_redirect!
+    end
+
+    describe "claim_escalations#create" do
+      let(:claim) { create(:claim, :submitted) }
+
+      it "escalates a claim" do
+        freeze_time do
+          post admin_claim_escalations_path(claim_id: claim.id, claim: {note: {body: "some reason."}})
+
+          follow_redirect!
+
+          expect(response.body).to include("Claim has been escalated successfully")
+
+          claim.reload
+          expect(claim.escalated_at).to eq(Time.zone.now)
+          expect(claim.escalated_by).to eq("123")
+          note = claim.notes.last
+          expect(note.body).to eq("some reason.")
+          expect(note.created_by).to eq("123")
+        end
+      end
+
+      context "when the claim is already approved" do
+        let(:claim) { create(:claim, :approved) }
+
+        it "cannot be escalated when already approved" do
+          post admin_claim_escalations_path(claim_id: claim.id)
+
+          follow_redirect!
+
+          expect(response.body).to include("Claim cannot be escalated")
+
+          claim.reload
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/admin_claim_rejection_spec.rb
+++ b/spec/requests/admin_claim_rejection_spec.rb
@@ -13,16 +13,18 @@ RSpec.describe "Admin claim rejections", type: :request do
 
       it "rejects a claim" do
         freeze_time do
-          post admin_claim_rejections_path(claim_id: claim.id)
+          post admin_claim_rejections_path(claim_id: claim.id, claim: {note: {body: "some reason."}})
 
           follow_redirect!
 
           expect(response.body).to include("Claim has been rejected successfully")
 
           claim.reload
-
           expect(claim.rejected_at).to eq(Time.zone.now)
           expect(claim.rejected_by).to eq("123")
+          note = claim.notes.last
+          expect(note.body).to eq("some reason.")
+          expect(note.created_by).to eq("123")
         end
       end
 

--- a/spec/requests/admin_claim_rejection_spec.rb
+++ b/spec/requests/admin_claim_rejection_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Admin claim rejections", type: :request do
+  context "when signed in as a service operator" do
+    before do
+      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+      post admin_dfe_sign_in_path
+      follow_redirect!
+    end
+
+    describe "claim_rejections#create" do
+      let(:claim) { create(:claim, :submitted) }
+
+      it "rejects a claim" do
+        freeze_time do
+          post admin_claim_rejections_path(claim_id: claim.id)
+
+          follow_redirect!
+
+          expect(response.body).to include("Claim has been rejected successfully")
+
+          claim.reload
+
+          expect(claim.rejected_at).to eq(Time.zone.now)
+          expect(claim.rejected_by).to eq("123")
+        end
+      end
+
+      context "when the claim is already approved" do
+        let(:claim) { create(:claim, :approved) }
+
+        it "cannot be rejected when already approved" do
+          post admin_claim_rejections_path(claim_id: claim.id)
+
+          follow_redirect!
+
+          expect(response.body).to include("Claim cannot be rejected")
+
+          claim.reload
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows service operators to escalate a claim, in a similar way to how claims can be rejected in #441 

This should not be merged until #441 is finished and merged, as it contains some commits from there too