### PR TITLE
Remove old VSP encryption key

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -211,16 +211,11 @@
         "keyVault": {
           "id": "${keyVaultId}"
         },
-        "secretName": "TeacherPaymentsDevVspSamlEncryption2KeyBase64"
+        "secretName": "TeacherPaymentsDevVspSamlEncryption6KeyBase64"
       }
     },
     "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
-      "reference": {
-        "keyVault": {
-          "id": "${keyVaultId}"
-        },
-        "secretName": "TeacherPaymentsDevVspSamlEncryption6KeyBase64"
-      }
+      "value": ""
     },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "value": "true"


### PR DESCRIPTION
We have let Verify know that we are running both old and new encryption keys and they have confirmed so the this step is to remove the reference to the old one and set the new one as the primary.

  
