### PR TITLE
Rework URL structure in preparation for Maths & Physics policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Rework URL structure in preparation for Maths & Physics policy
 - Changes to accessibility statement as we think we now meet AA standard
 
 ## [Release 014] - 2019-10-03

--- a/app/assets/javascripts/components/timeout_dialog.js.erb
+++ b/app/assets/javascripts/components/timeout_dialog.js.erb
@@ -20,7 +20,7 @@
 
   function refreshSession() {
     Rails.ajax({
-      url: "<%= Rails.application.routes.url_helpers.claim_refresh_session_path(policy: "student-loans") %>",
+      url: "<%= claim_refresh_session_path %>",
       type: "get",
       success: function() {
         clearInterval(window.sessionTimeoutTimer);
@@ -31,7 +31,7 @@
 
   function sessionTimedOut() {
     clearInterval(window.sessionTimeoutTimer);
-    window.location = "<%= Rails.application.routes.url_helpers.timeout_claim_path(policy: "student-loans") %>";
+    window.location = "<%= timeout_claim_path %>";
   }
 
   function showTimeoutDialog() {

--- a/app/assets/javascripts/components/timeout_dialog.js.erb
+++ b/app/assets/javascripts/components/timeout_dialog.js.erb
@@ -20,7 +20,7 @@
 
   function refreshSession() {
     Rails.ajax({
-      url: "<%= Rails.application.routes.url_helpers.claim_refresh_session_path %>",
+      url: "<%= Rails.application.routes.url_helpers.claim_refresh_session_path(policy: "student-loans") %>",
       type: "get",
       success: function() {
         clearInterval(window.sessionTimeoutTimer);
@@ -31,7 +31,7 @@
 
   function sessionTimedOut() {
     clearInterval(window.sessionTimeoutTimer);
-    window.location = "<%= Rails.application.routes.url_helpers.timeout_claim_path %>";
+    window.location = "<%= Rails.application.routes.url_helpers.timeout_claim_path(policy: "student-loans") %>";
   }
 
   function showTimeoutDialog() {

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,3 +13,12 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w[js_check.js google_analytics.js google_analytics/analytics.js accessible-autocomplete/src/autocomplete.css]
+
+# Include the url_helpers in the asset pipeline
+# We use url helpers in the some of .js.erb, calling them statically doesn't
+# set the correct defaults we need to include the helpers instead.
+Rails.application.config.assets.configure do |env|
+  env.context_class.class_eval do
+    include Rails.application.routes.url_helpers
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,12 +21,14 @@ Rails.application.routes.draw do
   get "/cookies", to: "static_pages#cookies", as: :cookies
   get "/accessibility_statement", to: "static_pages#accessibility_statement", as: :accessibility_statement
 
-  constraints slug: %r{#{PageSequence::SLUGS.join("|")}} do
-    resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/claim"
-  end
+  scope path: ":policy", defaults: {policy: "student-loans"}, constraints: {policy: %r{student-loans}} do
+    constraints slug: %r{#{PageSequence::SLUGS.join("|")}} do
+      resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/"
+    end
 
-  get "/claim/timeout", to: "claims#timeout", as: :timeout_claim
-  get "/claim/refresh-session", to: "claims#refresh_session"
+    get "timeout", to: "claims#timeout", as: :timeout_claim
+    get "refresh-session", to: "claims#refresh_session", as: :claim_refresh_session
+  end
 
   constraints lambda { |req| req.format == :json } do
     defaults format: :json do

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -2,11 +2,16 @@ require "rails_helper"
 
 describe "Routes", type: :routing do
   describe "Claims routing" do
-    it "only routes to pages in the claim sequence" do
-      expect(get: "claim/qts-year").to route_to "claims#show", slug: "qts-year"
-      expect(get: "claim/claim-school").to route_to "claims#show", slug: "claim-school"
+    it "only routes to valid policies" do
+      expect(get: "student-loans/qts-year").to be_routable
+      expect(get: "non-existent-policy/qts-year").not_to be_routable
+    end
 
-      expect(get: "claim/non-existent-page").not_to be_routable
+    it "only routes to pages in the claim sequence" do
+      expect(get: "student-loans/qts-year").to route_to "claims#show", slug: "qts-year", policy: "student-loans"
+      expect(get: "student-loans/claim-school").to route_to "claims#show", slug: "claim-school", policy: "student-loans"
+
+      expect(get: "student-loans/non-existent-page").not_to be_routable
     end
   end
 end


### PR DESCRIPTION
In preparation for adding another policy (Maths & Physics) we need to have different URLs for each one. 

- Include the policy name as a parameter available the controller
- Only allow valid policies in the URL
- Include URL helpers in the asset pipeline as calling them statically from assets doesn't set the correct defaults