### PR TITLE
Revert "Remove old VSP encryption key"

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -211,11 +211,16 @@
         "keyVault": {
           "id": "${keyVaultId}"
         },
-        "secretName": "TeacherPaymentsDevVspSamlEncryption6KeyBase64"
+        "secretName": "TeacherPaymentsDevVspSamlEncryption2KeyBase64"
       }
     },
     "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
-      "value": ""
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "TeacherPaymentsDevVspSamlEncryption6KeyBase64"
+      }
     },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "value": "true"


### PR DESCRIPTION
We're not sure the new encryption key is in place yet, we will try to revert the change that removed the old one in hopes that it's still in place while we investigate the issue with the new one.

Reverts DFE-Digital/dfe-teachers-payment-service#524