### PR TITLE
Set appropriate reply to address when sending notify emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add policy specific "Reply-to" address for claim emails
+
 ## [Release 029] - 2019-11-07
 
 - Make admin claim search case insensitive

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -30,7 +30,8 @@ class ClaimMailer < Mail::Notify::Mailer
     view_mail(
       ENV["NOTIFY_TEMPLATE_ID"],
       to: @claim.email_address,
-      subject: subject
+      subject: subject,
+      reply_to_id: claim.policy.notify_reply_to_id
     )
   end
 end

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module StudentLoans
   def self.start_page_url
     "https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments"
@@ -5,5 +7,9 @@ module StudentLoans
 
   def self.routing_name
     "student-loans"
+  end
+
+  def self.notify_reply_to_id
+    "962b3044-cdd4-4dbe-b6ea-c461530b3dc6"
   end
 end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -1,13 +1,20 @@
 require "rails_helper"
 
+RSpec.shared_examples "a claim mailer" do
+  it "sets the correct to address" do
+    expect(mail.to).to eq([claim.email_address])
+  end
+end
+
 RSpec.describe ClaimMailer, type: :mailer do
   describe "#submitted" do
     let(:claim) { create(:claim, :submittable, first_name: "Abraham", surname: "Lincoln") }
     let(:mail) { ClaimMailer.submitted(claim) }
 
-    it "renders the headers" do
+    it_behaves_like "a claim mailer"
+
+    it "renders the subject" do
       expect(mail.subject).to eq("Your claim was received")
-      expect(mail.to).to eq([claim.email_address])
     end
 
     it "renders the body" do
@@ -21,10 +28,11 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
     let(:mail) { ClaimMailer.approved(claim) }
 
-    it "renders the headers" do
+    it_behaves_like "a claim mailer"
+
+    it "renders the subject" do
       expect(mail.subject).to match("approved")
       expect(mail.subject).to match("reference number: #{claim.reference}")
-      expect(mail.to).to eq([claim.email_address])
     end
 
     it "renders the body" do
@@ -37,10 +45,11 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
     let(:mail) { ClaimMailer.rejected(claim) }
 
-    it "renders the headers" do
+    it_behaves_like "a claim mailer"
+
+    it "renders the subject" do
       expect(mail.subject).to match("rejected")
       expect(mail.subject).to match("reference number: #{claim.reference}")
-      expect(mail.to).to eq([claim.email_address])
     end
 
     it "renders the body" do
@@ -55,10 +64,11 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:payment_date_timestamp) { Time.new(2019, 1, 1).to_i }
     let(:mail) { ClaimMailer.payment_confirmation(payment.claim, payment_date_timestamp) }
 
-    it "renders the headers" do
+    it_behaves_like "a claim mailer"
+
+    it "renders the subject" do
       expect(mail.subject).to match("paying")
       expect(mail.subject).to match("reference number: #{claim.reference}")
-      expect(mail.to).to eq([claim.email_address])
     end
 
     it "renders the body" do

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -1,8 +1,12 @@
 require "rails_helper"
 
-RSpec.shared_examples "a claim mailer" do
+RSpec.shared_examples "a claim mailer" do |policy|
   it "sets the correct to address" do
     expect(mail.to).to eq([claim.email_address])
+  end
+
+  it "sets the correct GOV.UK Notify reply to id" do
+    expect(mail["reply_to_id"].value).to eql(policy.notify_reply_to_id)
   end
 end
 
@@ -11,7 +15,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:claim) { create(:claim, :submittable, first_name: "Abraham", surname: "Lincoln") }
     let(:mail) { ClaimMailer.submitted(claim) }
 
-    it_behaves_like "a claim mailer"
+    it_behaves_like "a claim mailer", StudentLoans
 
     it "renders the subject" do
       expect(mail.subject).to eq("Your claim was received")
@@ -28,7 +32,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
     let(:mail) { ClaimMailer.approved(claim) }
 
-    it_behaves_like "a claim mailer"
+    it_behaves_like "a claim mailer", StudentLoans
 
     it "renders the subject" do
       expect(mail.subject).to match("approved")
@@ -45,7 +49,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
     let(:mail) { ClaimMailer.rejected(claim) }
 
-    it_behaves_like "a claim mailer"
+    it_behaves_like "a claim mailer", StudentLoans
 
     it "renders the subject" do
       expect(mail.subject).to match("rejected")
@@ -64,7 +68,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:payment_date_timestamp) { Time.new(2019, 1, 1).to_i }
     let(:mail) { ClaimMailer.payment_confirmation(payment.claim, payment_date_timestamp) }
 
-    it_behaves_like "a claim mailer"
+    it_behaves_like "a claim mailer", StudentLoans
 
     it "renders the subject" do
       expect(mail.subject).to match("paying")


### PR DESCRIPTION
We're about to add the Maths and Physics policy to the service and will need to set a different reply-to address for each policy.

GOV.UK Notify allows us to create a whitelist of "Reply-to" addresses under `Settings > Reply-to email addresses`.