### PR TITLE
Admin navigation tweaks

### DIFF
--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     def sign_out
       session.destroy
-      redirect_to root_path, notice: "You've been signed out"
+      redirect_to admin_root_path, notice: "You've been signed out"
     end
 
     def callback

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -1,3 +1,5 @@
+<%= link_to "Back", admin_claims_path, class: "govuk-back-link" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @claim.payroll_gender_missing? %>

--- a/app/views/admin/page/index.html.erb
+++ b/app/views/admin/page/index.html.erb
@@ -1,18 +1,7 @@
 <div class="govuk-grid-row">
 
   <div class="govuk-grid-column-two-thirds">
-
-    <h1 class="govuk-heading-xl">
-      Admin
-    </h1>
-
-    <% if service_operator_signed_in? %>
-      <ul>
-        <li><%= link_to 'Check claims', admin_claims_path, class: "govuk-link" %></li>
-        <li><%= link_to 'Payroll', admin_payroll_runs_path, class: "govuk-link" %></li>
-      </ul>
-    <% end %>
-
+    &nbsp;
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -72,9 +72,12 @@
       <nav class="app-navigation govuk-clearfix">
         <ul class="app-navigation__list govuk-width-container">
           <% if service_operator_signed_in? %>
-          <li class="app-navigation__list-item">
-            <%= link_to "View claims", admin_claims_path, class: "govuk-link govuk-link--no-visited-state app-navigation__link" %>
-          </li>
+            <li class="app-navigation__list-item">
+              <%= link_to "View claims", admin_claims_path, class: "govuk-link govuk-link--no-visited-state app-navigation__link" %>
+            </li>
+            <li class="app-navigation__list-item">
+              <%= link_to 'Payroll', admin_payroll_runs_path, class: "govuk-link govuk-link--no-visited-state app-navigation__link" %>
+            </li>
           <% end %>
           <li class="app-navigation__list-item">
             <%= link_to "Sign out", admin_sign_out_path, method: :delete, class: "govuk-link govuk-link--no-visited-state app-navigation__link" %>

--- a/spec/features/admin_claim_approve_spec.rb
+++ b/spec/features/admin_claim_approve_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Admin approves a claim" do
         submitted_claims = create_list(:claim, 5, :submitted)
         claim_to_approve = submitted_claims.first
 
-        click_on "Check claims"
+        click_on "View claims"
 
         expect(page).to have_content(claim_to_approve.reference)
         expect(page).to have_content("5 claims awaiting checking")
@@ -40,7 +40,7 @@ RSpec.feature "Admin approves a claim" do
       let!(:claim_missing_payroll_gender) { create(:claim, :submitted, payroll_gender: :dont_know) }
 
       scenario "User is informed that the claim cannot be approved" do
-        click_on "Check claims"
+        click_on "View claims"
         find("a[href='#{admin_claim_path(claim_missing_payroll_gender)}']").click
 
         expect(page).to have_button("Approve", disabled: true)

--- a/spec/features/admin_claim_reject_spec.rb
+++ b/spec/features/admin_claim_reject_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Rejecting a claim" do
       submitted_claims = create_list(:claim, 5, :submitted)
       claim_to_reject = submitted_claims.first
 
-      click_on "Check claims"
+      click_on "View claims"
 
       expect(page).to have_content(claim_to_reject.reference)
       expect(page).to have_content("5 claims awaiting checking")

--- a/spec/features/admin_sessions_spec.rb
+++ b/spec/features/admin_sessions_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Admin sessions" do
   end
 
   scenario "Redirected to admin page after signing in" do
-    expect(page).to have_content("Admin")
+    expect(page).to have_link("Sign out")
   end
 
   scenario "Signing out" do

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Admin", type: :request do
           get admin_root_path
 
           expect(response).to be_successful
-          expect(response.body).to include("Admin")
+          expect(response.body).to include("Sign out")
           expect(session[:user_id]).to eq(user_id)
           expect(session[:organisation_id]).to eq(organisation_id)
           expect(session[:role_codes]).to eq([AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
@@ -52,7 +52,7 @@ RSpec.describe "Admin", type: :request do
           get admin_root_path
 
           expect(response).to be_successful
-          expect(response.body).to include("Admin")
+          expect(response.body).to include("Sign out")
           expect(session[:user_id]).to eq(user_id)
           expect(session[:organisation_id]).to eq(organisation_id)
           expect(session[:role_codes]).to eq([AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE])


### PR DESCRIPTION
Some tidying up in admin:

- add "Payroll" as a top-level navigation link
- remove redundant/duplicate navigation links from the root page
- add a "Back" link on `admin/claims#show`

No need for additional Changelog items as the most of this could fall under existing unreleased Changelog items.

The admin root now looks like this:

![Screenshot 2019-10-10 at 14 08 06](https://user-images.githubusercontent.com/3687/66571562-69c22200-eb67-11e9-8ae0-4e4a24f6de7b.png)
