### PR TITLE
Changes to accessibility statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Changes to accessibility statement as we think we now meet AA standard
+
 ## [Release 014] - 2019-10-03
 
 - Reword the question about how many courses the user studied

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -89,68 +89,7 @@
     </p>
 
     <p class="govuk-body">
-      This website is partially compliant with the Web Content Accessibility Guidelines version 2.1 A and AA standards,
-      due to the non-compliances listed below.
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <a href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html" class="govuk-link">
-          1.3.1 - Info and Relationships
-        </a>
-      </li>
-      <li>
-        <a href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html" class="govuk-link">
-          1.3.5 - Identify Input Purpose
-        </a>
-      </li>
-      <li>
-        <a href="https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html" class="govuk-link">
-        2.4.6 - Headings and Labels
-        </a>
-      </li>
-      <li>
-        <a href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html" class="govuk-link">
-        3.3.2 - Labels or Instructions
-        </a>
-      </li>
-      <li>
-        <a href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html" class="govuk-link">
-          4.1.2 - Name, Role, Value
-        </a>
-      </li>
-    </ul>
-
-    <h2 class="govuk-heading-l">Non accessible content</h2>
-
-    <p class="govuk-body">
-      The content listed below is non-accessible for the following reasons:
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        issues with the school search Accessible Autocomplete plugin
-      </li>
-    </ul>
-
-    <h2 class="govuk-heading-l">Non compliance with the accessibility regulations</h2>
-
-    <p class="govuk-body">
-      The school search plugin, Accessible Autocomplete has no associated label. The text input used to search for schools
-      does not have an associated label so when a user navigates to it, depending on the software used the question may
-      not be announced. This does not meet WCAG 2.1 success criterion 1.3.1 (info and relationships), 1.3.5 (identity
-      input purpose), 2.4.6 (headings and labels), 3.3.2 (labels or instructions), and 4.1.2 (name, role, value).
-    </p>
-
-    <p class="govuk-body">
-      The school search plugin, Accessible Autocomplete has incorrectly formatted autocompletes within it. When users of
-      the software JAWS search for a school they do not hear an announcement of the number of search results. This does
-      not meet WCAG 2.1 success criterion 1.3.5 (identity input purpose) and 4.1.2 (name, role, value).
-    </p>
-
-    <p class="govuk-body">
-      We plan to amend the Accessible Autocomplete plugin when an update is released. We expect this to be before
-      December 2020.
+      We believe this website is compliant with the Web Content Accessibility Guidelines version 2.1 AA standard.
     </p>
 
     <h2 class="govuk-heading-l">How we tested this website</h2>


### PR DESCRIPTION
As we have upgraded accessible autocomplete, it now appears to be AA
compliant on latest OS / IE / JAWS versions. Added in text saying we
think we are AA compliant and we haven't been externally tested to
confirm this.

