### PR TITLE
Bump Verify signing and encryption keys to 6

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -203,7 +203,7 @@
         "keyVault": {
           "id": "${keyVaultId}"
         },
-        "secretName": "TeacherPaymentsDevVspSamlSigning2KeyBase64"
+        "secretName": "TeacherPaymentsDevVspSamlSigning6KeyBase64"
       }
     },
     "VSP.SAML_PRIMARY_ENCRYPTION_KEY": {
@@ -215,7 +215,12 @@
       }
     },
     "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
-      "value": ""
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsDevVspSamlEncryption6KeyBase64"
+      }
     },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "value": "true"


### PR DESCRIPTION
This is the first PR to update the intergrtaion (development) certificates for Verify.

We update the signing key and we run two versions of the encryption key until verify have removed the old one. At that point there will be another PR to make the new key into the primary key and remove the old one.

#469 can also be merged once we have confirmed that these new keys are working correctly in the development environment.

## What happend to keys v3-5?
v3 was the key that we were never notified of due to a typo in the email address used.
v4-5 were not used as I was updating the script (#469) to include the email address and needed a way to test the generation of the CSRs.