### PR TITLE
Backfill note on claims that have already been checked

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ end
 group :test do
   gem "selenium-webdriver"
   gem "launchy"
+  gem "climate_control"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    climate_control (0.2.0)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -321,6 +322,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara
+  climate_control
   data_migrate
   delayed_cron_job
   delayed_job_active_record

--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -184,6 +184,14 @@
         "secretName": "NotifyTemplateID"
       }
     },
+    "NOTES_TO_BACKFILL": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "NotesToBackfill"
+      }
+    },
     "ROLLBAR_ACCESS_TOKEN": {
       "reference": {
         "keyVault": {

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -163,6 +163,14 @@
         "secretName": "NotifyTemplateID"
       }
     },
+    "NOTES_TO_BACKFILL": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "NotesToBackfill"
+      }
+    },
     "ROLLBAR_ACCESS_TOKEN": {
       "reference": {
         "keyVault": {

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -150,6 +150,9 @@
     "NOTIFY_TEMPLATE_ID": {
       "type": "string"
     },
+    "NOTES_TO_BACKFILL": {
+      "type": "string"
+    },
     "ROLLBAR_ACCESS_TOKEN": {
       "type": "securestring"
     },
@@ -443,6 +446,10 @@
               {
                 "name": "NOTIFY_TEMPLATE_ID",
                 "value": "[parameters('NOTIFY_TEMPLATE_ID')]"
+              },
+              {
+                "name": "NOTES_TO_BACKFILL",
+                "value": "[parameters('NOTES_TO_BACKFILL')]"
               },
               {
                 "name": "ROLLBAR_ACCESS_TOKEN",

--- a/db/data/20191029113201_backfill_note_on_already_checked_claims.rb
+++ b/db/data/20191029113201_backfill_note_on_already_checked_claims.rb
@@ -1,0 +1,20 @@
+class BackfillNoteOnAlreadyCheckedClaims < ActiveRecord::Migration[5.2]
+  def up
+    return unless ENV["NOTES_TO_BACKFILL"]
+
+    rows = ENV["NOTES_TO_BACKFILL"].split("|")
+
+    rows.each do |row|
+      row = row.split(",")
+      claim = Claim.find_by_reference(row[0])
+
+      next if claim.nil? || claim.check.nil?
+
+      claim.check.update_column(:notes, row[1])
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/db/data/backfill_note_on_already_checked_claims_spec.rb
+++ b/spec/db/data/backfill_note_on_already_checked_claims_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+require Rails.root.join("db", "data", "20191029113201_backfill_note_on_already_checked_claims")
+
+RSpec.describe BackfillNoteOnAlreadyCheckedClaims do
+  it "updates notes on already checked claims" do
+    approved_claims = create_list(:claim, 3, :approved)
+    rejected_claims = create_list(:claim, 2, :rejected)
+    claim_without_check = create(:claim, :submitted)
+
+    data = [
+      "#{approved_claims[0].reference},First note",
+      "#{approved_claims[1].reference},Second note",
+      "#{approved_claims[2].reference},Third note",
+      "#{claim_without_check.reference},This won't work",
+      "FAKE_CLAIM_ID,This also won't work",
+      "#{rejected_claims[0].reference},Fourth note",
+      "#{rejected_claims[1].reference},Fifth note",
+    ].join("|")
+
+    ClimateControl.modify NOTES_TO_BACKFILL: data do
+      described_class.new.up
+
+      expect(approved_claims[0].check.reload.notes).to eq("First note")
+      expect(approved_claims[1].check.reload.notes).to eq("Second note")
+      expect(approved_claims[2].check.reload.notes).to eq("Third note")
+      expect(rejected_claims[0].check.reload.notes).to eq("Fourth note")
+      expect(rejected_claims[1].check.reload.notes).to eq("Fifth note")
+
+      expect(claim_without_check.reload.check).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This adds a data migration to backfill notes on claims that have already been checked. To get around the possibility of adding personal/sensitive data to the repo, the notes are stored as an envrionment variable in CSV format in the Azure keyvault. 

**This variable will have to be set before the development/production deploy happens**

Once the data migration has happened, we can remove the environment variable.
