### PR TITLE
Service operators can see when details in a claim have been used before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- A clear warning is shown to service operators when a claim contains details
+  that have been used in other claims. The other claims are listed and linked
+
 ## [Release 025] - 2019-10-31
 
 - Adjusted ineligibility screens for users who may have taught at more than one

--- a/app/assets/stylesheets/components/flash.scss
+++ b/app/assets/stylesheets/components/flash.scss
@@ -18,4 +18,12 @@
     color: govuk-colour("red");
     border-color: govuk-colour("red");
   }
+  &__warning {
+    @extend %govuk-flash;
+    color: govuk-colour("orange");
+    border-color: govuk-colour("orange");
+    a {
+      color: govuk-colour("orange");
+    }
+  }
 }

--- a/app/controllers/admin/claim_checks_controller.rb
+++ b/app/controllers/admin/claim_checks_controller.rb
@@ -18,6 +18,7 @@ class Admin::ClaimChecksController < Admin::BaseAdminController
 
   def load_claim
     @claim = Claim.find(params[:claim_id])
+    @matching_claims = Claim::MatchingAttributeFinder.new(@claim).matching_claims
   end
 
   def reject_checked_claims

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -8,6 +8,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
   def show
     @claim = Claim.find(params[:id])
     @check = @claim.check || Check.new
+    @matching_claims = Claim::MatchingAttributeFinder.new(@claim).matching_claims
   end
 
   def search

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -68,6 +68,14 @@ module Admin
       content_tag(:strong, pluralize(days_until_check_deadline, "day"), class: "govuk-tag #{check_deadline_warning_class}")
     end
 
+    def matching_attributes(first_claim, second_claim)
+      first_attributes = first_claim.attributes.slice(*Claim::MatchingAttributeFinder::ATTRIBUTES_TO_MATCH).to_a
+      second_attributes = second_claim.attributes.slice(*Claim::MatchingAttributeFinder::ATTRIBUTES_TO_MATCH).to_a
+
+      matching_attributes = first_attributes & second_attributes
+      matching_attributes.to_h.compact.keys.map(&:humanize).sort
+    end
+
     private
 
     def days_between(first_date, second_date)

--- a/app/models/claim/matching_attribute_finder.rb
+++ b/app/models/claim/matching_attribute_finder.rb
@@ -1,0 +1,31 @@
+class Claim
+  class MatchingAttributeFinder
+    ATTRIBUTES_TO_MATCH = %w[
+      teacher_reference_number
+      email_address
+      national_insurance_number
+      bank_account_number
+      bank_sort_code
+      building_society_roll_number
+    ].freeze
+
+    def initialize(source_claim, claims_to_compare = Claim.submitted)
+      @source_claim = source_claim
+      @claims_to_compare = claims_to_compare
+    end
+
+    def matching_claims
+      predicates = []
+      values = []
+      ATTRIBUTES_TO_MATCH.each do |attribute|
+        value = @source_claim.read_attribute(attribute)
+        next unless value
+
+        predicates << "#{attribute} = ?"
+        values << value
+      end
+
+      @claims_to_compare.where.not(id: @source_claim.id).where(predicates.join(" OR "), *values)
+    end
+  end
+end

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -10,6 +10,12 @@
       </div>
     <% end %>
 
+    <% if @matching_claims.any? %>
+      <div class="govuk-body-l govuk-flash__warning">
+        <a href="#claims-with-matches">Details in this claim match those in other claims</a>
+      </div>
+    <% end %>
+
     <h1 class="govuk-heading-xl">
       Claim <%= @claim.reference %>
     </h1>
@@ -30,6 +36,32 @@
           This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
         </strong>
       </div>
+    <% end %>
+
+    <% if @matching_claims.any? %>
+      <table id="claims-with-matches" class="govuk-table govuk-!-margin-bottom-9">
+        <caption class="govuk-table__caption govuk-heading-l">Claims with matching details</caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Claim</th>
+            <th scope="col" class="govuk-table__header">Matching details</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @matching_claims.each do |matching_claim| %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header"><%= link_to matching_claim.reference, [:admin, matching_claim], class: "govuk-link" %>
+              <td class="govuk-table__cell">
+                <ul class="govuk-list">
+                <% matching_attributes(@claim, matching_claim).each do |attribute| %>
+                  <li><%= attribute %></li>
+                <% end %>
+                </ul>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
     <% end %>
 
     <% if @check.persisted? %>
@@ -62,7 +94,6 @@
           </span>
           <%= form.text_area :notes, class: "govuk-textarea", rows: 5 %>
           <%= form.submit "Submit", class: "govuk-button" %>
-
         <% end %>
       <% end %>
     <% end %>

--- a/spec/features/admin_duplicate_claims_spec.rb
+++ b/spec/features/admin_duplicate_claims_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.feature "Service operator can see potential duplicate claims" do
+  before do
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+  end
+
+  scenario "they are shown other claims with matching details" do
+    claim_to_approve = create(
+      :claim,
+      :submitted,
+      teacher_reference_number: "0902344",
+      national_insurance_number: "QQ891011C",
+      email_address: "genghis.khan@mongol-empire.com",
+      bank_account_number: "34682151",
+      bank_sort_code: "972654",
+      building_society_roll_number: "123456789/ABCD",
+    )
+
+    claim_with_matching_teacher_reference_number = create(:claim, :submitted, teacher_reference_number: claim_to_approve.teacher_reference_number)
+
+    click_on "View claims"
+
+    find("a[href='#{admin_claim_path(claim_to_approve)}']").click
+
+    expect(page).to have_content("Details in this claim match those in other claims")
+    expect(page).to have_content("Claims with matching details")
+
+    expect(page).to have_content("#{claim_with_matching_teacher_reference_number.reference}\nTeacher reference number")
+  end
+end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -173,4 +173,29 @@ describe Admin::ClaimsHelper do
       it { is_expected.to be_nil }
     end
   end
+
+  describe "#matching_attributes" do
+    let(:first_claim) {
+      build(
+        :claim,
+        teacher_reference_number: "0902344",
+        national_insurance_number: "QQ891011C",
+        email_address: "genghis.khan@mongol-empire.com",
+        bank_account_number: "34682151",
+        bank_sort_code: "972654",
+        building_society_roll_number: "123456789/ABCD",
+      )
+    }
+    let(:second_claim) { build(:claim, :submitted, teacher_reference_number: first_claim.teacher_reference_number, national_insurance_number: first_claim.national_insurance_number, building_society_roll_number: first_claim.building_society_roll_number) }
+    subject { helper.matching_attributes(first_claim, second_claim) }
+
+    it "returns the humanised names of the matching attributes" do
+      expect(subject).to eq(["Building society roll number", "National insurance number", "Teacher reference number"])
+    end
+
+    it "does not consider nil building society roll number to be a match" do
+      [first_claim, second_claim].each { |claim| claim.building_society_roll_number = nil }
+      expect(subject).to eq(["National insurance number", "Teacher reference number"])
+    end
+  end
 end

--- a/spec/models/claim/matching_attribute_finder_spec.rb
+++ b/spec/models/claim/matching_attribute_finder_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe Claim::MatchingAttributeFinder do
+  describe "#matching_claims" do
+    let(:source_claim) {
+      create(
+        :claim,
+        teacher_reference_number: "0902344",
+        national_insurance_number: "QQ891011C",
+        email_address: "genghis.khan@mongol-empire.com",
+        bank_account_number: "34682151",
+        bank_sort_code: "972654",
+        building_society_roll_number: "123456789/ABCD",
+      )
+    }
+
+    let!(:claim_with_no_matching_attributes) { create(:claim, :submitted) }
+    let!(:unsubmitted_claim_with_matching_teacher_reference_number) { create(:claim, :submittable, teacher_reference_number: source_claim.teacher_reference_number) }
+
+    subject(:matching_claims) { Claim::MatchingAttributeFinder.new(source_claim).matching_claims }
+
+    it "does not include the source claim, or claims that do not match, or claims that are not submitted" do
+      expect(matching_claims).to be_empty
+    end
+
+    it "includes a claim with a matching teacher reference number" do
+      claim_with_matching_attribute = create(:claim, :submitted, teacher_reference_number: source_claim.teacher_reference_number)
+
+      expect(matching_claims).to eq([claim_with_matching_attribute])
+    end
+
+    it "includes a claim with a matching national insurance number" do
+      claim_with_matching_attribute = create(:claim, :submitted, national_insurance_number: source_claim.national_insurance_number)
+
+      expect(matching_claims).to eq([claim_with_matching_attribute])
+    end
+
+    it "includes a claim with a matching email address" do
+      claim_with_matching_attribute = create(:claim, :submitted, email_address: source_claim.email_address)
+
+      expect(matching_claims).to eq([claim_with_matching_attribute])
+    end
+
+    it "includes a claim with a matching bank account number" do
+      claim_with_matching_attribute = create(:claim, :submitted, bank_account_number: source_claim.bank_account_number)
+
+      expect(matching_claims).to eq([claim_with_matching_attribute])
+    end
+
+    it "includes a claim with a matching bank sort code" do
+      claim_with_matching_attribute = create(:claim, :submitted, bank_sort_code: source_claim.bank_sort_code)
+
+      expect(matching_claims).to eq([claim_with_matching_attribute])
+    end
+
+    it "includes a claim with a matching building society roll number" do
+      claim_with_matching_attribute = create(:claim, :submitted, building_society_roll_number: source_claim.building_society_roll_number)
+
+      expect(matching_claims).to eq([claim_with_matching_attribute])
+    end
+
+    context "when the source claim building society roll number is nil" do
+      before do
+        source_claim.update!(building_society_roll_number: nil)
+      end
+
+      it "does not include any claim with a roll number of nil" do
+        create(:claim, :submitted, building_society_roll_number: nil)
+        expect(matching_claims).to be_empty
+      end
+    end
+  end
+end

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -20,10 +20,21 @@ RSpec.describe "Admin claims", type: :request do
   describe "claims#show" do
     let(:claim) { create(:claim, :submitted) }
 
-    it "returns a claim when one exists" do
+    it "returns the claim" do
       get admin_claim_path(claim)
 
       expect(response.body).to include(claim.reference)
+    end
+
+    context "when another claim has matching attributes" do
+      let!(:claim_with_matching_attributes) { create(:claim, :submitted) }
+
+      it "returns the claim and the duplicate" do
+        get admin_claim_path(claim)
+
+        expect(response.body).to include(claim.reference)
+        expect(response.body).to include(claim_with_matching_attributes.reference)
+      end
     end
   end
 


### PR DESCRIPTION
This is the first step for the work to prevent people being paid more than once. 

We think that checking for matching details in claims and what to do about it falls to the the service operators, therefore we want to get claims with matching attributes in-front of them as soon as we can.

This first step simply checks all other submitted claims for matching details and flags the claims up to the service operator.

It lets them see the other claims and links to them for comparison. We want to do more work around the UI for comparing claims later, with help from the service operators.

We also want to check for matches across combination of details, but this will also come later.

As the service does not distiguish between tax years, nor do the checks.

## Postgres Performance
We know this operation is quite expensive and looked at ways to optimise the query. Because the attributes that get compared (TRN, NINO, email address, etc) are always present in the source claim – they are required fields, the query was always planned to run sequentially and so indexes on columns would not get used.  

## Odd commit order
Rebasing has left the commits in an odd order – sorry!

## Screenshot
![Screenshot_2019-10-28 Claim additional payments for teaching – GOV UK](https://user-images.githubusercontent.com/480578/67678991-f77f7900-f97f-11e9-9e17-02351ebc032a.png)

<!-- Do you need to update CHANGELOG.md? -->

