### PR TITLE
Admin uses its own layout with with updated navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog]
 
 ## [Release 016] - 2019-10-08
 
+- Admin uses its own layout with with updated navigation
 - A service operator can reject a claim and an email is sent to the claimant
 - Make sure claimants cannot make a claim of £0
 

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -1,0 +1,103 @@
+// Typography
+$small-font-size: 0.9em;
+$large-font-size: 1.2em;
+$bold-font-weight: 700;
+
+// Colours
+$warning-color: govuk-colour("blue");
+
+// Breakpoints
+$large-screen: 1300px;
+$big-screen: 1024px;
+$medium-screen: 900px;
+$small-screen: 768px;
+$smaller-screen: 520px;
+$tiny-screen: 480px;
+
+// Borders
+$thick-border: 5px;
+
+.app-navigation {
+  $navigation-height: 50px;
+  $navigation-padding: 20px;
+  border-bottom: 1px solid govuk-colour("mid-grey");
+  font-weight: bold;
+  background-color: #f8f8f8;
+  line-height: 25px;
+
+  @include govuk-clearfix;
+
+  &__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    font-size: 0.85em;
+
+    @include govuk-media-query($from: tablet) {
+      font-size: 1em;
+    }
+
+    & > li {
+      box-sizing: border-box;
+      padding: $navigation-padding 0;
+      float: left;
+      -moz-box-sizing: border-box;
+      -webkit-box-sizing: border-box;
+      border-bottom: 4px solid transparent;
+
+      &:last-of-type {
+        float: right;
+      }
+
+      &:hover {
+        border-bottom: 4px solid $govuk-link-hover-colour;
+      }
+
+      &.active {
+        border-bottom: 4px solid govuk-colour("blue") !important;
+
+        a:hover {
+          color: $govuk-link-colour;
+        }
+      }
+
+      a {
+        display: block;
+        padding: 0 1em;
+        color: $govuk-link-colour;
+        text-decoration: none;
+        @include govuk-media-query($until: tablet) {
+          padding: 0 0.5em;
+        }
+
+        &:visited {
+          color: $govuk-link-colour;
+        }
+
+        &:hover {
+          color: $govuk-link-hover-colour;
+          text-decoration: underline;
+        }
+        &:focus {
+          color: $govuk-link-hover-colour;
+          -webkit-box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+          box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+        }
+      }
+    }
+  }
+}
+
+nav ul .mobile-header-underline-text {
+  @include govuk-media-query($until: desktop) {
+    font-weight: normal;
+    text-decoration: underline;
+  }
+}
+
+.mobile-header-top-border {
+  @include govuk-media-query($until: desktop) {
+    border-top: 3px solid #ffffff;
+    margin-top: 2px;
+  }
+}

--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -17,7 +17,7 @@ module Admin
         session[:user_id] = admin_session.user_id
         session[:organisation_id] = admin_session.organisation_id
         session[:role_codes] = admin_session.role_codes
-        redirect_to admin_path
+        redirect_to admin_root_path
       else
         render "failure", status: :unauthorized
       end

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class BaseAdminController < ApplicationController
+    layout "admin"
+
     before_action :ensure_authenticated_user
     helper_method :service_operator_signed_in?
 

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -1,3 +1,4 @@
+<%= link_to "Back", admin_root_path, class: "govuk-back-link" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template app-html-class">
+  <head>
+    <title>
+      <%= "#{t("service_name")} – GOV.UK" %>
+
+    </title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c" />
+
+    <%= favicon_link_tag %>
+    <%= favicon_link_tag 'govuk-mask-icon.svg', rel: 'mask-icon', type: 'image/svg+xml', color: '#0b0c0c' %>
+    <%= favicon_link_tag 'govuk-apple-touch-icon-180x180.png', rel: 'apple-touch-icon', type: 'image/png', sizes: '180x180' %>
+    <%= favicon_link_tag 'govuk-apple-touch-icon-167x167.png', rel: 'apple-touch-icon', type: 'image/png', sizes: '167x167' %>
+    <%= favicon_link_tag 'govuk-apple-touch-icon-152x152.png', rel: 'apple-touch-icon', type: 'image/png', sizes: '152x152' %>
+    <%= favicon_link_tag 'govuk-apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+    <% if ENV["GOOGLE_ANALYTICS_ID"] %>
+      <%= javascript_include_tag "google_analytics/analytics" %>
+      <%= javascript_include_tag "google_analytics", data: { "ga-id" => ENV["GOOGLE_ANALYTICS_ID"] } %>
+    <% end %>
+
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+  </head>
+
+  <body class="govuk-template__body">
+    <%= javascript_include_tag 'js_check' %>
+
+    <%= render partial: "timeout_dialog" %>
+
+    <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
+    <div id="global-cookie-message" class="govuk-cookie-banner" role="region" aria-label="cookie banner">
+      <div class="govuk-width-container">
+        <p class="govuk-cookie-banner__message"><%= t("service_name") %> uses cookies to make the site simpler.</p>
+        <div class="govuk-cookie-banner__buttons">
+          <button id="accept-cookies" class="govuk-button govuk-button--secondary" type="submit" data-module="govuk-button">Accept cookies</button>
+          <%= link_to('Cookie information', cookies_path, class: "govuk-button govuk-button--secondary ") %>
+        </div>
+      </div>
+    </div>
+
+    <header class="govuk-header" role="banner" data-module="govuk-header">
+      <div class="govuk-header__container govuk-width-container">
+
+        <div class="govuk-header__logo">
+          <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+
+              <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+
+                <image src="<%= image_path("govuk-logotype-crown.png") %>" class="govuk-header__logotype-crown-fallback-image"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+        <div class="govuk-header__content">
+          <%= link_to t("service_name"), admin_root_path, class: "govuk-header__link govuk-header__link--service-name" %>
+        </div>
+      </div>
+    </header>
+    <% if admin_signed_in? %>
+    <div class="govuk-width-container">
+      <nav class="app-navigation govuk-clearfix">
+        <ul class="app-navigation__list govuk-width-container">
+          <% if service_operator_signed_in? %>
+          <li class="app-navigation__list-item">
+            <%= link_to "View claims", admin_claims_path, class: "govuk-link govuk-link--no-visited-state app-navigation__link" %>
+          </li>
+          <% end %>
+          <li class="app-navigation__list-item">
+            <%= link_to "Sign out", admin_sign_out_path, method: :delete, class: "govuk-link govuk-link--no-visited-state app-navigation__link" %>
+          </li>
+        </ul>
+      </nav>
+    </div>
+    <% end %>
+
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
+        <% flash.each do |name, msg| %>
+          <div class="govuk-body-l govuk-flash__<%= name %>">
+            <%= msg %>
+          </div>
+        <% end %>
+        <%= yield %>
+      </main>
+    </div>
+
+    <footer class="govuk-footer " role="contentinfo">
+      <div class="govuk-width-container ">
+        <div class="govuk-footer__meta">
+          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+            <h2 class="govuk-visually-hidden">Support links</h2>
+            <ul class="govuk-footer__inline-list">
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to "Contact us", contact_us_path, class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to "Cookie", cookies_path, class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to "Terms and conditions", terms_conditions_path, class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to "Privacy notice", privacy_notice_path, class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to "Accessibility statement", accessibility_statement_path, class: "govuk-footer__link" %>
+              </li>
+            </ul>
+
+            <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+              />
+            </svg>
+            <span class="govuk-footer__licence-description">
+              All content is available under the
+              <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+            </span>
+          </div>
+          <div class="govuk-footer__meta-item">
+            <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <%= javascript_include_tag 'application' %>
+  </body>
+
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    get "/", to: "page#index"
+    get "/", to: "page#index", as: :root
 
     get "/auth/sign-in" => "auth#sign_in", :as => :sign_in
     delete "/auth/sign-out" => "auth#sign_out", :as => :sign_out

--- a/spec/features/admin_access_spec.rb
+++ b/spec/features/admin_access_spec.rb
@@ -4,14 +4,14 @@ RSpec.feature "Admin access" do
   scenario "User is shown a forbidden error when not from an allowed IP" do
     allow_any_instance_of(Rack::Request).to receive(:ip).and_return("1.1.1.1")
 
-    visit admin_path
+    visit admin_root_path
 
     expect(page.status_code).to eq(403)
     expect(page).to have_content("Forbidden")
   end
 
   scenario "User is shown the admin page when from an allowed IP" do
-    visit admin_path
+    visit admin_root_path
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content("Sign in with DfE Sign In")

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Admin approves a claim" do
   context "User is logged in as a service operator" do
     before do
       stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user_id)
-      visit admin_path
+      visit admin_root_path
       click_on "Sign in"
     end
 
@@ -54,7 +54,7 @@ RSpec.feature "Admin approves a claim" do
   context "User is logged in as a support user" do
     before do
       stub_dfe_sign_in_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
-      visit admin_path
+      visit admin_root_path
       click_on "Sign in"
     end
 

--- a/spec/features/admin_claim_reject_spec.rb
+++ b/spec/features/admin_claim_reject_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Rejecting a claim" do
   context "when a user is logged in as a service operator" do
     before do
       stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user_id)
-      visit admin_path
+      visit admin_root_path
       click_on "Sign in"
     end
 

--- a/spec/features/admin_csv_download_spec.rb
+++ b/spec/features/admin_csv_download_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Download CSV of claims" do
   context "User is logged in as a service operator" do
     before do
       stub_dfe_sign_in_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
-      visit admin_path
+      visit admin_root_path
       click_on "Sign in"
     end
 
@@ -26,7 +26,7 @@ RSpec.feature "Download CSV of claims" do
   context "User is logged in as a support user" do
     before do
       stub_dfe_sign_in_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
-      visit admin_path
+      visit admin_root_path
       click_on "Sign in"
     end
 

--- a/spec/features/admin_sessions_spec.rb
+++ b/spec/features/admin_sessions_spec.rb
@@ -6,14 +6,14 @@ RSpec.feature "Admin sessions" do
   end
 
   scenario "Redirected to admin page after signing in" do
-    visit admin_path
+    visit admin_root_path
     click_on "Sign in"
 
     expect(page).to have_content("Admin")
   end
 
   scenario "Signing out" do
-    visit admin_path
+    visit admin_root_path
     click_on "Sign in"
 
     click_on "Sign out"

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Admin", type: :request do
   describe "admin#index request" do
     context "when the user is not authenticated" do
       it "redirects to the sign in page and doesn’t set a session" do
-        get admin_path
+        get admin_root_path
 
         expect(response).to redirect_to(admin_sign_in_path)
         expect(session[:user_id]).to be_nil
@@ -25,7 +25,7 @@ RSpec.describe "Admin", type: :request do
         end
 
         it "renders the admin page and sets a session" do
-          get admin_path
+          get admin_root_path
 
           expect(response).to be_successful
           expect(response.body).to include("Admin")
@@ -53,7 +53,7 @@ RSpec.describe "Admin", type: :request do
         end
 
         it "renders the admin page and sets a session" do
-          get admin_path
+          get admin_root_path
 
           expect(response).to be_successful
           expect(response.body).to include("Admin")


### PR DESCRIPTION
This set the foundation for navigation within the /admin side of the
service. Admin views will now use a bespoke admin layout which keeps
the familiar look and feel of the user facing side with some tweaks

- admin side now has its own layout
- beta banner is removed as its not really relevant header
- parent service name has been used as the admin side will support more
  than student student
- Existing links have been refactored to use the new navigation bar
- claims page has a back link


![image](https://user-images.githubusercontent.com/13239597/66490929-dc6cc800-eaa9-11e9-9381-7c79808e4a1e.png)

![image](https://user-images.githubusercontent.com/13239597/66491026-02926800-eaaa-11e9-991a-b07bdacfd570.png)

