### PR TITLE
Make timeout code policy-agnostic

### DIFF
--- a/app/assets/javascripts/components/timeout_dialog.js.erb
+++ b/app/assets/javascripts/components/timeout_dialog.js.erb
@@ -20,7 +20,7 @@
 
   function refreshSession() {
     Rails.ajax({
-      url: "<%= claim_refresh_session_path %>",
+      url: "<%= refresh_session_path %>",
       type: "get",
       success: function() {
         clearInterval(window.sessionTimeoutTimer);

--- a/app/assets/javascripts/components/timeout_dialog.js.erb
+++ b/app/assets/javascripts/components/timeout_dialog.js.erb
@@ -9,6 +9,7 @@
   var warningTimeInMinutes = dialogElement.getAttribute("data-warning-in-minutes");
   var timeoutInMinutes = dialogElement.getAttribute("data-timeout-in-minutes");
   var timeoutInMilliseconds = (timeoutInMinutes - warningTimeInMinutes) * 60 * 1000;
+  var timeoutPath = dialogElement.getAttribute("data-timeout-path");
   var dialog = new window.A11yDialog(dialogElement);
 
   continueButtonElement.onclick = function() {
@@ -33,7 +34,7 @@
 
   function sessionTimedOut() {
     clearInterval(window.sessionTimeoutTimer);
-    window.location = "<%= timeout_claim_path %>";
+    window.location = timeoutPath;
   }
 
   function showTimeoutDialog() {

--- a/app/assets/javascripts/components/timeout_dialog.js.erb
+++ b/app/assets/javascripts/components/timeout_dialog.js.erb
@@ -2,10 +2,12 @@
 
 (function() {
   var dialogElement = document.getElementById("timeout_dialog");
+
+  if (!dialogElement) return;
+
   var continueButtonElement = document.getElementById("continue_session");
   var warningTimeInMinutes = dialogElement.getAttribute("data-warning-in-minutes");
   var timeoutInMinutes = dialogElement.getAttribute("data-timeout-in-minutes");
-  var claimInProgress = dialogElement.getAttribute("data-claim-in-progress");
   var timeoutInMilliseconds = (timeoutInMinutes - warningTimeInMinutes) * 60 * 1000;
   var dialog = new window.A11yDialog(dialogElement);
 
@@ -35,11 +37,9 @@
   }
 
   function showTimeoutDialog() {
-    if (claimInProgress === "true") {
-      dialogElement.setAttribute("aria-hidden", "false");
-      dialog.show();
-      setTimeout(sessionTimedOut, warningTimeInMinutes * 60 * 1000);
-    }
+    dialogElement.setAttribute("aria-hidden", "false");
+    dialog.show();
+    setTimeout(sessionTimedOut, warningTimeInMinutes * 60 * 1000);
   }
 
   window.sessionTimeoutTimer = setInterval(showTimeoutDialog, timeoutInMilliseconds);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,12 +9,16 @@ class ApplicationController < ActionController::Base
     if: -> { ENV["BASIC_AUTH_USERNAME"].present? },
   )
 
-  helper_method :admin_signed_in?, :claim_timeout_in_minutes, :claim_timeout_warning_in_minutes
+  helper_method :current_policy_routing_name, :admin_signed_in?, :claim_timeout_in_minutes, :claim_timeout_warning_in_minutes
   before_action :end_expired_admin_sessions
   before_action :end_expired_claim_sessions
   before_action :update_last_seen_at
 
   private
+
+  def current_policy_routing_name
+    params[:policy]
+  end
 
   def admin_signed_in?
     session.key?(:user_id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
     if: -> { ENV["BASIC_AUTH_USERNAME"].present? },
   )
 
-  helper_method :current_policy_routing_name, :admin_signed_in?, :claim_timeout_in_minutes, :claim_timeout_warning_in_minutes
+  helper_method :current_policy_routing_name, :admin_signed_in?, :admin_timeout_in_minutes, :claim_timeout_in_minutes, :timeout_warning_in_minutes
   before_action :end_expired_admin_sessions
   before_action :end_expired_claim_sessions
   before_action :update_last_seen_at
@@ -24,11 +24,15 @@ class ApplicationController < ActionController::Base
     session.key?(:user_id)
   end
 
+  def admin_timeout_in_minutes
+    ADMIN_TIMEOUT_LENGTH_IN_MINUTES
+  end
+
   def claim_timeout_in_minutes
     self.class::CLAIM_TIMEOUT_LENGTH_IN_MINUTES
   end
 
-  def claim_timeout_warning_in_minutes
+  def timeout_warning_in_minutes
     self.class::CLAIM_TIMEOUT_WARNING_LENGTH_IN_MINUTES
   end
 
@@ -49,7 +53,7 @@ class ApplicationController < ActionController::Base
   end
 
   def admin_session_timed_out?
-    admin_signed_in? && session[:last_seen_at] < ADMIN_TIMEOUT_LENGTH_IN_MINUTES.minutes.ago
+    admin_signed_in? && session[:last_seen_at] < admin_timeout_in_minutes.minutes.ago
   end
 
   def end_expired_admin_sessions

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,7 +1,7 @@
 class ClaimsController < ApplicationController
   include PartOfClaimJourney
 
-  skip_before_action :send_unstarted_claiments_to_the_start, only: [:new, :create, :timeout, :refresh_session]
+  skip_before_action :send_unstarted_claiments_to_the_start, only: [:new, :create, :timeout]
   before_action :check_page_is_in_sequence, only: [:show, :update]
 
   def new
@@ -37,10 +37,6 @@ class ClaimsController < ApplicationController
   end
 
   def timeout
-  end
-
-  def refresh_session
-    head :ok
   end
 
   private

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -76,6 +76,6 @@ class ClaimsController < ApplicationController
   end
 
   def claim_slug_sequence
-    current_claim.eligibility.class.parent::SlugSequence.new(current_claim)
+    current_claim.policy::SlugSequence.new(current_claim)
   end
 end

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -9,7 +9,7 @@ module PartOfClaimJourney
   private
 
   def current_policy_routing_name
-    current_claim.eligibility.class.parent.routing_name
+    current_claim.policy.routing_name
   end
 
   def send_unstarted_claiments_to_the_start

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -8,6 +8,10 @@ module PartOfClaimJourney
 
   private
 
+  def current_policy_routing_name
+    current_claim.eligibility.class.parent.routing_name
+  end
+
   def send_unstarted_claiments_to_the_start
     redirect_to StudentLoans.start_page_url unless current_claim.persisted?
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,5 @@
+class SessionsController < ApplicationController
+  def refresh
+    head :ok
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -208,6 +208,10 @@ class Claim < ApplicationRecord
     self.student_loan_plan = determine_student_loan_plan
   end
 
+  def policy
+    eligibility.class.parent
+  end
+
   private
 
   def normalise_trn

--- a/app/models/payroll/claim_csv_row.rb
+++ b/app/models/payroll/claim_csv_row.rb
@@ -128,7 +128,7 @@ module Payroll
     end
 
     def scheme_name
-      model.eligibility.class.name.deconstantize.titlecase
+      model.policy.name.titlecase
     end
 
     def scheme_amount

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -2,4 +2,8 @@ module StudentLoans
   def self.start_page_url
     "https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments"
   end
+
+  def self.routing_name
+    "student-loans"
+  end
 end

--- a/app/views/application/_timeout_dialog.html.erb
+++ b/app/views/application/_timeout_dialog.html.erb
@@ -5,6 +5,7 @@
     data: {
       "timeout-in-minutes" => timeout_in_minutes,
       "warning-in-minutes" => timeout_warning_in_minutes,
+      "timeout-path" => path_on_timeout,
     },
   ) do %>
   <div class="dialog-overlay" tabindex="-1" data-a11y-dialog-hide=""></div>

--- a/app/views/application/_timeout_dialog.html.erb
+++ b/app/views/application/_timeout_dialog.html.erb
@@ -1,4 +1,13 @@
-<div id="timeout_dialog" class="dialog" aria-hidden="true" data-timeout-in-minutes="<%= claim_timeout_in_minutes %>" data-warning-in-minutes="<%= claim_timeout_warning_in_minutes %>" data-claim-in-progress="<%= claim_in_progress? %>">
+<%= tag.div(
+    id: "timeout_dialog",
+    class: "dialog",
+    aria: {hidden: true},
+    data: {
+      "timeout-in-minutes" => claim_timeout_in_minutes,
+      "warning-in-minutes" => claim_timeout_warning_in_minutes,
+      "claim-in-progress" => claim_in_progress?,
+    },
+  ) do %>
   <div class="dialog-overlay" tabindex="-1" data-a11y-dialog-hide=""></div>
   <dialog class="dialog-content" aria-labelledby="timeout_dialog_title">
     <div class="timeout_dialog_titlebar">
@@ -20,4 +29,4 @@
       Continue session
     </button>
   </dialog>
-</div>
+<% end %>

--- a/app/views/application/_timeout_dialog.html.erb
+++ b/app/views/application/_timeout_dialog.html.erb
@@ -5,7 +5,6 @@
     data: {
       "timeout-in-minutes" => claim_timeout_in_minutes,
       "warning-in-minutes" => claim_timeout_warning_in_minutes,
-      "claim-in-progress" => claim_in_progress?,
     },
   ) do %>
   <div class="dialog-overlay" tabindex="-1" data-a11y-dialog-hide=""></div>

--- a/app/views/application/_timeout_dialog.html.erb
+++ b/app/views/application/_timeout_dialog.html.erb
@@ -3,8 +3,8 @@
     class: "dialog",
     aria: {hidden: true},
     data: {
-      "timeout-in-minutes" => claim_timeout_in_minutes,
-      "warning-in-minutes" => claim_timeout_warning_in_minutes,
+      "timeout-in-minutes" => timeout_in_minutes,
+      "warning-in-minutes" => timeout_warning_in_minutes,
     },
   ) do %>
   <div class="dialog-overlay" tabindex="-1" data-a11y-dialog-hide=""></div>
@@ -18,7 +18,7 @@
       </button>
     </div>
     <h1 id="timeout_dialog_title" class="govuk-heading-l">
-      Your session will expire in <%= claim_timeout_warning_in_minutes %> minutes
+      Your session will expire in <%= timeout_warning_in_minutes %> minutes
     </h1>
     <p class="govuk-body">
       We won't be able to save what you have done and you will lose

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -7,7 +7,7 @@
     <p class="govuk-body">
       For more information about the eligibility criteria, or if you need help with
       your claim, contact
-      <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>.
+      <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>.
     </p>
   </div>
 </div>

--- a/app/views/claims/verified.html.erb
+++ b/app/views/claims/verified.html.erb
@@ -22,7 +22,7 @@
       </summary>
       <div class="govuk-details__text">
         If you find that some of this information is incorrect please contact support at
-        <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>
+        <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>
         as this could affect your application.
       </div>
     </details>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -30,7 +30,7 @@
   <body class="govuk-template__body">
     <%= javascript_include_tag 'js_check' %>
 
-    <%= render partial: "timeout_dialog" %>
+    <%= render("timeout_dialog") if admin_signed_in? %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -30,7 +30,7 @@
   <body class="govuk-template__body">
     <%= javascript_include_tag 'js_check' %>
 
-    <%= render("timeout_dialog") if admin_signed_in? %>
+    <%= render("timeout_dialog", timeout_in_minutes: admin_timeout_in_minutes) if admin_signed_in? %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -30,7 +30,7 @@
   <body class="govuk-template__body">
     <%= javascript_include_tag 'js_check' %>
 
-    <%= render("timeout_dialog", timeout_in_minutes: admin_timeout_in_minutes) if admin_signed_in? %>
+    <%= render("timeout_dialog", timeout_in_minutes: admin_timeout_in_minutes, path_on_timeout: admin_sign_in_path) if admin_signed_in? %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template app-html-class">
   <head>
     <title>
-      <%= content_for(:page_title) || "#{policy_service_name(params[:policy])} – GOV.UK" %>
+      <%= content_for(:page_title) || "#{policy_service_name(current_policy_routing_name)} – GOV.UK" %>
     </title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -35,7 +35,7 @@
 
     <div id="global-cookie-message" class="govuk-cookie-banner" role="region" aria-label="cookie banner">
       <div class="govuk-width-container">
-        <p class="govuk-cookie-banner__message"><%= policy_service_name(params[:policy]) %> uses cookies to make the site simpler.</p>
+        <p class="govuk-cookie-banner__message"><%= policy_service_name(current_policy_routing_name) %> uses cookies to make the site simpler.</p>
         <div class="govuk-cookie-banner__buttons">
           <button id="accept-cookies" class="govuk-button govuk-button--secondary" type="submit" data-module="govuk-button">Accept cookies</button>
           <%= link_to('Cookie information', cookies_path, class: "govuk-button govuk-button--secondary ") %>
@@ -63,7 +63,7 @@
         </div>
         <div class="govuk-header__content">
 
-          <%= link_to policy_service_name(params[:policy]), StudentLoans.start_page_url, class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to policy_service_name(current_policy_routing_name), StudentLoans.start_page_url, class: "govuk-header__link govuk-header__link--service-name" %>
 
           <% if admin_signed_in? %>
           <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
   <body class="govuk-template__body">
     <%= javascript_include_tag 'js_check' %>
 
-    <%= render("timeout_dialog") if claim_in_progress? %>
+    <%= render("timeout_dialog", timeout_in_minutes: claim_timeout_in_minutes) if claim_in_progress? %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
   <body class="govuk-template__body">
     <%= javascript_include_tag 'js_check' %>
 
-    <%= render partial: "timeout_dialog" %>
+    <%= render("timeout_dialog") if claim_in_progress? %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
   <body class="govuk-template__body">
     <%= javascript_include_tag 'js_check' %>
 
-    <%= render("timeout_dialog", timeout_in_minutes: claim_timeout_in_minutes) if claim_in_progress? %>
+    <%= render("timeout_dialog", timeout_in_minutes: claim_timeout_in_minutes, path_on_timeout: timeout_claim_path(current_policy_routing_name)) if claim_in_progress? %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -1,10 +1,10 @@
-<%= page_title("Accessibility statement for #{policy_service_name(params[:policy])}") %>
+<%= page_title("Accessibility statement for #{policy_service_name(current_policy_routing_name)}") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">
-      Accessibility statement for <%= policy_service_name(params[:policy]) %>
+      Accessibility statement for <%= policy_service_name(current_policy_routing_name) %>
     </h1>
 
     <p class="govuk-body">
@@ -53,7 +53,7 @@
 
     <p class="govuk-body">
       If you need information on this website in a different format or cannot use the service,
-      contact us at <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>.
+      contact us at <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>.
     </p>
 
     <p class="govuk-body">
@@ -67,7 +67,7 @@
     <p class="govuk-body">
       We’re always looking to improve the accessibility of this website. If you find any problems that aren’t listed on
       this page or think we’re not meeting accessibility requirements, contact us at
-      <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>.
+      <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>.
     </p>
 
     <h2 class="govuk-heading-l">
@@ -105,7 +105,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        the ‘<%= policy_service_name(params[:policy]) %> service’
+        the ‘<%= policy_service_name(current_policy_routing_name) %> service’
       </li>
     </ul>
 

--- a/app/views/static_pages/contact_us.html.erb
+++ b/app/views/static_pages/contact_us.html.erb
@@ -9,7 +9,7 @@
 
     <p class="govuk-body">
       If you have any problems using this service contact us by emailing
-      <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-footer__link" %>.
+      <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-footer__link" %>.
     </p>
 
   </div>

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -23,7 +23,7 @@
     </ul>
 
     <div class="panel panel-border-wide">
-      <p class="govuk-body"><%= policy_service_name(params[:policy]) %>  cookies aren’t used to identify you personally.</p>
+      <p class="govuk-body"><%= policy_service_name(current_policy_routing_name) %>  cookies aren’t used to identify you personally.</p>
     </div>
 
     <p class="govuk-body">
@@ -35,7 +35,7 @@
     </h2>
 
     <p class="govuk-body">
-      We use Google Analytics software to collect information about how you use <%= policy_service_name(params[:policy]) %>.
+      We use Google Analytics software to collect information about how you use <%= policy_service_name(current_policy_routing_name) %>.
       We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
     </p>
 
@@ -44,7 +44,7 @@
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>the pages you visit on <%= policy_service_name(params[:policy]) %></li>
+      <li>the pages you visit on <%= policy_service_name(current_policy_routing_name) %></li>
       <li>how long you spend on each page</li>
       <li>how you got to the site</li>
       <li>what you click on while you’re visiting the site</li>
@@ -71,13 +71,13 @@
       <tbody>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">_ga</td>
-          <td class="govuk-table__cell">This helps us count how many people visit <%= policy_service_name(params[:policy]) %> by tracking if you’ve visited before</td>
+          <td class="govuk-table__cell">This helps us count how many people visit <%= policy_service_name(current_policy_routing_name) %> by tracking if you’ve visited before</td>
           <td class="govuk-table__cell">After 2 years</td>
         </tr>
         <tr>
           <tr class="govuk-table__row">
           <td class="govuk-table__cell">_gid</td>
-          <td class="govuk-table__cell">This helps us count how many people visit <%= policy_service_name(params[:policy]) %> by tracking if you’ve visited before</td>
+          <td class="govuk-table__cell">This helps us count how many people visit <%= policy_service_name(current_policy_routing_name) %> by tracking if you’ve visited before</td>
           <td class="govuk-table__cell">After 24 hours</td>
         </tr>
         <tr>
@@ -98,7 +98,7 @@
     </h2>
 
     <p class="govuk-body">
-      We use Google Forms software to collect information about what you thought of the <%= policy_service_name(params[:policy]) %> service.
+      We use Google Forms software to collect information about what you thought of the <%= policy_service_name(current_policy_routing_name) %> service.
       We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
     </p>
 
@@ -136,7 +136,7 @@
     </h2>
 
     <p class="govuk-body">
-      You will see a pop-up cookie consent message when you visit <%= policy_service_name(params[:policy]) %>.
+      You will see a pop-up cookie consent message when you visit <%= policy_service_name(current_policy_routing_name) %>.
       If you give us consent to, we'll store a cookie so that your computer knows you’ve consented to non-essential cookies and don't ask you again.
     </p>
 

--- a/app/views/static_pages/maintenance.html.erb
+++ b/app/views/static_pages/maintenance.html.erb
@@ -22,7 +22,7 @@
     </p>
 
     <p class="govuk-body">
-      Contact <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>
+      Contact <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>
       if you need further information.
     </p>
   </div>

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -1,10 +1,10 @@
-<%= page_title("Privacy Notice: #{policy_service_name(params[:policy])}") %>
+<%= page_title("Privacy Notice: #{policy_service_name(current_policy_routing_name)}") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">
-      Privacy Notice: <%= policy_service_name(params[:policy]) %>
+      Privacy Notice: <%= policy_service_name(current_policy_routing_name) %>
     </h1>
 
     <h2 class="govuk-heading-l">
@@ -14,8 +14,8 @@
     <p class="govuk-body">
       This work is being carried out by the Department for Education (DfE) Digital, which is a part of DfE. DfE engages
       the private companies The Dextrous Web Ltd and Paper Design Studio Ltd to help improve and provide the service. For the purpose of data protection legislation, DfE
-      is the data controller for the personal data processed as part of <%= policy_service_name(params[:policy]) %>.
-      <%= policy_service_name(params[:policy]) %> is a free and optional service for eligible teachers to claim back student loan
+      is the data controller for the personal data processed as part of <%= policy_service_name(current_policy_routing_name) %>.
+      <%= policy_service_name(current_policy_routing_name) %> is a free and optional service for eligible teachers to claim back student loan
       repayments.
     </p>
 
@@ -66,7 +66,7 @@
 
     <p class="govuk-body">
       In order for our use of your personal data to be lawful, we need to meet one or more conditions in the data
-      protection legislation.  For the purpose of ‘<%= policy_service_name(params[:policy]) %>‘, the Department processes your
+      protection legislation.  For the purpose of ‘<%= policy_service_name(current_policy_routing_name) %>‘, the Department processes your
       data where it is necessary for the performance of a task carried out in the public interest or in the exercise of
       official authority (Article 6(1)(e) of the General Data Protection Regulation).
     </p>
@@ -95,7 +95,7 @@
         to enable users to use the service and receive updates
       </li>
       <li>
-        for security purposes: collecting the IP addresses of people visiting ‘<%= policy_service_name(params[:policy]) %>’
+        for security purposes: collecting the IP addresses of people visiting ‘<%= policy_service_name(current_policy_routing_name) %>’
         (for example, if we were receiving continuous direct denial of service attacks from an IP address then we could block it)
       </li>
     </ul>

--- a/app/views/static_pages/terms_conditions.html.erb
+++ b/app/views/static_pages/terms_conditions.html.erb
@@ -12,11 +12,11 @@
     </h2>
 
     <h3 class="govuk-heading-m">
-      Using the <%= policy_service_name(params[:policy]) %> service
+      Using the <%= policy_service_name(current_policy_routing_name) %> service
     </h3>
 
     <p class="govuk-body">
-      Please read these Terms of Use (“General Terms”) carefully before using this <%= policy_service_name(params[:policy]) %> service (the “Service”).
+      Please read these Terms of Use (“General Terms”) carefully before using this <%= policy_service_name(current_policy_routing_name) %> service (the “Service”).
     </p>
 
     <p class="govuk-body">
@@ -43,7 +43,7 @@
 
     <p class="govuk-body">
       You can contact us using the following email address:
-      <%= mail_to support_email_address(params[:policy]), support_email_address(params[:policy]), class: "govuk-link" %>
+      <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>
     </p>
 
     <h3 class="govuk-heading-m">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
     match "*path", to: "static_pages#maintenance", via: :all, constraints: lambda { |req| !%r{^/admin($|/)}.match?(req.path) }
   end
 
+  get "refresh-session", to: "sessions#refresh", as: :refresh_session
+
   scope path: ":policy", defaults: {policy: "student-loans"}, constraints: {policy: %r{student-loans}} do
     constraints slug: %r{#{StudentLoans::SlugSequence::SLUGS.join("|")}} do
       resources :claims, only: [:show, :update], param: :slug, path: "/"
@@ -30,7 +32,6 @@ Rails.application.routes.draw do
     get "claims/confirmation", as: :claim_confirmation, to: "submissions#show"
 
     get "timeout", to: "claims#timeout", as: :timeout_claim
-    get "refresh-session", to: "claims#refresh_session", as: :claim_refresh_session
 
     %w[privacy_notice terms_conditions contact_us cookies accessibility_statement].each do |page_name|
       get page_name.dasherize, to: "static_pages##{page_name}", as: page_name

--- a/spec/features/admin_timeout_spec.rb
+++ b/spec/features/admin_timeout_spec.rb
@@ -5,8 +5,8 @@ RSpec.feature "Admin user session timeout", js: true do
   let(:two_seconds_in_minutes) { 2 / 60.to_f }
 
   before do
-    allow_any_instance_of(ApplicationController).to receive(:claim_timeout_in_minutes) { two_seconds_in_minutes }
-    allow_any_instance_of(ApplicationController).to receive(:claim_timeout_warning_in_minutes) { one_second_in_minutes }
+    allow_any_instance_of(ApplicationController).to receive(:admin_timeout_in_minutes) { two_seconds_in_minutes }
+    allow_any_instance_of(ApplicationController).to receive(:timeout_warning_in_minutes) { one_second_in_minutes }
 
     sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
   end
@@ -20,5 +20,13 @@ RSpec.feature "Admin user session timeout", js: true do
     expect(page).to have_content("Your session will expire in #{one_second_in_minutes} minutes")
     expect_any_instance_of(SessionsController).to receive(:update_last_seen_at)
     click_on "Continue session"
+  end
+
+  scenario "automatically signs out the admin session if no action taken" do
+    wait_until_visible { find("h1", text: "Your session has ended due to inactivity") }
+    expect(current_path).to eql(timeout_claim_path)
+
+    visit admin_root_path
+    expect(page).to have_content("Sign in with DfE Sign In")
   end
 end

--- a/spec/features/admin_timeout_spec.rb
+++ b/spec/features/admin_timeout_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.feature "Admin user session timeout", js: true do
+  let(:one_second_in_minutes) { 1 / 60.to_f }
+  let(:two_seconds_in_minutes) { 2 / 60.to_f }
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:claim_timeout_in_minutes) { two_seconds_in_minutes }
+    allow_any_instance_of(ApplicationController).to receive(:claim_timeout_warning_in_minutes) { one_second_in_minutes }
+
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+  end
+
+  scenario "Dialog warns user their session will timeout" do
+    expect(page).to have_content("Your session will expire in #{one_second_in_minutes} minutes")
+    expect(page).to have_button("Continue session")
+  end
+
+  scenario "can refresh their session" do
+    expect(page).to have_content("Your session will expire in #{one_second_in_minutes} minutes")
+    expect_any_instance_of(SessionsController).to receive(:update_last_seen_at)
+    click_on "Continue session"
+  end
+end

--- a/spec/features/admin_timeout_spec.rb
+++ b/spec/features/admin_timeout_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature "Admin user session timeout", js: true do
   end
 
   scenario "automatically signs out the admin session if no action taken" do
-    wait_until_visible { find("h1", text: "Your session has ended due to inactivity") }
-    expect(current_path).to eql(timeout_claim_path)
+    wait_until_visible { find("h1", text: "Sign in with DfE Sign In") }
+    expect(current_path).to eql(admin_sign_in_path)
 
     visit admin_root_path
     expect(page).to have_content("Sign in with DfE Sign In")

--- a/spec/features/timeout_spec.rb
+++ b/spec/features/timeout_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Teacher Student Loan Repayments claims", js: true do
 
   scenario "Claimants can refresh their session" do
     expect(page).to have_content("Your session will expire in #{one_second_in_minutes} minutes")
-    expect_any_instance_of(ClaimsController).to receive(:update_last_seen_at)
+    expect_any_instance_of(SessionsController).to receive(:update_last_seen_at)
     click_on "Continue session"
   end
 

--- a/spec/features/timeout_spec.rb
+++ b/spec/features/timeout_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Teacher Student Loan Repayments claims", js: true do
 
   before do
     allow_any_instance_of(ApplicationController).to receive(:claim_timeout_in_minutes) { two_seconds_in_minutes }
-    allow_any_instance_of(ApplicationController).to receive(:claim_timeout_warning_in_minutes) { one_second_in_minutes }
+    allow_any_instance_of(ApplicationController).to receive(:timeout_warning_in_minutes) { one_second_in_minutes }
     start_claim
   end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -304,6 +304,12 @@ RSpec.describe Claim, type: :model do
     end
   end
 
+  describe "#policy" do
+    it "returns the claim’s policy namespace" do
+      expect(Claim.new(eligibility: StudentLoans::Eligibility.new).policy).to eq StudentLoans
+    end
+  end
+
   describe "#submit!" do
     around do |example|
       freeze_time { example.run }

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -107,20 +107,6 @@ RSpec.describe "Claims", type: :request do
     end
   end
 
-  describe "claim#refresh_session" do
-    it "updates the last seen at timestamp" do
-      freeze_time do
-        get claim_refresh_session_path
-        expect(session[:last_seen_at]).to eql(Time.zone.now)
-      end
-    end
-
-    it "gives a successful response" do
-      get claim_refresh_session_path
-      expect(response).to have_http_status(:ok)
-    end
-  end
-
   describe "claims#update request" do
     context "when a claim is already in progress" do
       let(:in_progress_claim) { Claim.order(:created_at).last }

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "Sessions", type: :request do
+  describe "#refresh" do
+    it "updates the last_seen_at session timestamp and responds with OK" do
+      travel_to(1.day.from_now) do
+        get refresh_session_path
+
+        expect(session[:last_seen_at]).to eql(Time.zone.now)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is part of the work to prepare for introducing the Maths & Physics policy. It focuses on updating the timeout-related code such that it isn't coupled to the routing for the Student Loans policy.

There were two routes that were hardcoded in the timeout JavaScript:

- `claim_refresh_session_path`, which translated to `"/student-loans/refresh-session"`
- `timeout_claim_path`, which translated to `"/student-loans/timeout"`

The session refresh routing is dealt with by moving the action so it no longer sits under the policy namespace. This makes sense, as refreshing the session will be the same regardless of the policy, and is also used for admin sessions.

The timeout redirection path is dealt with by making the path for redirection configurable by setting it in the DOM, rather than having it hardcoded in the JS.

This work uncovered some inconsistencies in the timeout dialog behaviour for admin users, which should now be tided up.