### PR TITLE
Redirect to start of claim journey in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Architecture decision records can be found in the
      section.
 2. Run `bundle install` and `yarn install` to install the dependencies
 3. Run `bundle exec rails db:setup` to set up the database development
-4. Run `bundle exec foreman start` to launch the app on
-   https://localhost:3000/student-loans/claim
+4. Run `bundle exec foreman start` to launch the app on https://localhost:3000/
 
 ### DfE Sign In credentials
 

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -1,6 +1,10 @@
 module StudentLoans
   def self.start_page_url
-    "https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments"
+    if Rails.env.production?
+      "https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments"
+    else
+      "/#{routing_name}/claim"
+    end
   end
 
   def self.routing_name


### PR DESCRIPTION
At the moment, in development, when a dev goes to `http://localhost:3000`, or a claim times out, they're redirected to the GOV.UK start page, which is disorienting. This redirects the user to the start of the claim journey if we're in development.
