### PR TITLE
Implement the new multiple schools journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Add a link to our service's satisfaction survey to the confirmation page
+- Improve journey for users that worked at more than one school during the claim
+  period
 
 ## [Release 028] - 2019-11-06
 

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -73,4 +73,8 @@ module ClaimsHelper
       two_words_connector: connector
     )
   end
+
+  def school_search_question(searching_for_additional_school)
+    searching_for_additional_school ? t("student_loans.questions.additional_school") : t("student_loans.questions.claim_school")
+  end
 end

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -19,7 +19,7 @@ module ClaimsHelper
       a << [t("student_loans.questions.qts_award_year"), I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}"), "qts-year"]
       a << [t("student_loans.questions.claim_school"), eligibility.claim_school_name, "claim-school"]
       a << [t("questions.current_school"), eligibility.current_school_name, "still-teaching"]
-      a << [t("student_loans.questions.subjects_taught"), subject_list(eligibility.subjects_taught), "subjects-taught"]
+      a << [t("student_loans.questions.subjects_taught", school: eligibility.claim_school_name), subject_list(eligibility.subjects_taught), "subjects-taught"]
       a << [t("student_loans.questions.leadership_position"), (eligibility.had_leadership_position? ? "Yes" : "No"), "leadership-position"]
       a << [t("student_loans.questions.mostly_performed_leadership_duties"), (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No"), "mostly-performed-leadership-duties"] if eligibility.had_leadership_position?
     end

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -21,8 +21,8 @@ module StudentLoans
       SUBJECT_ATTRIBUTES,
     ].flatten.freeze
     ATTRIBUTE_DEPENDENCIES = {
-      "claim_school_id" => "employment_status",
-      "had_leadership_position" => "mostly_performed_leadership_duties",
+      "claim_school_id" => ["taught_eligible_subjects", *SUBJECT_ATTRIBUTES, "employment_status"],
+      "had_leadership_position" => ["mostly_performed_leadership_duties"],
     }.freeze
 
     self.table_name = "student_loans_eligibilities"
@@ -87,8 +87,10 @@ module StudentLoans
     end
 
     def reset_dependent_answers
-      ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_name|
-        write_attribute(dependent_attribute_name, nil) if changed.include?(attribute_name)
+      ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
+        dependent_attribute_names.each do |dependent_attribute_name|
+          write_attribute(dependent_attribute_name, nil) if changed.include?(attribute_name)
+        end
       end
       self.current_school = inferred_current_school if employment_status_changed?
     end

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -12,9 +12,9 @@ module StudentLoans
     SLUGS = [
       "qts-year",
       "claim-school",
+      "subjects-taught",
       "still-teaching",
       "current-school",
-      "subjects-taught",
       "leadership-position",
       "mostly-performed-leadership-duties",
       "eligibility-confirmed",

--- a/app/views/claims/_ineligibility_reason_generic.erb
+++ b/app/views/claims/_ineligibility_reason_generic.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-xl">
+  You're not eligible for this payment
+</h1>

--- a/app/views/claims/_ineligibility_reason_generic.erb
+++ b/app/views/claims/_ineligibility_reason_generic.erb
@@ -1,3 +1,0 @@
-<h1 class="govuk-heading-xl">
-  You're not eligible for this payment
-</h1>

--- a/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -10,6 +10,9 @@
 
 <p class="govuk-body">
   If you taught at more than one school during this period, you can
-  <%= link_to "start your claim again", new_claim_path, class: "govuk-link" %> with another school.
+  search again with the next school.
   You only need to have worked at one eligible school to claim.
 </p>
+
+<%= link_to "Enter another school", claim_path(policy: current_policy_routing_name, slug: "claim-school", additional_school: true), class: "govuk-button" %>
+<%= link_to "I've tried all of my schools", claim_path(policy: current_policy_routing_name, slug: "ineligible", generic: true), class: "govuk-button govuk-button--secondary" %>

--- a/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -1,18 +1,22 @@
-<h1 class="govuk-heading-xl">
-  This school is not eligible
-</h1>
+<% if params[:no_more_schools] %>
+  <%= render partial: "ineligibility_reason_no_more_schools" %>
+<% else %>
+  <h1 class="govuk-heading-xl">
+    This school is not eligible
+  </h1>
 
-<p class="govuk-body">
-  <%= claim_school_name %> is not an eligible school. You can only get this
-  payment if you  were employed at an eligible school between 6 April 2018
-  and 5 April 2019.
-</p>
+  <p class="govuk-body">
+    <%= claim_school_name %> is not an eligible school. You can only get this
+    payment if you  were employed at an eligible school between 6 April 2018
+    and 5 April 2019.
+  </p>
 
-<p class="govuk-body">
-  If you taught at more than one school during this period, you can
-  search again with the next school.
-  You only need to have worked at one eligible school to claim.
-</p>
+  <p class="govuk-body">
+    If you taught at more than one school during this period, you can
+    search again with the next school.
+    You only need to have worked at one eligible school to claim.
+  </p>
 
-<%= link_to "Enter another school", claim_path(policy: current_policy_routing_name, slug: "claim-school", additional_school: true), class: "govuk-button" %>
-<%= link_to "I've tried all of my schools", claim_path(policy: current_policy_routing_name, slug: "ineligible", generic: true), class: "govuk-button govuk-button--secondary" %>
+  <%= link_to "Enter another school", claim_path(policy: current_policy_routing_name, slug: "claim-school", additional_school: true), class: "govuk-button" %>
+  <%= link_to "I've tried all of my schools", claim_path(policy: current_policy_routing_name, slug: "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary" %>
+<% end %>

--- a/app/views/claims/_ineligibility_reason_no_more_schools.erb
+++ b/app/views/claims/_ineligibility_reason_no_more_schools.erb
@@ -1,0 +1,7 @@
+<h1 class="govuk-heading-xl">
+  You're not eligible for this payment
+</h1>
+
+<p class="govuk-body">
+  You must have been employed by at least one eligible school and taught eligible subjects to claim between 6 April 2018 and 5 April 2019.
+</p>

--- a/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -1,30 +1,33 @@
-<h1 class="govuk-heading-xl">
-  You did not select an eligible subject
-</h1>
+<% if params[:no_more_schools] %>
+  <%= render partial: "ineligibility_reason_no_more_schools" %>
+<% else %>
+  <h1 class="govuk-heading-xl">
+    You did not select an eligible subject
+  </h1>
 
-<p class="govuk-body">
-  You did not teach an eligible subject at <%= claim_school_name %>.
-</p>
+  <p class="govuk-body">
+    You did not teach an eligible subject at <%= claim_school_name %>.
+  </p>
 
-<p class="govuk-body">
-  You can only get this payment if you taught one or more of the following
-  subjects between 6 April 2018 and 5 April 2019:
-</p>
+  <p class="govuk-body">
+    You can only get this payment if you taught one or more of the following
+    subjects between 6 April 2018 and 5 April 2019:
+  </p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>biology</li>
-  <li>chemistry</li>
-  <li>physics</li>
-  <li>computer science</li>
-  <li>languages (not including English)</li>
-</ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>biology</li>
+    <li>chemistry</li>
+    <li>physics</li>
+    <li>computer science</li>
+    <li>languages (not including English)</li>
+  </ul>
 
-<p class="govuk-body">
-  If you taught at more than one school during this period, you can
-  search again with the next school.
-  You only need to have worked at one eligible school to claim.
-</p>
+  <p class="govuk-body">
+    If you taught at more than one school during this period, you can
+    search again with the next school.
+    You only need to have worked at one eligible school to claim.
+  </p>
 
-<%= link_to "Enter another school", claim_path(policy: current_policy_routing_name, slug: "claim-school", additional_school: true), class: "govuk-button" %>
-<%= link_to "I've tried all of my schools", claim_path(policy: current_policy_routing_name, slug: "ineligible", generic: true), class: "govuk-button govuk-button--secondary" %>
-
+  <%= link_to "Enter another school", claim_path(policy: current_policy_routing_name, slug: "claim-school", additional_school: true), class: "govuk-button" %>
+  <%= link_to "I've tried all of my schools", claim_path(policy: current_policy_routing_name, slug: "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary" %>
+<% end %>

--- a/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -20,10 +20,11 @@
 </ul>
 
 <p class="govuk-body">
-  If you taught at more than one school between April 6 2018 and April 5 2019,
-  you can <%= link_to "start your claim again", new_claim_path, class: "govuk-link" %> with another
-  school. You only need to have taught an eligible subject at one eligible
-  school to claim.
-<p>
+  If you taught at more than one school during this period, you can
+  search again with the next school.
+  You only need to have worked at one eligible school to claim.
+</p>
 
+<%= link_to "Enter another school", claim_path(policy: current_policy_routing_name, slug: "claim-school", additional_school: true), class: "govuk-button" %>
+<%= link_to "I've tried all of my schools", claim_path(policy: current_policy_routing_name, slug: "ineligible", generic: true), class: "govuk-button govuk-button--secondary" %>
 

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -33,7 +33,7 @@
         Enter the school name. Use at least four characters.
       </span>
 
-      <% if school_id_param == :claim_school_id %>
+      <% if school_id_param == :claim_school_id && !params.has_key?(:additional_school) %>
         <span class="govuk-hint">
           If you worked at multiple schools during this period, enter the first school you think might be eligible.
         </span>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -1,14 +1,14 @@
-<%= page_title(t("student_loans.questions.claim_school"), show_error: current_claim.errors.any?) %>
+<%= page_title(school_search_question(params[:additional_school]), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @schools.blank? %>
 
       <%= render "school_search",
-                 question: t("student_loans.questions.claim_school"),
+                 question: school_search_question(params[:additional_school]),
                  school_param: :claim_school,
                  school_id_param: :claim_school_id,
-                 school_search_value: current_claim.eligibility.claim_school_name,
+                 school_search_value: (current_claim.eligibility.claim_school_name unless params[:additional_school]),
                  exclude_closed: false
       %>
 

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -2,7 +2,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}", locals: { claim_school_name: current_claim.eligibility.claim_school_name, current_school_name: current_claim.eligibility.current_school_name } %>
+    <% if params[:generic] %>
+      <%= render partial: "ineligibility_reason_generic" %>
+    <% else %>
+      <%= render partial: "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}", locals: { claim_school_name: current_claim.eligibility.claim_school_name, current_school_name: current_claim.eligibility.current_school_name } %>
+    <% end %>
 
     <p class="govuk-body">
       For more information about the eligibility criteria, or if you need help with

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -2,11 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if params[:generic] %>
-      <%= render partial: "ineligibility_reason_generic" %>
-    <% else %>
-      <%= render partial: "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}", locals: { claim_school_name: current_claim.eligibility.claim_school_name, current_school_name: current_claim.eligibility.current_school_name } %>
-    <% end %>
+    <%= render partial: "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}", locals: { claim_school_name: current_claim.eligibility.claim_school_name, current_school_name: current_claim.eligibility.current_school_name } %>
 
     <p class="govuk-body">
       For more information about the eligibility criteria, or if you need help with

--- a/app/views/claims/subjects_taught.html.erb
+++ b/app/views/claims/subjects_taught.html.erb
@@ -12,7 +12,7 @@
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("student_loans.questions.subjects_taught") %>
+                <%= t("student_loans.questions.subjects_taught", school: current_claim.eligibility.claim_school_name) %>
               </h1>
             </legend>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,7 +110,7 @@ en:
       claim_school: "Which school were you employed at between 6 April 2018 and 5 April 2019?"
       additional_school: "Which additional school you were employed at between 6 April 2018 and 5 April 2019?"
       employment_status: "Are you still employed to teach at a school in England?"
-      subjects_taught: "Did you teach any of these subjects between 6 April 2018 and 5 April 2019?"
+      subjects_taught: "Which of the following subjects did you teach at %{school} between 6 April 2018 and 5 April 2019?"
       leadership_position: "Were you employed in a leadership position between 6 April 2018 and 5 April 2019?"
       mostly_performed_leadership_duties:
         "Were more than half your working hours spent on leadership duties between 6 April 2018 and 5 April 2019?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,7 @@ en:
         before_september_2013: "Before 1 September 2013"
         on_or_after_september_2013: "On or after 1 September 2013"
       claim_school: "Which school were you employed at between 6 April 2018 and 5 April 2019?"
+      additional_school: "Which additional school you were employed at between 6 April 2018 and 5 April 2019?"
       employment_status: "Are you still employed to teach at a school in England?"
       subjects_taught: "Did you teach any of these subjects between 6 April 2018 and 5 April 2019?"
       leadership_position: "Were you employed in a leadership position between 6 April 2018 and 5 April 2019?"

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -168,59 +168,77 @@ RSpec.feature "Changing the answers on a submittable claim" do
         expect(eligibility.reload.claim_school).to eql new_claim_school
       end
 
-      scenario "Teacher is redirected to the are you still employed screen" do
-        expect(current_path).to eq(claim_path("still-teaching"))
+      scenario "Teacher is redirected to the subjects taught screen" do
+        expect(current_path).to eq(claim_path("subjects-taught"))
       end
 
-      context "When still teaching at the claim school" do
+      context "When still teaching eligible subjects" do
         before do
-          choose "Yes, at Claim School"
+          check I18n.t("student_loans.questions.eligible_subjects.biology_taught"), visible: false
+          check I18n.t("student_loans.questions.eligible_subjects.chemistry_taught"), visible: false
+
           click_on "Continue"
         end
 
-        scenario "current school is set correctly" do
-          expect(eligibility.reload.employment_status).to eql("claim_school")
-          expect(eligibility.current_school).to eql new_claim_school
+        scenario "Eligible subjects are set correctly" do
+          expect(eligibility.reload.biology_taught).to eq(true)
+          expect(eligibility.chemistry_taught).to eq(true)
         end
 
-        scenario "Teacher is redirected to the check your answers page" do
-          expect(current_path).to eq(claim_path("check-your-answers"))
-        end
-      end
-
-      context "When still teaching but at a different school" do
-        before do
-          choose_still_teaching "Yes, at another school"
-
-          fill_in :school_search, with: "Hampstead"
-          click_on "Search"
-
-          choose "Hampstead School"
-          click_on "Continue"
+        scenario "Teacher is redirected to the are you still employed screen" do
+          expect(current_path).to eq(claim_path("still-teaching"))
         end
 
-        scenario "School and employment status are set correctly" do
-          expect(eligibility.reload.employment_status).to eql("different_school")
-          expect(eligibility.reload.current_school).to eql schools(:hampstead_school)
+        context "When still teaching at the claim school" do
+          before do
+            choose "Yes, at Claim School"
+            click_on "Continue"
+          end
+
+          scenario "current school is set correctly" do
+            expect(eligibility.reload.employment_status).to eql("claim_school")
+            expect(eligibility.current_school).to eql new_claim_school
+          end
+
+          scenario "Teacher is redirected to the check your answers page" do
+            expect(current_path).to eq(claim_path("check-your-answers"))
+          end
         end
 
-        scenario "Teacher is redirected to the check your answers page" do
-          expect(current_path).to eq(claim_path("check-your-answers"))
-        end
-      end
+        context "When still teaching but at a different school" do
+          before do
+            choose_still_teaching "Yes, at another school"
 
-      context "When no longer teaching" do
-        before do
-          choose_still_teaching "No"
+            fill_in :school_search, with: "Hampstead"
+            click_on "Search"
+
+            choose "Hampstead School"
+            click_on "Continue"
+          end
+
+          scenario "School and employment status are set correctly" do
+            expect(eligibility.reload.employment_status).to eql("different_school")
+            expect(eligibility.reload.current_school).to eql schools(:hampstead_school)
+          end
+
+          scenario "Teacher is redirected to the check your answers page" do
+            expect(current_path).to eq(claim_path("check-your-answers"))
+          end
         end
 
-        scenario "Employment status is set correctly" do
-          expect(eligibility.reload.employment_status).to eq("no_school")
-        end
+        context "When no longer teaching" do
+          before do
+            choose_still_teaching "No"
+          end
 
-        scenario "Teacher is told they are not eligible" do
-          expect(page).to have_text("You’re not eligible")
-          expect(page).to have_text("You can only get this payment if you’re still employed at a school.")
+          scenario "Employment status is set correctly" do
+            expect(eligibility.reload.employment_status).to eq("no_school")
+          end
+
+          scenario "Teacher is told they are not eligible" do
+            expect(page).to have_text("You’re not eligible")
+            expect(page).to have_text("You can only get this payment if you’re still employed at a school.")
+          end
         end
       end
     end

--- a/spec/features/current_school_with_closed_claim_school_spec.rb
+++ b/spec/features/current_school_with_closed_claim_school_spec.rb
@@ -6,6 +6,8 @@ RSpec.feature "Current school with closed claim school" do
   scenario "Still teaching only has two options" do
     start_claim
     choose_school claim_school
+    check "Physics"
+    click_on "Continue"
 
     expect(page).to have_text("Yes")
     expect(page).to have_text("No")
@@ -16,6 +18,8 @@ RSpec.feature "Current school with closed claim school" do
   scenario "Choosing yes to still teaching prompts to search for a school" do
     claim = start_claim
     choose_school claim_school
+    check "Physics"
+    click_on "Continue"
 
     choose_still_teaching "Yes"
 

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -6,8 +6,9 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
 
     @claim = start_claim
     choose_school schools(:penistone_grammar_school)
-    choose_still_teaching
     choose_subjects_taught
+    choose_still_teaching
+    choose_leadership
     click_on "Continue"
   end
 

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -115,6 +115,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     choose_school schools(:penistone_grammar_school)
 
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
   end
 end

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     claim = start_claim
 
     choose_school schools(:penistone_grammar_school)
+    choose_subjects_taught
 
     choose_still_teaching "Yes, at another school"
 
@@ -28,7 +29,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.current_school).to eql schools(:hampstead_school)
 
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
+    expect(page).to have_text(I18n.t("student_loans.questions.leadership_position"))
   end
 
   scenario "chooses an ineligible claim school" do
@@ -44,6 +45,8 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     start_claim
 
     choose_school schools(:penistone_grammar_school)
+    choose_subjects_taught
+
     choose_still_teaching "Yes, at another school"
 
     fill_in :school_search, with: "Bradford"
@@ -59,6 +62,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   scenario "no longer teaching" do
     claim = start_claim
     choose_school schools(:penistone_grammar_school)
+    choose_subjects_taught
 
     choose_still_teaching "No"
 
@@ -70,7 +74,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   scenario "did not teach an eligible subject" do
     claim = start_claim
     choose_school schools(:penistone_grammar_school)
-    choose_still_teaching
 
     choose I18n.t("student_loans.questions.eligible_subjects.none_taught")
     click_on "Continue"
@@ -83,10 +86,10 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   scenario "was in a leadership position and performed leadership duties for more than half of their time" do
     claim = start_claim
     choose_school schools(:penistone_grammar_school)
-    choose_still_teaching
-
     check "Biology"
     click_on "Continue"
+
+    choose_still_teaching
 
     choose "Yes"
     click_on "Continue"
@@ -111,6 +114,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     choose_qts_year
 
     choose_school schools(:penistone_grammar_school)
-    expect(page).to have_text("Are you still employed to teach at a school in England?")
+
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
   end
 end

--- a/spec/features/missing_verify_information_spec.rb
+++ b/spec/features/missing_verify_information_spec.rb
@@ -4,8 +4,9 @@ RSpec.feature "Missing information from GOV.UK Verify" do
   scenario "Claimant is asked a payroll gender question when Verify doesn’t provide their gender" do
     claim = start_claim
     choose_school schools(:penistone_grammar_school)
-    choose_still_teaching
     choose_subjects_taught
+    choose_still_teaching
+    choose_leadership
     click_on "Continue"
 
     perform_verify_step("identity-verified-other-gender")
@@ -55,8 +56,9 @@ RSpec.feature "Missing information from GOV.UK Verify" do
   scenario "Claimant is asked an address question when Verify doesn’t provide their address" do
     claim = start_claim
     choose_school schools(:penistone_grammar_school)
-    choose_still_teaching
     choose_subjects_taught
+    choose_still_teaching
+    choose_leadership
     click_on "Continue"
 
     perform_verify_step("identity-verified-no-address")

--- a/spec/features/multiple_claim_schools_spec.rb
+++ b/spec/features/multiple_claim_schools_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Applicant worked at multiple schools" do
     choose_school schools(:penistone_grammar_school)
     expect(claim.eligibility.reload.claim_school).to eq schools(:penistone_grammar_school)
 
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
   end
 
   scenario "first claim school is ineligible, as is the subsequent school" do

--- a/spec/features/multiple_claim_schools_spec.rb
+++ b/spec/features/multiple_claim_schools_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.feature "Applicant worked at multiple schools" do
-  let(:claim) { Claim.order(:created_at).last }
-  let(:eligibility) { claim.eligibility }
+  let!(:eligible_school) { create(:school, :student_loan_eligible) }
 
-  scenario "first claim school is ineligible, but subsequent school is eligible" do
-    claim = start_claim
+  let!(:claim) { start_claim }
+
+  scenario "first claim school is ineligible and subsequent school is eligible" do
     choose_school schools(:hampstead_school)
 
     expect(claim.eligibility.reload.claim_school).to eq schools(:hampstead_school)
@@ -24,15 +24,59 @@ RSpec.feature "Applicant worked at multiple schools" do
     expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
   end
 
-  scenario "first claim school is ineligible, as is the subsequent school" do
-    start_claim
+  scenario "first claim school is ineligible and subsequent school is ineligible too" do
     choose_school schools(:hampstead_school)
+    click_on "Enter another school"
+
+    choose_school schools(:bradford_grammar_school)
+    expect(page).to have_text("This school is not eligible")
+    expect(page).to have_text("#{schools(:bradford_grammar_school).name} is not an eligible school.")
+
+    click_on "I've tried all of my schools"
+
+    expect(page).to have_text("You're not eligible for this payment")
+  end
+
+  scenario "didn't teach eligible subjects, but taught eligible subjects at a different eligible school" do
+    choose_school schools(:penistone_grammar_school)
+
+    choose I18n.t("student_loans.questions.eligible_subjects.none_taught")
+    click_on "Continue"
+
+    expect(page).to have_text("You did not select an eligible subject")
+    expect(page).to have_text("You did not teach an eligible subject at Penistone Grammar School.")
 
     click_on "Enter another school"
 
-    choose_school schools(:hampstead_school)
-    expect(page).to have_text("This school is not eligible")
-    expect(page).to have_text("Hampstead School is not an eligible school.")
+    expect(page).to_not have_css("input[value=\"Penistone Grammar School\"]")
+    expect(page).to have_text(I18n.t("student_loans.questions.additional_school"))
+
+    choose_school eligible_school
+
+    check I18n.t("student_loans.questions.eligible_subjects.biology_taught")
+    check I18n.t("student_loans.questions.eligible_subjects.physics_taught")
+    click_on "Continue"
+
+    expect(claim.eligibility.reload.taught_eligible_subjects).to eq(true)
+    expect(claim.eligibility.biology_taught).to eq(true)
+    expect(claim.eligibility.physics_taught).to eq(true)
+  end
+
+  scenario "didn't teach eligible subjects and did not teach eligible subjects at a different eligible school" do
+    choose_school schools(:penistone_grammar_school)
+
+    choose I18n.t("student_loans.questions.eligible_subjects.none_taught")
+    click_on "Continue"
+
+    click_on "Enter another school"
+
+    choose_school eligible_school
+
+    choose I18n.t("student_loans.questions.eligible_subjects.none_taught")
+    click_on "Continue"
+
+    expect(page).to have_text("You did not select an eligible subject")
+    expect(page).to have_text("You did not teach an eligible subject at #{eligible_school.name}.")
 
     click_on "I've tried all of my schools"
 

--- a/spec/features/multiple_claim_schools_spec.rb
+++ b/spec/features/multiple_claim_schools_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Applicant worked at multiple schools" do
     choose_school schools(:penistone_grammar_school)
     expect(claim.eligibility.reload.claim_school).to eq schools(:penistone_grammar_school)
 
-    expect(page).to have_text(I18n.t("student_loans.questions.employment_status"))
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
   end
 
   scenario "first claim school is ineligible, as is the subsequent school" do

--- a/spec/features/multiple_claim_schools_spec.rb
+++ b/spec/features/multiple_claim_schools_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.feature "Applicant worked at multiple schools" do
+  let(:claim) { Claim.order(:created_at).last }
+  let(:eligibility) { claim.eligibility }
+
+  scenario "first claim school is ineligible, but subsequent school is eligible" do
+    claim = start_claim
+    choose_school schools(:hampstead_school)
+
+    expect(claim.eligibility.reload.claim_school).to eq schools(:hampstead_school)
+    expect(page).to have_text("This school is not eligible")
+    expect(page).to have_text("Hampstead School is not an eligible school.")
+
+    click_on "Enter another school"
+
+    expect(page).to_not have_css("input[value=\"Hampstead School\"]")
+    expect(page).to have_text(I18n.t("student_loans.questions.additional_school"))
+    expect(page).to_not have_text("If you worked at multiple schools")
+
+    choose_school schools(:penistone_grammar_school)
+    expect(claim.eligibility.reload.claim_school).to eq schools(:penistone_grammar_school)
+
+    expect(page).to have_text(I18n.t("student_loans.questions.employment_status"))
+  end
+
+  scenario "first claim school is ineligible, as is the subsequent school" do
+    start_claim
+    choose_school schools(:hampstead_school)
+
+    click_on "Enter another school"
+
+    choose_school schools(:hampstead_school)
+    expect(page).to have_text("This school is not eligible")
+    expect(page).to have_text("Hampstead School is not an eligible school.")
+
+    click_on "I've tried all of my schools"
+
+    expect(page).to have_text("You're not eligible for this payment")
+  end
+end

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     click_on "Continue"
 
     expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
   end
 
   scenario "searches again to find school" do
@@ -34,7 +34,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     click_on "Continue"
 
     expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
   end
 
   scenario "Claim school search with autocomplete", js: true do
@@ -50,7 +50,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
     click_button "Continue"
 
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
   end
 
   scenario "Current school search with autocomplete", js: true do

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     click_on "Continue"
 
     expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text("Are you still employed to teach at a school in England")
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
   end
 
   scenario "searches again to find school" do
@@ -34,7 +34,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     click_on "Continue"
 
     expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text("Are you still employed to teach at a school in England")
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
   end
 
   scenario "Claim school search with autocomplete", js: true do
@@ -50,13 +50,15 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
     click_button "Continue"
 
-    expect(page).to have_text(I18n.t("student_loans.questions.employment_status"))
+    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
   end
 
   scenario "Current school search with autocomplete", js: true do
     start_claim
 
     choose_school schools(:penistone_grammar_school)
+    choose_subjects_taught
+
     choose_still_teaching "Yes, at another school"
 
     expect(page).to have_text(I18n.t("questions.current_school"))
@@ -69,7 +71,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
     click_button "Continue"
 
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
+    expect(page).to have_text(I18n.t("student_loans.questions.leadership_position"))
   end
 
   scenario "School search form still works like a normal form if submitted", js: true do
@@ -126,6 +128,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   scenario "Current school search excludes closed schools" do
     start_claim
     choose_school schools(:penistone_grammar_school)
+    choose_subjects_taught
     choose_still_teaching "Yes, at another school"
 
     expect(page).to have_text(I18n.t("questions.current_school"))
@@ -151,6 +154,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     start_claim
 
     choose_school schools(:penistone_grammar_school)
+    choose_subjects_taught
     choose_still_teaching "Yes, at another school"
 
     expect(page).to have_text(I18n.t("questions.current_school"))

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -19,15 +19,15 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       choose_school schools(:penistone_grammar_school)
       expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
+      expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
+
+      check "Physics"
+      click_on "Continue"
       expect(page).to have_text(I18n.t("student_loans.questions.employment_status"))
 
       choose_still_teaching
       expect(claim.eligibility.reload.employment_status).to eql("claim_school")
       expect(claim.eligibility.current_school).to eql(schools(:penistone_grammar_school))
-
-      expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
-      check "Physics"
-      click_on "Continue"
 
       expect(claim.eligibility.reload.subjects_taught).to eq([:physics_taught])
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       choose_school schools(:penistone_grammar_school)
       expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
-      expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught"))
+      expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
 
       check "Physics"
       click_on "Continue"

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments claims" do
   before do
     start_claim
-    visit claim_path("subjects-taught")
+    choose_school schools(:penistone_grammar_school)
   end
 
   context "with JS enabled", js: true do
@@ -39,10 +39,10 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
 
       click_on "Continue"
 
-      choose "Yes"
+      choose "Yes, at Penistone Grammar School"
       click_on "Continue"
 
-      expect(page).to have_text(I18n.t("student_loans.questions.mostly_performed_leadership_duties"))
+      expect(page).to have_text(I18n.t("student_loans.questions.leadership_position"))
     end
   end
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -22,7 +22,7 @@ describe ClaimsHelper do
         [I18n.t("student_loans.questions.qts_award_year"), "On or after 1 September 2013", "qts-year"],
         [I18n.t("student_loans.questions.claim_school"), school.name, "claim-school"],
         [I18n.t("questions.current_school"), school.name, "still-teaching"],
-        [I18n.t("student_loans.questions.subjects_taught"), "Chemistry and Physics", "subjects-taught"],
+        [I18n.t("student_loans.questions.subjects_taught", school: school.name), "Chemistry and Physics", "subjects-taught"],
         [I18n.t("student_loans.questions.leadership_position"), "Yes", "leadership-position"],
         [I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "No", "mostly-performed-leadership-duties"],
       ]

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -152,6 +152,11 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
         :eligible,
         claim_school: schools(:penistone_grammar_school),
         current_school: schools(:hampstead_school),
+        taught_eligible_subjects: true,
+        chemistry_taught: true,
+        physics_taught: true,
+        computer_science_taught: true,
+        languages_taught: true,
         employment_status: :different_school,
         had_leadership_position: true,
       )
@@ -165,6 +170,21 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       expect { eligibility.reset_dependent_answers }
         .to change { eligibility.employment_status }
         .from("different_school").to(nil)
+    end
+
+    it "resets the subject fields when the value of the claim_school changes" do
+      eligibility.claim_school = schools(:penistone_grammar_school)
+      expect { eligibility.reset_dependent_answers }.not_to change { eligibility.attributes }
+
+      eligibility.claim_school = schools(:hampstead_school)
+      eligibility.reset_dependent_answers
+
+      expect(eligibility.taught_eligible_subjects).to eq(nil)
+      expect(eligibility.physics_taught).to eq(nil)
+      expect(eligibility.chemistry_taught).to eq(nil)
+      expect(eligibility.physics_taught).to eq(nil)
+      expect(eligibility.computer_science_taught).to eq(nil)
+      expect(eligibility.languages_taught).to eq(nil)
     end
 
     it "resets mostly_performed_leadership_duties when the value of had_leadership_position changes" do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -2,9 +2,10 @@ module FeatureHelpers
   def answer_all_student_loans_claim_questions
     start_claim
     choose_school schools(:penistone_grammar_school)
+    choose_subjects_taught
     choose_still_teaching "Yes, at another school"
     choose_school schools(:hampstead_school)
-    choose_subjects_taught
+    choose_leadership
     click_on "Continue"
 
     perform_verify_step
@@ -56,7 +57,9 @@ module FeatureHelpers
   def choose_subjects_taught
     check "Physics"
     click_on "Continue"
+  end
 
+  def choose_leadership
     choose "Yes"
     click_on "Continue"
 


### PR DESCRIPTION
This implements the new multiple schools journey. Now if a teacher did not teach at an eligible school, they are given the opportunity to try again with another school that they may have taught at in the same period. We also change the flow so they are asked if they taught eligibile subjects relative to the school they taught in, if they didn't they are given the opportunity to choose another school where they may have taught eligible subjects.

![image](https://user-images.githubusercontent.com/109774/68284956-4f03a000-0076-11ea-9f0a-c04ff949c500.png)

![image](https://user-images.githubusercontent.com/109774/68284983-59be3500-0076-11ea-869b-b2a2cf2f2941.png)

![image](https://user-images.githubusercontent.com/109774/68285266-d9e49a80-0076-11ea-9f9b-f28239d3239f.png)

![image](https://user-images.githubusercontent.com/109774/68285045-765a6d00-0076-11ea-8937-c0f110451e2e.png)

![image](https://user-images.githubusercontent.com/109774/68285073-81150200-0076-11ea-99bc-81a5fa9cca89.png)

![image](https://user-images.githubusercontent.com/109774/68318185-46ca5580-00b4-11ea-894f-c27484f83fe6.png)

