### PR TITLE
Allow user to restart claim by visiting start page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Allow user to restart their claim by visiting start page
+
 ## [Release 024] - 2019-10-31
 
 - Updated feedback URL ready for public beta

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -5,11 +5,8 @@ class ClaimsController < ApplicationController
   before_action :check_page_is_in_sequence, only: [:show, :update]
 
   def new
-    if current_claim.persisted?
-      redirect_to claim_path(page_sequence.slugs.first)
-    else
-      render first_template_in_sequence
-    end
+    clear_claim_session
+    render first_template_in_sequence
   end
 
   def create

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -98,4 +98,19 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between 6 April 2018 and 5 April 2019.")
   end
+
+  scenario "claimant can start a fresh claim after being told they are ineligible, by visiting the start page" do
+    start_claim
+    choose_school schools(:hampstead_school)
+    expect(page).to have_text("You’re not eligible")
+
+    visit new_claim_path
+
+    expect(page).to have_content("When did you complete your initial teacher training?")
+    expect(page).not_to have_css("input[checked]")
+    choose_qts_year
+
+    choose_school schools(:penistone_grammar_school)
+    expect(page).to have_text("Are you still employed to teach at a school in England?")
+  end
 end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -2,16 +2,21 @@ require "rails_helper"
 
 RSpec.describe "Claims", type: :request do
   describe "claims#new request" do
-    it "renders the first page in the sequence" do
-      get new_claim_path
-      expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
+    context "the user has not already started a claim" do
+      it "renders the first page in the sequence" do
+        get new_claim_path
+        expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
+      end
     end
 
-    it "redirects to the first page in the sequence if a claim has been started already" do
-      start_claim
+    context "the user has already started a claim" do
+      before { start_claim }
 
-      get new_claim_path
-      expect(response).to redirect_to(claim_path(StudentLoans::SlugSequence::SLUGS.first))
+      it "clears the current claim from the session, and renders the first page in the sequence" do
+        expect { get new_claim_path }.to change { session[:claim_id] }.from(String).to(nil)
+
+        expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
+      end
     end
   end
 


### PR DESCRIPTION
If the user submits answers that make their claim ineligible, we want
them to still be able to start a new claim.

This is fixing a regression, that was introduced when we removed our
temporary start page, which performed a POST to the first question.

As a future piece of work, we should also consider allowing the user to go
back to the answer that caused their claim to become ineligible, instead
of having to restart their claim.