### PR TITLE
Ineligibility page becomes policy-independent

### DIFF
--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -1,12 +1,11 @@
-<%= page_title("You’re not eligible for this payment", show_error: current_claim.errors.any?) %>
+<%= page_title("You’re not eligible for this payment") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}", locals: { claim_school_name: current_claim.eligibility.claim_school_name, current_school_name: current_claim.eligibility.current_school_name } %>
+    <%= render "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}" %>
 
     <p class="govuk-body">
-      For more information about the eligibility criteria, or if you need help with
-      your claim, contact
+      For more information about the eligibility criteria, or if you need help with your claim, contact
       <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>.
     </p>
   </div>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -6,7 +6,7 @@
   </h1>
 
   <p class="govuk-body">
-    <%= claim_school_name %> is not an eligible school. You can only get this
+    <%= current_claim.eligibility.claim_school_name %> is not an eligible school. You can only get this
     payment if you  were employed at an eligible school between 6 April 2018
     and 5 April 2019.
   </p>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_current_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_current_school.html.erb
@@ -4,6 +4,6 @@
 
 <p class="govuk-body">
   You must be employed at a state-funded secondary school to be eligible for
-  this payment. <%= current_school_name %>, where you are currently employed,
+  this payment. <%= current_claim.eligibility.current_school_name %>, where you are currently employed,
   is not a state-funded secondary school.
 </p>

--- a/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -6,7 +6,7 @@
   </h1>
 
   <p class="govuk-body">
-    You did not teach an eligible subject at <%= claim_school_name %>.
+    You did not teach an eligible subject at <%= current_claim.eligibility.claim_school_name %>.
   </p>
 
   <p class="govuk-body">


### PR DESCRIPTION
Passing in the school names as locals couples the view to the Student
Loans policy. Instead, leave the partials to figure out what they need
to show themselves, based on the current_claim.

Also there's no need to check the claim for errors for the page title as
the ineligible screen is not shown for an errored claim.