### PR TITLE
Use next_slug on eligibility confirmed screen

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -48,6 +48,7 @@ class ClaimsController < ApplicationController
     ClaimUpdate.new(current_claim, claim_params, page_sequence.current_slug).perform
   end
 
+  helper_method :next_slug
   def next_slug
     page_sequence.next_slug
   end

--- a/app/views/claims/eligibility_confirmed.html.erb
+++ b/app/views/claims/eligibility_confirmed.html.erb
@@ -6,6 +6,6 @@
     <h1 class="govuk-heading-xl">You are eligible to claim back student loan repayments</h1>
     <p class="govuk-body">Based on your answers, you can claim back the student loan repayments you made between 6 April 2018 and 5 April 2019.</p>
 
-    <%= link_to "Continue", claim_path("information-provided"), class: "govuk-button", role: "button" %>
+    <%= link_to "Continue", claim_path(next_slug), class: "govuk-button", role: "button" %>
   </div>
 </div>


### PR DESCRIPTION
This is a slight enhancement that has been included in a couple of recently closed PRs, it would be good to get it in.

To make the journey more robust and open to changes we can make `next_slug` a helper method and use it in any directly linked paths.
