### PR TITLE
Add Virtual Network to ProjectCore resource group

### DIFF
--- a/azure/resource_groups/ProjectCore/parameters/development.json
+++ b/azure/resource_groups/ProjectCore/parameters/development.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vnetAddressSpaceCIDR": {
+      "value": "11.0.1.0/24"
+    }
+  }
+}

--- a/azure/resource_groups/ProjectCore/parameters/production.json
+++ b/azure/resource_groups/ProjectCore/parameters/production.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vnetAddressSpaceCIDR": {
+      "value": "11.0.3.0/24"
+    }
+  }
+}

--- a/azure/resource_groups/ProjectCore/template.json
+++ b/azure/resource_groups/ProjectCore/template.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceNamePrefix": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().name]"
+    },
+    "vnetAddressSpaceCIDR": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "platformBuildingBlocksDeploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/7a4748a0cf366193d31434bd7796d483bd281385/templates/",
+    "vnetDeploymentName": "[concat(parameters('resourceNamePrefix'), '-virtualnetwork')]",
+    "vnetName": "[concat(parameters('resourceNamePrefix'), '-vn')]",
+    "defaultSubnetAddressPrefix": "[parameters('vnetAddressSpaceCIDR')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "name": "[variables('vnetDeploymentName')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('platformBuildingBlocksDeploymentUrlBase'), 'virtual-network.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vnetName": {
+            "value": "[variables('vnetName')]"
+          },
+          "vnetAddressSpaceCIDR": {
+            "value": "[parameters('vnetAddressSpaceCIDR')]"
+          },
+          "subnetConfiguration": {
+            "value": [
+              {
+                "name": "default",
+                "properties": {
+                  "addressPrefix": "[variables('defaultSubnetAddressPrefix')]",
+                  "serviceEndpoints": [],
+                  "delegations": [],
+                  "privateEndpointNetworkPolicies": "Enabled"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "resourceGroupId": {
+      "type": "string",
+      "value": "[resourceGroup().id]"
+    }
+  }
+}

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -58,6 +58,9 @@ case $ENVIRONMENT_NAME in
     ;;
 esac
 
+PROJECT_CORE_RESOURCE_GROUP_NAME="$RESOURCE_GROUP_PREFIX-ProjectCore"
+PROJECT_CORE_DEPLOYMENT_NAME=$PROJECT_CORE_RESOURCE_GROUP_NAME
+
 SECRETS_RESOURCE_GROUP_NAME="$RESOURCE_GROUP_PREFIX-secrets"
 SECRETS_DEPLOYMENT_NAME=$SECRETS_RESOURCE_GROUP_NAME
 
@@ -109,6 +112,9 @@ SCRIPT_PATH=$(cd "$(dirname "$0")" ; pwd -P)
 
 RESOURCE_LOCATION="West Europe"
 
+PROJECT_CORE_TEMPLATE_FILE_PATH="$SCRIPT_PATH/../azure/resource_groups/ProjectCore/template.json"
+PROJECT_CORE_PARAMETERS_FILE_PATH="$SCRIPT_PATH/../azure/resource_groups/ProjectCore/parameters/$ENVIRONMENT_NAME.json"
+
 SECRETS_TEMPLATE_FILE_PATH="$SCRIPT_PATH/../azure/resource_groups/secrets/template.json"
 SECRETS_PARAMETERS_FILE_PATH="$SCRIPT_PATH/../azure/resource_groups/secrets/parameters/$ENVIRONMENT_NAME.json"
 
@@ -128,6 +134,36 @@ fi
 
 echo "Setting default subscription to $SUBSCRIPTION_ID..."
 az account set --subscription "$SUBSCRIPTION_ID"
+
+if ! az group show --name "$PROJECT_CORE_RESOURCE_GROUP_NAME" > /dev/null; then
+  echo "$PROJECT_CORE_RESOURCE_GROUP_NAME does not exist"
+  exit 1
+fi
+
+echo "Starting ProjectCore deployment..."
+
+PROJECT_CORE_DEPLOYMENT_RESULT=$(
+  az group deployment create \
+    --name "$PROJECT_CORE_DEPLOYMENT_NAME" \
+    --resource-group "$PROJECT_CORE_RESOURCE_GROUP_NAME" \
+    --template-file "$PROJECT_CORE_TEMPLATE_FILE_PATH" \
+    --parameters "@$PROJECT_CORE_PARAMETERS_FILE_PATH" \
+    --mode Complete \
+    --verbose \
+    <&- || true
+)
+
+if ! [ "$PROJECT_CORE_DEPLOYMENT_RESULT" ]; then
+  echo "Deployment failed!"
+  echo "There may be some parameters missing from $PROJECT_CORE_PARAMETERS_FILE_PATH or something else might have gone wrong."
+  exit 1
+fi
+
+echo "$PROJECT_CORE_DEPLOYMENT_RESULT"
+
+echo
+echo "$PROJECT_CORE_RESOURCE_GROUP_NAME deployed!"
+echo
 
 ensure-resource-group-exists $SECRETS_RESOURCE_GROUP_NAME
 


### PR DESCRIPTION
At the moment we're not using the virtual network for anything, however we intend to use it for either protecting resources with a firewall or splitting out worker processes (both require our own virtual network)

Virtual networks are [free of charge](https://azure.microsoft.com/en-us/pricing/details/virtual-network/).

We add the virtual network first as we expect to rely on these in the later resource group deployments.