### PR TITLE
A service operator can reject a claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
-- A service operator can reject a claim
+- A service operator can reject a claim and an email is sent to the claimant
 - Make sure claimants cannot make a claim of £0
 
 ## [Release 015] - 2019-10-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- A service operator can reject a claim
 - Make sure claimants cannot make a claim of £0
 
 ## [Release 015] - 2019-10-07

--- a/app/controllers/admin/claim_checks_controller.rb
+++ b/app/controllers/admin/claim_checks_controller.rb
@@ -5,7 +5,7 @@ class Admin::ClaimChecksController < Admin::BaseAdminController
 
   def create
     @claim.create_check!(checked_by: admin_session.user_id, result: params[:result])
-    ClaimMailer.approved(@claim).deliver_later if @claim.check.result == "approved"
+    send_claim_result_email
     redirect_to admin_claims_path, notice: "Claim has been #{@claim.check.result} successfully"
   end
 
@@ -19,5 +19,10 @@ class Admin::ClaimChecksController < Admin::BaseAdminController
     if @claim.check.present?
       redirect_to admin_claim_path(@claim), notice: "Claim already checked"
     end
+  end
+
+  def send_claim_result_email
+    ClaimMailer.approved(@claim).deliver_later if @claim.check.result == "approved"
+    ClaimMailer.rejected(@claim).deliver_later if @claim.check.result == "rejected"
   end
 end

--- a/app/controllers/admin/claim_checks_controller.rb
+++ b/app/controllers/admin/claim_checks_controller.rb
@@ -5,8 +5,8 @@ class Admin::ClaimChecksController < Admin::BaseAdminController
 
   def create
     @claim.create_check!(checked_by: admin_session.user_id, result: params[:result])
-    ClaimMailer.approved(@claim).deliver_later
-    redirect_to admin_claims_path, notice: "Claim has been approved successfully"
+    ClaimMailer.approved(@claim).deliver_later if @claim.check.result == "approved"
+    redirect_to admin_claims_path, notice: "Claim has been #{@claim.check.result} successfully"
   end
 
   private

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -2,7 +2,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
   before_action :ensure_service_operator
 
   def index
-    @claims = Claim.includes(eligibility: [:claim_school, :current_school]).awaiting_approval.order(:submitted_at)
+    @claims = Claim.includes(eligibility: [:claim_school, :current_school]).awaiting_checking.order(:submitted_at)
   end
 
   def show

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -7,6 +7,10 @@ class ClaimMailer < Mail::Notify::Mailer
     view_mail_with_claim_and_subject(claim, "Your claim to get your student loan repayments back has been approved, reference number: #{claim.reference}")
   end
 
+  def rejected(claim)
+    view_mail_with_claim_and_subject(claim, "Your claim to get your student loan repayments back has been rejected, reference number: #{claim.reference}")
+  end
+
   private
 
   def view_mail_with_claim_and_subject(claim, subject)

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -5,6 +5,7 @@ class Check < ApplicationRecord
 
   enum result: {
     approved: 0,
+    rejected: 1,
   }
 
   def readonly?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -105,7 +105,7 @@ class Claim < ApplicationRecord
   before_save :normalise_bank_sort_code, if: :bank_sort_code_changed?
 
   scope :submitted, -> { where.not(submitted_at: nil) }
-  scope :awaiting_approval, -> { submitted.left_outer_joins(:check).where(checks: {claim_id: nil}) }
+  scope :awaiting_checking, -> { submitted.left_outer_joins(:check).where(checks: {claim_id: nil}) }
   scope :approved, -> { joins(:check).where("checks.result" => :approved) }
 
   def submit!

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -6,7 +6,7 @@
 
     <% if @claims.any? %>
 
-      <h2 class="govuk-heading-m"><%= pluralize(@claims.count, "claim") %> awaiting approval</h2>
+      <h2 class="govuk-heading-m"><%= pluralize(@claims.count, "claim") %> awaiting checking</h2>
 
       <table class="govuk-table">
         <thead class="govuk-table__head">

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -14,9 +14,14 @@
 
     <%= button_to "Approve",
                   admin_claim_checks_path(@claim),
-                  method: :post,
                   params: { result: "approved" },
                   class: "govuk-button",
                   data: { confirm: "Are you sure you want to approve this claim?" } %>
+
+    <%= button_to "Reject",
+                admin_claim_checks_path(@claim),
+                params: { result: "rejected" },
+                class: "govuk-button govuk-button--secondary",
+                data: { confirm: "Are you sure you want to reject this claim?" } %>
   </div>
 </div>

--- a/app/views/admin/page/index.html.erb
+++ b/app/views/admin/page/index.html.erb
@@ -8,7 +8,7 @@
 
     <% if service_operator_signed_in? %>
       <ul>
-        <li><%= link_to 'Approve claims', admin_claims_path, class: "govuk-link" %></li>
+        <li><%= link_to 'Check claims', admin_claims_path, class: "govuk-link" %></li>
         <li><%= link_to 'Download payroll data', payroll_admin_claims_path(format: :csv), class: "govuk-link" %></li>
       </ul>
     <% end %>
@@ -21,8 +21,8 @@
 
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-    <h2 class="govuk-heading-m">Claims awaiting approval</h2>
-    <p class="govuk-body govuk-!-font-size-36"><%= Claim.awaiting_approval.count %></p>
+    <h2 class="govuk-heading-m">Claims awaiting checking</h2>
+    <p class="govuk-body govuk-!-font-size-36"><%= Claim.awaiting_checking.count %></p>
   </div>
 
 </div>

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -1,7 +1,7 @@
 Dear <%= @display_name %>,
 
 
-Unfortunately your claim to get your student loan payments back has been denied.
+Unfortunately your claim to get your student loan payments back has been rejected.
 
 # Appeals process and support
 

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -1,0 +1,14 @@
+Dear <%= @display_name %>,
+
+
+Unfortunately your claim to get your student loan payments back has been denied.
+
+# Appeals process and support
+
+If you feel that we have made a mistake in the processing of your application or something is incorrect please email studentloanteacherpayment@digital.education.gov.uk giving your reference number: <%= @claim.reference %> if you have any questions about your claim.
+
+Regards,
+
+The claim additional payments for teaching team.
+
+

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -13,10 +13,10 @@ RSpec.feature "Admin approves a claim" do
         submitted_claims = create_list(:claim, 5, :submitted)
         claim_to_approve = submitted_claims.first
 
-        click_on "Approve claims"
+        click_on "Check claims"
 
         expect(page).to have_content(claim_to_approve.reference)
-        expect(page).to have_content("5 claims awaiting approval")
+        expect(page).to have_content("5 claims awaiting checking")
 
         find("a[href='#{admin_claim_path(claim_to_approve)}']").click
         perform_enqueued_jobs { click_on "Approve" }
@@ -47,7 +47,7 @@ RSpec.feature "Admin approves a claim" do
       click_on "Sign in"
     end
 
-    scenario "User cannot view claims to approve" do
+    scenario "User cannot view claims to check" do
       expect(page).to_not have_link(nil, href: admin_claims_path)
 
       visit admin_claims_path

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -32,12 +32,9 @@ RSpec.feature "Admin approves a claim" do
 
         mail = ActionMailer::Base.deliveries.first
 
-        expect(mail.subject).to eq(
-          "Your claim to get your student loan repayments back has been approved, reference number: #{claim_to_approve.reference}"
-        )
-        expect(mail.body.raw_source).to match(
-          "Your claim to get your student loan repayments back has been approved"
-        )
+        expect(mail.subject).to match("been approved")
+        expect(mail.to).to eq([claim_to_approve.email_address])
+        expect(mail.body.raw_source).to match("been approved")
       end
     end
   end

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
 
 RSpec.feature "Admin approves a claim" do
+  let(:user_id) { "userid-345" }
+
   context "User is logged in as a service operator" do
     before do
-      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "12345")
+      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user_id)
       visit admin_path
       click_on "Sign in"
     end
@@ -21,7 +23,7 @@ RSpec.feature "Admin approves a claim" do
         find("a[href='#{admin_claim_path(claim_to_approve)}']").click
         perform_enqueued_jobs { click_on "Approve" }
 
-        expect(claim_to_approve.check.checked_by).to eq("12345")
+        expect(claim_to_approve.check.checked_by).to eq(user_id)
 
         expect(page).to have_content("Claim has been approved successfully")
         expect(page).to_not have_content(claim_to_approve.reference)

--- a/spec/features/admin_claim_reject_spec.rb
+++ b/spec/features/admin_claim_reject_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
 
 RSpec.feature "Rejecting a claim" do
+  let(:user_id) { "userid-345" }
+
   context "when a user is logged in as a service operator" do
     before do
-      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "12345")
+      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user_id)
       visit admin_path
       click_on "Sign in"
     end
@@ -22,7 +24,6 @@ RSpec.feature "Rejecting a claim" do
       perform_enqueued_jobs { click_on "Reject" }
 
       expect(claim_to_reject.check.checked_by).to eq(user_id)
-
       expect(page).to have_content("Claim has been rejected successfully")
       expect(page).to_not have_content(claim_to_reject.reference)
 

--- a/spec/features/admin_claim_reject_spec.rb
+++ b/spec/features/admin_claim_reject_spec.rb
@@ -29,12 +29,9 @@ RSpec.feature "Rejecting a claim" do
 
       mail = ActionMailer::Base.deliveries.last
 
-      expect(mail.subject).to eq(
-        "Your claim to get your student loan repayments back has been rejected, reference number: #{claim_to_reject.reference}"
-      )
-      expect(mail.body.raw_source).to match(
-        "Unfortunately your claim to get your student loan payments back has been denied."
-      )
+      expect(mail.subject).to match("been rejected")
+      expect(mail.to).to eq([claim_to_reject.email_address])
+      expect(mail.body.raw_source).to match("been denied.")
     end
   end
 end

--- a/spec/features/admin_claim_reject_spec.rb
+++ b/spec/features/admin_claim_reject_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Rejecting a claim" do
 
       expect(mail.subject).to match("been rejected")
       expect(mail.to).to eq([claim_to_reject.email_address])
-      expect(mail.body.raw_source).to match("been denied.")
+      expect(mail.body.raw_source).to match("been rejected.")
     end
   end
 end

--- a/spec/features/admin_claim_reject_spec.rb
+++ b/spec/features/admin_claim_reject_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.feature "Rejecting a claim" do
+  context "when a user is logged in as a service operator" do
+    before do
+      stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "12345")
+      visit admin_path
+      click_on "Sign in"
+    end
+
+    scenario "they can reject a claim" do
+      submitted_claims = create_list(:claim, 5, :submitted)
+      claim_to_reject = submitted_claims.first
+
+      click_on "Check claims"
+
+      expect(page).to have_content(claim_to_reject.reference)
+      expect(page).to have_content("5 claims awaiting checking")
+
+      find("a[href='#{admin_claim_path(claim_to_reject)}']").click
+
+      perform_enqueued_jobs { click_on "Reject" }
+
+      expect(claim_to_reject.check.checked_by).to eq(user_id)
+
+      expect(page).to have_content("Claim has been rejected successfully")
+      expect(page).to_not have_content(claim_to_reject.reference)
+
+      mail = ActionMailer::Base.deliveries.last
+
+      expect(mail.subject).to eq(
+        "Your claim to get your student loan repayments back has been rejected, reference number: #{claim_to_reject.reference}"
+      )
+      expect(mail.body.raw_source).to match(
+        "Unfortunately your claim to get your student loan payments back has been denied."
+      )
+    end
+  end
+end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -32,4 +32,20 @@ RSpec.describe ClaimMailer, type: :mailer do
       expect(mail.body.encoded).to match("Email studentloanteacherpayment@digital.education.gov.uk giving your reference number: #{claim.reference} if you have any questions.")
     end
   end
+
+  describe "#rejected" do
+    let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
+    let(:mail) { ClaimMailer.rejected(claim) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Your claim to get your student loan repayments back has been rejected, reference number: #{claim.reference}")
+      expect(mail.to).to eq([claim.email_address])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Dear John Kennedy,")
+      expect(mail.body.encoded).to match("Unfortunately your claim to get your student loan payments back has been denied.")
+      expect(mail.body.encoded).to match("If you feel that we have made a mistake in the processing of your application or something is incorrect please email studentloanteacherpayment@digital.education.gov.uk giving your reference number: #{claim.reference} if you have any questions about your claim.")
+    end
+  end
 end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match("Dear John Kennedy,")
-      expect(mail.body.encoded).to match("been denied")
+      expect(mail.body.encoded).to match("been rejected")
     end
   end
 end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -22,14 +22,14 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:mail) { ClaimMailer.approved(claim) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("Your claim to get your student loan repayments back has been approved, reference number: #{claim.reference}")
+      expect(mail.subject).to match("approved")
+      expect(mail.subject).to match("reference number: #{claim.reference}")
       expect(mail.to).to eq([claim.email_address])
     end
 
     it "renders the body" do
       expect(mail.body.encoded).to match("Dear John Kennedy,")
-      expect(mail.body.encoded).to match("Your claim to get your student loan repayments back has been approved.")
-      expect(mail.body.encoded).to match("Email studentloanteacherpayment@digital.education.gov.uk giving your reference number: #{claim.reference} if you have any questions.")
+      expect(mail.body.encoded).to match("been approved")
     end
   end
 
@@ -38,14 +38,14 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:mail) { ClaimMailer.rejected(claim) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("Your claim to get your student loan repayments back has been rejected, reference number: #{claim.reference}")
+      expect(mail.subject).to match("rejected")
+      expect(mail.subject).to match("reference number: #{claim.reference}")
       expect(mail.to).to eq([claim.email_address])
     end
 
     it "renders the body" do
       expect(mail.body.encoded).to match("Dear John Kennedy,")
-      expect(mail.body.encoded).to match("Unfortunately your claim to get your student loan payments back has been denied.")
-      expect(mail.body.encoded).to match("If you feel that we have made a mistake in the processing of your application or something is incorrect please email studentloanteacherpayment@digital.education.gov.uk giving your reference number: #{claim.reference} if you have any questions about your claim.")
+      expect(mail.body.encoded).to match("been denied")
     end
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -360,13 +360,13 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe "awaiting_approval" do
+  describe "awaiting_checking" do
     let!(:submitted_claims) { create_list(:claim, 5, :submitted) }
     let!(:unsubmitted_claims) { create_list(:claim, 2, :submittable) }
     let!(:approved_claims) { create_list(:claim, 5, :approved) }
 
-    it "returns submitted claims awaiting approval" do
-      expect(subject.class.awaiting_approval).to match_array(submitted_claims)
+    it "returns submitted claims awaiting checking" do
+      expect(subject.class.awaiting_checking).to match_array(submitted_claims)
     end
   end
 

--- a/spec/requests/admin_claim_checks_spec.rb
+++ b/spec/requests/admin_claim_checks_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Admin claim approvals", type: :request do
+RSpec.describe "Admin claim checks", type: :request do
   context "when signed in as a service operator" do
     before do
       stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)

--- a/spec/requests/admin_claim_checks_spec.rb
+++ b/spec/requests/admin_claim_checks_spec.rb
@@ -11,20 +11,29 @@ RSpec.describe "Admin claim checks", type: :request do
     describe "claim_checks#create" do
       let(:claim) { create(:claim, :submitted) }
 
-      it "approves a claim" do
-        freeze_time do
-          post admin_claim_checks_path(claim_id: claim.id, result: "approved")
+      it "can approve a claim" do
+        post admin_claim_checks_path(claim_id: claim.id, result: "approved")
 
-          follow_redirect!
+        follow_redirect!
 
-          expect(response.body).to include("Claim has been approved successfully")
+        expect(response.body).to include("Claim has been approved successfully")
 
-          expect(claim.check.checked_by).to eq("123")
-          expect(claim.check.result).to eq("approved")
-        end
+        expect(claim.check.checked_by).to eq("123")
+        expect(claim.check.result).to eq("approved")
       end
 
-      context "when claim is already approved" do
+      it "can reject a claim" do
+        post admin_claim_checks_path(claim_id: claim.id, result: "rejected")
+
+        follow_redirect!
+
+        expect(response.body).to include("Claim has been rejected successfully")
+
+        expect(claim.check.checked_by).to eq("123")
+        expect(claim.check.result).to eq("rejected")
+      end
+
+      context "when claim is already checked" do
         let(:claim) { create(:claim, :approved) }
 
         it "shows an error" do


### PR DESCRIPTION
This PR introduces the concept of _rejecting_ a claim. The goal was to do the smallest possible work to achieve that without trying to guess at what the process around claim rejection will look like.

We know claims will have to be rejected so we are confident of that, we do not know what the claims checking process looks like around rejections so want to keep the code as flexible as possible.

There were three steps:

1. change the words on the UI so it is clear we are not just approving claims, rather checking them
2. allow a `Check` to have a result of `rejected`
3. send a notification to the user

Some obvious omissions we know about are:

- the UI has had no thought as this is a seperate piece of work – I wonder if we should show the reject button at all?
- no record of why a claim is rejected is asked for or stored
- the email is missing the reason why the claim was rejected as we do not have it

in-line with the teams focus on only approving claims for the moment, we do not intend to use the reject feature until we understand more.

P.S. the commits are in a strange order, I think it is because I cherry-picked the notification one from older work – if someone can tell me how to sort that, that would be amazing! :D