### PR TITLE
Make sure claimants cannot make a claim for £0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Make sure claimants cannot make a claim of £0
+
 ## [Release 015] - 2019-10-07
 
 - Update the first page of the claim to initialise, rather than create a claim

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -40,7 +40,7 @@ module StudentLoans
     validates :had_leadership_position, on: [:"leadership-position", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
     validates :mostly_performed_leadership_duties, on: [:"mostly-performed-leadership-duties", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}, if: :had_leadership_position?
     validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
-    validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 99999
+    validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than: 0, less_than_or_equal_to: 99999
 
     delegate :name, to: :claim_school, prefix: true, allow_nil: true
     delegate :name, to: :current_school, prefix: true, allow_nil: true

--- a/app/views/claims/student_loan_amount.html.erb
+++ b/app/views/claims/student_loan_amount.html.erb
@@ -28,7 +28,7 @@
                   :student_loan_repayment_amount,
                   class: css_classes_for_input(current_claim, :student_loan_repayment_amount, "govuk-currency-input__input govuk-input--width-5"),
                   step: 'any',
-                  min: 0,
+                  min: 1,
                   max: 99999,
                   value: currency_value_for_number_field(fields.object.student_loan_repayment_amount),
                 )

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "-99")).not_to be_valid
       expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "150")).to be_valid
     end
+
+    it "validates that the loan repayment is not zero" do
+      expect(StudentLoans::Eligibility.new(student_loan_repayment_amount: "0")).not_to be_valid
+    end
   end
 
   describe "#claim_school_name" do


### PR DESCRIPTION
This makes sure a claimant can't submit £0 for their student loan payment by updating the validations, and also changing to minimum amount that can be entered in the number field to `1`. Again, £1 might not be a realistic amount, but it's easier to deal with than £0!