### PR TITLE
Prepare PageSequence for Maths & Physics

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -85,6 +85,10 @@ class ClaimsController < ApplicationController
   end
 
   def page_sequence
-    @page_sequence ||= PageSequence.new(current_claim, params[:slug])
+    @page_sequence ||= PageSequence.new(current_claim, claim_slug_sequence, params[:slug])
+  end
+
+  def claim_slug_sequence
+    current_claim.eligibility.class.parent::SlugSequence.new(current_claim)
   end
 end

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -1,22 +1,17 @@
 # frozen_string_literal: true
 
-# Represents the pages in the claim process.
-#
-# Depending on the state of `claim`,  the sequence of slugs will change,
-# filtering out pages that are not relevant. For example, the sequence for a
-# claim that states it is still employed at the same school as the
-# `claim_school` will skip the `current-school` page as `current_school` is
-# inferred to be the same as `claim_school.
+# Used to model the sequence of pages that make up the claim process.
 class PageSequence
   attr_reader :claim, :current_slug
 
-  def initialize(claim, current_slug)
+  def initialize(claim, slug_sequence, current_slug)
     @claim = claim
     @current_slug = current_slug
+    @slug_sequence = slug_sequence
   end
 
   def slugs
-    StudentLoans::SlugSequence.new(claim).slugs
+    @slug_sequence.slugs
   end
 
   def next_slug

--- a/app/models/page_sequence.rb
+++ b/app/models/page_sequence.rb
@@ -8,33 +8,6 @@
 # `claim_school` will skip the `current-school` page as `current_school` is
 # inferred to be the same as `claim_school.
 class PageSequence
-  SLUGS = [
-    "qts-year",
-    "claim-school",
-    "still-teaching",
-    "current-school",
-    "subjects-taught",
-    "leadership-position",
-    "mostly-performed-leadership-duties",
-    "eligibility-confirmed",
-    "information-provided",
-    "verified",
-    "address",
-    "gender",
-    "teacher-reference-number",
-    "national-insurance-number",
-    "student-loan",
-    "student-loan-country",
-    "student-loan-how-many-courses",
-    "student-loan-start-date",
-    "student-loan-amount",
-    "email-address",
-    "bank-details",
-    "check-your-answers",
-    "confirmation",
-    "ineligible",
-  ].freeze
-
   attr_reader :claim, :current_slug
 
   def initialize(claim, current_slug)
@@ -43,15 +16,7 @@ class PageSequence
   end
 
   def slugs
-    SLUGS.dup.tap do |sequence|
-      sequence.delete("current-school") if claim.eligibility.employed_at_claim_school?
-      sequence.delete("mostly-performed-leadership-duties") unless claim.eligibility.had_leadership_position?
-      sequence.delete("student-loan-country") if claim.no_student_loan?
-      sequence.delete("student-loan-how-many-courses") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
-      sequence.delete("student-loan-start-date") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
-      sequence.delete("address") if claim.address_verified?
-      sequence.delete("gender") if claim.payroll_gender_verified?
-    end
+    StudentLoans::SlugSequence.new(claim).slugs
   end
 
   def next_slug

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -1,0 +1,57 @@
+module StudentLoans
+  # Determines the slugs that make up the claim process for a Student Loans
+  # claim. Based on the existing answers on the claim, the sequence of slugs
+  # will change. For example, if the claimant has said they are not paying off a
+  # student loan, the questions to determine their loan plan will not be part of
+  # the sequence.
+  #
+  # Note that the sequence is recalculated on each call to `slugs` so that it
+  # accounts for any changes that may have been made to the claim and always
+  # reflects the sequence based on the claim's current state.
+  class SlugSequence
+    SLUGS = [
+      "qts-year",
+      "claim-school",
+      "still-teaching",
+      "current-school",
+      "subjects-taught",
+      "leadership-position",
+      "mostly-performed-leadership-duties",
+      "eligibility-confirmed",
+      "information-provided",
+      "verified",
+      "address",
+      "gender",
+      "teacher-reference-number",
+      "national-insurance-number",
+      "student-loan",
+      "student-loan-country",
+      "student-loan-how-many-courses",
+      "student-loan-start-date",
+      "student-loan-amount",
+      "email-address",
+      "bank-details",
+      "check-your-answers",
+      "confirmation",
+      "ineligible",
+    ].freeze
+
+    attr_reader :claim
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def slugs
+      SLUGS.dup.tap do |sequence|
+        sequence.delete("current-school") if claim.eligibility.employed_at_claim_school?
+        sequence.delete("mostly-performed-leadership-duties") unless claim.eligibility.had_leadership_position?
+        sequence.delete("student-loan-country") if claim.no_student_loan?
+        sequence.delete("student-loan-how-many-courses") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
+        sequence.delete("student-loan-start-date") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
+        sequence.delete("address") if claim.address_verified?
+        sequence.delete("gender") if claim.payroll_gender_verified?
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   get "/accessibility_statement", to: "static_pages#accessibility_statement", as: :accessibility_statement
 
   scope path: ":policy", defaults: {policy: "student-loans"}, constraints: {policy: %r{student-loans}} do
-    constraints slug: %r{#{PageSequence::SLUGS.join("|")}} do
+    constraints slug: %r{#{StudentLoans::SlugSequence::SLUGS.join("|")}} do
       resources :claims, only: [:show, :update], param: :slug, path: "/"
     end
 

--- a/spec/models/page_sequence_spec.rb
+++ b/spec/models/page_sequence_spec.rb
@@ -5,62 +5,6 @@ require "rails_helper"
 RSpec.describe PageSequence do
   let(:claim) { build(:claim) }
 
-  describe "#slugs" do
-    it "excludes “current-school” when the claimant still works at the school they are claiming against" do
-      claim.eligibility.employment_status = :claim_school
-      page_sequence = PageSequence.new(claim, "still-teaching")
-
-      expect(page_sequence.slugs).not_to include("current-school")
-    end
-
-    it "excludes student loan-related pages when the claimant no longer has a student loan" do
-      claim.has_student_loan = false
-      page_sequence = PageSequence.new(claim, "still-teaching")
-      expect(page_sequence.slugs).not_to include("student-loan-country")
-      expect(page_sequence.slugs).not_to include("student-loan-how-many-courses")
-      expect(page_sequence.slugs).not_to include("student-loan-start-date")
-
-      claim.has_student_loan = true
-      page_sequence = PageSequence.new(claim, "still-teaching")
-      expect(page_sequence.slugs).to include("student-loan-country")
-      expect(page_sequence.slugs).to include("student-loan-how-many-courses")
-      expect(page_sequence.slugs).to include("student-loan-start-date")
-    end
-
-    it "excludes the remaining student loan-related pages when the claimant received their student loan in Scotland or Northern Ireland" do
-      claim.has_student_loan = true
-
-      StudentLoans::PLAN_1_COUNTRIES.each do |plan_1_country|
-        claim.student_loan_country = plan_1_country
-        page_sequence = PageSequence.new(claim, "student-loan-country")
-        expect(page_sequence.slugs).not_to include("student-loan-how-many-courses")
-        expect(page_sequence.slugs).not_to include("student-loan-start-date")
-      end
-
-      %w[england wales].each do |variable_plan_country|
-        claim.student_loan_country = variable_plan_country
-        page_sequence = PageSequence.new(claim, "student-loan-country")
-        expect(page_sequence.slugs).to include("student-loan-how-many-courses")
-        expect(page_sequence.slugs).to include("student-loan-start-date")
-      end
-    end
-
-    it "excludes the gender page if a response has been returned from Verify" do
-      claim.verified_fields = ["payroll_gender"]
-      page_sequence = PageSequence.new(claim, "student-loan-country")
-      expect(page_sequence.slugs).to_not include("gender")
-
-      claim.verified_fields = []
-      expect(page_sequence.slugs).to include("gender")
-    end
-
-    it "excludes the address page if the address was returned by verify" do
-      claim.verified_fields = ["postcode"]
-      page_sequence = PageSequence.new(claim, "student-loan-country")
-      expect(page_sequence.slugs).to_not include("address")
-    end
-  end
-
   describe "#next_slug" do
     it "assumes we're at the beginning of the sequence if no current_slug is specified" do
       expect(PageSequence.new(claim, nil).next_slug).to eq "claim-school"

--- a/spec/models/student_loans/slug_sequence_spec.rb
+++ b/spec/models/student_loans/slug_sequence_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe StudentLoans::SlugSequence do
+  let(:claim) { build(:claim) }
+
+  subject(:slug_sequence) { StudentLoans::SlugSequence.new(claim) }
+
+  describe "The sequence as defined by #slugs" do
+    it "excludes “current-school” if the claimant still works at the school they are claiming against" do
+      claim.eligibility.employment_status = :claim_school
+
+      expect(slug_sequence.slugs).not_to include("current-school")
+    end
+
+    it "excludes student loan plan slugs if the claimant is not paying off a student loan" do
+      claim.has_student_loan = false
+      expect(slug_sequence.slugs).not_to include("student-loan-country")
+      expect(slug_sequence.slugs).not_to include("student-loan-how-many-courses")
+      expect(slug_sequence.slugs).not_to include("student-loan-start-date")
+
+      claim.has_student_loan = true
+      expect(slug_sequence.slugs).to include("student-loan-country")
+      expect(slug_sequence.slugs).to include("student-loan-how-many-courses")
+      expect(slug_sequence.slugs).to include("student-loan-start-date")
+    end
+
+    it "excludes the remaining student loan plan slugs if the claimant received their student loan in a Plan 1 country" do
+      claim.has_student_loan = true
+
+      StudentLoans::PLAN_1_COUNTRIES.each do |plan_1_country|
+        claim.student_loan_country = plan_1_country
+        expect(slug_sequence.slugs).to include("student-loan-country")
+        expect(slug_sequence.slugs).not_to include("student-loan-how-many-courses")
+        expect(slug_sequence.slugs).not_to include("student-loan-start-date")
+      end
+
+      %w[england wales].each do |variable_plan_country|
+        claim.student_loan_country = variable_plan_country
+        expect(slug_sequence.slugs).to include("student-loan-country")
+        expect(slug_sequence.slugs).to include("student-loan-how-many-courses")
+        expect(slug_sequence.slugs).to include("student-loan-start-date")
+      end
+    end
+
+    it "excludes the “gender” slug if the claim's payroll_gender were acquired supplied by GOV.UK Verify" do
+      claim.verified_fields = []
+      expect(slug_sequence.slugs).to include("gender")
+
+      claim.verified_fields = ["payroll_gender"]
+      expect(slug_sequence.slugs).to_not include("gender")
+    end
+
+    it "excludes the “address” slug if any address fields were acquired from GOV.UK Verify" do
+      claim.verified_fields = []
+      expect(slug_sequence.slugs).to include("address")
+
+      claim.verified_fields = ["postcode"]
+      expect(slug_sequence.slugs).to_not include("address")
+    end
+  end
+end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Claims", type: :request do
       start_claim
 
       get new_claim_path
-      expect(response).to redirect_to(claim_path(PageSequence::SLUGS.first))
+      expect(response).to redirect_to(claim_path(StudentLoans::SlugSequence::SLUGS.first))
     end
   end
 


### PR DESCRIPTION
This work makes `PageSequence` policy-agnostic by allowing the policy-specific slug sequence to be passed in, paving the way for the introduction of the Maths & Physics policy.