### PR TITLE
Extract a BasePublicController to mirror admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
-  CLAIM_TIMEOUT_LENGTH_IN_MINUTES = 30
-  CLAIM_TIMEOUT_WARNING_LENGTH_IN_MINUTES = 2
+  TIMEOUT_WARNING_LENGTH_IN_MINUTES = 2
 
   http_basic_authenticate_with(
     name: ENV["BASIC_AUTH_USERNAME"],
@@ -8,38 +7,14 @@ class ApplicationController < ActionController::Base
     if: -> { ENV["BASIC_AUTH_USERNAME"].present? },
   )
 
-  helper_method :current_policy_routing_name, :claim_timeout_in_minutes, :timeout_warning_in_minutes
-  before_action :end_expired_claim_sessions
   after_action :update_last_seen_at
+
+  helper_method :timeout_warning_in_minutes
 
   private
 
-  def current_policy_routing_name
-    params[:policy]
-  end
-
-  def claim_timeout_in_minutes
-    self.class::CLAIM_TIMEOUT_LENGTH_IN_MINUTES
-  end
-
   def timeout_warning_in_minutes
-    self.class::CLAIM_TIMEOUT_WARNING_LENGTH_IN_MINUTES
-  end
-
-  def end_expired_claim_sessions
-    if claim_session_timed_out?
-      clear_claim_session
-      redirect_to timeout_claim_path
-    end
-  end
-
-  def claim_session_timed_out?
-    session.key?(:claim_id) && session[:last_seen_at] < claim_timeout_in_minutes.minutes.ago
-  end
-
-  def clear_claim_session
-    session.delete(:claim_id)
-    session.delete(:verify_request_id)
+    TIMEOUT_WARNING_LENGTH_IN_MINUTES
   end
 
   def update_last_seen_at

--- a/app/controllers/base_public_controller.rb
+++ b/app/controllers/base_public_controller.rb
@@ -1,0 +1,32 @@
+class BasePublicController < ApplicationController
+  CLAIM_TIMEOUT_LENGTH_IN_MINUTES = 30
+
+  helper_method :current_policy_routing_name, :claim_timeout_in_minutes
+  before_action :end_expired_claim_sessions
+
+  private
+
+  def current_policy_routing_name
+    params[:policy]
+  end
+
+  def claim_timeout_in_minutes
+    self.class::CLAIM_TIMEOUT_LENGTH_IN_MINUTES
+  end
+
+  def end_expired_claim_sessions
+    if claim_session_timed_out?
+      clear_claim_session
+      redirect_to timeout_claim_path(current_policy_routing_name)
+    end
+  end
+
+  def claim_session_timed_out?
+    session.key?(:claim_id) && session[:last_seen_at] < claim_timeout_in_minutes.minutes.ago
+  end
+
+  def clear_claim_session
+    session.delete(:claim_id)
+    session.delete(:verify_request_id)
+  end
+end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,4 +1,4 @@
-class ClaimsController < ApplicationController
+class ClaimsController < BasePublicController
   include PartOfClaimJourney
 
   skip_before_action :send_unstarted_claiments_to_the_start, only: [:new, :create, :timeout]

--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -1,4 +1,4 @@
-class SchoolSearchController < ApplicationController
+class SchoolSearchController < BasePublicController
   def create
     search_schools
     render status: errors.blank? ? :ok : :bad_request

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,4 @@
-class StaticPagesController < ApplicationController
+class StaticPagesController < BasePublicController
   def accessibility_statement
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,4 +1,4 @@
-class SubmissionsController < ApplicationController
+class SubmissionsController < BasePublicController
   include PartOfClaimJourney
 
   def create

--- a/app/controllers/verify/authentications_controller.rb
+++ b/app/controllers/verify/authentications_controller.rb
@@ -1,5 +1,5 @@
 module Verify
-  class AuthenticationsController < ApplicationController
+  class AuthenticationsController < BasePublicController
     CLAIM_TIMEOUT_LENGTH_IN_MINUTES = 90
 
     include PartOfClaimJourney

--- a/spec/features/timeout_spec.rb
+++ b/spec/features/timeout_spec.rb
@@ -5,8 +5,8 @@ RSpec.feature "Teacher Student Loan Repayments claims", js: true do
   let(:two_seconds_in_minutes) { 2 / 60.to_f }
 
   before do
-    allow_any_instance_of(ApplicationController).to receive(:claim_timeout_in_minutes) { two_seconds_in_minutes }
-    allow_any_instance_of(ApplicationController).to receive(:timeout_warning_in_minutes) { one_second_in_minutes }
+    allow_any_instance_of(BasePublicController).to receive(:claim_timeout_in_minutes) { two_seconds_in_minutes }
+    allow_any_instance_of(BasePublicController).to receive(:timeout_warning_in_minutes) { one_second_in_minutes }
     start_claim
   end
 

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Claim session timing out", type: :request do
-  let(:timeout_length_in_minutes) { ApplicationController::CLAIM_TIMEOUT_LENGTH_IN_MINUTES }
+  let(:timeout_length_in_minutes) { BasePublicController::CLAIM_TIMEOUT_LENGTH_IN_MINUTES }
 
   context "no actions performed for more than the timeout period" do
     before do


### PR DESCRIPTION
This creates a clearer separation between the controller code for the public-facing part of the application and the admin part, as requested in https://github.com/DFE-Digital/dfe-teachers-payment-service/pull/579.
