### PR TITLE
Small fix for admin navigation padding

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -38,32 +38,19 @@ $thick-border: 5px;
     }
 
     & > li {
-      box-sizing: border-box;
-      padding: $navigation-padding 0;
       float: left;
-      -moz-box-sizing: border-box;
-      -webkit-box-sizing: border-box;
-      border-bottom: 4px solid transparent;
 
       &:last-of-type {
         float: right;
       }
 
-      &:hover {
-        border-bottom: 4px solid $govuk-link-hover-colour;
-      }
-
-      &.active {
-        border-bottom: 4px solid govuk-colour("blue") !important;
-
-        a:hover {
-          color: $govuk-link-colour;
-        }
-      }
-
       a {
         display: block;
-        padding: 0 1em;
+        padding: $navigation-padding 1em;
+        box-sizing: border-box;
+        -moz-box-sizing: border-box;
+        -webkit-box-sizing: border-box;
+        border-bottom: 4px solid transparent;
         color: $govuk-link-colour;
         text-decoration: none;
         @include govuk-media-query($until: tablet) {
@@ -77,11 +64,19 @@ $thick-border: 5px;
         &:hover {
           color: $govuk-link-hover-colour;
           text-decoration: underline;
+          border-bottom: 4px solid $govuk-link-hover-colour;
         }
         &:focus {
           color: $govuk-link-hover-colour;
           -webkit-box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
           box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+        }
+        &.active {
+          border-bottom: 4px solid govuk-colour("blue") !important;
+
+          a:hover {
+            color: $govuk-link-colour;
+          }
         }
       }
     }


### PR DESCRIPTION
The padding and hover styles were on `li` element causing incorrect user feedback when a user hovered over the `li`.

Combining both these styles on to the anchor tag makes the hover style appear in the correct way.

## Before
![74417a2f9b185c7a698a1e9bf1d47189](https://user-images.githubusercontent.com/2804149/67302065-3cbb2b00-f4e8-11e9-9262-69714286d516.gif)

## After
![d2ebfee278cbedbb370f8d2f804c4691](https://user-images.githubusercontent.com/2804149/67302071-3f1d8500-f4e8-11e9-81ab-ab36dfeb174a.gif)

