### PR TITLE
Payment email tweaks

### DIFF
--- a/app/views/claim_mailer/payment_confirmation.text.erb
+++ b/app/views/claim_mailer/payment_confirmation.text.erb
@@ -12,12 +12,20 @@ This payment is treated as part of your salary and is subject to the deductions 
 
 We pay the Income Tax and National Insurance contribution (NIC) on your behalf, so these are not deducted from the amount you receive.
 
+<% if @payment.student_loan_repayment.present? %>
+<% if @payment.student_loan_repayment.zero? %>
+If you have made a student loan contribution, this is deducted from your payment amount and credited to SLC.
+<% else %>
 We do not pay your student loan contribution for you. Your student loan contribution is deducted from your payment amount and credited to SLC.
+<% end %>
+<% end %>
 
 * Total before deductions: <%= number_to_currency(@payment.gross_value) %>
 * Income Tax (paid by us): <%= number_to_currency(@payment.tax) %>
-* Employee National Insurance (paid by us): <%= number_to_currency(@payment.national_insurance) %>
-* Student loan (deducted): <%= number_to_currency(@payment.student_loan_repayment) || "Not applicable" %>
+* Employee NIC (paid by us): <%= number_to_currency(@payment.national_insurance) %>
+<% if @payment.student_loan_repayment.present? %>
+* Student loan<%= @payment.student_loan_repayment.positive? ? " (deducted)" : "" %>: <%= number_to_currency(@payment.student_loan_repayment) %>
+<% end %>
 
 ^ Payment you receive: <%= number_to_currency(@payment.net_pay) %>
 

--- a/app/views/claim_mailer/payment_confirmation.text.erb
+++ b/app/views/claim_mailer/payment_confirmation.text.erb
@@ -36,3 +36,7 @@ The ‘earnings period’ used to set the thresholds for student loan and Nation
 # Contact us
 
 Email studentloanteacherpayment@digital.education.gov.uk giving your reference: <%= @reference %>, if you have any questions.
+
+----
+
+We’d appreciate any feedback you can give us on this email. You can complete our short survey here: https://forms.gle/T7sZ9ponQMw9h8V59

--- a/app/views/claim_mailer/payment_confirmation.text.erb
+++ b/app/views/claim_mailer/payment_confirmation.text.erb
@@ -4,7 +4,7 @@ We’re paying your claim to get back the student loan repayments you made while
 
 This payment does not change the amount that was credited to your Student Loans Company (SLC) account in the last financial year.
 
-You will receive <%=number_to_currency(@payment.net_pay) %> on or after <%= l(@payment_date) %>.
+^ You will receive <%=number_to_currency(@payment.net_pay) %> on or after <%= l(@payment_date) %>.
 
 # Breakdown of payment
 


### PR DESCRIPTION
These are the final payment confirmation email tweaks from Faye, as well as adding a link to a feedback survey (to be removed once we start making public beta payments)