### PR TITLE
Use db:migrate:with_data to run schema and data migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Run schema and data migrations at the same time
 - Exclude /admin from maintenance mode
 - Allow service to be put into maintenance mode
 

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -11,10 +11,8 @@ else
     echo "No tables exist - setting up the database"
     rails db:setup
   else
-    echo "Running the schema migrations"
-    rails db:migrate
-    echo "Running the data migrations"
-    rails data:migrate
+    echo "Running the schema and data migrations"
+    rails db:migrate:with_data
   fi
 fi
 


### PR DESCRIPTION
We've been noticing some ConcurrentMigration errors in our logs since our first deploy that included some proper data migrations. We think this may be because we're running data and schema migrations separately and they're taking a while to complete.