### PR TITLE
Allow retrying RSpec failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ localhost.key
 
 # Ignore Verify Service Provider
 bin/vsp/*
+
+# Ignore RSpec example status persistence file
+spec/examples.txt

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,12 +58,12 @@ RSpec.configure do |config|
   #   # aliases for `it`, `describe`, and `context` that include `:focus`
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   #   config.filter_run_when_matching :focus
-  #
-  #   # Allows RSpec to persist some state between runs in order to support
-  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
-  #   # you configure your source control system to ignore this file.
-  #   config.example_status_persistence_file_path = "spec/examples.txt"
-  #
+
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
   #   # Limits the available syntax to the non-monkey patched syntax that is
   #   # recommended. For more details, see:
   #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/


### PR DESCRIPTION
During the refactor work I found myself reaching for this command several times. It's useful when working through a number of failures in batches.

The command is `rspec --only-failures` and can be re-ran several times while fixing specs until there aren't from the original failures left.
