### PR TITLE
Make static content policy aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Make static pages such as "Cookies", and "Contact us" policy aware
+
 ## [Release 023] - 2019-10-29
 
 - Update copy to make it clear we may deduct a student loan repayment from

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,4 +19,9 @@ module ApplicationHelper
 
     number_to_currency(value, delimiter: "", unit: "")
   end
+
+  def support_email_address(policy = nil)
+    translation_key = [policy&.underscore, "support_email_address"].compact.join(".")
+    t(translation_key)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
       [].tap do |a|
         a << "Error" if show_error
         a << title
-        a << t("student_loans.journey_name")
+        a << t("student_loans.policy_name")
         a << "GOV.UK"
       end.join(" - ")
     end
@@ -23,5 +23,9 @@ module ApplicationHelper
   def support_email_address(policy = nil)
     translation_key = [policy&.underscore, "support_email_address"].compact.join(".")
     t(translation_key)
+  end
+
+  def policy_service_name(policy = nil)
+    policy ? t("#{policy.underscore}.policy_name") : t("service_name")
   end
 end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -1,4 +1,6 @@
 class ClaimMailer < Mail::Notify::Mailer
+  helper :application
+
   def submitted(claim)
     view_mail_with_claim_and_subject(claim, "Your claim was received")
   end

--- a/app/views/claim_mailer/approved.text.erb
+++ b/app/views/claim_mailer/approved.text.erb
@@ -6,4 +6,4 @@ We will now calculate your payment.
 
 We will email you confirming the amount when we are ready to make the payment.
 
-Email studentloanteacherpayment@digital.education.gov.uk giving your reference number: <%= @claim.reference %> if you have any questions.
+Email <%= support_email_address("student-loans") %>  giving your reference number: <%= @claim.reference %> if you have any questions.

--- a/app/views/claim_mailer/payment_confirmation.text.erb
+++ b/app/views/claim_mailer/payment_confirmation.text.erb
@@ -35,7 +35,7 @@ The ‘earnings period’ used to set the thresholds for student loan and Nation
 
 # Contact us
 
-Email studentloanteacherpayment@digital.education.gov.uk giving your reference: <%= @reference %>, if you have any questions.
+Email <%= support_email_address("student-loans") %> giving your reference: <%= @reference %>, if you have any questions.
 
 ----
 

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -5,7 +5,7 @@ Unfortunately your claim to get your student loan payments back has been rejecte
 
 # Appeals process and support
 
-If you feel that we have made a mistake in the processing of your application or something is incorrect please email studentloanteacherpayment@digital.education.gov.uk giving your reference number: <%= @claim.reference %> if you have any questions about your claim.
+If you feel that we have made a mistake in the processing of your application or something is incorrect please email <%= support_email_address("student-loans") %>  giving your reference number: <%= @claim.reference %> if you have any questions about your claim.
 
 Regards,
 

--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -14,4 +14,4 @@ This service is in development. If we cannot make the payment within 18 weeks we
 
 # Contact us
 
-Reply to this email or send an email to <%= t("student_loans.support_email_address") %> with your unique reference and your query.
+Reply to this email or send an email to <%= support_email_address("student-loans") %> with your unique reference and your query.

--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -14,4 +14,4 @@ This service is in development. If we cannot make the payment within 18 weeks we
 
 # Contact us
 
-Reply to this email or send an email to <%= t("student_loans.support_email") %> with your unique reference and your query.
+Reply to this email or send an email to <%= t("student_loans.support_email_address") %> with your unique reference and your query.

--- a/app/views/claims/verified.html.erb
+++ b/app/views/claims/verified.html.erb
@@ -21,7 +21,7 @@
         </span>
       </summary>
       <div class="govuk-details__text">
-        If you find that some of this information is incorrect please contact support at <%= mail_to t("student_loans.support_email"), t("student_loans.support_email"), class: "govuk-link" %> as this could affect your application.
+        If you find that some of this information is incorrect please contact support at <%= mail_to t("student_loans.support_email_address"), t("student_loans.support_email_address"), class: "govuk-link" %> as this could affect your application.
       </div>
     </details>
   </div>

--- a/app/views/claims/verified.html.erb
+++ b/app/views/claims/verified.html.erb
@@ -21,7 +21,9 @@
         </span>
       </summary>
       <div class="govuk-details__text">
-        If you find that some of this information is incorrect please contact support at <%= mail_to t("student_loans.support_email_address"), t("student_loans.support_email_address"), class: "govuk-link" %> as this could affect your application.
+        If you find that some of this information is incorrect please contact support at
+        <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>
+        as this could affect your application.
       </div>
     </details>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template app-html-class">
   <head>
     <title>
-      <%= content_for(:page_title) || "#{t("student_loans.journey_name")} – GOV.UK" %>
+      <%= content_for(:page_title) || "#{policy_service_name(params[:policy])} – GOV.UK" %>
     </title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -35,7 +35,7 @@
 
     <div id="global-cookie-message" class="govuk-cookie-banner" role="region" aria-label="cookie banner">
       <div class="govuk-width-container">
-        <p class="govuk-cookie-banner__message"><%= t("service_name") %> uses cookies to make the site simpler.</p>
+        <p class="govuk-cookie-banner__message"><%= policy_service_name(params[:policy]) %> uses cookies to make the site simpler.</p>
         <div class="govuk-cookie-banner__buttons">
           <button id="accept-cookies" class="govuk-button govuk-button--secondary" type="submit" data-module="govuk-button">Accept cookies</button>
           <%= link_to('Cookie information', cookies_path, class: "govuk-button govuk-button--secondary ") %>
@@ -63,7 +63,7 @@
         </div>
         <div class="govuk-header__content">
 
-          <%= link_to t("student_loans.journey_name"), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to policy_service_name(params[:policy]), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
 
           <% if admin_signed_in? %>
           <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -1,10 +1,10 @@
-<%= page_title("Accessibility statement for #{t("service_name")}") %>
+<%= page_title("Accessibility statement for #{policy_service_name(params[:policy])}") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">
-      Accessibility statement for <%= t("service_name") %>
+      Accessibility statement for <%= policy_service_name(params[:policy]) %>
     </h1>
 
     <p class="govuk-body">
@@ -105,7 +105,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        the ‘<%= t("service_name") %> service’
+        the ‘<%= policy_service_name(params[:policy]) %> service’
       </li>
     </ul>
 

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -53,7 +53,7 @@
 
     <p class="govuk-body">
       If you need information on this website in a different format or cannot use the service,
-      contact us at <%= mail_to t("support_email_address"), t("support_email_address"), class: "govuk-link" %>.
+      contact us at <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>.
     </p>
 
     <p class="govuk-body">
@@ -66,8 +66,8 @@
 
     <p class="govuk-body">
       We’re always looking to improve the accessibility of this website. If you find any problems that aren’t listed on
-      this page or think we’re not meeting accessibility requirements, contact us at <%= mail_to t("support_email_address"),
-      t("support_email_address"), class: "govuk-link" %>.
+      this page or think we’re not meeting accessibility requirements, contact us at
+      <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>.
     </p>
 
     <h2 class="govuk-heading-l">

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -95,8 +95,8 @@
     <h2 class="govuk-heading-l">How we tested this website</h2>
 
     <p class="govuk-body">
-      This website was last tested on 2 September 2019. The test was carried out by the <a href="https://digitalaccessibilitycentre.org/">
-      Digital Accessibility Centre</a>.
+      This website was last tested on 2 September 2019. The test was carried out by the
+      <%= link_to "Digital Accessibility Centre", "https://digitalaccessibilitycentre.org/", class: "govuk-link" %>.
     </p>
 
     <p class="govuk-body">

--- a/app/views/static_pages/contact_us.html.erb
+++ b/app/views/static_pages/contact_us.html.erb
@@ -8,7 +8,8 @@
     </h1>
 
     <p class="govuk-body">
-      If you have any problems using this service contact us by emailing <%= mail_to t("support_email_address"), t("support_email_address"), class: "govuk-footer__link" %>.
+      If you have any problems using this service contact us by emailing
+      <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-footer__link" %>.
     </p>
 
   </div>

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -23,7 +23,7 @@
     </ul>
 
     <div class="panel panel-border-wide">
-      <p class="govuk-body"><%= t("service_name") %>  cookies aren’t used to identify you personally.</p>
+      <p class="govuk-body"><%= policy_service_name(params[:policy]) %>  cookies aren’t used to identify you personally.</p>
     </div>
 
     <p class="govuk-body">
@@ -35,7 +35,7 @@
     </h2>
 
     <p class="govuk-body">
-      We use Google Analytics software to collect information about how you use <%= t("service_name") %>.
+      We use Google Analytics software to collect information about how you use <%= policy_service_name(params[:policy]) %>.
       We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
     </p>
 
@@ -44,7 +44,7 @@
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>the pages you visit on <%= t("service_name") %></li>
+      <li>the pages you visit on <%= policy_service_name(params[:policy]) %></li>
       <li>how long you spend on each page</li>
       <li>how you got to the site</li>
       <li>what you click on while you’re visiting the site</li>
@@ -71,13 +71,13 @@
       <tbody>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">_ga</td>
-          <td class="govuk-table__cell">This helps us count how many people visit <%= t("service_name") %> by tracking if you’ve visited before</td>
+          <td class="govuk-table__cell">This helps us count how many people visit <%= policy_service_name(params[:policy]) %> by tracking if you’ve visited before</td>
           <td class="govuk-table__cell">After 2 years</td>
         </tr>
         <tr>
           <tr class="govuk-table__row">
           <td class="govuk-table__cell">_gid</td>
-          <td class="govuk-table__cell">This helps us count how many people visit <%= t("service_name") %> by tracking if you’ve visited before</td>
+          <td class="govuk-table__cell">This helps us count how many people visit <%= policy_service_name(params[:policy]) %> by tracking if you’ve visited before</td>
           <td class="govuk-table__cell">After 24 hours</td>
         </tr>
         <tr>
@@ -98,7 +98,7 @@
     </h2>
 
     <p class="govuk-body">
-      We use Google Forms software to collect information about what you thought of the <%= t("service_name") %> service.
+      We use Google Forms software to collect information about what you thought of the <%= policy_service_name(params[:policy]) %> service.
       We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
     </p>
 
@@ -136,7 +136,7 @@
     </h2>
 
     <p class="govuk-body">
-      You will see a pop-up cookie consent message when you visit <%= t("service_name") %>.
+      You will see a pop-up cookie consent message when you visit <%= policy_service_name(params[:policy]) %>.
       If you give us consent to, we'll store a cookie so that your computer knows you’ve consented to non-essential cookies and don't ask you again.
     </p>
 

--- a/app/views/static_pages/maintenance.html.erb
+++ b/app/views/static_pages/maintenance.html.erb
@@ -22,7 +22,7 @@
     </p>
 
     <p class="govuk-body">
-      Contact <%= mail_to t("support_email_address"), t("support_email_address"), class: "govuk-link" %>
+      Contact <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>
       if you need further information.
     </p>
   </div>

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -1,10 +1,10 @@
-<%= page_title("Privacy Notice: #{t("service_name")}") %>
+<%= page_title("Privacy Notice: #{policy_service_name(params[:policy])}") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">
-      Privacy Notice: <%= t("service_name") %>
+      Privacy Notice: <%= policy_service_name(params[:policy]) %>
     </h1>
 
     <h2 class="govuk-heading-l">
@@ -14,8 +14,8 @@
     <p class="govuk-body">
       This work is being carried out by the Department for Education (DfE) Digital, which is a part of DfE. DfE engages
       the private companies The Dextrous Web Ltd and Paper Design Studio Ltd to help improve and provide the service. For the purpose of data protection legislation, DfE
-      is the data controller for the personal data processed as part of <%= t("service_name") %>.
-      <%= t("service_name") %> is a free and optional service for eligible teachers to claim back student loan
+      is the data controller for the personal data processed as part of <%= policy_service_name(params[:policy]) %>.
+      <%= policy_service_name(params[:policy]) %> is a free and optional service for eligible teachers to claim back student loan
       repayments.
     </p>
 
@@ -66,7 +66,7 @@
 
     <p class="govuk-body">
       In order for our use of your personal data to be lawful, we need to meet one or more conditions in the data
-      protection legislation.  For the purpose of ‘<%= t("service_name") %>‘, the Department processes your
+      protection legislation.  For the purpose of ‘<%= policy_service_name(params[:policy]) %>‘, the Department processes your
       data where it is necessary for the performance of a task carried out in the public interest or in the exercise of
       official authority (Article 6(1)(e) of the General Data Protection Regulation).
     </p>
@@ -95,7 +95,7 @@
         to enable users to use the service and receive updates
       </li>
       <li>
-        for security purposes: collecting the IP addresses of people visiting ‘<%= t("service_name") %>’
+        for security purposes: collecting the IP addresses of people visiting ‘<%= policy_service_name(params[:policy]) %>’
         (for example, if we were receiving continuous direct denial of service attacks from an IP address then we could block it)
       </li>
     </ul>

--- a/app/views/static_pages/start_page.html.erb
+++ b/app/views/static_pages/start_page.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        <%= t('student_loans.journey_name') %>
+        <%= policy_service_name("student-loans") %>
       </h1>
 
       <p class="govuk-body">

--- a/app/views/static_pages/terms_conditions.html.erb
+++ b/app/views/static_pages/terms_conditions.html.erb
@@ -12,11 +12,11 @@
     </h2>
 
     <h3 class="govuk-heading-m">
-      Using the <%= t("service_name") %> service
+      Using the <%= policy_service_name(params[:policy]) %> service
     </h3>
 
     <p class="govuk-body">
-      Please read these Terms of Use (“General Terms”) carefully before using this <%= t("service_name") %> service (the “Service”).
+      Please read these Terms of Use (“General Terms”) carefully before using this <%= policy_service_name(params[:policy]) %> service (the “Service”).
     </p>
 
     <p class="govuk-body">

--- a/app/views/static_pages/terms_conditions.html.erb
+++ b/app/views/static_pages/terms_conditions.html.erb
@@ -42,7 +42,8 @@
     </p>
 
     <p class="govuk-body">
-      You can contact us using the following email address: <%= mail_to t("support_email_address"), t("support_email_address"), class: "govuk-link" %>
+      You can contact us using the following email address:
+      <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>
     </p>
 
     <h3 class="govuk-heading-m">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,8 @@ en:
     payroll_gender: "gender"
     address: "address"
     full_name: "Full name"
+  maths_and_physics:
+    support_email_address: "mathsphysicsteacherpayment@digital.education.gov.uk"
   student_loans:
     journey_name: "Teachers: claim back your student loan repayments"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,7 @@ en:
     full_name: "Full name"
   student_loans:
     journey_name: "Teachers: claim back your student loan repayments"
-    support_email: "studentloanteacherpayment@digital.education.gov.uk"
+    support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
       qts_award_year: "When did you complete your initial teacher training?"
       qts_award_years:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,9 +97,10 @@ en:
     address: "address"
     full_name: "Full name"
   maths_and_physics:
+    policy_name: "Claim a payment for teaching maths or physics"
     support_email_address: "mathsphysicsteacherpayment@digital.education.gov.uk"
   student_loans:
-    journey_name: "Teachers: claim back your student loan repayments"
+    policy_name: "Teachers: claim back your student loan repayments"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
       qts_award_year: "When did you complete your initial teacher training?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,13 +21,6 @@ Rails.application.routes.draw do
     root "static_pages#start_page"
   end
 
-  # setup static pages
-  get "/privacy_notice", to: "static_pages#privacy_notice", as: :privacy_notice
-  get "/terms_conditions", to: "static_pages#terms_conditions", as: :terms_conditions
-  get "/contact_us", to: "static_pages#contact_us", as: :contact_us
-  get "/cookies", to: "static_pages#cookies", as: :cookies
-  get "/accessibility_statement", to: "static_pages#accessibility_statement", as: :accessibility_statement
-
   scope path: ":policy", defaults: {policy: "student-loans"}, constraints: {policy: %r{student-loans}} do
     constraints slug: %r{#{StudentLoans::SlugSequence::SLUGS.join("|")}} do
       resources :claims, only: [:show, :update], param: :slug, path: "/"
@@ -40,6 +33,10 @@ Rails.application.routes.draw do
 
     get "timeout", to: "claims#timeout", as: :timeout_claim
     get "refresh-session", to: "claims#refresh_session", as: :claim_refresh_session
+
+    %w[privacy_notice terms_conditions contact_us cookies accessibility_statement].each do |page_name|
+      get page_name, to: "static_pages##{page_name}", as: page_name
+    end
   end
 
   constraints lambda { |req| req.format == :json } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
     get "refresh-session", to: "claims#refresh_session", as: :claim_refresh_session
 
     %w[privacy_notice terms_conditions contact_us cookies accessibility_statement].each do |page_name|
-      get page_name, to: "static_pages##{page_name}", as: page_name
+      get page_name.dasherize, to: "static_pages##{page_name}", as: page_name
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -32,4 +32,15 @@ describe ApplicationHelper do
       expect(title).to eq("Error - Some Title - #{I18n.t("student_loans.journey_name")} - GOV.UK")
     end
   end
+
+  describe "#support_email_address" do
+    it "defaults to the generic support address" do
+      expect(support_email_address).to eq t("support_email_address")
+    end
+
+    it "returns a policy-specific email address" do
+      expect(support_email_address("student-loans")).to eq t("student_loans.support_email_address")
+      expect(support_email_address("maths-and-physics")).to eq t("maths_and_physics.support_email_address")
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -22,14 +22,14 @@ describe ApplicationHelper do
       page_title("Some Title", show_error: false)
       title = content_for(:page_title)
 
-      expect(title).to eq("Some Title - #{I18n.t("student_loans.journey_name")} - GOV.UK")
+      expect(title).to eq("Some Title - #{I18n.t("student_loans.policy_name")} - GOV.UK")
     end
 
     it "Returns an error prefix" do
       page_title("Some Title", show_error: true)
       title = content_for(:page_title)
 
-      expect(title).to eq("Error - Some Title - #{I18n.t("student_loans.journey_name")} - GOV.UK")
+      expect(title).to eq("Error - Some Title - #{I18n.t("student_loans.policy_name")} - GOV.UK")
     end
   end
 
@@ -41,6 +41,17 @@ describe ApplicationHelper do
     it "returns a policy-specific email address" do
       expect(support_email_address("student-loans")).to eq t("student_loans.support_email_address")
       expect(support_email_address("maths-and-physics")).to eq t("maths_and_physics.support_email_address")
+    end
+  end
+
+  describe "#policy_service_name" do
+    it "defaults to the generic service name" do
+      expect(policy_service_name).to eq t("service_name")
+    end
+
+    it "returns a policy-specific service name" do
+      expect(policy_service_name("student-loans")).to eq t("student_loans.policy_name")
+      expect(policy_service_name("maths-and-physics")).to eq t("maths_and_physics.policy_name")
     end
   end
 end


### PR DESCRIPTION
This moves the static pages found in the footer (e.g. "Contact us", "Privacy notice", etc) from the root of the domain to be namespaced under a policy. So `/contact-us` now lives at `/student-loans/contact-us`. This means that these pages can now be made policy-aware, and display appropriate titles and support email addresses, based on the routing.

This continues the work to prepare the way for introducing the Maths & Physics policy to the service.