### PR TITLE
Allow users to search for a claim by reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Allow service operators to search for a claim
 - No longer ask for specific year for QTS award year
 
 ## [Release 021] - 2019-10-22

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -9,4 +9,16 @@ class Admin::ClaimsController < Admin::BaseAdminController
     @claim = Claim.find(params[:id])
     @check = @claim.check || Check.new
   end
+
+  def search
+    return unless params[:reference].present?
+
+    claim = Claim.find_by(reference: params[:reference])
+
+    if claim
+      redirect_to(admin_claim_url(claim))
+    else
+      flash.now[:notice] = "Cannot find a claim with reference \"#{params[:reference]}\""
+    end
+  end
 end

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -1,0 +1,20 @@
+<%= link_to "Back", admin_root_path, class: "govuk-back-link" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      Search for a claim
+    </h1>
+
+    <%= form_with url: search_admin_claims_path, method: :get, local: true do |form| %>
+      <div class="govuk-form-group">
+        <%= form.label :reference, "Enter a reference", class: "govuk-label" %>
+        <%= form.text_field :reference, class: "govuk-input" %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.submit "Search", class: "govuk-button" %>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -75,6 +75,9 @@
             <li class="app-navigation__list-item">
               <%= link_to "View claims", admin_claims_path, class: "govuk-link govuk-link--no-visited-state app-navigation__link" %>
             </li>
+            <li>
+              <%= link_to "Search for a claim", search_admin_claims_path, class: "govuk-link govuk-link--no-visited-state app-navigation__link" %>
+            </li>
             <li class="app-navigation__list-item">
               <%= link_to 'Payroll', admin_payroll_runs_path, class: "govuk-link govuk-link--no-visited-state app-navigation__link" %>
             </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
 
     resources :claims, only: [:index, :show] do
       resources :checks, only: [:create], controller: "claim_checks"
+      get "search", on: :collection
     end
 
     resources :payroll_runs, only: [:index, :new, :create, :show]

--- a/spec/features/admin_search_spec.rb
+++ b/spec/features/admin_search_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.feature "Admin search" do
+  before do
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+  end
+
+  it "redirects to the claim" do
+    claim = create(:claim, :submitted)
+
+    visit search_admin_claims_path
+
+    fill_in :reference, with: claim.reference
+    click_on "Search"
+
+    expect(page).to have_content(claim.reference)
+  end
+end

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -26,4 +26,22 @@ RSpec.describe "Admin claims", type: :request do
       expect(response.body).to include(claim.reference)
     end
   end
+
+  describe "claims#search" do
+    let(:claim) { create(:claim, :submitted) }
+
+    it "redirects to a claim when one exists" do
+      get search_admin_claims_path(reference: claim.reference)
+
+      expect(response).to redirect_to(admin_claim_path(claim))
+    end
+
+    it "shows an error if a claim can't be found" do
+      reference = "12345678"
+      get search_admin_claims_path(reference: reference)
+
+      expected_flash = CGI.escapeHTML("Cannot find a claim with reference \"#{reference}\"")
+      expect(response.body).to include(expected_flash)
+    end
+  end
 end


### PR DESCRIPTION
This allows a service operator to search for a claim by its reference. If a claim is found, it redirects to the relevant claim, otherwise the user gets an error. UI is very basic, so may need some @titlescreen ❤️ 

![image](https://user-images.githubusercontent.com/109774/67367732-00321280-f56e-11e9-8591-986b3097ccf4.png)

![image](https://user-images.githubusercontent.com/109774/67367774-150ea600-f56e-11e9-83d0-1e789626afaf.png)
