### PR TITLE
Remove VSP encryption cert v2

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -211,16 +211,11 @@
         "keyVault": {
           "id": "${keyVaultId}"
         },
-        "secretName": "TeacherPaymentsDevVspSamlEncryption2KeyBase64"
+        "secretName": "TeacherPaymentsDevVspSamlEncryption6KeyBase64"
       }
     },
     "VSP.SAML_SECONDARY_ENCRYPTION_KEY": {
-      "reference": {
-        "keyVault": {
-          "id": "${keyVaultId}"
-        },
-        "secretName": "TeacherPaymentsDevVspSamlEncryption6KeyBase64"
-      }
+      "value": ""
     },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "value": "true"


### PR DESCRIPTION
We've had confirmation from the Verify team that the old encryption key has been removed so we can safely remove it from the configuration now.

This completes the VSP key rotation.

Once this PR is merge we _must_ confrim the development enviroment is able to comple the Verify step.