### PR TITLE
Add a link to our service's Done page in Whitehall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add a link to our service's satisfaction survey to the confirmation page
+
 ## [Release 028] - 2019-11-06
 
 - Always save claimant's National Insurance number in upper case

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -39,5 +39,10 @@
       It can take up to 18 weeks to process your application and
       make the payment into your account.
     </div>
+
+    <p class="govuk-body">
+      <%= link_to "What did you think of this service?", "https://www.gov.uk/done/claim-additional-teaching-payment", class: "govuk-link" %>
+      (takes 30 seconds)
+    </p>
   </div>
 </div>


### PR DESCRIPTION
Follows the confirmation page pattern on the Design System. Faye has approved the text.

https://design-system.service.gov.uk/patterns/confirmation-pages

## Screenshot 

<img width="1279" alt="Screenshot 2019-11-06 at 15 11 19" src="https://user-images.githubusercontent.com/2804149/68311482-85a6de00-00a9-11ea-8fc5-5ebeca97a529.png">
