### PR TITLE
Fix flakey current school search spec

### DIFF
--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -1,114 +1,54 @@
-<% if @schools.blank? %>
+<%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { school_search: "school_search" }) if current_claim.errors.any? %>
 
-  <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { school_search: "school_search" }) if current_claim.errors.any? %>
+<%= form_for current_claim,
+             url: claim_path,
+             method: :get,
+             data: {
+               "school-id-param": "claim_eligibility_attributes_#{school_id_param}",
+               "exclude-closed": exclude_closed
+             },
+             html: { class: "school_search_form" } do |form|
+%>
+  <%= hidden_field_tag :_method, "get", id: nil %>
+  <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
 
-  <%= form_for current_claim,
-               url: claim_path,
-               method: :get,
-               data: {
-                 "school-id-param": "claim_eligibility_attributes_#{school_id_param}",
-                 "exclude-closed": exclude_closed
-               },
-               html: { class: "school_search_form" } do |form|
-  %>
-    <%= hidden_field_tag :_method, "get", id: nil %>
-    <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+  <%= form.fields_for :eligibility, include_id: false do |fields| %>
+    <%= fields.hidden_field school_id_param %>
+  <% end %>
 
-    <%= form.fields_for :eligibility, include_id: false do |fields| %>
-      <%= fields.hidden_field school_id_param %>
-    <% end %>
+  <%= form_group_tag current_claim, :school_search do %>
 
-    <%= form_group_tag current_claim, :school_search do %>
+    <%= hidden_field_tag :exclude_closed, exclude_closed, id: nil %>
 
-      <%= hidden_field_tag :exclude_closed, exclude_closed, id: nil %>
+    <h1 class="govuk-label-wrapper">
+      <%= label_tag :school_search, question, class: "govuk-label govuk-label--xl" %>
+    </h1>
 
-      <h1 class="govuk-label-wrapper">
-        <%= label_tag :school_search, question, class: "govuk-label govuk-label--xl" %>
-      </h1>
+    <% if params[:school_search].present? && current_claim.errors.empty? %>
+      <p class="govuk-body">
+        <strong>No results match that search term. Try again.</strong>
+      </p>
+    <% else %>
+      <span class="govuk-hint">
+        Enter the school name. Use at least four characters.
+      </span>
 
-      <% if params[:school_search].present? && current_claim.errors.empty? %>
-        <p class="govuk-body">
-          <strong>No results match that search term. Try again.</strong>
-        </p>
-      <% else %>
+      <% if school_id_param == :claim_school_id %>
         <span class="govuk-hint">
-          Enter the school name. Use at least four characters.
+          If you worked at multiple schools during this period, enter the first school you think might be eligible.
         </span>
-
-        <% if school_id_param == :claim_school_id %>
-          <span class="govuk-hint">
-            If you worked at multiple schools during this period, enter the first school you think might be eligible.
-          </span>
-        <% end %>
       <% end %>
-
-      <div id="school-search-container">
-
-        <%= errors_tag current_claim, :school_search %>
-        <%= text_field_tag :school_search, params[:school_search], id: :school_search, class: css_classes_for_input(current_claim, :school_search), value: school_search_value %>
-
-      </div>
-
     <% end %>
 
-    <%= submit_tag "Search", class: "govuk-button" %>
+    <div id="school-search-container">
+
+      <%= errors_tag current_claim, :school_search %>
+      <%= text_field_tag :school_search, params[:school_search], id: :school_search, class: css_classes_for_input(current_claim, :school_search), value: school_search_value %>
+
+    </div>
 
   <% end %>
 
-<% else %>
-
-  <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.#{school_param}": "claim_eligibility_attributes_#{school_id_param}_#{@schools.first.id}" }) if current_claim.errors.any?
-  %>
-
-  <%= form_for current_claim, url: claim_path do |form| %>
-    <%= form_group_tag current_claim do %>
-      <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
-
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            <%= question %>
-          </h1>
-        </legend>
-
-        <span id="school-search-result-hint" class="govuk-hint">
-          Select your school from the search results.
-        </span>
-
-        <%= hidden_field_tag :school_search, params[:school_search] %>
-
-        <%= errors_tag current_claim.eligibility, school_param %>
-
-        <div class="govuk-radios">
-          <%= form.fields_for :eligibility, include_id: false do |fields| %>
-            <%= fields.collection_radio_buttons school_id_param, @schools, :id, :name do |b| %>
-              <div class="govuk-radios__item">
-                <%= b.radio_button class: "govuk-radios__input" %>
-                <%= b.label class: "govuk-radios__label govuk-label--s govuk-radios__label govuk-!-padding-0" do %>
-                  <div class="school-search__suggestion">
-                    <div class="school-search__suggestion-main-section">
-                      <div class="govuk-label govuk-radios__label govuk-label--s">
-                        <%= b.text %>
-                      </div>
-                      <span class="govuk-hint govuk-radios__hint"><%= b.object.address %></span>
-                    </div>
-                    <% if b.object.close_date.present? %>
-                      <div class="school-search__closed-status">
-                        <span class="govuk-hint govuk-radios__hint govuk-!-margin-bottom-1">Closed on <%= l(b.object.close_date) %></span>
-                      </div>
-                    <% end %>
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
-
-      </fieldset>
-    <% end %>
-
-    <%= form.submit "Continue", class: "govuk-button" %>
-    <%= link_to "Search again", claim_path, class: "govuk-button govuk-button--secondary" %>
-
-  <% end %>
+  <%= submit_tag "Search", class: "govuk-button" %>
 
 <% end %>

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -31,18 +31,14 @@
           <strong>No results match that search term. Try again.</strong>
         </p>
       <% else %>
-        <p class="govuk-body">
-          <span class="govuk-hint">
-            Enter the school name. Use at least four characters.
-          </span>
-        </p>
+        <span class="govuk-hint">
+          Enter the school name. Use at least four characters.
+        </span>
 
         <% if school_id_param == :claim_school_id %>
-          <p class="govuk-body">
-            <span class="govuk-hint">
-              If you worked at multiple schools during this period, enter the first school you think might be eligible.
-            </span>
-          </p>
+          <span class="govuk-hint">
+            If you worked at multiple schools during this period, enter the first school you think might be eligible.
+          </span>
         <% end %>
       <% end %>
 

--- a/app/views/claims/_school_search_results.html.erb
+++ b/app/views/claims/_school_search_results.html.erb
@@ -1,0 +1,53 @@
+<%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.#{school_param}": "claim_eligibility_attributes_#{school_id_param}_#{@schools.first.id}" }) if current_claim.errors.any?
+%>
+
+<%= form_for current_claim, url: claim_path do |form| %>
+  <%= form_group_tag current_claim do %>
+    <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
+
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <h1 class="govuk-fieldset__heading">
+          <%= question %>
+        </h1>
+      </legend>
+
+      <span id="school-search-result-hint" class="govuk-hint">
+          Select your school from the search results.
+        </span>
+
+      <%= hidden_field_tag :school_search, params[:school_search] %>
+
+      <%= errors_tag current_claim.eligibility, school_param %>
+
+      <div class="govuk-radios">
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+          <%= fields.collection_radio_buttons school_id_param, @schools, :id, :name do |b| %>
+            <div class="govuk-radios__item">
+              <%= b.radio_button class: "govuk-radios__input" %>
+              <%= b.label class: "govuk-radios__label govuk-label--s govuk-radios__label govuk-!-padding-0" do %>
+                <div class="school-search__suggestion">
+                  <div class="school-search__suggestion-main-section">
+                    <div class="govuk-label govuk-radios__label govuk-label--s">
+                      <%= b.text %>
+                    </div>
+                    <span class="govuk-hint govuk-radios__hint"><%= b.object.address %></span>
+                  </div>
+                  <% if b.object.close_date.present? %>
+                    <div class="school-search__closed-status">
+                      <span class="govuk-hint govuk-radios__hint govuk-!-margin-bottom-1">Closed on <%= l(b.object.close_date) %></span>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+
+    </fieldset>
+  <% end %>
+
+  <%= form.submit "Continue", class: "govuk-button" %>
+  <%= link_to "Search again", claim_path, class: "govuk-button govuk-button--secondary" %>
+
+<% end %>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -2,12 +2,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "school_search",
-               question: t("student_loans.questions.claim_school"),
-               school_param: :claim_school,
-               school_id_param: :claim_school_id,
-               school_search_value: current_claim.eligibility.claim_school_name,
-               exclude_closed: false
-    %>
+    <% if @schools.blank? %>
+
+      <%= render "school_search",
+                 question: t("student_loans.questions.claim_school"),
+                 school_param: :claim_school,
+                 school_id_param: :claim_school_id,
+                 school_search_value: current_claim.eligibility.claim_school_name,
+                 exclude_closed: false
+      %>
+
+    <% else %>
+      <%= render "school_search_results",
+                 question: t("student_loans.questions.claim_school"),
+                 school_param: :claim_school,
+                 school_id_param: :claim_school_id
+      %>
+    <% end %>
   </div>
 </div>

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -2,6 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if @schools.blank? %>
+
     <%= render "school_search",
                question: t("questions.current_school"),
                school_param: :current_school,
@@ -9,5 +11,13 @@
                school_search_value: current_claim.eligibility.current_school_name,
                exclude_closed: true
     %>
+
+    <% else %>
+      <%= render "school_search_results",
+                 question: t("questions.current_school"),
+                 school_param: :current_school,
+                 school_id_param: :current_school_id
+      %>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
The diff for this PR isn't very helpful as we included a small refactor to untangle things slightly.

The diff for the fix can be seen in 93578335ef27fc2cbe86d659dcc1350fc17a7528

We're not sure what's causing the error to happen, some combination of headless chrome not liking the `<p class="govuk-body">` tag wrapping the hint. Changing the paragraph's class to anything else fixes the error. Adding a sleep before the failing expectation also fixes the error.

We felt that this solution was smallest change that we could get to pass consistently.

We had concerns about the way that screen readers might read the two span tags that are back to back, but we checked it in VoiceOver and it made sense.