### PR TITLE
Set application time zone to London

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,8 @@ module DfeTeachersPaymentService
 
     # Set a css_compressor so sassc-rails does not overwrite the compressor
     config.assets.css_compressor = nil
+
+    # Set the application time zone to UK. Times are still stored as UTC in the database
+    config.time_zone = "London"
   end
 end


### PR DESCRIPTION
I noticed when testing adding notes to claim checking that we're displaying times using the Rails default time zone (UTC).

By setting the time zone to "London" all times will be shown in local time but still stored in UTC.
