### PR TITLE
Tweak URL paths for new/create and refine handling of return visitors

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -5,7 +5,7 @@ class ClaimsController < ApplicationController
   after_action :clear_claim_session, if: :submission_complete?
 
   def new
-    render claim_page_template
+    render current_template
   end
 
   def create
@@ -13,13 +13,13 @@ class ClaimsController < ApplicationController
       session[:claim_id] = @current_claim.to_param
       redirect_to claim_path(next_slug)
     else
-      render claim_page_template
+      render current_template
     end
   end
 
   def show
     search_schools if params[:school_search]
-    render claim_page_template
+    render current_template
   end
 
   def update
@@ -64,7 +64,7 @@ class ClaimsController < ApplicationController
     params.fetch(:claim, {}).permit(StudentLoans::PermittedParameters.new(current_claim).keys)
   end
 
-  def claim_page_template
+  def current_template
     params[:slug].underscore
   end
 

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -10,11 +10,11 @@ class ClaimsController < ApplicationController
 
   def create
     current_claim.attributes = claim_params
-    if current_claim.save(context: params[:slug].to_sym)
+    if current_claim.save(context: page_sequence.slugs.first.to_sym)
       session[:claim_id] = current_claim.to_param
       redirect_to claim_path(next_slug)
     else
-      render current_template
+      render first_template_in_sequence
     end
   end
 

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -5,7 +5,11 @@ class ClaimsController < ApplicationController
   after_action :clear_claim_session, if: :submission_complete?
 
   def new
-    render first_template_in_sequence
+    if current_claim.persisted?
+      redirect_to claim_path(page_sequence.slugs.first)
+    else
+      render first_template_in_sequence
+    end
   end
 
   def create

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -9,8 +9,9 @@ class ClaimsController < ApplicationController
   end
 
   def create
-    if update_current_claim!
-      session[:claim_id] = @current_claim.to_param
+    current_claim.attributes = claim_params
+    if current_claim.save(context: params[:slug].to_sym)
+      session[:claim_id] = current_claim.to_param
       redirect_to claim_path(next_slug)
     else
       render current_template

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -5,7 +5,7 @@ class ClaimsController < ApplicationController
   after_action :clear_claim_session, if: :submission_complete?
 
   def new
-    render current_template
+    render first_template_in_sequence
   end
 
   def create
@@ -66,6 +66,10 @@ class ClaimsController < ApplicationController
 
   def current_template
     params[:slug].underscore
+  end
+
+  def first_template_in_sequence
+    page_sequence.slugs.first.underscore
   end
 
   def check_page_is_in_sequence

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -41,7 +41,7 @@ class ClaimsController < ApplicationController
   private
 
   def update_current_claim!
-    ClaimUpdate.new(current_claim, claim_params, params[:slug]).perform
+    ClaimUpdate.new(current_claim, claim_params, page_sequence.current_slug).perform
   end
 
   def next_slug
@@ -49,7 +49,7 @@ class ClaimsController < ApplicationController
   end
 
   def submission_complete?
-    params[:slug] == "confirmation" && current_claim.submitted?
+    page_sequence.current_slug == "confirmation" && current_claim.submitted?
   end
 
   def search_schools
@@ -66,7 +66,7 @@ class ClaimsController < ApplicationController
   end
 
   def current_template
-    params[:slug].underscore
+    page_sequence.current_slug.underscore
   end
 
   def first_template_in_sequence

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -68,6 +68,6 @@ class PageSequence
   private
 
   def current_slug_index
-    slugs.index(current_slug)
+    slugs.index(current_slug) || 0
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
     end
 
     get "claim", as: :new_claim, to: "claims#new"
-    post "/", as: :claims, to: "claims#create", params: {slug: PageSequence::SLUGS.first}
+    post "claim", as: :claims, to: "claims#create"
 
     get "timeout", to: "claims#timeout", as: :timeout_claim
     get "refresh-session", to: "claims#refresh_session", as: :claim_refresh_session

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
       resources :claims, only: [:show, :update], param: :slug, path: "/"
     end
 
-    get "new", as: :new_claim, to: "claims#new", params: {slug: PageSequence::SLUGS.first}
+    get "claim", as: :new_claim, to: "claims#new"
     post "/", as: :claims, to: "claims#create", params: {slug: PageSequence::SLUGS.first}
 
     get "timeout", to: "claims#timeout", as: :timeout_claim

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe PageSequence do
   end
 
   describe "#next_slug" do
+    it "assumes we're at the beginning of the sequence if no current_slug is specified" do
+      expect(PageSequence.new(claim, nil).next_slug).to eq "claim-school"
+    end
+
     it "returns the next slug in the sequence" do
       expect(PageSequence.new(claim, "qts-year").next_slug).to eq "claim-school"
       expect(PageSequence.new(claim, "claim-school").next_slug).to eq "still-teaching"

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -2,9 +2,16 @@ require "rails_helper"
 
 RSpec.describe "Claims", type: :request do
   describe "claims#new request" do
-    it "renders the correct template" do
+    it "renders the first page in the sequence" do
       get new_claim_path
       expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
+    end
+
+    it "redirects to the first page in the sequence if a claim has been started already" do
+      start_claim
+
+      get new_claim_path
+      expect(response).to redirect_to(claim_path(PageSequence::SLUGS.first))
     end
   end
 

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe "Claims", type: :request do
 
       expect(response).to redirect_to(claim_path("claim-school"))
     end
+
+    it "validates against the context for the first page in sequence" do
+      expect { post claims_path }.not_to change { Claim.count }
+      expect(response.body).to include("Select the academic year you were awarded qualified teacher status")
+    end
   end
 
   describe "claims#show request" do


### PR DESCRIPTION
This does a couple of things.

Firstly it reworks the URLS to be a bit friendlier to the user:

- `#new` becomes `/student-loans/claim` instead of `/student-loans/new?slug=qts-year`
- `#create` becomes `/student-loans/claim` instead of `/student-loans?slug=qts-year`

Secondly it adds some code to handle the scenario where a user visits `#new` with an already in-progress claim. This was resulting in exceptions being raised.