### PR TITLE
Load GOVUK Frontend from npm package

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,10 +21,6 @@ gem "jbuilder", "~> 2.9"
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-# Use Gov UK Kit
-gem "dxw_govuk_frontend_rails"
-gem "sprockets", "~> 3"
-
 # Generate human-readable reference numbers
 gem "nanoid"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,6 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
-    dxw_govuk_frontend_rails (3.3.0)
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (5.1.1)
@@ -326,7 +325,6 @@ DEPENDENCIES
   delayed_cron_job
   delayed_job_active_record
   dotenv-rails
-  dxw_govuk_frontend_rails
   factory_bot_rails
   foreman
   jbuilder (~> 2.9)
@@ -348,7 +346,6 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
-  sprockets (~> 3)
   standard
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,10 +11,10 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require govuk_frontend_rails
 //= require a11y-dialog/a11y-dialog.min.js
 //= require accessible-autocomplete/dist/accessible-autocomplete.min.js
 //= require cookie_functions.js
+//= require govuk-frontend/govuk/all.js
 //= require_tree .
 //= stub js_check.js
 //= stub google_analytics.js

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,8 @@
-@import "govuk-frontend-rails";
+// Use the Rails helpers to load images and fonts
+$govuk-font-url-function: "image-url";
+$govuk-image-url-function: "font-url";
+
+@import "govuk-frontend/govuk/all";
 @import "accessible-autocomplete/src/autocomplete";
 
 @import "**/*";

--- a/app/assets/stylesheets/components/a11y_dialog.scss
+++ b/app/assets/stylesheets/components/a11y_dialog.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend-rails";
+@import "govuk-frontend/govuk/all";
 
 [data-a11y-dialog-native] > :first-child {
   display: none;

--- a/app/assets/stylesheets/components/accessible_autocomplete_tweaks.scss
+++ b/app/assets/stylesheets/components/accessible_autocomplete_tweaks.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend-rails";
+@import "govuk-frontend/govuk/all";
 
 .autocomplete__wrapper {
   .autocomplete__menu {

--- a/app/assets/stylesheets/components/cookie_banner.scss
+++ b/app/assets/stylesheets/components/cookie_banner.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend-rails";
+@import "govuk-frontend/govuk/all";
 
 $govuk-cookie-banner-background: govuk-colour("white");
 $govuk-cookie-banner-text-green: #00823b;

--- a/app/assets/stylesheets/components/currency_input.scss
+++ b/app/assets/stylesheets/components/currency_input.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend-rails";
+@import "govuk-frontend/govuk/all";
 
 .govuk-currency-input {
   position: relative;

--- a/app/assets/stylesheets/components/flash.scss
+++ b/app/assets/stylesheets/components/flash.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend-rails";
+@import "govuk-frontend/govuk/all";
 
 %govuk-flash {
   padding: $govuk-gutter-half;

--- a/app/assets/stylesheets/components/tag.scss
+++ b/app/assets/stylesheets/components/tag.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend-rails";
+@import "govuk-frontend/govuk/all";
 
 %tag {
   text-transform: none;

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,6 +5,14 @@ Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
+
+# Because these paths are searched in order, we want the assets to come first
+# Add the GOVUK Frontend images path
+Rails.application.config.assets.paths << Rails.root.join("node_modules", "govuk-frontend", "govuk", "assets", "images")
+
+# Add the GOVUK Frontend fonts path
+Rails.application.config.assets.paths << Rails.root.join("node_modules", "govuk-frontend", "govuk", "assets", "fonts")
+
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
@@ -13,6 +21,20 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w[js_check.js google_analytics.js google_analytics/analytics.js accessible-autocomplete/src/autocomplete.css]
+
+# Add GOVUK assets by name, these are assets not loaded via sass
+Rails.application.config.assets.precompile += [
+  "favicon.ico",
+  "govuk-apple-touch-icon-152x152.png",
+  "govuk-apple-touch-icon-167x167.png",
+  "govuk-apple-touch-icon-180x180.png",
+  "govuk-apple-touch-icon.png",
+  "govuk-crest-2x.png",
+  "govuk-crest.png",
+  "govuk-logotype-crown.png",
+  "govuk-mask-icon.svg",
+  "govuk-opengraph-image.png",
+]
 
 # Include the url_helpers in the asset pipeline
 # We use url helpers in the some of .js.erb, calling them statically doesn't

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "dependencies": {
     "a11y-dialog": "^5.2.0",
-    "accessible-autocomplete": "^2.0.1"
+    "accessible-autocomplete": "^2.0.1",
+    "govuk-frontend": "^3.0.0"
   },
   "devDependencies": {
     "prettier": "^1.18.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,11 @@ accessible-autocomplete@^2.0.1:
   dependencies:
     preact "^8.3.1"
 
+govuk-frontend@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.3.0.tgz#90c55209b7baf5df2e400ee3aa111e1bc160f9b4"
+  integrity sha512-ncOGTAV6mzz1CPBlr/UGETiG3IO6P3b0CvSI0wxBz7Uo0A/6jttLoxkvuYXju2oNA2yqRh2NjD1zJUOP3Q32CQ==
+
 preact@^8.3.1:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"


### PR DESCRIPTION
Loading the GOVUK Frontend styles, js and assets from a gem worked great until
it didn't when an update to sprockets broke it.

Althought the gem is fixed, as the GOVUK Frontend is distrubuted as a npm
package it makes more sense to load it from there and keep the dependency
tighter.

This commit removes the gem and makes the changes to load the assets from the
npm package in node_modules.

I propose this as a replacement to #549 which I've closed.

<!-- Do you need to update CHANGELOG.md? -->
