### PR TITLE
Re-organise session handling code to separate claim session code from admin session code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Admin users are sent to the sign in page when their session times out
 - Add noindex and nofollow directives to prevent search engines indexing pages
 
 ## [Release 026] - 2019-11-04

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,20 +63,7 @@
           </a>
         </div>
         <div class="govuk-header__content">
-
           <%= link_to policy_service_name(current_policy_routing_name), StudentLoans.start_page_url, class: "govuk-header__link govuk-header__link--service-name" %>
-
-          <% if admin_signed_in? %>
-          <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-          <nav>
-            <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-              <li class="govuk-header__navigation-item">
-                <%= link_to "Sign out", admin_sign_out_path, method: :delete, class: "govuk-header__link" %>
-              </li>
-            </ul>
-          </nav>
-          <% end %>
-
         </div>
       </div>
     </header>

--- a/spec/features/admin_timeout_spec.rb
+++ b/spec/features/admin_timeout_spec.rb
@@ -5,8 +5,8 @@ RSpec.feature "Admin user session timeout", js: true do
   let(:two_seconds_in_minutes) { 2 / 60.to_f }
 
   before do
-    allow_any_instance_of(ApplicationController).to receive(:admin_timeout_in_minutes) { two_seconds_in_minutes }
-    allow_any_instance_of(ApplicationController).to receive(:timeout_warning_in_minutes) { one_second_in_minutes }
+    allow_any_instance_of(Admin::BaseAdminController).to receive(:admin_timeout_in_minutes) { two_seconds_in_minutes }
+    allow_any_instance_of(Admin::BaseAdminController).to receive(:timeout_warning_in_minutes) { one_second_in_minutes }
 
     sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
   end

--- a/spec/requests/admin_timeout_spec.rb
+++ b/spec/requests/admin_timeout_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin session timing out", type: :request do
-  let(:timeout_length_in_minutes) { ApplicationController::ADMIN_TIMEOUT_LENGTH_IN_MINUTES }
+  let(:timeout_length_in_minutes) { Admin::BaseAdminController::ADMIN_TIMEOUT_LENGTH_IN_MINUTES }
   let(:user_id) { "userid-345" }
   let(:organisation_id) { "organisationid-6789" }
 
@@ -27,26 +27,6 @@ RSpec.describe "Admin session timing out", type: :request do
 
         follow_redirect!
         expect(response.body).to include("Your session has timed out due to inactivity")
-      end
-    end
-  end
-
-  context "user visits a non-admin page after the timeout period" do
-    let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
-
-    it "still clears the admin session" do
-      expect(session[:user_id]).to eq(user_id)
-      expect(session[:organisation_id]).to eq(organisation_id)
-      expect(session[:role_codes]).to eq([AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
-
-      travel after_expiry do
-        get new_claim_path
-
-        expect(session[:user_id]).to be_nil
-        expect(session[:organisation_id]).to be_nil
-        expect(session[:role_codes]).to be_nil
-
-        expect(response).to be_successful
       end
     end
   end


### PR DESCRIPTION
This mostly organises the code for admin sessions and public-facing user sessions such that they are entirely separate, the exception being the update_last_seen_at method, which updates the timestamp for the user regardless of the type of user they are.

A test was deleted as part of this mostly because it was a mostly false requirement - we do not expect admin users to be visiting the public-facing site, and if they do, it's not a major issue that their sign-in session will get extended because of it.