### PR TITLE
Speed up the changing answers spec

### DIFF
--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Changing the answers on a submittable claim" do
   let(:eligibility) { claim.eligibility }
 
   before do
-    answer_all_student_loans_claim_questions
+    claim = start_claim
+    claim.update!(attributes_for(:claim, :submittable))
+    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible))
+    visit claim_path("check-your-answers")
   end
 
   scenario "Teacher can edit a field" do
@@ -28,223 +31,151 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     expect(find("#claim_eligibility_attributes_qts_award_year_on_or_after_september_2013").checked?).to eq(true)
 
-    choose I18n.t("student_loans.questions.qts_award_years.on_or_after_september_2013")
+    choose I18n.t("student_loans.questions.qts_award_years.before_september_2013")
     click_on "Continue"
 
-    expect(eligibility.reload.qts_award_year).to eq("on_or_after_september_2013")
+    expect(eligibility.reload.qts_award_year).to eq("before_september_2013")
+
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You can only get this payment if you completed your initial teacher training on or after 1 September 2013.")
+  end
+
+  scenario "Teacher changes the subjects they taught" do
+    find("a[href='#{claim_path("subjects-taught")}']").click
+
+    expect(find("#eligible_subjects_physics_taught").checked?).to eq(true)
+
+    uncheck I18n.t("student_loans.questions.eligible_subjects.physics_taught"), visible: false
+
+    check I18n.t("student_loans.questions.eligible_subjects.biology_taught"), visible: false
+    check I18n.t("student_loans.questions.eligible_subjects.chemistry_taught"), visible: false
+
+    click_on "Continue"
+
+    expect(eligibility.reload.physics_taught).to eq(false)
+    expect(eligibility.biology_taught).to eq(true)
+    expect(eligibility.chemistry_taught).to eq(true)
 
     expect(current_path).to eq(claim_path("check-your-answers"))
   end
 
-  context "when changing subjects taught" do
+  scenario "Teacher changes their leadership position to no" do
+    claim.eligibility.had_leadership_position = true
+    claim.save!
+
+    find("a[href='#{claim_path("leadership-position")}']").click
+
+    choose "No"
+    click_on "Continue"
+
+    expect(eligibility.reload.had_leadership_position).to eq(false)
+
+    expect(eligibility.reload.mostly_performed_leadership_duties).to eq(nil)
+
+    expect(current_path).to eq(claim_path("check-your-answers"))
+  end
+
+  context "Teacher changes their leadership position to yes" do
     before do
-      find("a[href='#{claim_path("subjects-taught")}']").click
+      claim.eligibility.had_leadership_position = false
+      claim.save!
+
+      find("a[href='#{claim_path("leadership-position")}']").click
+
+      choose "Yes"
+      click_on "Continue"
     end
 
-    scenario "Teacher sees their original choices" do
-      expect(find("#eligible_subjects_physics_taught").checked?).to eq(true)
+    scenario "and spent less than half their time performing leadership duties" do
+      expect(eligibility.reload.had_leadership_position).to eq(true)
+      expect(eligibility.reload.mostly_performed_leadership_duties).to eq(nil)
+
+      expect(current_path).to eq(claim_path("mostly-performed-leadership-duties"))
+
+      choose "No"
+      click_on "Continue"
+
+      expect(eligibility.reload.mostly_performed_leadership_duties).to eq(false)
+      expect(current_path).to eq(claim_path("check-your-answers"))
     end
 
-    context "Teacher changes their subjects" do
-      before do
-        uncheck I18n.t("student_loans.questions.eligible_subjects.physics_taught"), visible: false
+    scenario "and spent more than half their time performing leadership duties" do
+      choose "Yes"
+      click_on "Continue"
 
-        check I18n.t("student_loans.questions.eligible_subjects.biology_taught"), visible: false
-        check I18n.t("student_loans.questions.eligible_subjects.chemistry_taught"), visible: false
+      expect(eligibility.reload.mostly_performed_leadership_duties).to eq(true)
 
-        click_on "Continue"
-      end
-
-      scenario "Eligible subjects are set correctly" do
-        expect(eligibility.reload.physics_taught).to eq(false)
-        expect(eligibility.biology_taught).to eq(true)
-        expect(eligibility.chemistry_taught).to eq(true)
-      end
-
-      scenario "Teacher is redirected to the check your answers page" do
-        expect(current_path).to eq(claim_path("check-your-answers"))
-      end
-    end
-  end
-
-  context "when changing whether they had a leadership position" do
-    context "when changing their answer to no" do
-      before do
-        claim.eligibility.had_leadership_position = true
-        claim.save!
-
-        find("a[href='#{claim_path("leadership-position")}']").click
-
-        choose "No"
-        click_on "Continue"
-      end
-
-      scenario "Sets had leadership position correctly" do
-        expect(eligibility.reload.had_leadership_position).to eq(false)
-      end
-
-      scenario "Sets mostly performed leadership duties correctly" do
-        expect(eligibility.reload.mostly_performed_leadership_duties).to eq(nil)
-      end
-
-      scenario "Teacher is redirected to the check your answers page" do
-        expect(current_path).to eq(claim_path("check-your-answers"))
-      end
-    end
-
-    context "when changing their answer to yes" do
-      before do
-        claim.eligibility.had_leadership_position = false
-        claim.save!
-
-        find("a[href='#{claim_path("leadership-position")}']").click
-
-        choose "Yes"
-        click_on "Continue"
-      end
-
-      scenario "Sets had leadership position correctly" do
-        expect(eligibility.reload.had_leadership_position).to eq(true)
-      end
-
-      scenario "Sets mostly performed leadership duties correctly" do
-        expect(eligibility.reload.mostly_performed_leadership_duties).to eq(nil)
-      end
-
-      scenario "Teacher is redirected to ask if they were mostly performing leadership duties" do
-        expect(current_path).to eq(claim_path("mostly-performed-leadership-duties"))
-      end
-
-      context "Teacher spent less than half their time performing leadership duties" do
-        before do
-          choose "No"
-          click_on "Continue"
-        end
-
-        scenario "Sets mostly performed leadership duties correctly" do
-          expect(eligibility.reload.mostly_performed_leadership_duties).to eq(false)
-        end
-
-        scenario "Teacher is redirected to the check your answers page" do
-          expect(current_path).to eq(claim_path("check-your-answers"))
-        end
-      end
-
-      context "Teacher spent more than half their time performing leadership duties" do
-        before do
-          choose "Yes"
-          click_on "Continue"
-        end
-
-        scenario "Sets mostly performed leadership duties correctly" do
-          expect(eligibility.reload.mostly_performed_leadership_duties).to eq(true)
-        end
-
-        scenario "Teacher is told they are not eligible" do
-          expect(page).to have_text("You’re not eligible")
-          expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between 6 April 2018 and 5 April 2019.")
-        end
-      end
+      expect(page).to have_text("You’re not eligible")
+      expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between 6 April 2018 and 5 April 2019.")
     end
   end
 
-  context "When changing claim school" do
+  context "Teacher changes claim school to another eligible school" do
     let!(:new_claim_school) { create(:school, :student_loan_eligible, name: "Claim School") }
 
     before do
       find("a[href='#{claim_path("claim-school")}']").click
+
+      choose_school new_claim_school
     end
 
-    scenario "Teacher sees their original claim school" do
-      expect(find("input[name='school_search']").value).to eq(eligibility.claim_school_name)
+    scenario "and is still teaching eligible subjects at the new claim school" do
+      expect(eligibility.reload.claim_school).to eql new_claim_school
+      expect(current_path).to eq(claim_path("subjects-taught"))
+
+      check I18n.t("student_loans.questions.eligible_subjects.biology_taught"), visible: false
+      check I18n.t("student_loans.questions.eligible_subjects.chemistry_taught"), visible: false
+
+      click_on "Continue"
+
+      expect(eligibility.reload.biology_taught).to eq(true)
+      expect(eligibility.chemistry_taught).to eq(true)
+
+      expect(current_path).to eq(claim_path("still-teaching"))
+
+      choose_still_teaching "Yes, at Claim School"
+
+      expect(eligibility.reload.employment_status).to eql("claim_school")
+      expect(eligibility.current_school).to eql new_claim_school
+
+      expect(current_path).to eq(claim_path("check-your-answers"))
     end
 
-    context "When choosing a new claim school" do
-      before do
-        choose_school new_claim_school
-      end
+    scenario "and still teaching eligible subjects at a different school" do
+      check I18n.t("student_loans.questions.eligible_subjects.biology_taught"), visible: false
+      check I18n.t("student_loans.questions.eligible_subjects.chemistry_taught"), visible: false
 
-      scenario "school is changed correctly" do
-        expect(eligibility.reload.claim_school).to eql new_claim_school
-      end
+      click_on "Continue"
 
-      scenario "Teacher is redirected to the subjects taught screen" do
-        expect(current_path).to eq(claim_path("subjects-taught"))
-      end
+      choose_still_teaching "Yes, at another school"
 
-      context "When still teaching eligible subjects" do
-        before do
-          check I18n.t("student_loans.questions.eligible_subjects.biology_taught"), visible: false
-          check I18n.t("student_loans.questions.eligible_subjects.chemistry_taught"), visible: false
+      fill_in :school_search, with: "Hampstead"
+      click_on "Search"
 
-          click_on "Continue"
-        end
+      choose "Hampstead School"
+      click_on "Continue"
 
-        scenario "Eligible subjects are set correctly" do
-          expect(eligibility.reload.biology_taught).to eq(true)
-          expect(eligibility.chemistry_taught).to eq(true)
-        end
+      expect(eligibility.reload.employment_status).to eql("different_school")
+      expect(eligibility.reload.current_school).to eql schools(:hampstead_school)
 
-        scenario "Teacher is redirected to the are you still employed screen" do
-          expect(current_path).to eq(claim_path("still-teaching"))
-        end
+      expect(current_path).to eq(claim_path("check-your-answers"))
+    end
 
-        context "When still teaching at the claim school" do
-          before do
-            choose "Yes, at Claim School"
-            click_on "Continue"
-          end
+    scenario "and no longer teaching" do
+      check I18n.t("student_loans.questions.eligible_subjects.biology_taught"), visible: false
+      check I18n.t("student_loans.questions.eligible_subjects.chemistry_taught"), visible: false
 
-          scenario "current school is set correctly" do
-            expect(eligibility.reload.employment_status).to eql("claim_school")
-            expect(eligibility.current_school).to eql new_claim_school
-          end
+      click_on "Continue"
 
-          scenario "Teacher is redirected to the check your answers page" do
-            expect(current_path).to eq(claim_path("check-your-answers"))
-          end
-        end
+      choose_still_teaching "No"
 
-        context "When still teaching but at a different school" do
-          before do
-            choose_still_teaching "Yes, at another school"
-
-            fill_in :school_search, with: "Hampstead"
-            click_on "Search"
-
-            choose "Hampstead School"
-            click_on "Continue"
-          end
-
-          scenario "School and employment status are set correctly" do
-            expect(eligibility.reload.employment_status).to eql("different_school")
-            expect(eligibility.reload.current_school).to eql schools(:hampstead_school)
-          end
-
-          scenario "Teacher is redirected to the check your answers page" do
-            expect(current_path).to eq(claim_path("check-your-answers"))
-          end
-        end
-
-        context "When no longer teaching" do
-          before do
-            choose_still_teaching "No"
-          end
-
-          scenario "Employment status is set correctly" do
-            expect(eligibility.reload.employment_status).to eq("no_school")
-          end
-
-          scenario "Teacher is told they are not eligible" do
-            expect(page).to have_text("You’re not eligible")
-            expect(page).to have_text("You can only get this payment if you’re still employed at a school.")
-          end
-        end
-      end
+      expect(eligibility.reload.employment_status).to eq("no_school")
+      expect(page).to have_text("You’re not eligible")
+      expect(page).to have_text("You can only get this payment if you’re still employed at a school.")
     end
   end
 
-  scenario "changing the are you still employed question (employment_status)" do
+  scenario "Teacher changes the are you still employed question (employment_status)" do
     find("a[href='#{claim_path("still-teaching")}']").click
 
     choose "Yes, at Penistone Grammar School"
@@ -255,7 +186,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     expect(eligibility.current_school).to eq(schools(:penistone_grammar_school))
   end
 
-  scenario "going from same school to different school" do
+  scenario "Teacher changes the current school from same school to different school" do
     eligibility.update!(employment_status: "claim_school")
 
     find("a[href='#{claim_path("still-teaching")}']").click
@@ -337,19 +268,17 @@ RSpec.feature "Changing the answers on a submittable claim" do
     expect(claim.reload.payroll_gender).to eq("dont_know")
   end
 
-  context "when changing the student loan repayment amount" do
-    scenario "user can change answer and it preserves two decimal places" do
-      claim.eligibility.update!(student_loan_repayment_amount: 100.1)
-      visit claim_path("check-your-answers")
+  scenario "when changing the student loan repayment amount the user can change answer and it preserves two decimal places" do
+    claim.eligibility.update!(student_loan_repayment_amount: 100.1)
+    visit claim_path("check-your-answers")
 
-      expect(page).to have_content("£100.10")
-      find("a[href='#{claim_path("student-loan-amount")}']").click
+    expect(page).to have_content("£100.10")
+    find("a[href='#{claim_path("student-loan-amount")}']").click
 
-      expect(find("#claim_eligibility_attributes_student_loan_repayment_amount").value).to eq("100.10")
-      fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), with: "150.20"
-      click_on "Continue"
+    expect(find("#claim_eligibility_attributes_student_loan_repayment_amount").value).to eq("100.10")
+    fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), with: "150.20"
+    click_on "Continue"
 
-      expect(page).to have_content("£150.20")
-    end
+    expect(page).to have_content("£150.20")
   end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,35 +1,4 @@
 module FeatureHelpers
-  def answer_all_student_loans_claim_questions
-    start_claim
-    choose_school schools(:penistone_grammar_school)
-    choose_subjects_taught
-    choose_still_teaching "Yes, at another school"
-    choose_school schools(:hampstead_school)
-    choose_leadership
-    click_on "Continue"
-
-    perform_verify_step
-    click_on "Continue"
-
-    fill_in :claim_teacher_reference_number, with: "1234567"
-    click_on "Continue"
-
-    fill_in "National Insurance number", with: "QQ123456C"
-    click_on "Continue"
-
-    answer_student_loan_plan_questions
-    fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), with: "1100"
-    click_on "Continue"
-
-    fill_in I18n.t("questions.email_address"), with: "name@example.tld"
-    click_on "Continue"
-
-    fill_in "Name on the account", with: "Jo Bloggs"
-    fill_in "Sort code", with: "123456"
-    fill_in "Account number", with: "87654321"
-    click_on "Continue"
-  end
-
   def start_claim
     visit new_claim_path
     choose_qts_year


### PR DESCRIPTION
Before, we were completing the student flow completely before each scenario. I've tweaked this now, so we create a submittable claim, and then visit the check-your-answers page. I've also cut down on the amount of nested scenarios, which speeds things up further.

This cuts down the amount of time the spec takes to run from ~20 seconds to ~5 seconds, and takes our total test suite run time down from ~1 minute 20s seconds, to ~57 seconds (so under 1 minute! 🙌 )
