### PR TITLE
Make it clear we may deduct student loan repayment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Update copy to make it clear we may deduct a student loan repayment from
+  amount the claimant receives
 - Inform the user that their claim is ineligible, if the school that they are
   currently employed at is not eligible
 - Claimants recieve payment notifications once a payroll run has been processed

--- a/app/views/claims/information_provided.html.erb
+++ b/app/views/claims/information_provided.html.erb
@@ -15,15 +15,15 @@
       <li>the Teachers Pension Service</li>
     </ul>
 
-    <p class="govuk-body">To pay your claim we will:</p>
+    <p class="govuk-body">Your claim payment is taxable. We’ll send some of your personal information to HMRC to ensure the following contributions are met:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>send some of your personal information to HMRC</li>
-      <li>pay tax, student loan and national insurance contributions to HMRC</li>
+      <li>Income Tax and Employee National Insurance (NIC), which we pay on your behalf</li>
+      <li>student loan repayment, which is deducted from your claim payment if applicable</li>
     </ul>
 
     <p class="govuk-body">
-      We will send you details about these payments once we have processed your claim.
+      We’ll send you a breakdown of these payments when we process your claim.
     </p>
 
     <%= link_to "Continue", new_verify_authentications_path, class: "govuk-button", role: "button" %>
@@ -36,8 +36,7 @@
       </summary>
       <div class="govuk-details__text">
         We send HMRC your full name, date of birth, payment amount and gender details to ensure your
-        tax contributions are met. You will still receive your full payment as we cover your tax
-        obligations in addition to the payment we make to you.
+        tax contributions are met.
       </div>
     </details>
   </div>


### PR DESCRIPTION
The current copy makes it sound like the claimant will always receive
the full amount that they claimed. This is not true, as we may need to
deduct a student loan repayment from the amount they receive.

Also, tweak the copy a little for readability and consistency.

These changes come from Faye, our content designer.

![Screenshot_2019-10-29 How we will use the information you provide - Teachers claim back your student loan repayments - GOV UK](https://user-images.githubusercontent.com/53756884/67783890-d5aaf280-fa62-11e9-872f-8edd39355dc1.png)
