### PR TITLE
Exclude /admin from maintenance mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Exclude /admin from maintenance mode
 - Allow service to be put into maintenance mode
 
 ## [Release 017] - 2019-10-10

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,9 +12,11 @@ Rails.application.routes.draw do
   # setup a simple healthcheck endpoint for monitoring purposes
   get "/healthcheck", to: proc { [200, {}, ["OK"]] }
 
+  # Catch-all for when the service has been placed in maintenance mode.
+  # Excludes /admin so Service Operators can continue to check claims.
   if Rails.application.config.maintenance_mode
     root "static_pages#maintenance"
-    match "*path", to: redirect("/"), via: :all
+    match "*path", to: redirect("/"), via: :all, constraints: lambda { |req| !%r{^/admin($|/)}.match?(req.path) }
   else
     root "static_pages#start_page"
   end

--- a/spec/requests/maintenance_mode_spec.rb
+++ b/spec/requests/maintenance_mode_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe "Maintenance Mode", type: :request do
       expect(response.body).to include("You will be able to use the service later today.")
     end
 
+    it "still allows access to /admin for service operator access" do
+      get "/admin"
+      expect(response).to redirect_to(admin_sign_in_path)
+
+      get "/admin/auth/sign-in"
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Sign in with DfE Sign In")
+    end
+
     context "when the availability message is set" do
       let(:message) { "You will be able to use the service from 2pm today" }
 


### PR DESCRIPTION
Whilst we want to be able to put the service into maintenance mode and prevent users from making claims during scheduled maintenance, or when the service is taken offline outside of the claim window, we still need service operators to be able to access the back-office for the service so they can continue to check claims and provide support to existing claimants.