### PR TITLE
Service operators can easily identify claims that are close to their deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Service operators can easily identify claims that are close to their deadline
+
 ## [Release 019] - 2019-10-17
 
 - Put the service into "permanent" maintenance mode until public beta

--- a/app/assets/stylesheets/components/tag.scss
+++ b/app/assets/stylesheets/components/tag.scss
@@ -16,3 +16,10 @@
   @extend %tag;
   background-color: govuk-colour("red");
 }
+
+.govuk-summary-list {
+  .tag--warning,
+  .tag--alert {
+    margin-left: 1em;
+  }
+}

--- a/app/assets/stylesheets/components/tag.scss
+++ b/app/assets/stylesheets/components/tag.scss
@@ -1,0 +1,18 @@
+@import "govuk-frontend-rails";
+
+%tag {
+  text-transform: none;
+  letter-spacing: 0;
+  min-width: 4em;
+  text-align: center;
+}
+
+.tag--warning {
+  @extend %tag;
+  background-color: govuk-colour("orange");
+}
+
+.tag--alert {
+  @extend %tag;
+  background-color: govuk-colour("red");
+}

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -2,7 +2,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
   before_action :ensure_service_operator
 
   def index
-    @claims = Claim.includes(eligibility: [:claim_school, :current_school]).awaiting_checking.order(:submitted_at)
+    @claims = Claim.includes(:check, eligibility: [:claim_school, :current_school]).awaiting_checking.order(:submitted_at)
   end
 
   def show

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -35,6 +35,7 @@ module Admin
       [
         [t("admin.started_at"), l(claim.created_at)],
         [t("admin.submitted_at"), l(claim.submitted_at)],
+        [t("admin.check_deadline"), [l(claim.check_deadline_date), check_deadline_warning(claim)].compact.join.html_safe],
       ]
     end
 

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -50,5 +50,19 @@ module Admin
       ].join(" ").html_safe
       sanitize(html, tags: %w[span a], attributes: %w[href class])
     end
+
+    def check_deadline_warning(claim)
+      days_until_check_deadline = days_between(Date.today, claim.check_deadline_date)
+      return if days_until_check_deadline.days > Claim::CHECK_DEADLINE_WARNING_POINT
+
+      check_deadline_warning_class = days_until_check_deadline < 0 ? "tag--alert" : "tag--warning"
+      content_tag(:strong, pluralize(days_until_check_deadline, "day"), class: "govuk-tag #{check_deadline_warning_class}")
+    end
+
+    private
+
+    def days_between(first_date, second_date)
+      (second_date - first_date).to_i
+    end
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -144,6 +144,10 @@ class Claim < ApplicationRecord
     %w[male female].exclude?(payroll_gender)
   end
 
+  def check_deadline_date
+    (submitted_at + CHECK_DEADLINE).to_date
+  end
+
   def address(seperator = ", ")
     Claim::ADDRESS_ATTRIBUTES.map { |attr| send(attr) }.reject(&:blank?).join(seperator)
   end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -39,6 +39,8 @@ class Claim < ApplicationRecord
     building_society_roll_number: true,
     payroll_run_id: false,
   }.freeze
+  CHECK_DEADLINE = 6.weeks
+  CHECK_DEADLINE_WARNING_POINT = 2.weeks
 
   enum student_loan_country: StudentLoans::COUNTRIES
   enum student_loan_start_date: StudentLoans::COURSE_START_DATES
@@ -115,6 +117,8 @@ class Claim < ApplicationRecord
   scope :submitted, -> { where.not(submitted_at: nil) }
   scope :awaiting_checking, -> { submitted.left_outer_joins(:check).where(checks: {claim_id: nil}) }
   scope :approved, -> { joins(:check).where("checks.result" => :approved) }
+  scope :approaching_check_deadline, -> { awaiting_checking.where("submitted_at < ? AND submitted_at > ?", CHECK_DEADLINE.ago + CHECK_DEADLINE_WARNING_POINT, CHECK_DEADLINE.ago) }
+  scope :passed_check_deadline, -> { awaiting_checking.where("submitted_at < ?", CHECK_DEADLINE.ago) }
 
   delegate :award_amount, to: :eligibility
 

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -6,6 +6,7 @@
     </h1>
 
     <% if @claims.any? %>
+      <% claims_with_warning = Claim.approaching_check_deadline.count + Claim.passed_check_deadline.count %>
 
       <h2 class="govuk-heading-m"><%= pluralize(@claims.count, "claim") %> awaiting checking</h2>
       <table class="govuk-table">
@@ -13,7 +14,9 @@
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Reference</th>
             <th scope="col" class="govuk-table__header">Applicant Name</th>
-            <th scope="col" class="govuk-table__header">Check warning</th>
+            <% if claims_with_warning.nonzero? %>
+              <th scope="col" class="govuk-table__header">Check warning</th>
+            <% end %>
             <th scope="col" class="govuk-table__header">Check deadline</th>
             <th scope="col" class="govuk-table__header"></th>
           </tr>
@@ -23,7 +26,9 @@
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header"><%= claim.reference %></th>
               <td class="govuk-table__cell"><%= claim.full_name %></td>
-              <td class="govuk-table__cell"><%= check_deadline_warning(claim) %></td>
+              <% if claims_with_warning.nonzero? %>
+                <td class="govuk-table__cell"><%= check_deadline_warning(claim) %></td>
+              <% end %>
               <td class="govuk-table__cell"><%= l(claim.check_deadline_date) %></td>
               <td class="govuk-table__cell"><%= link_to 'View claim', admin_claim_path(claim), class: "govuk-link" %></td>
             </tr>

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -8,12 +8,13 @@
     <% if @claims.any? %>
 
       <h2 class="govuk-heading-m"><%= pluralize(@claims.count, "claim") %> awaiting checking</h2>
-
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Reference</th>
             <th scope="col" class="govuk-table__header">Applicant Name</th>
+            <th scope="col" class="govuk-table__header">Check warning</th>
+            <th scope="col" class="govuk-table__header">Check deadline</th>
             <th scope="col" class="govuk-table__header"></th>
           </tr>
         </thead>
@@ -22,6 +23,8 @@
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header"><%= claim.reference %></th>
               <td class="govuk-table__cell"><%= claim.full_name %></td>
+              <td class="govuk-table__cell"><%= check_deadline_warning(claim) %></td>
+              <td class="govuk-table__cell"><%= l(claim.check_deadline_date) %></td>
               <td class="govuk-table__cell"><%= link_to 'View claim', admin_claim_path(claim), class: "govuk-link" %></td>
             </tr>
           <% end %>

--- a/app/views/admin/page/index.html.erb
+++ b/app/views/admin/page/index.html.erb
@@ -1,17 +1,24 @@
 <div class="govuk-grid-row">
 
-  <div class="govuk-grid-column-two-thirds">
-    &nbsp;
-  </div>
-
-  <div class="govuk-grid-column-one-third">
-    <h2 class="govuk-heading-m">Total claims received</h2>
-    <p class="govuk-body govuk-!-font-size-36"><%= Claim.submitted.count %></p>
-
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
+  <div class="govuk-grid-column-one-half">
     <h2 class="govuk-heading-m">Claims awaiting checking</h2>
     <p class="govuk-body govuk-!-font-size-36"><%= Claim.awaiting_checking.count %></p>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m">Total claims received</h2>
+    <p class="govuk-body govuk-!-font-size-36"><%= Claim.submitted.count %></p>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
   </div>
 
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-m">Claims approaching deadline</h2>
+    <p class="govuk-body govuk-!-font-size-36"><%= Claim.approaching_check_deadline.count %></p>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-m">Claims passed deadline</h2>
+    <p class="govuk-body govuk-!-font-size-36"><%= Claim.passed_check_deadline.count %></p>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
     email_address: "Email address"
     started_at: "Started at"
     submitted_at: "Submitted at"
+    check_deadline: "Check deadline"
   answers:
     student_loan_start_date:
       one_course:

--- a/spec/features/admin_stats_spec.rb
+++ b/spec/features/admin_stats_spec.rb
@@ -3,17 +3,18 @@ require "rails_helper"
 RSpec.feature "Admin stats" do
   before do
     @submitted_claims = create_list(:claim, 6, :submitted)
-    @approved_claims = create_list(:claim, 4, :approved)
+    @approved_claims = create_list(:claim, 4, :approved, submitted_at: 10.weeks.ago)
     @unfinished_claims = create_list(:claim, 1, :submittable)
+    @claims_approaching_deadline = create_list(:claim, 2, :submitted, submitted_at: 5.weeks.ago)
+    @claims_passed_deadline = create_list(:claim, 1, :submitted, submitted_at: 10.weeks.ago)
     sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
     visit admin_root_path
   end
 
-  scenario "Service operator is shown how many claims have been submitted" do
+  scenario "Service operator is shown total numbers of claims in various states" do
     expect(page).to have_text("Total claims received\n#{Claim.submitted.count}")
-  end
-
-  scenario "Service operator is shown how many claims are waiting to be checked" do
     expect(page).to have_text("Claims awaiting checking\n#{Claim.awaiting_checking.count}")
+    expect(page).to have_text("Claims approaching deadline\n#{@claims_approaching_deadline.count}")
+    expect(page).to have_text("Claims passed deadline\n#{@claims_passed_deadline.count}")
   end
 end

--- a/spec/features/admin_stats_spec.rb
+++ b/spec/features/admin_stats_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.feature "Admin stats" do
+  before do
+    @submitted_claims = create_list(:claim, 6, :submitted)
+    @approved_claims = create_list(:claim, 4, :approved)
+    @unfinished_claims = create_list(:claim, 1, :submittable)
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    visit admin_root_path
+  end
+
+  scenario "Service operator is shown how many claims have been submitted" do
+    expect(page).to have_text("Total claims received\n#{Claim.submitted.count}")
+  end
+
+  scenario "Service operator is shown how many claims are waiting to be checked" do
+    expect(page).to have_text("Claims awaiting checking\n#{Claim.awaiting_checking.count}")
+  end
+end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -114,4 +114,30 @@ describe Admin::ClaimsHelper do
       )
     end
   end
+
+  describe "#check_deadline_warning" do
+    subject { helper.check_deadline_warning(claim) }
+    before { travel_to Time.zone.local(2019, 10, 11, 7, 0, 0) }
+    after { travel_back }
+
+    context "when a claim is approaching it's deadline" do
+      let(:claim) { build(:claim, :submitted, submitted_at: 5.weeks.ago) }
+
+      it { is_expected.to have_content("7 days") }
+      it { is_expected.to have_selector(".tag--warning") }
+    end
+
+    context "when a claim has passed it's deadline" do
+      let(:claim) { build(:claim, :submitted, submitted_at: 10.weeks.ago) }
+
+      it { is_expected.to have_content("-28 days") }
+      it { is_expected.to have_selector(".tag--alert") }
+    end
+
+    context "when a claim is not near it's deadline" do
+      let(:claim) { build(:claim, :submitted, submitted_at: 1.day.ago) }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -94,7 +94,20 @@ describe Admin::ClaimsHelper do
       expect(helper.admin_submission_details(claim)).to eq([
         [I18n.t("admin.started_at"), l(claim.created_at)],
         [I18n.t("admin.submitted_at"), l(claim.submitted_at)],
+        [I18n.t("admin.check_deadline"), l(claim.check_deadline_date)],
       ])
+    end
+
+    context "when the claim is approaching its deadline" do
+      let(:claim) { create(:claim, :submitted, submitted_at: 5.weeks.ago) }
+
+      it "always includes the deadline date" do
+        expect(helper.admin_submission_details(claim)[2].last).to have_content(l(claim.check_deadline_date))
+      end
+
+      it "includes the deadline warning" do
+        expect(helper.admin_submission_details(claim)[2].last).to have_selector(".tag--warning")
+      end
     end
   end
 


### PR DESCRIPTION
We tell users they will hear back on the outcome of their claim "within 6 weeks". To help Service Operators ensure they check claims within the 6 weeks, they should be able to easily see when a claim is nearing the end of this period, and when it has passed it.

## Screenshots

<img width="1785" alt="Screenshot 2019-10-14 at 14 44 29" src="https://user-images.githubusercontent.com/2804149/66756103-364a0500-ee91-11e9-96de-52b476fa9ecc.png">
<img width="1785" alt="Screenshot 2019-10-14 at 14 44 38" src="https://user-images.githubusercontent.com/2804149/66756104-364a0500-ee91-11e9-9f9c-80a8f3dc9ba5.png">
<img width="1785" alt="Screenshot 2019-10-14 at 14 44 48" src="https://user-images.githubusercontent.com/2804149/66756105-364a0500-ee91-11e9-8d47-b9c88ce28fd1.png">
