### PR TITLE
Allow service to be put into maintenance mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Allow service to be put into maintenance mode
+
 ## [Release 017] - 2019-10-10
 
 - Remove the legacy payroll CSV download feature

--- a/README.md
+++ b/README.md
@@ -199,5 +199,14 @@ file in `azure/resource_groups/app/parameters/{environment_name}.template.json`
 
 Then commit the changes, open a pull request, and get it merged in.
 
+Alternatively you can run the following script to immediately put the
+application into maintenance mode:
+
+```bash
+bin/set-maintenance-mode ENVIRONMENT "OPTIONAL_AVAILABILITY_MESSAGE"
+```
+
+Bear in mind here, any subsequent deploys will unset the environment variables.
+
 To restore the service, unset the environment variables, and get the changes
 deployed. The service will become operational again on the next deploy.

--- a/README.md
+++ b/README.md
@@ -180,9 +180,24 @@ possible to put ther service into maintenance mode.
 To do this, we set the environment variable `MAINTENANCE_MODE` to a value of
 `1`. If you know when the service will be operational again, you can also set a
 `MAINTENANCE_MODE_AVAILABILITY_MESSAGE` environment variable with a
-human-readable value of when to expect the service to be operational again, for
-example `the service will be available from 2pm today` or
+human-readable value of when to expect the service to be operational again as a
+full sentence, for example `The service will be available from 2pm today.` or
 `Private beta has ended. You will be able to use the service again in November`.
 
-To restore the service, unset the environment variables, and the service will
-become operational again.
+To do this, it's best to update the variables in the relevant Azure parameter
+file in `azure/resource_groups/app/parameters/{environment_name}.template.json`
+, and change the empty strings to real variables, i.e.:
+
+```json
+    "MAINTENANCE_MODE": {
+      "value": "1"
+    },
+    "MAINTENANCE_MODE_AVAILABILITY_MESSAGE": {
+      "value": "The service will be available from 2pm today."
+    },
+```
+
+Then commit the changes, open a pull request, and get it merged in.
+
+To restore the service, unset the environment variables, and get the changes
+deployed. The service will become operational again on the next deploy.

--- a/README.md
+++ b/README.md
@@ -174,8 +174,15 @@ The service architecture is currently defined [on confluence].
 ## Putting the application into maintenance mode
 
 If we need to take the service offline for any reason (for example, we're
-investigating and issue, or we want to deploy a journey-breaking change), it's
-possible to put ther service into maintenance mode. To do this, we set the
-environment variable `MAINTENANCE_MODE` to a value of `1`. To restore the
-service, unset the environment variable, and the service will become operational
-again.
+investigating an issue, or we want to deploy a journey-breaking change), it's
+possible to put ther service into maintenance mode.
+
+To do this, we set the environment variable `MAINTENANCE_MODE` to a value of
+`1`. If you know when the service will be operational again, you can also set a
+`MAINTENANCE_MODE_AVAILABILITY_MESSAGE` environment variable with a
+human-readable value of when to expect the service to be operational again, for
+example `the service will be available from 2pm today` or
+`Private beta has ended. You will be able to use the service again in November`.
+
+To restore the service, unset the environment variables, and the service will
+become operational again.

--- a/README.md
+++ b/README.md
@@ -170,3 +170,12 @@ The service architecture is currently defined [on confluence].
 [on confluence]:
   https://dfedigital.atlassian.net/wiki/spaces/TP/pages/1049559041/Service+Architecture
 [openjdk]: https://adoptopenjdk.net/
+
+## Putting the application into maintenance mode
+
+If we need to take the service offline for any reason (for example, we're
+investigating and issue, or we want to deploy a journey-breaking change), it's
+possible to put ther service into maintenance mode. To do this, we set the
+environment variable `MAINTENANCE_MODE` to a value of `1`. To restore the
+service, unset the environment variable, and the service will become operational
+again.

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -18,6 +18,7 @@ class StaticPagesController < ApplicationController
   end
 
   def maintenance
+    @availability_message = Rails.configuration.maintenance_mode_availability_message
     render status: :service_unavailable
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -16,4 +16,8 @@ class StaticPagesController < ApplicationController
 
   def terms_conditions
   end
+
+  def maintenance
+    render status: :service_unavailable
+  end
 end

--- a/app/views/static_pages/maintenance.html.erb
+++ b/app/views/static_pages/maintenance.html.erb
@@ -5,7 +5,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      You will be able to use the service later today.
+      <% if @availability_message %>
+        <%= @availability_message %>
+      <% else %>
+        You will be able to use the service later today.
+      <% end %>
     </p>
 
     <p class="govuk-body">

--- a/app/views/static_pages/maintenance.html.erb
+++ b/app/views/static_pages/maintenance.html.erb
@@ -1,0 +1,22 @@
+<%= page_title("Sorry, the service is unavailable") %>
+
+<h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      You will be able to use the service later today.
+    </p>
+
+    <p class="govuk-body">
+      We have not saved your answers. When the service is available, you will have to start again.
+    </p>
+
+    <p class="govuk-body">
+      Contact
+      <a href="mailto:additionalteachingpayment@digital.education.gov.uk" class="govuk-link">
+        additionalteachingpayment@digital.education.gov.uk
+      </a> if you need further information.
+    </p>
+  </div>
+</div>

--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -162,6 +162,12 @@
     "GOOGLE_ANALYTICS_ID": {
       "value": ""
     },
+    "MAINTENANCE_MODE": {
+      "value": ""
+    },
+    "MAINTENANCE_MODE_AVAILABILITY_MESSAGE": {
+      "value": ""
+    },
     "NOTIFY_API_KEY": {
       "reference": {
         "keyVault": {

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -141,6 +141,12 @@
         "secretName": "GoogleAnalyticsId"
       }
     },
+    "MAINTENANCE_MODE": {
+      "value": ""
+    },
+    "MAINTENANCE_MODE_AVAILABILITY_MESSAGE": {
+      "value": ""
+    },
     "NOTIFY_API_KEY": {
       "reference": {
         "keyVault": {

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -135,6 +135,12 @@
     "ADMIN_ALLOWED_IPS": {
       "type": "string"
     },
+    "MAINTENANCE_MODE": {
+      "type": "string"
+    },
+    "MAINTENANCE_MODE_AVAILABILITY_MESSAGE": {
+      "type": "string"
+    },
     "GOOGLE_ANALYTICS_ID": {
       "type": "string"
     },
@@ -413,6 +419,14 @@
               {
                 "name": "DFE_SIGN_IN_API_ENDPOINT",
                 "value": "[parameters('DFE_SIGN_IN_API_ENDPOINT')]"
+              },
+              {
+                "name": "MAINTENANCE_MODE",
+                "value": "[parameters('MAINTENANCE_MODE')]"
+              },
+              {
+                "name": "MAINTENANCE_MODE_AVAILABILITY_MESSAGE",
+                "value": "[parameters('MAINTENANCE_MODE_AVAILABILITY_MESSAGE')]"
               },
               {
                 "name": "ADMIN_ALLOWED_IPS",

--- a/bin/set-maintenance-mode
+++ b/bin/set-maintenance-mode
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+ENVIRONMENT_NAME=$1
+AVAILABILITY_MESSAGE=$2
+
+case $ENVIRONMENT_NAME in
+  "development")
+    SUBSCRIPTION_ID="8655985a-2f87-44d7-a541-0be9a8c2779d"
+    RESOURCE_GROUP="s118d01-app"
+    APP_SERVICE="$RESOURCE_GROUP-as"
+    ;;
+  "production")
+    SUBSCRIPTION_ID="88bd392f-df19-458b-a100-22b4429060ed"
+    RESOURCE_GROUP="s118p01-app"
+    APP_SERVICE="$RESOURCE_GROUP-as"
+    ;;
+  *)
+    echo "Could not find a known environment with the name: $ENVIRONMENT_NAME"
+    exit 1
+    ;;
+esac
+
+if ! az account show > /dev/null; then
+  echo "Logging in..."
+  az login
+fi
+
+echo "Setting default subscription to $SUBSCRIPTION_ID..."
+az account set --subscription "$SUBSCRIPTION_ID"
+
+echo "Setting maintenance environment variables..."
+az webapp config appsettings set -g $RESOURCE_GROUP \
+      -n $APP_SERVICE \
+      --settings \
+      MAINTENANCE_MODE=1 \
+      MAINTENANCE_MODE_AVAILABILITY_MESSAGE="$AVAILABILITY_MESSAGE" \
+      > /dev/null
+
+echo "Restarting the app..."
+az webapp restart -g $RESOURCE_GROUP \
+      -n $APP_SERVICE

--- a/config/initializers/maintenance_mode.rb
+++ b/config/initializers/maintenance_mode.rb
@@ -1,1 +1,2 @@
 Rails.application.config.maintenance_mode = ENV["MAINTENANCE_MODE"].present?
+Rails.application.config.maintenance_mode_availability_message = ENV["MAINTENANCE_MODE_AVAILABILITY_MESSAGE"]

--- a/config/initializers/maintenance_mode.rb
+++ b/config/initializers/maintenance_mode.rb
@@ -1,0 +1,1 @@
+Rails.application.config.maintenance_mode = ENV["MAINTENANCE_MODE"].present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,10 +9,15 @@ Rails.application.routes.draw do
     end
   end
 
-  root "static_pages#start_page"
-
   # setup a simple healthcheck endpoint for monitoring purposes
   get "/healthcheck", to: proc { [200, {}, ["OK"]] }
+
+  if Rails.application.config.maintenance_mode
+    root "static_pages#maintenance"
+    match "*path", to: redirect("/"), via: :all
+  else
+    root "static_pages#start_page"
+  end
 
   # setup static pages
   get "/privacy_notice", to: "static_pages#privacy_notice", as: :privacy_notice

--- a/spec/requests/maintenance_mode_spec.rb
+++ b/spec/requests/maintenance_mode_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Maintenance Mode", type: :request do
+  context "when MAINTENANCE_MODE is set" do
+    before do
+      @original_maintenance_mode_value = Rails.application.config.maintenance_mode
+      Rails.application.config.maintenance_mode = true
+      Rails.application.reload_routes!
+    end
+
+    after do
+      Rails.application.config.maintenance_mode = @original_maintenance_mode_value
+      Rails.application.reload_routes!
+    end
+
+    it "shows the maintenance page" do
+      get "/"
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response).to have_attributes body: /service is unavailable/i
+    end
+
+    it "redirects a GET request to the maintenance page" do
+      expect(get("/contact")).to redirect_to("/")
+    end
+
+    it "redirects a POST request to the maintenance page" do
+      expect(post("/claim")).to redirect_to("/")
+    end
+  end
+end

--- a/spec/requests/maintenance_mode_spec.rb
+++ b/spec/requests/maintenance_mode_spec.rb
@@ -16,7 +16,26 @@ RSpec.describe "Maintenance Mode", type: :request do
     it "shows the maintenance page" do
       get "/"
       expect(response).to have_http_status(:service_unavailable)
-      expect(response).to have_attributes body: /service is unavailable/i
+      expect(response.body).to include("service is unavailable")
+      expect(response.body).to include("You will be able to use the service later today.")
+    end
+
+    context "when the availability message is set" do
+      let(:message) { "You will be able to use the service from 2pm today" }
+
+      before do
+        @original_maintenance_mode_availability_message = Rails.application.config.maintenance_mode_availability_message
+        Rails.application.config.maintenance_mode_availability_message = message
+      end
+
+      after do
+        Rails.application.config.maintenance_mode_availability_message = @original_maintenance_mode_availability_message
+      end
+
+      it "shows the time it will be available from" do
+        get "/"
+        expect(response.body).to include(message)
+      end
     end
 
     it "redirects a GET request to the maintenance page" do

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -14,4 +14,33 @@ describe "Routes", type: :routing do
       expect(get: "student-loans/non-existent-page").not_to be_routable
     end
   end
+
+  describe "service is unavailable" do
+    before do
+      @original_maintenance_mode_value = Rails.application.config.maintenance_mode
+      Rails.application.config.maintenance_mode = maintenance_mode
+      Rails.application.reload_routes!
+    end
+
+    after do
+      Rails.application.config.maintenance_mode = @original_maintenance_mode_value
+      Rails.application.reload_routes!
+    end
+
+    context "when MAINTENANCE_MODE is set" do
+      let(:maintenance_mode) { true }
+
+      it "routes to the maintenance page by default" do
+        expect(get: "/").to route_to("static_pages#maintenance")
+      end
+    end
+
+    context "when MAINTENANCE_MODE is not set" do
+      let(:maintenance_mode) { false }
+
+      it "routes to the correct default page" do
+        expect(get: "/").to route_to("static_pages#start_page")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows the service to be put into maintenance mode by setting an environment variable. Based on [prior art from the Schools Experience team](https://github.com/DFE-Digital/schools-experience/pull/987)