### PR TITLE
Adjust content on the school claim screen to help users who worked in multiple schools

### DIFF
--- a/app/views/claims/_ineligibility_reason_employed_at_no_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_employed_at_no_school.html.erb
@@ -1,3 +1,7 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
 <p class="govuk-body">
   You can only get this payment if you’re still employed at a school.
 </p>

--- a/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -10,6 +10,6 @@
 
 <p class="govuk-body">
   If you taught at more than one school during this period, you can
-  <%= link_to "start your claim again", new_claim_path %> with another school.
+  <%= link_to "start your claim again", new_claim_path, class: "govuk-link" %> with another school.
   You only need to have worked at one eligible school to claim.
 </p>

--- a/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -1,5 +1,11 @@
 <p class="govuk-body">
-  <%= claim_school_name %>, where you were employed between 6 April 2018 and 5
-  April 2019, is not an eligible school. You can only get this payment if you
-  were employed at an eligible school.
+  <%= claim_school_name %> is not an eligible school. You can only get this
+  payment if you  were employed at an eligible school between 6 April 2018
+  and 5 April 2019.
+</p>
+
+<p class="govuk-body">
+  If you taught at more than one school during this period, you can
+  <%= link_to "start your claim again", new_claim_path %> with another school.
+  You only need to have worked at one eligible school to claim.
 </p>

--- a/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -1,3 +1,7 @@
+<h1 class="govuk-heading-xl">
+  This school is not eligible
+</h1>
+
 <p class="govuk-body">
   <%= claim_school_name %> is not an eligible school. You can only get this
   payment if you  were employed at an eligible school between 6 April 2018

--- a/app/views/claims/_ineligibility_reason_ineligible_current_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_current_school.html.erb
@@ -1,3 +1,7 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
 <p class="govuk-body">
   You must be employed at a state-funded secondary school to be eligible for
   this payment. <%= current_school_name %>, where you are currently employed,

--- a/app/views/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -1,3 +1,7 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
 <p class="govuk-body">
   You can only get this payment if you completed your initial teacher training
   on or after 1 September 2013.

--- a/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -1,3 +1,7 @@
+<h1 class="govuk-heading-xl">
+  You did not select an eligible subject
+</h1>
+
 <p class="govuk-body">
   You did not teach an eligible subject at <%= claim_school_name %>.
 </p>

--- a/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -1,4 +1,8 @@
 <p class="govuk-body">
+  You did not teach an eligible subject at <%= claim_school_name %>.
+</p>
+
+<p class="govuk-body">
   You can only get this payment if you taught one or more of the following
   subjects between 6 April 2018 and 5 April 2019:
 </p>
@@ -10,3 +14,12 @@
   <li>computer science</li>
   <li>languages (not including English)</li>
 </ul>
+
+<p class="govuk-body">
+  If you taught at more than one school between April 6 2018 and April 5 2019,
+  you can <%= link_to "start your claim again", new_claim_path %> with another
+  school. You only need to have taught an eligible subject at one eligible
+  school to claim.
+<p>
+
+

--- a/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -21,7 +21,7 @@
 
 <p class="govuk-body">
   If you taught at more than one school between April 6 2018 and April 5 2019,
-  you can <%= link_to "start your claim again", new_claim_path %> with another
+  you can <%= link_to "start your claim again", new_claim_path, class: "govuk-link" %> with another
   school. You only need to have taught an eligible subject at one eligible
   school to claim.
 <p>

--- a/app/views/claims/_ineligibility_reason_not_taught_enough.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_enough.html.erb
@@ -1,3 +1,7 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
 <p class="govuk-body">
   You can only get this payment if you spent less than half your working hours
   performing leadership duties between 6 April 2018 and 5 April 2019.

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -31,9 +31,19 @@
           <strong>No results match that search term. Try again.</strong>
         </p>
       <% else %>
-        <span class="govuk-hint">
-          Enter the school name. Use at least four characters.
-        </span>
+        <p class="govuk-body">
+          <span class="govuk-hint">
+            Enter the school name. Use at least four characters.
+          </span>
+        </p>
+
+        <% if school_id_param == :claim_school_id %>
+          <p class="govuk-body">
+            <span class="govuk-hint">
+              If you worked at multiple schools during this period, enter the first school you think might be eligible.
+            </span>
+          </p>
+        <% end %>
       <% end %>
 
       <div id="school-search-container">

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -9,7 +9,9 @@
     <%= render partial: "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}", locals: { claim_school_name: current_claim.eligibility.claim_school_name, current_school_name: current_claim.eligibility.current_school_name } %>
 
     <p class="govuk-body">
-      You can find more information on the <%= link_to "guidance for this service", tslr_guidance_url, class: 'govuk-link' %>.
+      For more information about the eligibility criteria, or if you need help with
+      your claim, contact
+      <%= mail_to "studentloanteacherpayment@digital.education.gov.uk", "studentloanteacherpayment@digital.education.gov.uk", class: "govuk-link" %>.
     </p>
   </div>
 </div>

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -2,10 +2,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      You’re not eligible for this payment
-    </h1>
-
     <%= render partial: "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}", locals: { claim_school_name: current_claim.eligibility.claim_school_name, current_school_name: current_claim.eligibility.current_school_name } %>
 
     <p class="govuk-body">

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -7,7 +7,7 @@
     <p class="govuk-body">
       For more information about the eligibility criteria, or if you need help with
       your claim, contact
-      <%= mail_to "studentloanteacherpayment@digital.education.gov.uk", "studentloanteacherpayment@digital.education.gov.uk", class: "govuk-link" %>.
+      <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>.
     </p>
   </div>
 </div>

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -36,8 +36,8 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     choose_school schools(:hampstead_school)
 
     expect(claim.eligibility.reload.claim_school).to eq schools(:hampstead_school)
-    expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("Hampstead School, where you were employed between 6 April 2018 and 5 April 2019, is not an eligible school.")
+    expect(page).to have_text("This school is not eligible")
+    expect(page).to have_text("Hampstead School is not an eligible school.")
   end
 
   scenario "chooses an ineligible current school" do
@@ -76,7 +76,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     click_on "Continue"
 
     expect(claim.eligibility.reload.taught_eligible_subjects?).to eq(false)
-    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You did not select an eligible subject")
     expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
   end
 
@@ -102,7 +102,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   scenario "claimant can start a fresh claim after being told they are ineligible, by visiting the start page" do
     start_claim
     choose_school schools(:hampstead_school)
-    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("This school is not eligible")
 
     visit new_claim_path
 

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
 
       click_on "Continue"
 
-      expect(page).to have_text("You’re not eligible")
+      expect(page).to have_text("You did not select an eligible subject")
       expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
     end
 
@@ -54,7 +54,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       choose I18n.t("student_loans.questions.eligible_subjects.none_taught")
       click_on "Continue"
 
-      expect(page).to have_text("You’re not eligible")
+      expect(page).to have_text("You did not select an eligible subject")
       expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
     end
 
@@ -64,7 +64,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       check "Biology"
       click_on "Continue"
 
-      expect(page).to have_text("You’re not eligible")
+      expect(page).to have_text("You did not select an eligible subject")
       expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
     end
   end


### PR DESCRIPTION
This adds the copy added by Faye to the school search page and the relevant ineligibility pages. Here's how they look:

![image](https://user-images.githubusercontent.com/109774/67947555-cc916100-fbdb-11e9-8ba1-9a5cc7b993df.png)

![image](https://user-images.githubusercontent.com/109774/67947711-2b56da80-fbdc-11e9-8d3c-2b361fac2781.png)

![image](https://user-images.githubusercontent.com/109774/67947767-49bcd600-fbdc-11e9-93aa-4929e03487b2.png)
