### PR TITLE
Prevent search engines from indexing the service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add noindex and nofollow directives to prevent search engines indexing pages
+
 ## [Release 026] - 2019-11-04
 
 - A clear warning is shown to service operators when a claim contains details

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -8,7 +8,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="theme-color" content="#0b0c0c" />
+    <meta name="theme-color" content="#0b0c0c">
+    <meta name="robots" content="noindex,nofollow">
 
     <%= favicon_link_tag %>
     <%= favicon_link_tag 'govuk-mask-icon.svg', rel: 'mask-icon', type: 'image/svg+xml', color: '#0b0c0c' %>
@@ -17,7 +18,7 @@
     <%= favicon_link_tag 'govuk-apple-touch-icon-152x152.png', rel: 'apple-touch-icon', type: 'image/png', sizes: '152x152' %>
     <%= favicon_link_tag 'govuk-apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>
 
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <% if ENV["GOOGLE_ANALYTICS_ID"] %>
       <%= javascript_include_tag "google_analytics/analytics" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="theme-color" content="#0b0c0c" />
+    <meta name="theme-color" content="#0b0c0c">
+    <meta name="robots" content="noindex,nofollow">
 
     <%= favicon_link_tag %>
     <%= favicon_link_tag 'govuk-mask-icon.svg', rel: 'mask-icon', type: 'image/svg+xml', color: '#0b0c0c' %>
@@ -16,7 +17,7 @@
     <%= favicon_link_tag 'govuk-apple-touch-icon-152x152.png', rel: 'apple-touch-icon', type: 'image/png', sizes: '152x152' %>
     <%= favicon_link_tag 'govuk-apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>
 
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <% if ENV["GOOGLE_ANALYTICS_ID"] %>
       <%= javascript_include_tag "google_analytics/analytics" %>


### PR DESCRIPTION
Following the guidance onthe service-manual[1], we tell search engines
not to index pages on the service so that users will always start their
journey on our start pages.

https://www.gov.uk/service-manual/technology/get-a-domain-name#ensure-users-start-their-journey-on-govuk