### PR TITLE
Scope current claim methods to specific controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,27 +9,15 @@ class ApplicationController < ActionController::Base
     if: -> { ENV.key?("BASIC_AUTH_USERNAME") },
   )
 
-  helper_method :admin_signed_in?, :current_claim, :claim_timeout_in_minutes, :claim_timeout_warning_in_minutes
+  helper_method :admin_signed_in?, :claim_timeout_in_minutes, :claim_timeout_warning_in_minutes
   before_action :end_expired_admin_sessions
   before_action :end_expired_claim_sessions
   before_action :update_last_seen_at
 
   private
 
-  def send_unstarted_claiments_to_the_start
-    redirect_to root_url unless current_claim.persisted?
-  end
-
   def admin_signed_in?
     session.key?(:user_id)
-  end
-
-  def current_claim
-    @current_claim ||= current_claim_from_session || Claim.new(eligibility: StudentLoans::Eligibility.new)
-  end
-
-  def current_claim_from_session
-    Claim.find(session[:claim_id]) if session.key?(:claim_id)
   end
 
   def claim_timeout_in_minutes

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -35,9 +35,6 @@ class ClaimsController < ApplicationController
     end
   end
 
-  def ineligible
-  end
-
   def refresh_session
     head :ok
   end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -35,6 +35,9 @@ class ClaimsController < ApplicationController
     end
   end
 
+  def timeout
+  end
+
   def refresh_session
     head :ok
   end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,5 +1,5 @@
 class ClaimsController < ApplicationController
-  before_action :send_unstarted_claiments_to_the_start, only: [:show, :update, :ineligible]
+  before_action :send_unstarted_claiments_to_the_start, except: [:new, :create, :timeout, :refresh_session]
   before_action :check_page_is_in_sequence, only: [:show, :update]
 
   after_action :clear_claim_session, if: :submission_complete?

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,5 +1,7 @@
 class ClaimsController < ApplicationController
-  before_action :send_unstarted_claiments_to_the_start, except: [:new, :create, :timeout, :refresh_session]
+  include PartOfClaimJourney
+
+  skip_before_action :send_unstarted_claiments_to_the_start, only: [:new, :create, :timeout, :refresh_session]
   before_action :check_page_is_in_sequence, only: [:show, :update]
 
   after_action :clear_claim_session, if: :submission_complete?

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -1,0 +1,22 @@
+module PartOfClaimJourney
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :send_unstarted_claiments_to_the_start
+    helper_method :current_claim
+  end
+
+  private
+
+  def send_unstarted_claiments_to_the_start
+    redirect_to root_url unless current_claim.persisted?
+  end
+
+  def current_claim
+    @current_claim ||= claim_from_session || Claim.new(eligibility: StudentLoans::Eligibility.new)
+  end
+
+  def claim_from_session
+    Claim.find(session[:claim_id]) if session.key?(:claim_id)
+  end
+end

--- a/app/controllers/verify/authentications_controller.rb
+++ b/app/controllers/verify/authentications_controller.rb
@@ -2,7 +2,8 @@ module Verify
   class AuthenticationsController < ApplicationController
     CLAIM_TIMEOUT_LENGTH_IN_MINUTES = 90
 
-    before_action :send_unstarted_claiments_to_the_start
+    include PartOfClaimJourney
+
     skip_before_action :verify_authenticity_token, only: [:create]
 
     # Page where a new Verify authentication request is generated and posted, as

--- a/app/controllers/verify/authentications_controller.rb
+++ b/app/controllers/verify/authentications_controller.rb
@@ -3,7 +3,6 @@ module Verify
     CLAIM_TIMEOUT_LENGTH_IN_MINUTES = 90
 
     before_action :send_unstarted_claiments_to_the_start
-    before_action :update_last_seen_at
     skip_before_action :verify_authenticity_token, only: [:create]
 
     # Page where a new Verify authentication request is generated and posted, as


### PR DESCRIPTION
Rather than defining claim-specific methods in the base controller and having them present in all controllers of the application, we only include them in the places where a current claim is expected and being worked with.

This is part of the work to prepare us for introducing Maths & Physics by reducing the places in the codebase where a specific policy is referenced, i.e. in this case the `StudentoLoans::Eligibility`. In the context of `ClaimsController` we will know the policy because of the `:policy` param we get as part of the routing, which means we'll be able to modify the method to set an appropriate eligibility based on the param.

The only other place where the `current_claim` is checked and modified is the `Verify::AuthenticationsController`. This doesn't have routing scoped by a `:polocy`, but it also doesn't serve requests for unstarted claims so that shouldn't be a problem.