### PR TITLE
A service operator can see if a claim is missing a payroll gender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- A service operator can see if a claim is missing a payroll gender
+
 ## [Release 016] - 2019-10-08
 
 - A service operator can reject a claim and an email is sent to the claimant

--- a/app/assets/stylesheets/components/flash.scss
+++ b/app/assets/stylesheets/components/flash.scss
@@ -13,4 +13,9 @@
     color: govuk-colour("blue");
     border-color: govuk-colour("blue");
   }
+  &__alert {
+    @extend %govuk-flash;
+    color: govuk-colour("red");
+    border-color: govuk-colour("red");
+  }
 }

--- a/app/controllers/admin/claim_checks_controller.rb
+++ b/app/controllers/admin/claim_checks_controller.rb
@@ -4,6 +4,7 @@ class Admin::ClaimChecksController < Admin::BaseAdminController
   before_action :reject_checked_claims
 
   def create
+    return redirect_to admin_claim_path(@claim), alert: "Claim cannot be approved" if params[:result] == "approved" && @claim.payroll_gender_missing?
     @claim.create_check!(checked_by: admin_session.user_id, result: params[:result])
     send_claim_result_email
     redirect_to admin_claims_path, notice: "Claim has been #{@claim.check.result} successfully"

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -126,6 +126,10 @@ class Claim < ApplicationRecord
     valid?(:submit) && !submitted?
   end
 
+  def payroll_gender_missing?
+    %w[male female].exclude?(payroll_gender)
+  end
+
   def address(seperator = ", ")
     Claim::ADDRESS_ATTRIBUTES.map { |attr| send(attr) }.reject(&:blank?).join(seperator)
   end

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -1,5 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if @claim.payroll_gender_missing? %>
+      <div class="govuk-body-l govuk-flash__notice">
+        This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
+      </div>
+    <% end %>
+
     <h1 class="govuk-heading-xl">
       Claim <%= @claim.reference %>
     </h1>
@@ -11,6 +17,16 @@
     <%= render partial: "answer_section", locals: {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
 
     <%= render partial: "answer_section", locals: {heading: "Submission details", answers: admin_submission_details(@claim)} %>
+
+    <% if @claim.payroll_gender_missing? %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
+        </strong>
+      </div>
+    <% end %>
 
     <%= button_to "Approve",
                   admin_claim_checks_path(@claim),

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -16,7 +16,8 @@
                   admin_claim_checks_path(@claim),
                   params: { result: "approved" },
                   class: "govuk-button",
-                  data: { confirm: "Are you sure you want to approve this claim?" } %>
+                  data: { confirm: "Are you sure you want to approve this claim?" },
+                  disabled: @claim.payroll_gender_missing? %>
 
     <%= button_to "Reject",
                 admin_claim_checks_path(@claim),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,9 @@ en:
     formats:
       default: "%-d %B %Y"
       day_month_year: "%d/%m/%Y"
+  time:
+    formats:
+      default: "%-d %B %Y %l:%M%P"
   number:
     currency:
       format:

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -46,6 +46,7 @@ RSpec.feature "Admin approves a claim" do
         find("a[href='#{admin_claim_path(claim_missing_payroll_gender)}']").click
 
         expect(page).to have_button("Approve", disabled: true)
+        expect(page).to have_content("This claim cannot be approved, the payroll gender is missing")
       end
     end
   end

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -37,6 +37,17 @@ RSpec.feature "Admin approves a claim" do
         expect(mail.body.raw_source).to match("been approved")
       end
     end
+
+    context "When the payroll gender is missing" do
+      let!(:claim_missing_payroll_gender) { create(:claim, :submitted, payroll_gender: :dont_know) }
+
+      scenario "User is informed that the claim cannot be approved" do
+        click_on "Check claims"
+        find("a[href='#{admin_claim_path(claim_missing_payroll_gender)}']").click
+
+        expect(page).to have_button("Approve", disabled: true)
+      end
+    end
   end
 
   context "User is logged in as a support user" do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -383,6 +383,20 @@ RSpec.describe Claim, type: :model do
     end
   end
 
+  describe "#payroll_gender_missing?" do
+    it "returns true when the claimant doesn't know their payroll gender" do
+      claim = build(:claim, payroll_gender: :dont_know)
+
+      expect(claim.payroll_gender_missing?).to eq true
+    end
+
+    it "returns false when the payroll gender is one accepted by the payroll provider" do
+      claim = build(:claim, payroll_gender: :female)
+
+      expect(claim.payroll_gender_missing?).to eq false
+    end
+  end
+
   describe "#address_verified?" do
     it "returns true if any address attributes are in the list of verified fields" do
       expect(Claim.new.payroll_gender_verified?).to eq false

--- a/spec/requests/admin_claim_checks_spec.rb
+++ b/spec/requests/admin_claim_checks_spec.rb
@@ -44,6 +44,29 @@ RSpec.describe "Admin claim checks", type: :request do
           expect(response.body).to include("Claim already checked")
         end
       end
+
+      context "when the claim is missing a payroll gender" do
+        let(:claim) { create(:claim, :submitted, payroll_gender: :dont_know) }
+        before do
+          post admin_claim_checks_path(claim_id: claim.id, result: result)
+          follow_redirect!
+        end
+
+        context "and the user attempts to approve" do
+          let(:result) { "approved" }
+          it "shows an error" do
+            expect(response.body).to include("Claim cannot be approved")
+          end
+        end
+
+        context "and the user attempts to reject" do
+          let(:result) { "rejected" }
+          it "doesn’t show an error and rejects successfully" do
+            expect(response.body).not_to include("Claim cannot be approved")
+            expect(response.body).to include("Claim has been rejected successfully")
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Claims that don't have a payroll gender cannot be approved because our payroll provider (and HMRC) have gender as a required field. It is possible for users to submit a claim and answer "I don't know" to the question we ask about payroll gender.

We need to prevent admins from being able to approve these claims and flag it to them as something to investigate.

There's no official pattern for [alerts in the Design System yet](https://github.com/alphagov/govuk-design-system-backlog/issues/2), so I decided to reuse the informative banner style we use for flash messages for now. @titlescreen may have opinions on it?

I've also included some warning text next to the disabled button to remind the user why they can't approve it.

Also includes a fix for the time formatting

# Screenshots

<img width="1314" alt="Screenshot 2019-10-07 at 15 00 49" src="https://user-images.githubusercontent.com/2804149/66318551-6f272e80-e913-11e9-871d-59600696c3d9.png">

<img width="1363" alt="Screenshot 2019-10-07 at 15 01 01" src="https://user-images.githubusercontent.com/2804149/66318568-764e3c80-e913-11e9-9c1e-cdc0dffd43a7.png">

