### PR TITLE
Prepare for an external start page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Update the first page of the claim to initialise, rather than create a claim
 - Rework URL structure in preparation for Maths & Physics policy
 - Changes to accessibility statement as we think we now meet AA standard
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
   private
 
   def send_unstarted_claiments_to_the_start
-    redirect_to root_url unless current_claim.present?
+    redirect_to root_url unless current_claim.persisted?
   end
 
   def admin_signed_in?
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_claim
-    @current_claim ||= current_claim_from_session
+    @current_claim ||= current_claim_from_session || Claim.new(eligibility: StudentLoans::Eligibility.new)
   end
 
   def current_claim_from_session

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,11 @@ class ApplicationController < ActionController::Base
   end
 
   def current_claim
-    @current_claim ||= Claim.find(session[:claim_id]) if session.key?(:claim_id)
+    @current_claim ||= current_claim_from_session
+  end
+
+  def current_claim_from_session
+    Claim.find(session[:claim_id]) if session.key?(:claim_id)
   end
 
   def claim_timeout_in_minutes

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -4,6 +4,11 @@ class ClaimsController < ApplicationController
 
   after_action :clear_claim_session, if: :submission_complete?
 
+  def new
+    @current_claim = Claim.new(eligibility: StudentLoans::Eligibility.new)
+    render claim_page_template
+  end
+
   def create
     claim = Claim.create!(eligibility: StudentLoans::Eligibility.new)
     session[:claim_id] = claim.to_param

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -5,13 +5,10 @@ class ClaimsController < ApplicationController
   after_action :clear_claim_session, if: :submission_complete?
 
   def new
-    @current_claim = Claim.new(eligibility: StudentLoans::Eligibility.new)
     render claim_page_template
   end
 
   def create
-    @current_claim = Claim.new(eligibility: StudentLoans::Eligibility.new)
-
     if update_current_claim!
       session[:claim_id] = @current_claim.to_param
       redirect_to claim_path(next_slug)

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -10,10 +10,14 @@ class ClaimsController < ApplicationController
   end
 
   def create
-    claim = Claim.create!(eligibility: StudentLoans::Eligibility.new)
-    session[:claim_id] = claim.to_param
+    @current_claim = Claim.new(eligibility: StudentLoans::Eligibility.new)
 
-    redirect_to claim_path("qts-year")
+    if update_current_claim!
+      session[:claim_id] = @current_claim.to_param
+      redirect_to claim_path(next_slug)
+    else
+      render claim_page_template
+    end
   end
 
   def show

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -3,8 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.qts_award_year": "claim_eligibility_attributes_qts_award_year_before_2013" }) if current_claim.errors.any? %>
-
-    <%= form_for current_claim, url: claim_path do |form| %>
+    <%= form_for current_claim, url: (current_claim.persisted? ? claim_path : claims_path) do |form| %>
       <%= form_group_tag current_claim do %>
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">

--- a/app/views/static_pages/start_page.html.erb
+++ b/app/views/static_pages/start_page.html.erb
@@ -31,7 +31,7 @@
         <li>sign in details for ‘Verify’ – the government’s secure way of proving who you are, if you do not have a Verify account, you’ll need your passport or photocard driving licence to sign up</li>
       </ul>
 
-      <%= button_to claims_path, method: :post, class: "govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start", role: "button" do %>
+      <%= link_to new_claim_path, class: "govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start", role: "button" do %>
         Start now
         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
           <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,10 +23,11 @@ Rails.application.routes.draw do
 
   scope path: ":policy", defaults: {policy: "student-loans"}, constraints: {policy: %r{student-loans}} do
     constraints slug: %r{#{PageSequence::SLUGS.join("|")}} do
-      resources :claims, only: [:create, :show, :update], param: :slug, path: "/"
+      resources :claims, only: [:show, :update], param: :slug, path: "/"
     end
 
     get "new", as: :new_claim, to: "claims#new", params: {slug: PageSequence::SLUGS.first}
+    post "/", as: :claims, to: "claims#create", params: {slug: PageSequence::SLUGS.first}
 
     get "timeout", to: "claims#timeout", as: :timeout_claim
     get "refresh-session", to: "claims#refresh_session", as: :claim_refresh_session

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,10 @@ Rails.application.routes.draw do
 
   scope path: ":policy", defaults: {policy: "student-loans"}, constraints: {policy: %r{student-loans}} do
     constraints slug: %r{#{PageSequence::SLUGS.join("|")}} do
-      resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/"
+      resources :claims, only: [:create, :show, :update], param: :slug, path: "/"
     end
+
+    get "new", as: :new_claim, to: "claims#new", params: {slug: PageSequence::SLUGS.first}
 
     get "timeout", to: "claims#timeout", as: :timeout_claim
     get "refresh-session", to: "claims#refresh_session", as: :claim_refresh_session

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -23,6 +23,19 @@ RSpec.feature "Changing the answers on a submittable claim" do
     expect(page).to have_content("Check your answers before sending your application")
   end
 
+  scenario "Teacher changes their year" do
+    find("a[href='#{claim_path("qts-year")}']").click
+
+    expect(find("#claim_eligibility_attributes_qts_award_year_2014_2015").checked?).to eq(true)
+
+    choose I18n.t("student_loans.questions.qts_award_years.2013_2014")
+    click_on "Continue"
+
+    expect(eligibility.reload.qts_award_year).to eq("2013_2014")
+
+    expect(current_path).to eq(claim_path("check-your-answers"))
+  end
+
   context "when changing subjects taught" do
     before do
       find("a[href='#{claim_path("subjects-taught")}']").click

--- a/spec/features/current_school_with_closed_claim_school_spec.rb
+++ b/spec/features/current_school_with_closed_claim_school_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature "Current school with closed claim school" do
 
   scenario "Still teaching only has two options" do
     start_claim
-    choose_qts_year
     choose_school claim_school
 
     expect(page).to have_text("Yes")
@@ -16,7 +15,6 @@ RSpec.feature "Current school with closed claim school" do
 
   scenario "Choosing yes to still teaching prompts to search for a school" do
     claim = start_claim
-    choose_qts_year
     choose_school claim_school
 
     choose_still_teaching "Yes"

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
     stub_vsp_generate_request
 
     @claim = start_claim
-    choose_qts_year
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching
     choose_subjects_taught

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -2,10 +2,9 @@ require "rails_helper"
 
 RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   scenario "qualified before the first eligible year" do
-    claim = start_claim
-
-    choose "Before 1 September 2013"
-    click_on "Continue"
+    visit new_claim_path
+    choose_qts_year("Before 1 September 2013")
+    claim = Claim.order(:created_at).last
 
     expect(claim.eligibility.reload.qts_award_year).to eql("before_2013")
     expect(page).to have_text("You’re not eligible")
@@ -14,7 +13,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
   scenario "now works for a different school" do
     claim = start_claim
-    choose_qts_year
+
     choose_school schools(:penistone_grammar_school)
 
     choose_still_teaching "Yes, at another school"
@@ -34,7 +33,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
   scenario "chooses an ineligible school" do
     claim = start_claim
-    choose_qts_year
     choose_school schools(:hampstead_school)
 
     expect(claim.eligibility.reload.claim_school).to eq schools(:hampstead_school)
@@ -44,7 +42,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
   scenario "no longer teaching" do
     claim = start_claim
-    choose_qts_year
     choose_school schools(:penistone_grammar_school)
 
     choose_still_teaching "No"
@@ -56,7 +53,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
   scenario "did not teach an eligible subject" do
     claim = start_claim
-    choose_qts_year
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching
 
@@ -70,7 +66,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
   scenario "was in a leadership position and performed leadership duties for more than half of their time" do
     claim = start_claim
-    choose_qts_year
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching
 

--- a/spec/features/missing_verify_information_spec.rb
+++ b/spec/features/missing_verify_information_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.feature "Missing information from GOV.UK Verify" do
   scenario "Claimant is asked a payroll gender question when Verify doesn’t provide their gender" do
     claim = start_claim
-    choose_qts_year
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching
     choose_subjects_taught
@@ -54,7 +53,6 @@ RSpec.feature "Missing information from GOV.UK Verify" do
 
   scenario "Claimant is asked an address question when Verify doesn’t provide their address" do
     claim = start_claim
-    choose_qts_year
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching
     choose_subjects_taught

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.feature "Searching for school during Teacher Student Loan Repayments claims" do
   scenario "doesn't select a school from the search results the first time around" do
     claim = start_claim
-    choose_qts_year
 
     fill_in :school_search, with: "Penistone"
     click_on "Search"
@@ -22,7 +21,6 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
   scenario "searches again to find school" do
     claim = start_claim
-    choose_qts_year
 
     fill_in :school_search, with: "hamp"
     click_on "Search"
@@ -41,7 +39,6 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
   scenario "Claim school search with autocomplete", js: true do
     start_claim
-    choose_qts_year
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
@@ -58,7 +55,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
   scenario "Current school search with autocomplete", js: true do
     start_claim
-    choose_qts_year
+
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching "Yes, at another school"
 
@@ -77,7 +74,6 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
   scenario "School search form still works like a normal form if submitted", js: true do
     start_claim
-    choose_qts_year
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
@@ -95,7 +91,6 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
   scenario "Editing school search after autocompletion clears last selection", js: true do
     start_claim
-    choose_qts_year
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
@@ -118,7 +113,6 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
   scenario "Claim school search includes closed schools" do
     start_claim
-    choose_qts_year
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
@@ -131,7 +125,6 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
   scenario "Current school search excludes closed schools" do
     start_claim
-    choose_qts_year
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching "Yes, at another school"
 
@@ -146,7 +139,6 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
   scenario "Claim school search with autocomplete includes closed schools", js: true do
     start_claim
-    choose_qts_year
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
@@ -157,7 +149,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
   scenario "Current school search with autocomplete excludes closed schools", js: true do
     start_claim
-    choose_qts_year
+
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching "Yes, at another school"
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -2,11 +2,14 @@ require "rails_helper"
 
 RSpec.feature "Teacher Student Loan Repayments claims" do
   scenario "Teacher claims back student loan repayments" do
-    claim = start_claim
+    visit new_claim_path
     expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
 
     choose_qts_year
+    claim = Claim.order(:created_at).last
+
     expect(claim.eligibility.reload.qts_award_year).to eql("2014_2015")
+
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
 
     choose_school schools(:penistone_grammar_school)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,6 +62,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FeatureHelpers, type: :feature
+  config.include RequestHelpers, type: :request
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveJob::TestHelper
   config.include DfeSignInHelpers

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe "Claims", type: :request do
 
   describe "claims#create request" do
     it "creates a new Claim and redirects to the QTS question" do
-      expect { post claims_path }.to change { Claim.count }.by(1)
+      expect { start_claim }.to change { Claim.count }.by(1)
 
-      expect(response).to redirect_to(claim_path("qts-year"))
+      expect(response).to redirect_to(claim_path("claim-school"))
     end
   end
 
   describe "claims#show request" do
     context "when a claim is already in progress" do
-      before { post claims_path }
+      before { start_claim }
 
       it "renders the requested page in the sequence" do
         get claim_path("qts-year")
@@ -62,7 +62,7 @@ RSpec.describe "Claims", type: :request do
 
     context "when the user reaches the confirmation page after submitting their claim" do
       before do
-        post claims_path
+        start_claim
 
         claim = Claim.order(:created_at).last
         claim.update_attributes(attributes_for(:claim, :submittable))
@@ -81,7 +81,7 @@ RSpec.describe "Claims", type: :request do
 
   describe "the claims ineligible page" do
     context "when a claim is already in progress" do
-      before { post claims_path }
+      before { start_claim }
 
       it "renders a static ineligibility page" do
         Claim.order(:created_at).last.eligibility.update(employment_status: "no_school")
@@ -126,7 +126,7 @@ RSpec.describe "Claims", type: :request do
     context "when a claim is already in progress" do
       let(:in_progress_claim) { Claim.order(:created_at).last }
 
-      before { post claims_path }
+      before { start_claim }
 
       it "updates the claim with the submitted form data" do
         put claim_path("qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "2014_2015"}}}

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.describe "Claims", type: :request do
+  describe "claims#new request" do
+    it "renders the correct template" do
+      get new_claim_path
+      expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
+    end
+  end
+
   describe "claims#create request" do
     it "creates a new Claim and redirects to the QTS question" do
       expect { post claims_path }.to change { Claim.count }.by(1)

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Claim session timing out", type: :request do
 
   context "no actions performed for more than the timeout period" do
     before do
-      post claims_path
+      start_claim
       start_verify_authentication_process
     end
 
@@ -28,7 +28,7 @@ RSpec.describe "Claim session timing out", type: :request do
 
   context "no action performed just within the timeout period" do
     before do
-      post claims_path
+      start_claim
       start_verify_authentication_process
     end
 

--- a/spec/requests/verify_authentications_spec.rb
+++ b/spec/requests/verify_authentications_spec.rb
@@ -3,7 +3,7 @@ require "verify/fake_sso"
 
 RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :request do
   context "when a claim is in progress" do
-    before { post claims_path }
+    before { start_claim }
 
     describe "verify/authentications/new" do
       before do
@@ -23,7 +23,7 @@ RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :reque
 
     describe "POST verify/authentications (i.e. the verify callback handler)" do
       before do
-        post claims_path
+        start_claim
 
         stub_vsp_generate_request
         get new_verify_authentications_path # sets the authentication request request_id in the session
@@ -97,7 +97,7 @@ RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :reque
   end
 
   describe "GET verify/authentications/failed" do
-    before { post claims_path }
+    before { start_claim }
 
     it "renders the failure content" do
       get failed_verify_authentications_path
@@ -108,7 +108,7 @@ RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :reque
   end
 
   describe "GET verify/authentications/no_auth" do
-    before { post claims_path }
+    before { start_claim }
 
     it "renders the no-auth content" do
       get no_auth_verify_authentications_path

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,7 +1,6 @@
 module FeatureHelpers
   def answer_all_student_loans_claim_questions
     start_claim
-    choose_qts_year
     choose_school schools(:penistone_grammar_school)
     choose_still_teaching "Yes, at another school"
     choose_school schools(:hampstead_school)
@@ -30,8 +29,8 @@ module FeatureHelpers
   end
 
   def start_claim
-    visit root_path
-    click_on "Start now"
+    visit new_claim_path
+    choose_qts_year
     Claim.order(:created_at).last
   end
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,11 @@
+module RequestHelpers
+  def start_claim
+    post claims_path, params: {
+      claim: {
+        eligibility_attributes: {
+          qts_award_year: "2016_2017",
+        },
+      },
+    }
+  end
+end


### PR DESCRIPTION
This updates the first page of the claim to be a `new` action, rather than a `create` action, which then starts the claim process. This means that the start of the journey will be able to be linked to from a GOV.UK start page. 

The bulk of the lines of code in this PR are test changes, I've endeavoured to tidy up the tests a bit by adding a Request helper that means we're not always repeating ourselves when we're POSTing to create a Claim. This will also make things easier to change if / when we change the journey in any way. 
