### PR TITLE
Don't match blank building society roll numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fixed bug in claim matcher code that would match blank building society roll
+  numbers
 - Admin users are sent to the sign in page when their session times out
 - Add noindex and nofollow directives to prevent search engines indexing pages
 

--- a/app/models/claim/matching_attribute_finder.rb
+++ b/app/models/claim/matching_attribute_finder.rb
@@ -19,7 +19,7 @@ class Claim
       values = []
       ATTRIBUTES_TO_MATCH.each do |attribute|
         value = @source_claim.read_attribute(attribute)
-        next unless value
+        next if value.blank?
 
         predicates << "#{attribute} = ?"
         values << value

--- a/spec/models/claim/matching_attribute_finder_spec.rb
+++ b/spec/models/claim/matching_attribute_finder_spec.rb
@@ -59,15 +59,18 @@ RSpec.describe Claim::MatchingAttributeFinder do
       expect(matching_claims).to eq([claim_with_matching_attribute])
     end
 
-    context "when the source claim building society roll number is nil" do
-      before do
-        source_claim.update!(building_society_roll_number: nil)
-      end
+    it "does not match claims with nil building society roll numbers" do
+      source_claim.update!(building_society_roll_number: nil)
+      create(:claim, :submitted, building_society_roll_number: nil)
 
-      it "does not include any claim with a roll number of nil" do
-        create(:claim, :submitted, building_society_roll_number: nil)
-        expect(matching_claims).to be_empty
-      end
+      expect(matching_claims).to be_empty
+    end
+
+    it "does not match claims with blank building society roll numbers" do
+      source_claim.update!(building_society_roll_number: "")
+      create(:claim, :submitted, building_society_roll_number: "")
+
+      expect(matching_claims).to be_empty
     end
   end
 end


### PR DESCRIPTION
It might be that we have stored building_society_roll_numbers that are blank strings. Those should not be flagged as matches.