### PR TITLE
Unset maintenance mode in production

### DIFF
--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -142,10 +142,10 @@
       }
     },
     "MAINTENANCE_MODE": {
-      "value": "1"
+      "value": ""
     },
     "MAINTENANCE_MODE_AVAILABILITY_MESSAGE": {
-      "value": "It's not possible to make a claim at the moment. The service will be back in November."
+      "value": ""
     },
     "NOTIFY_API_KEY": {
       "reference": {


### PR DESCRIPTION
I've turned maintenance mode off in production temporarily, but this makes the change permanent (or at least until we decide to enable it agai). This will take effect on the next production deploy.
