### PR TITLE
Cleanup any stale VSP processes when starting the service in dev

### DIFF
--- a/bin/launch-vsp
+++ b/bin/launch-vsp
@@ -15,6 +15,18 @@ if [ ! -d $VSP_PATH ]; then
   echo "Verify Service provider successfully installed!"
 fi
 
+echo "Checking for any running VSP processes"
+echo
+
+PORT=50300
+PID=$(lsof -t -i :$PORT)
+
+if [ ${#PID} -ne 0 ]; then
+  echo "Cleaning up running VSP processes..."
+  echo
+  kill -9 "$PID"
+fi
+
 echo "Launching Verify Service Provider..."
 echo
 


### PR DESCRIPTION
Sometimes when spinning up the VSP locally, I get an error because a previous VSP process hasn't exited properly, which means I have to search around to find what port it's running on, then Google the incantation to find out the PID number using a specific port, which eats up a bunch of time. This does the checking for me before spinning up the VSP, and then kills the process if it's found, before spinning up the VSP
