### PR TITLE
Upcase when normalising National Insurance number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Always save claimant's National Insurance number in upper case
 - When checking whether a claim's details have been used in other claims, ignore
   the case (i.e. capitalisation) of the claims' details
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -231,12 +231,12 @@ class Claim < ApplicationRecord
   end
 
   def normalised_ni_number
-    national_insurance_number.gsub(/\s/, "")
+    national_insurance_number.gsub(/\s/, "").upcase
   end
 
   def ni_number_is_correct_format
     errors.add(:national_insurance_number, "Enter a National Insurance number in the correct format") \
-      if national_insurance_number.present? && !normalised_ni_number.match(/\A[a-z]{2}[0-9]{6}[a-d]{1}\Z/i)
+      if national_insurance_number.present? && !normalised_ni_number.match(/\A[A-Z]{2}[0-9]{6}[A-D]{1}\Z/)
   end
 
   def normalise_bank_account_number

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -94,6 +94,13 @@ RSpec.describe Claim, type: :model do
         expect(claim.bank_sort_code).to eql("123456")
         expect(claim.bank_account_number).to eql("12345678")
       end
+
+      it "strips spaces from and upcases the National Insurance number" do
+        claim = build(:claim, national_insurance_number: "qq 34 56 78 c")
+        claim.save!
+
+        expect(claim.national_insurance_number).to eq("QQ345678C")
+      end
     end
   end
 


### PR DESCRIPTION
Now that we're performing case-insensitive comparisons when detecting
matching claims, this is no longer strictly necessary. It does however
seem like good data hygiene, and something that we should have done when
we first wrote the normalisation.

There will also be a data migration to upcase the existing NI numbers,
but this will be deployed in a subsequent release, to ensure that,
before we run the data migration, all of the running web servers are
already using this new normalisation. Since we have zero-downtime
deploys, we cannot make this guarantee if we deploy the new code and the
data migration simultaneously.

<!-- Do you need to update CHANGELOG.md? -->
