### PR TITLE
Run default rake task in the order specified

### DIFF
--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1,1 +1,1 @@
-task default: %i[shellcheck standard prettier brakeman:run spec] if Rails.env.test? || Rails.env.development?
+task(:default).clear_prerequisites.enhance(%i[shellcheck standard prettier brakeman:run spec]) if Rails.env.test? || Rails.env.development?


### PR DESCRIPTION
When installed, Rspec removes the 'test' task from the default rake task
and replaces it with it's own 'spec' task.

Clear default task prerequisites ('spec') and then specify our own tasks
to get the expected order instead of the spec task always first.

Run the style checks first so we do not have to wait for the specs to
run only to find a small style error.

<!-- Do you need to update CHANGELOG.md? -->
