### PR TITLE
Make the page sequence handle changes in user journeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add support for multiple page sequences
 - Update Cantium CSV fields
 
 ## [Release 013] - 2019-10-01

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ gem "application_insights", git: "https://github.com/microsoft/ApplicationInsigh
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+  gem "pry"
 
   gem "rspec-rails"
   gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       xpath (~> 3.2)
     childprocess (2.0.0)
       rake (< 13.0)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -170,6 +171,9 @@ GEM
     parser (2.6.4.1)
       ast (~> 2.4.0)
     pg (1.1.4)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (4.0.1)
     puma (4.2.0)
       nio4r (~> 2.0)
@@ -341,6 +345,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   pg (>= 0.18, < 2.0)
+  pry
   puma (~> 4.2)
   rails (~> 5.2.2)
   rollbar

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -7,6 +7,7 @@ class ClaimsController < ApplicationController
   def create
     claim = Claim.create!(eligibility: StudentLoans::Eligibility.new)
     session[:claim_id] = claim.to_param
+    session[:sequence_version] = PageSequence::CURRENT_SEQUENCE_VERSION
 
     redirect_to claim_path("qts-year")
   end
@@ -68,6 +69,6 @@ class ClaimsController < ApplicationController
   end
 
   def page_sequence
-    @page_sequence ||= PageSequence.new(current_claim, params[:slug])
+    @page_sequence ||= PageSequence.new(current_claim, params[:slug], sequence_version: session[:sequence_version])
   end
 end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -37,6 +37,7 @@ class ClaimsController < ApplicationController
     ClaimUpdate.new(current_claim, claim_params, params[:slug]).perform
   end
 
+  helper_method :next_slug
   def next_slug
     page_sequence.next_slug
   end

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -71,7 +71,19 @@ class PageSequence
     return "confirmation" if claim.submitted?
     return "check-your-answers" if claim.submittable?
 
-    slugs[current_slug_index + 1]
+    slugs.each do |slug|
+      break if slug == current_slug
+
+      return slug if claim.invalid?(slug.to_sym)
+    end
+
+    next_slug = current_slug_index.nil? ? nil : slugs[current_slug_index + 1]
+
+    if next_slug.nil?
+      self.class.all_slugs.detect { |slug| claim.invalid?(slug.to_sym) }
+    else
+      next_slug
+    end
   end
 
   def in_sequence?(slug)

--- a/app/views/claims/eligibility_confirmed.html.erb
+++ b/app/views/claims/eligibility_confirmed.html.erb
@@ -6,6 +6,6 @@
     <h1 class="govuk-heading-xl">You are eligible to claim back student loan repayments</h1>
     <p class="govuk-body">Based on your answers, you can claim back the student loan repayments you made between 6 April 2018 and 5 April 2019.</p>
 
-    <%= link_to "Continue", claim_path("information-provided"), class: "govuk-button", role: "button" %>
+    <%= link_to "Continue", claim_path(next_slug), class: "govuk-button", role: "button" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   get "/cookies", to: "static_pages#cookies", as: :cookies
   get "/accessibility_statement", to: "static_pages#accessibility_statement", as: :accessibility_statement
 
-  constraints slug: %r{#{PageSequence::SLUGS.join("|")}} do
+  constraints slug: %r{#{PageSequence.all_slugs.join("|")}} do
     resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/claim"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,5 +5,6 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-puts "Importing Schools information, this may take a minute..."
-SchoolDataImporter.new.run
+
+ENV["FIXTURES_PATH"] = "spec/fixtures"
+Rake::Task["db:fixtures:load"].invoke

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -4,12 +4,7 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
   before do
     stub_vsp_generate_request
 
-    @claim = start_claim
-    choose_qts_year
-    choose_school schools(:penistone_grammar_school)
-    choose_still_teaching
-    choose_subjects_taught
-    click_on "Continue"
+    @claim = answer_all_student_loans_eligibility_questions
   end
 
   context "successful verification" do

--- a/spec/features/missing_verify_information_spec.rb
+++ b/spec/features/missing_verify_information_spec.rb
@@ -2,12 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Missing information from GOV.UK Verify" do
   scenario "Claimant is asked a payroll gender question when Verify doesn’t provide their gender" do
-    claim = start_claim
-    choose_qts_year
-    choose_school schools(:penistone_grammar_school)
-    choose_still_teaching
-    choose_subjects_taught
-    click_on "Continue"
+    claim = answer_all_student_loans_eligibility_questions
 
     perform_verify_step("identity-verified-other-gender")
     expect(page).to have_text("This is your first name, middle name, surname, address, and date of birth from your digital identity")
@@ -53,12 +48,7 @@ RSpec.feature "Missing information from GOV.UK Verify" do
   end
 
   scenario "Claimant is asked an address question when Verify doesn’t provide their address" do
-    claim = start_claim
-    choose_qts_year
-    choose_school schools(:penistone_grammar_school)
-    choose_still_teaching
-    choose_subjects_taught
-    click_on "Continue"
+    claim = answer_all_student_loans_eligibility_questions
 
     perform_verify_step("identity-verified-no-address")
     expect(page).to have_text("This is your first name, surname, date of birth, and gender from your digital identity")

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments claims" do
   before do
     start_claim
-    visit claim_path("subjects-taught")
+    choose_qts_year
+    choose_school schools(:penistone_grammar_school)
+    choose_still_teaching
   end
 
   context "with JS enabled", js: true do
@@ -39,10 +41,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
 
       click_on "Continue"
 
-      choose "Yes"
-      click_on "Continue"
-
-      expect(page).to have_text(I18n.t("student_loans.questions.mostly_performed_leadership_duties"))
+      expect(page).to have_text(I18n.t("student_loans.questions.leadership_position"))
     end
   end
 

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -4,24 +4,65 @@ require "rails_helper"
 
 RSpec.describe PageSequence do
   let(:claim) { build(:claim) }
+  let(:sequence_version) { 0 }
+
+  describe ".all_slugs" do
+    it "returns a list of all possible slugs in any order" do
+      expect(PageSequence.all_slugs).to match_array([
+        "qts-year",
+        "claim-school",
+        "still-teaching",
+        "current-school",
+        "subjects-taught",
+        "leadership-position",
+        "mostly-performed-leadership-duties",
+        "eligibility-confirmed",
+        "information-provided",
+        "verified",
+        "address",
+        "gender",
+        "teacher-reference-number",
+        "national-insurance-number",
+        "student-loan",
+        "student-loan-country",
+        "student-loan-how-many-courses",
+        "student-loan-start-date",
+        "student-loan-amount",
+        "email-address",
+        "bank-details",
+        "check-your-answers",
+        "confirmation",
+        "ineligible",
+      ])
+    end
+  end
 
   describe "#slugs" do
+    it "only returns slugs in the given sequence" do
+      stub_const("PageSequence::QUESTION_SLUGS", PageSequence::QUESTION_SLUGS.merge(test_version: ["test-slug"]))
+
+      page_sequence = PageSequence.new(claim, "qts-year", sequence_version: sequence_version)
+
+      expect(PageSequence::QUESTION_SLUGS[:test_version]).to include("test-slug")
+      expect(page_sequence.slugs).not_to include("test-slug")
+    end
+
     it "excludes “current-school” when the claimant still works at the school they are claiming against" do
       claim.eligibility.employment_status = :claim_school
-      page_sequence = PageSequence.new(claim, "still-teaching")
+      page_sequence = PageSequence.new(claim, "still-teaching", sequence_version: sequence_version)
 
       expect(page_sequence.slugs).not_to include("current-school")
     end
 
     it "excludes student loan-related pages when the claimant no longer has a student loan" do
       claim.has_student_loan = false
-      page_sequence = PageSequence.new(claim, "still-teaching")
+      page_sequence = PageSequence.new(claim, "still-teaching", sequence_version: sequence_version)
       expect(page_sequence.slugs).not_to include("student-loan-country")
       expect(page_sequence.slugs).not_to include("student-loan-how-many-courses")
       expect(page_sequence.slugs).not_to include("student-loan-start-date")
 
       claim.has_student_loan = true
-      page_sequence = PageSequence.new(claim, "still-teaching")
+      page_sequence = PageSequence.new(claim, "still-teaching", sequence_version: sequence_version)
       expect(page_sequence.slugs).to include("student-loan-country")
       expect(page_sequence.slugs).to include("student-loan-how-many-courses")
       expect(page_sequence.slugs).to include("student-loan-start-date")
@@ -32,14 +73,14 @@ RSpec.describe PageSequence do
 
       StudentLoans::PLAN_1_COUNTRIES.each do |plan_1_country|
         claim.student_loan_country = plan_1_country
-        page_sequence = PageSequence.new(claim, "student-loan-country")
+        page_sequence = PageSequence.new(claim, "student-loan-country", sequence_version: sequence_version)
         expect(page_sequence.slugs).not_to include("student-loan-how-many-courses")
         expect(page_sequence.slugs).not_to include("student-loan-start-date")
       end
 
       %w[england wales].each do |variable_plan_country|
         claim.student_loan_country = variable_plan_country
-        page_sequence = PageSequence.new(claim, "student-loan-country")
+        page_sequence = PageSequence.new(claim, "student-loan-country", sequence_version: sequence_version)
         expect(page_sequence.slugs).to include("student-loan-how-many-courses")
         expect(page_sequence.slugs).to include("student-loan-start-date")
       end
@@ -47,7 +88,7 @@ RSpec.describe PageSequence do
 
     it "excludes the gender page if a response has been returned from Verify" do
       claim.verified_fields = ["payroll_gender"]
-      page_sequence = PageSequence.new(claim, "student-loan-country")
+      page_sequence = PageSequence.new(claim, "student-loan-country", sequence_version: sequence_version)
       expect(page_sequence.slugs).to_not include("gender")
 
       claim.verified_fields = []
@@ -56,22 +97,25 @@ RSpec.describe PageSequence do
 
     it "excludes the address page if the address was returned by verify" do
       claim.verified_fields = ["postcode"]
-      page_sequence = PageSequence.new(claim, "student-loan-country")
+      page_sequence = PageSequence.new(claim, "student-loan-country", sequence_version: sequence_version)
       expect(page_sequence.slugs).to_not include("address")
     end
   end
 
   describe "#next_slug" do
     it "returns the next slug in the sequence" do
-      expect(PageSequence.new(claim, "qts-year").next_slug).to eq "claim-school"
-      expect(PageSequence.new(claim, "claim-school").next_slug).to eq "still-teaching"
+      expect(PageSequence.new(claim, "qts-year", sequence_version: sequence_version).next_slug).to eq "claim-school"
+
+      claim.eligibility.qts_award_year = :"2013_2014"
+
+      expect(PageSequence.new(claim, "claim-school", sequence_version: sequence_version).next_slug).to eq "still-teaching"
     end
 
     context "with an ineligible claim" do
       let(:claim) { build(:claim, eligibility: build(:student_loans_eligibility, employment_status: :no_school)) }
 
       it "returns “ineligible” as the next slug" do
-        expect(PageSequence.new(claim, "still-teaching").next_slug).to eq "ineligible"
+        expect(PageSequence.new(claim, "still-teaching", sequence_version: sequence_version).next_slug).to eq "ineligible"
       end
     end
 
@@ -79,13 +123,13 @@ RSpec.describe PageSequence do
       let(:claim) { build(:claim, :submittable) }
 
       it "returns “check-your-answers” as the next slug" do
-        expect(PageSequence.new(claim, "qts-year").next_slug).to eq "check-your-answers"
+        expect(PageSequence.new(claim, "qts-year", sequence_version: sequence_version).next_slug).to eq "check-your-answers"
       end
     end
   end
 
   describe "in_sequence?" do
-    let(:page_sequence) { PageSequence.new(claim, "gender") }
+    let(:page_sequence) { PageSequence.new(claim, "gender", sequence_version: sequence_version) }
 
     context "when the page is not in the sequence" do
       before do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,12 +1,6 @@
 module FeatureHelpers
   def answer_all_student_loans_claim_questions
-    start_claim
-    choose_qts_year
-    choose_school schools(:penistone_grammar_school)
-    choose_still_teaching "Yes, at another school"
-    choose_school schools(:hampstead_school)
-    choose_subjects_taught
-    click_on "Continue"
+    claim = answer_all_student_loans_eligibility_questions
 
     perform_verify_step
     click_on "Continue"
@@ -27,6 +21,21 @@ module FeatureHelpers
     fill_in "Sort code", with: "123456"
     fill_in "Account number", with: "87654321"
     click_on "Continue"
+
+    claim
+  end
+
+  def answer_all_student_loans_eligibility_questions
+    claim = start_claim
+    choose_qts_year
+    choose_school schools(:penistone_grammar_school)
+    choose_still_teaching "Yes, at another school"
+    choose_school schools(:hampstead_school)
+    choose_subjects_taught
+    choose_mostly_not_leadership
+    click_on "Continue"
+
+    claim
   end
 
   def start_claim
@@ -56,7 +65,9 @@ module FeatureHelpers
   def choose_subjects_taught
     check "Physics"
     click_on "Continue"
+  end
 
+  def choose_mostly_not_leadership
     choose "Yes"
     click_on "Continue"
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -30,7 +30,7 @@ module FeatureHelpers
     choose_qts_year
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching "Yes, at another school"
-    choose_school schools(:hampstead_school)
+    choose_school schools(:penistone_grammar_school)
     choose_subjects_taught
     choose_mostly_not_leadership
     click_on "Continue"


### PR DESCRIPTION
The intention is for users on a specific sequence to continue on that sequence, and rely on data migrations to backfill questions they didn't answer.

If any pages are new (and so missing from old sequences) and backfilling isn't possible, we ask them of the user at the end before checking their answers.

Open question: should the check your answers page, therefore, be fixed to refer to the latest version, causing a bit of jank for the users in that it might report questions they didn't answer or in a different order? Extra work would be required to make that not the case.