### PR TITLE
Update privacy notice to include IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Update privacy notice to include the collection of IP address
 - Remove the admin claims CSV download
 
 ## [Release 011] - 2019-09-23

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -48,6 +48,7 @@
         your email address if you include it with feedback to us on the service or agree to be contacted for user research
         purposes
       </li>
+      <li>your Internet Protocol (IP) address</li>
     </ul>
 
     <h2 class="govuk-heading-l">
@@ -92,6 +93,10 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>
         to enable users to use the service and receive updates
+      </li>
+      <li>
+        for security purposes: collecting the IP addresses of people visiting ‘<%= t("service_name") %>’
+        (for example, if we were receiving continuous direct denial of service attacks from an IP address then we could block it)
       </li>
     </ul>
 

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -53,7 +53,7 @@
 
     <h2 class="govuk-heading-l">
       How we will use your information
-    </h3>
+    </h2>
 
     <p class="govuk-body">
       If you contact us, DfE and (where applicable) The Dextrous Web Ltd and Paper Design Studio Ltd will use your name and contact information for the purpose of


### PR DESCRIPTION
We are now sending the client IP address to Application Insights so we state that in the notice.
