### PR TITLE
Service operators see when details in a claim have been used before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- A clear warning is shown to service operators when a claim contains details
+  that have been used in other claims. The other claims are listed and linked
+
 ## [Release 022] - 2019-10-24
 
 - The Payment Confirmation Report for a payroll run can be uploaded and

--- a/app/assets/stylesheets/components/flash.scss
+++ b/app/assets/stylesheets/components/flash.scss
@@ -18,4 +18,12 @@
     color: govuk-colour("red");
     border-color: govuk-colour("red");
   }
+  &__warning {
+    @extend %govuk-flash;
+    color: govuk-colour("orange");
+    border-color: govuk-colour("orange");
+    a {
+      color: govuk-colour("orange");
+    }
+  }
 }

--- a/app/controllers/admin/claim_checks_controller.rb
+++ b/app/controllers/admin/claim_checks_controller.rb
@@ -18,6 +18,7 @@ class Admin::ClaimChecksController < Admin::BaseAdminController
 
   def load_claim
     @claim = Claim.find(params[:claim_id])
+    @claim_ids_with_matching_attributes = Claim::MatchingAttributeFinder.new(@claim).claim_ids_with_matching_attributes
   end
 
   def reject_checked_claims

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -8,6 +8,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
   def show
     @claim = Claim.find(params[:id])
     @check = @claim.check || Check.new
+    @claim_ids_with_matching_attributes = Claim::MatchingAttributeFinder.new(@claim).claim_ids_with_matching_attributes
   end
 
   def search

--- a/app/models/claim/matching_attribute_finder.rb
+++ b/app/models/claim/matching_attribute_finder.rb
@@ -1,0 +1,40 @@
+class Claim
+  class MatchingAttributeFinder
+    ATTRIBUTES_TO_MATCH = [
+      "teacher_reference_number",
+      "email_address",
+      "national_insurance_number",
+      "bank_account_number",
+      "bank_sort_code",
+      "building_society_roll_number",
+    ].freeze
+
+    def initialize(claim, relation = Claim.all)
+      @claim = claim
+      @relation = relation
+    end
+
+    def claim_ids_with_matching_attributes
+      duplicates.map { |claim_with_matching_attributes|
+        [claim_with_matching_attributes.id, matching_attributes(claim_with_matching_attributes)]
+      }.to_h
+    end
+
+    private
+
+    def duplicates
+      @relation.where(teacher_reference_number: @claim.teacher_reference_number)
+        .or(@relation.where(national_insurance_number: @claim.national_insurance_number))
+        .or(@relation.where(email_address: @claim.email_address))
+        .or(@relation.where(bank_account_number: @claim.bank_account_number))
+        .or(@relation.where(bank_sort_code: @claim.bank_sort_code))
+        .or(@relation.where(building_society_roll_number: @claim.building_society_roll_number))
+        .where.not(id: @claim.id)
+    end
+
+    def matching_attributes(claim)
+      matching_attributes = @claim.attributes.slice(*ATTRIBUTES_TO_MATCH).to_a & claim.attributes.slice(*ATTRIBUTES_TO_MATCH).to_a
+      matching_attributes.to_h.keys.map(&:humanize)
+    end
+  end
+end

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -10,6 +10,12 @@
       </div>
     <% end %>
 
+    <% if @claim_ids_with_matching_attributes.present? %>
+      <div class="govuk-body-l govuk-flash__warning">
+        <a href="#claims-with-matches">Details in this claim match those in other claims</a>
+      </div>
+    <% end %>
+
     <h1 class="govuk-heading-xl">
       Claim <%= @claim.reference %>
     </h1>
@@ -30,6 +36,32 @@
           This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
         </strong>
       </div>
+    <% end %>
+
+    <% if @claim_ids_with_matching_attributes.present? %>
+      <table id="claims-with-matches" class="govuk-table govuk-!-margin-bottom-9">
+        <caption class="govuk-table__caption govuk-heading-l">Claims with matching details</caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Claim</th>
+            <th scope="col" class="govuk-table__header">Matching details</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @claim_ids_with_matching_attributes.each do |claim_id, matching_attributes| %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header"><%= link_to Claim.find(claim_id).reference, admin_claim_path(Claim.find(claim_id)), class: "govuk-link" %>
+              <td class="govuk-table__cell">
+                <ul class="govuk-list">
+                <% matching_attributes.each do |attribute| %>
+                  <li><%= attribute %></li>
+                <% end %>
+                </ul>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
     <% end %>
 
     <% if @check.persisted? %>
@@ -62,7 +94,6 @@
           </span>
           <%= form.text_area :notes, class: "govuk-textarea", rows: 5 %>
           <%= form.submit "Submit", class: "govuk-button" %>
-
         <% end %>
       <% end %>
     <% end %>

--- a/spec/features/admin_matching_attributes_spec.rb
+++ b/spec/features/admin_matching_attributes_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.feature "Admin checking duplicates" do
+  let(:user_id) { "userid-345" }
+
+  before do
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user_id)
+  end
+
+  scenario "they are shown the possible duplicates" do
+    claim_to_approve = create(
+      :claim,
+      :submitted,
+      teacher_reference_number: "2136521",
+    )
+
+    claim_with_matching_teacher_reference_number = create(:claim, :submitted, teacher_reference_number: claim_to_approve.teacher_reference_number)
+
+    click_on "View claims"
+
+    find("a[href='#{admin_claim_path(claim_to_approve)}']").click
+
+    expect(page).to have_content("Details in this claim match those in other claims")
+    expect(page).to have_content("Claims with matching details")
+
+    expect(page).to have_content("#{claim_with_matching_teacher_reference_number.reference}\nTeacher reference number")
+  end
+end

--- a/spec/models/claim/matching_attribute_finder_spec.rb
+++ b/spec/models/claim/matching_attribute_finder_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe Claim::MatchingAttributeFinder do
+  describe "#claim_ids_with_matching_attributes" do
+    let(:teacher_reference_number) { "0902344" }
+    let(:national_insurance_number) { "QQ891011C" }
+    let(:email_address) { "genghis.khan@mongol-empire.com" }
+    let(:bank_account_number) { "34682151" }
+    let(:bank_sort_code) { "972654" }
+    let(:building_society_roll_number) { "123456789/ABCD" }
+
+    let(:source_claim) {
+      create(
+        :claim,
+        teacher_reference_number: teacher_reference_number,
+        national_insurance_number: national_insurance_number,
+        email_address: email_address,
+        bank_account_number: bank_account_number,
+        bank_sort_code: bank_sort_code,
+        building_society_roll_number: building_society_roll_number,
+      )
+    }
+
+    let!(:another_claim) { create(:claim, :submitted) }
+
+    let(:claim_with_matching_attributes) { build(:claim, :submitted) }
+
+    let(:claims_with_matching_attributes) { Claim::MatchingAttributeFinder.new(source_claim).claim_ids_with_matching_attributes }
+
+    it "does not include the id of the source claim" do
+      expect(claims_with_matching_attributes).not_to include(source_claim.id)
+    end
+
+    it "does not include the id of a claim without any matcheing attributes" do
+      expect(claims_with_matching_attributes).not_to include(another_claim.id)
+    end
+
+    it "includes the id of a claim with a mathching teacher reference number" do
+      claim_with_matching_attributes.teacher_reference_number = teacher_reference_number
+      claim_with_matching_attributes.save
+
+      expect(claims_with_matching_attributes).to include(claim_with_matching_attributes.id)
+      expect(claims_with_matching_attributes[claim_with_matching_attributes.id]).to include("Teacher reference number")
+    end
+
+    it "includes the id of a claim with a mathching national insurance number" do
+      claim_with_matching_attributes.national_insurance_number = national_insurance_number
+      claim_with_matching_attributes.save
+
+      expect(claims_with_matching_attributes).to include(claim_with_matching_attributes.id)
+      expect(claims_with_matching_attributes[claim_with_matching_attributes.id]).to include("National insurance number")
+    end
+
+    it "includes the id of a claim with a mathching email address" do
+      claim_with_matching_attributes.email_address = email_address
+      claim_with_matching_attributes.save
+
+      expect(claims_with_matching_attributes).to include(claim_with_matching_attributes.id)
+      expect(claims_with_matching_attributes[claim_with_matching_attributes.id]).to include("Email address")
+    end
+
+    it "includes the id of a claim with a mathching bank account number" do
+      claim_with_matching_attributes.bank_account_number = bank_account_number
+      claim_with_matching_attributes.save
+
+      expect(claims_with_matching_attributes).to include(claim_with_matching_attributes.id)
+      expect(claims_with_matching_attributes[claim_with_matching_attributes.id]).to include("Bank account number")
+    end
+
+    it "includes the id of a claim with a mathching bank sort code" do
+      claim_with_matching_attributes.bank_sort_code = bank_sort_code
+      claim_with_matching_attributes.save
+
+      expect(claims_with_matching_attributes).to include(claim_with_matching_attributes.id)
+      expect(claims_with_matching_attributes[claim_with_matching_attributes.id]).to include("Bank sort code")
+    end
+
+    it "includes the id of a claim with a mathching building society roll number" do
+      claim_with_matching_attributes.building_society_roll_number = building_society_roll_number
+      claim_with_matching_attributes.save
+
+      expect(claims_with_matching_attributes).to include(claim_with_matching_attributes.id)
+      expect(claims_with_matching_attributes[claim_with_matching_attributes.id]).to include("Building society roll number")
+    end
+  end
+end

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -20,10 +20,23 @@ RSpec.describe "Admin claims", type: :request do
   describe "claims#show" do
     let(:claim) { create(:claim, :submitted) }
 
-    it "returns a claim when one exists" do
-      get admin_claim_path(claim)
+    context "when a claim has no matching attributes" do
+      it "returns a claim when one exists" do
+        get admin_claim_path(claim)
 
-      expect(response.body).to include(claim.reference)
+        expect(response.body).to include(claim.reference)
+      end
+    end
+
+    context "when a claim has matching attributes" do
+      let!(:duplicate_claim) { create(:claim, :submitted) }
+
+      it "returns the claim and the duplicate" do
+        get admin_claim_path(claim)
+
+        expect(response.body).to include(claim.reference)
+        expect(response.body).to include(duplicate_claim.reference)
+      end
     end
   end
 


### PR DESCRIPTION
This is the first step for the work to prevent people being paid more than once. 

We think that checking for matching details in claims and what to do about it falls to the the service operators, therefore we want to get claims with matching attributes in-front of them as soon as we can.

This first step simply checks all other claims for matching details and flags the claims up to the service operator.

It lets them see the other claims and links to them for comparison. We want to do more work around the UI for comparing claims later, with help from the service operators.

As the service does not distiguish between tax years, nor do the checks.

## Screenshot
![Screenshot_2019-10-28 Claim additional payments for teaching – GOV UK](https://user-images.githubusercontent.com/480578/67678991-f77f7900-f97f-11e9-9e17-02351ebc032a.png)

<!-- Do you need to update CHANGELOG.md? -->

