### PR TITLE
Change the payroll start and end dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Payroll export start date is the second Monday of the month and the end date
+  is the following Sunday
+
 ## [Release 018] - 2019-10-16
 
 - Run schema and data migrations at the same time

--- a/app/models/payroll/claim_csv_row.rb
+++ b/app/models/payroll/claim_csv_row.rb
@@ -41,15 +41,17 @@ module Payroll
     end
 
     def start_date
-      start_of_month.strftime(DATE_FORMAT)
+      second_monday_of_month.strftime(DATE_FORMAT)
     end
 
     def end_date
-      (start_of_month + 7.days).strftime(DATE_FORMAT)
+      second_monday_of_month.end_of_week.strftime(DATE_FORMAT)
     end
 
-    def start_of_month
-      Date.today.at_beginning_of_month
+    def second_monday_of_month
+      day = Date.today.at_beginning_of_month
+      day += 1.days until day.monday?
+      day.next_week
     end
 
     def date_of_birth

--- a/spec/models/payroll/claim_csv_row_spec.rb
+++ b/spec/models/payroll/claim_csv_row_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Payroll::ClaimCsvRow do
 
   describe "to_s" do
     let(:row) { CSV.parse(subject.to_s).first }
-    let(:start_of_month) { Date.today.at_beginning_of_month }
 
     let(:claim) do
       build(:claim, :submittable,
@@ -23,38 +22,72 @@ RSpec.describe Payroll::ClaimCsvRow do
     end
 
     it "generates a csv row" do
-      expect(row).to eq([
-        "Captain",
-        claim.first_name,
-        claim.middle_name,
-        claim.surname,
-        claim.national_insurance_number,
-        "F",
-        start_of_month.strftime("%Y%m%d"),
-        (start_of_month + 7.days).strftime("%Y%m%d"),
-        claim.date_of_birth.strftime("%Y%m%d"),
-        claim.email_address,
-        claim.address_line_1,
-        claim.postcode,
-        nil,
-        nil,
-        nil,
-        nil,
-        "United Kingdom",
-        "BR",
-        "0",
-        "3",
-        "A",
-        "T",
-        "2",
-        claim.banking_name,
-        claim.bank_sort_code,
-        claim.bank_account_number,
-        claim.building_society_roll_number,
-        "Student Loans",
-        claim.eligibility.student_loan_repayment_amount.to_s,
-        claim.reference,
-      ])
+      travel_to Date.new(2019, 9, 26) do
+        expect(row).to eq([
+          "Captain",
+          claim.first_name,
+          claim.middle_name,
+          claim.surname,
+          claim.national_insurance_number,
+          "F",
+          "20190909",
+          "20190915",
+          claim.date_of_birth.strftime("%Y%m%d"),
+          claim.email_address,
+          claim.address_line_1,
+          claim.postcode,
+          nil,
+          nil,
+          nil,
+          nil,
+          "United Kingdom",
+          "BR",
+          "0",
+          "3",
+          "A",
+          "T",
+          "2",
+          claim.banking_name,
+          claim.bank_sort_code,
+          claim.bank_account_number,
+          claim.building_society_roll_number,
+          "Student Loans",
+          claim.eligibility.student_loan_repayment_amount.to_s,
+          claim.reference,
+        ])
+      end
+    end
+
+    describe "start and end dates" do
+      context "when the first of the month is a Friday" do
+        it "returns the date of the second Monday and Sunday" do
+          travel_to Date.parse "20 February 2019" do
+            row = CSV.parse(subject.to_s).first
+            expect(row[6]).to eq "20190211"
+            expect(row[7]).to eq "20190217"
+          end
+        end
+      end
+
+      context "when the first of the month is a Sunday" do
+        it "returns the date of the second Monday and Sunday" do
+          travel_to Date.parse "9 July 2040" do
+            row = CSV.parse(subject.to_s).first
+            expect(row[6]).to eq "20400709"
+            expect(row[7]).to eq "20400715"
+          end
+        end
+      end
+
+      context "when the first of the month is a Monday" do
+        it "returns the date of the second Monday and Sunday" do
+          travel_to Date.parse "1 June 2020" do
+            row = CSV.parse(subject.to_s).first
+            expect(row[6]).to eq "20200608"
+            expect(row[7]).to eq "20200614"
+          end
+        end
+      end
     end
 
     it "escapes fields with strings that could be dangerous in Microsoft Excel and friends" do


### PR DESCRIPTION
The start and end dates in the payroll export is the fictional period a
claimant was employed in order for DfE to pay them.

We did not want the start date to be before the 6th of a given month as
the tax year runs from the 6 April until the 5 May the following year.

By setting the start date to the second Monday in the month and the end
date to the following Sunday, we avoid this issue.

I debated with myself about the spec for this for ages and ended up deciding 
I wanted a context to show what is being tested is the day of the 1st of the 
current month as that has the most impact on the code working correctly 
and wasn't really shown without consulting a calendar – appreciate thoughts 
on that.

