### PR TITLE
Make admin claim search case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Make admin claim search case insensitive
 - Change all of the existing claims' National Insurance numbers to upper case
 - Add a link to our service's satisfaction survey to the confirmation page
 

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -14,7 +14,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
   def search
     return unless params[:reference].present?
 
-    claim = Claim.find_by(reference: params[:reference])
+    claim = Claim.find_by(reference: params[:reference].upcase)
 
     if claim
       redirect_to(admin_claim_url(claim))


### PR DESCRIPTION
We exploit the fact that all claim references are upper case, by
searching for the upcased search text. This lets us continue using the
existing database index.