### PR TITLE
Ignore case when checking for matching attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- When checking whether a claim's details have been used in other claims, ignore
+  the case (i.e. capitalisation) of the claims' details
+
 ## [Release 027] - 2019-11-05
 
 - Fixed bug in claim matcher code that would match blank building society roll

--- a/app/models/claim/matching_attribute_finder.rb
+++ b/app/models/claim/matching_attribute_finder.rb
@@ -21,7 +21,7 @@ class Claim
         value = @source_claim.read_attribute(attribute)
         next if value.blank?
 
-        predicates << "#{attribute} = ?"
+        predicates << "LOWER(#{attribute}) = LOWER(?)"
         values << value
       end
 

--- a/spec/models/claim/matching_attribute_finder_spec.rb
+++ b/spec/models/claim/matching_attribute_finder_spec.rb
@@ -35,8 +35,20 @@ RSpec.describe Claim::MatchingAttributeFinder do
       expect(matching_claims).to eq([claim_with_matching_attribute])
     end
 
+    it "includes a claim with a matching national insurance number with a different capitalisation" do
+      claim_with_matching_attribute = create(:claim, :submitted, national_insurance_number: source_claim.national_insurance_number.downcase)
+
+      expect(matching_claims).to eq([claim_with_matching_attribute])
+    end
+
     it "includes a claim with a matching email address" do
       claim_with_matching_attribute = create(:claim, :submitted, email_address: source_claim.email_address)
+
+      expect(matching_claims).to eq([claim_with_matching_attribute])
+    end
+
+    it "includes a claim with a matching email address with a different capitalisation" do
+      claim_with_matching_attribute = create(:claim, :submitted, email_address: source_claim.email_address.upcase)
 
       expect(matching_claims).to eq([claim_with_matching_attribute])
     end


### PR DESCRIPTION
For example, a claim with a National Insurance number that differs only
in capitalisation should be considered a match.