### PR TITLE
Update brakeman ignore list with payroll filename

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "7b1c061f9ce9081188ad606d9371226ffaa79a96bd6326dbb186287eba3c62ed",
+      "fingerprint": "0abff43dcdd2496e934169e4e4369c174359e4ed129bfed9f52a2bfec684cc86",
       "check_name": "SendFile",
       "message": "Model attribute used in file name",
       "file": "app/controllers/admin/payroll_runs_controller.rb",
       "line": 25,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(Payroll::ClaimsCsv.new(PayrollRun.find(params[:id]).claims).file, :type => \"text/csv\", :filename => (\"payroll_data_#{PayrollRun.find(params[:id]).id}.csv\"))",
+      "code": "send_file(Payroll::ClaimsCsv.new(PayrollRun.find(params[:id]).claims).file, :type => \"text/csv\", :filename => (\"payroll_data_#{PayrollRun.find(params[:id]).created_at.to_date.iso8601}.csv\"))",
       "render_path": null,
       "location": {
         "type": "method",
@@ -18,9 +18,9 @@
       },
       "user_input": "Payroll::ClaimsCsv.new(PayrollRun.find(params[:id]).claims).file",
       "confidence": "Medium",
-      "note": "This is a false positive. The params[:id] is never directly inserted into a filename for reading from the server; it is only used to look up a PayrollRun record."
+      "note": ""
     }
   ],
-  "updated": "2019-10-08 15:39:25 +0100",
+  "updated": "2019-10-15 11:45:43 +0100",
   "brakeman_version": "4.6.1"
 }


### PR DESCRIPTION
We ignore this brakeman warning, which a previous commit changed when
the date was added to the filename.

This adds the new fingerprint to the ignore file so we are not
warned about it.

<!-- Do you need to update CHANGELOG.md? -->
