### PR TITLE
Claim is ineligible if current school is ineligible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Inform the user that their claim is ineligible, if the school that they are
+  currently employed at is not eligible
 - Claimants recieve payment notifications once a payroll run has been processed
 
 ## [Release 022] - 2019-10-24

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -114,6 +114,10 @@ class School < ApplicationRecord
     StudentLoans::SchoolEligibility.new(self).eligible_claim_school?
   end
 
+  def eligible_for_student_loans_as_current_school?
+    StudentLoans::SchoolEligibility.new(self).eligible_current_school?
+  end
+
   def eligible_for_maths_and_physics?
     MathsAndPhysics::SchoolEligibility.new(self).check
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -110,8 +110,8 @@ class School < ApplicationRecord
     [street, locality, town, county, postcode].reject(&:blank?).join(", ")
   end
 
-  def eligible_for_student_loans?
-    StudentLoans::SchoolEligibility.new(self).check
+  def eligible_for_student_loans_as_claim_school?
+    StudentLoans::SchoolEligibility.new(self).eligible_claim_school?
   end
 
   def eligible_for_maths_and_physics?

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -66,7 +66,6 @@ module StudentLoans
       ineligible_qts_award_year? ||
         ineligible_claim_school? ||
         employed_at_no_school? ||
-        current_school_closed? ||
         ineligible_current_school? ||
         not_taught_eligible_subjects? ||
         not_taught_enough?
@@ -77,7 +76,6 @@ module StudentLoans
         :ineligible_qts_award_year,
         :ineligible_claim_school,
         :employed_at_no_school,
-        :current_school_closed,
         :ineligible_current_school,
         :not_taught_eligible_subjects,
         :not_taught_enough,
@@ -115,10 +113,6 @@ module StudentLoans
 
     def one_subject_must_be_selected
       errors.add(:subjects_taught, "Choose a subject, or select No") if subjects_taught.empty?
-    end
-
-    def current_school_closed?
-      current_school.present? && !current_school.open?
     end
 
     def ineligible_current_school?

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -67,6 +67,7 @@ module StudentLoans
         ineligible_claim_school? ||
         employed_at_no_school? ||
         current_school_closed? ||
+        ineligible_current_school? ||
         not_taught_eligible_subjects? ||
         not_taught_enough?
     end
@@ -77,6 +78,7 @@ module StudentLoans
         :ineligible_claim_school,
         :employed_at_no_school,
         :current_school_closed,
+        :ineligible_current_school,
         :not_taught_eligible_subjects,
         :not_taught_enough,
       ].find { |eligibility_check| send("#{eligibility_check}?") }
@@ -117,6 +119,10 @@ module StudentLoans
 
     def current_school_closed?
       current_school.present? && !current_school.open?
+    end
+
+    def ineligible_current_school?
+      current_school.present? && !current_school.eligible_for_student_loans_as_current_school?
     end
 
     def inferred_current_school

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -100,7 +100,7 @@ module StudentLoans
     end
 
     def ineligible_claim_school?
-      claim_school.present? && !claim_school.eligible_for_student_loans?
+      claim_school.present? && !claim_school.eligible_for_student_loans_as_claim_school?
     end
 
     def not_taught_eligible_subjects?

--- a/app/models/student_loans/school_eligibility.rb
+++ b/app/models/student_loans/school_eligibility.rb
@@ -42,7 +42,8 @@ module StudentLoans
     end
 
     def eligible_current_school?
-      @school.state_funded? &&
+      @school.open? &&
+        @school.state_funded? &&
         (eligible_phase? || eligible_special_school?)
     end
 

--- a/app/models/student_loans/school_eligibility.rb
+++ b/app/models/student_loans/school_eligibility.rb
@@ -41,6 +41,11 @@ module StudentLoans
         (eligible_phase? || eligible_special_school?)
     end
 
+    def eligible_current_school?
+      @school.state_funded? &&
+        (eligible_phase? || eligible_special_school?)
+    end
+
     private
 
     def eligible_local_authority?

--- a/app/models/student_loans/school_eligibility.rb
+++ b/app/models/student_loans/school_eligibility.rb
@@ -34,7 +34,7 @@ module StudentLoans
       @school = school
     end
 
-    def check
+    def eligible_claim_school?
       !closed_before_policy_start? &&
         eligible_local_authority? &&
         @school.state_funded? &&

--- a/app/views/claims/_ineligibility_reason_current_school_closed.html.erb
+++ b/app/views/claims/_ineligibility_reason_current_school_closed.html.erb
@@ -1,4 +1,0 @@
-<p class="govuk-body">
-  <%= claim_school_name %> is closed. You can only get this payment if you’re
-  still employed at a school.
-</p>

--- a/app/views/claims/_ineligibility_reason_ineligible_current_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_current_school.html.erb
@@ -1,0 +1,5 @@
+<p class="govuk-body">
+  You must be employed at a state-funded secondary school to be eligible for
+  this payment. <%= current_school_name %>, where you are currently employed,
+  is not a state-funded secondary school.
+</p>

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -6,7 +6,7 @@
       You’re not eligible for this payment
     </h1>
 
-    <%= render partial: "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}", locals: { claim_school_name: current_claim.eligibility.claim_school_name } %>
+    <%= render partial: "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}", locals: { claim_school_name: current_claim.eligibility.claim_school_name, current_school_name: current_claim.eligibility.current_school_name } %>
 
     <p class="govuk-body">
       You can find more information on the <%= link_to "guidance for this service", tslr_guidance_url, class: 'govuk-link' %>.

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -31,13 +31,29 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
   end
 
-  scenario "chooses an ineligible school" do
+  scenario "chooses an ineligible claim school" do
     claim = start_claim
     choose_school schools(:hampstead_school)
 
     expect(claim.eligibility.reload.claim_school).to eq schools(:hampstead_school)
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("Hampstead School, where you were employed between 6 April 2018 and 5 April 2019, is not an eligible school.")
+  end
+
+  scenario "chooses an ineligible current school" do
+    start_claim
+
+    choose_school schools(:penistone_grammar_school)
+    choose_still_teaching "Yes, at another school"
+
+    fill_in :school_search, with: "Bradford"
+    click_on "Search"
+
+    choose "Bradford Grammar School"
+    click_on "Continue"
+
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("Bradford Grammar School, where you are currently employed, is not a state-funded secondary school.")
   end
 
   scenario "no longer teaching" do

--- a/spec/fixtures/schools.yml
+++ b/spec/fixtures/schools.yml
@@ -30,7 +30,7 @@ the_samuel_lister_academy:
   county: West Yorkshire
   postcode: BD16 1TZ
 
-# Student loans and Maths and Physics Ineligible
+# Student loans ineligible as claim school, Maths and Physics Ineligible
 
 hampstead_school:
   name: Hampstead School
@@ -44,3 +44,17 @@ hampstead_school:
   locality: Hampstead
   town: London
   postcode: NW2 3RT
+
+# Student loans ineligible as current school
+
+bradford_grammar_school:
+  name: Bradford Grammar School
+  urn: 107455
+  phase: not_applicable
+  school_type_group: independent_schools
+  school_type: other_independent_school
+  local_authority: bradford
+  local_authority_district: bradford
+  street: Keighley Road
+  town: Bradford
+  postcode: BD9 4JP

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -102,6 +102,11 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       expect(StudentLoans::Eligibility.new(claim_school: schools(:penistone_grammar_school)).ineligible?).to eql false
     end
 
+    it "returns true when the current_school is not eligible" do
+      expect(StudentLoans::Eligibility.new(current_school: schools(:bradford_grammar_school)).ineligible?).to eql true
+      expect(StudentLoans::Eligibility.new(current_school: schools(:penistone_grammar_school)).ineligible?).to eql false
+    end
+
     it "returns true when no longer teaching" do
       expect(StudentLoans::Eligibility.new(employment_status: :no_school).ineligible?).to eql true
       expect(StudentLoans::Eligibility.new(employment_status: :claim_school).ineligible?).to eql false

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       expect(StudentLoans::Eligibility.new(qts_award_year: "before_september_2013").ineligibility_reason).to eq :ineligible_qts_award_year
       expect(StudentLoans::Eligibility.new(claim_school: schools(:hampstead_school)).ineligibility_reason).to eq :ineligible_claim_school
       expect(StudentLoans::Eligibility.new(employment_status: :no_school).ineligibility_reason).to eq :employed_at_no_school
-      expect(StudentLoans::Eligibility.new(current_school: schools(:the_samuel_lister_academy)).ineligibility_reason).to eq :current_school_closed
+      expect(StudentLoans::Eligibility.new(current_school: schools(:the_samuel_lister_academy)).ineligibility_reason).to eq :ineligible_current_school
       expect(StudentLoans::Eligibility.new(taught_eligible_subjects: false).ineligibility_reason).to eq :not_taught_eligible_subjects
       expect(StudentLoans::Eligibility.new(mostly_performed_leadership_duties: true).ineligibility_reason).to eq :not_taught_enough
     end

--- a/spec/models/student_loans/school_eligibility_spec.rb
+++ b/spec/models/student_loans/school_eligibility_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe StudentLoans::SchoolEligibility do
-  describe "#check" do
-    subject { StudentLoans::SchoolEligibility.new(school).check }
+  describe "#eligible_claim_school?" do
+    subject { StudentLoans::SchoolEligibility.new(school).eligible_claim_school? }
     let(:school) { build(:school, school_attributes.merge({local_authority: local_authority})) }
 
     context "when it is in an eligible area" do

--- a/spec/models/student_loans/school_eligibility_spec.rb
+++ b/spec/models/student_loans/school_eligibility_spec.rb
@@ -208,5 +208,10 @@ RSpec.describe StudentLoans::SchoolEligibility do
       let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :community_special_school} }
       it { is_expected.to be(true) }
     end
+
+    context "with a closed school that would otherwise be eligible" do
+      let(:school_attributes) { {phase: :secondary, school_type_group: :la_maintained, close_date: Date.yesterday} }
+      it { is_expected.to be(false) }
+    end
   end
 end

--- a/spec/models/student_loans/school_eligibility_spec.rb
+++ b/spec/models/student_loans/school_eligibility_spec.rb
@@ -150,4 +150,63 @@ RSpec.describe StudentLoans::SchoolEligibility do
       it { is_expected.to be true }
     end
   end
+
+  describe "#eligible_current_school?" do
+    subject { StudentLoans::SchoolEligibility.new(school).eligible_current_school? }
+    let(:school) { build(:school, school_attributes) }
+
+    # e.g. Hampstead School, URN 4567
+    context "with a local authority maintained secondary school" do
+      let(:school_attributes) { {phase: :secondary, school_type_group: :la_maintained} }
+      it { is_expected.to be(true) }
+    end
+
+    # e.g. Hursthead Infant School, URN 106052
+    context "with a local authority maintained primary school" do
+      let(:school_attributes) { {phase: :primary, school_type_group: :la_maintained} }
+      it { is_expected.to be(false) }
+    end
+
+    # e.g. The Samuel Lister Academy, URN 137576
+    context "with a secondary academy" do
+      let(:school_attributes) { {phase: :secondary, school_type_group: :academies} }
+      it { is_expected.to be(true) }
+    end
+
+    # e.g. Willow Bank Primary School, URN 136932
+    context "with a primary academy" do
+      let(:school_attributes) { {phase: :primary, school_type_group: :academies} }
+      it { is_expected.to be(false) }
+    end
+
+    # e.g. West London Free School, URN 136750
+    context "with a secondary free school" do
+      let(:school_attributes) { {phase: :secondary, school_type_group: :free_schools} }
+      it { is_expected.to be(true) }
+    end
+
+    # e.g. Stockport College, URN 130512
+    context "with a sixteen-plus college" do
+      let(:school_attributes) { {phase: :sixteen_plus, school_type_group: :colleges} }
+      it { is_expected.to be(false) }
+    end
+
+    # e.g. Bradford Grammar School, URN 107455
+    context "with an independent school with not_applicable phase" do
+      let(:school_attributes) { {phase: :not_applicable, school_type_group: :independent_schools} }
+      it { is_expected.to be(false) }
+    end
+
+    # e.g. Coney Hill School, URN 101696
+    context "with a non-maintained special school with not_applicable phase" do
+      let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :non_maintained_special_school} }
+      it { is_expected.to be(true) }
+    end
+
+    # e.g. Frank Barnes School for Deaf Children, URN 100091
+    context "with a community special school with not_applicable phase" do
+      let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :community_special_school} }
+      it { is_expected.to be(true) }
+    end
+  end
 end


### PR DESCRIPTION
Inform the user that their claim is ineligible, if the school that they are currently employed at is not eligible.

This is the message informing the user that their claim is ineligible:

![Screenshot_2019-10-28 You’re not eligible for this payment - Teachers claim back your student loan repayments - GOV UK(1)](https://user-images.githubusercontent.com/53756884/67698879-13484680-f9a3-11e9-81f7-d10ff85ff669.png)
