### PR TITLE
Make the page_title helper policy aware

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,9 @@
 module ApplicationHelper
-  def page_title(title, show_error: false)
+  def page_title(title, policy:, show_error: false)
     [].tap do |a|
       a << "Error" if show_error
       a << title
-      a << t("student_loans.policy_name")
+      a << policy_service_name(policy)
       a << "GOV.UK"
     end.join(" - ")
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
       a << title
       a << policy_service_name(policy)
       a << "GOV.UK"
-    end.join(" - ")
+    end.join(" — ")
   end
 
   def claim_in_progress?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,11 @@
 module ApplicationHelper
   def page_title(title, show_error: false)
-    content_for :page_title do
-      [].tap do |a|
-        a << "Error" if show_error
-        a << title
-        a << t("student_loans.policy_name")
-        a << "GOV.UK"
-      end.join(" - ")
-    end
+    [].tap do |a|
+      a << "Error" if show_error
+      a << title
+      a << t("student_loans.policy_name")
+      a << "GOV.UK"
+    end.join(" - ")
   end
 
   def claim_in_progress?

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.address"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.address"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.address"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.address"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/address.html.erb
+++ b/app/views/claims/address.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.address"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.address"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.bank_details"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.bank_details"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.bank_details"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.bank_details"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.bank_details"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.bank_details"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/check_your_answers.html.erb
+++ b/app/views/claims/check_your_answers.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Check your answers before sending your application", show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title("Check your answers before sending your application", policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/check_your_answers.html.erb
+++ b/app/views/claims/check_your_answers.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("Check your answers before sending your application", show_error: current_claim.errors.any?) %>
+<% page_title("Check your answers before sending your application", show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/check_your_answers.html.erb
+++ b/app/views/claims/check_your_answers.html.erb
@@ -1,4 +1,4 @@
-<% page_title("Check your answers before sending your application", show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title("Check your answers before sending your application", show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.current_school"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.current_school"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.current_school"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.current_school"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.current_school"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.current_school"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.email_address"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.email_address"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.email_address"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.email_address"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.email_address"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.email_address"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.payroll_gender"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.payroll_gender"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.payroll_gender"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.payroll_gender"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.payroll_gender"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.payroll_gender"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -1,4 +1,4 @@
-<% page_title("You’re not eligible for this payment") %>
+<% content_for(:page_title, page_title("You’re not eligible for this payment")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("You’re not eligible for this payment")) %>
+<% content_for(:page_title, page_title("You’re not eligible for this payment", policy: current_policy_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("You’re not eligible for this payment") %>
+<% page_title("You’re not eligible for this payment") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/information_provided.html.erb
+++ b/app/views/claims/information_provided.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("How we will use the information you provide", show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title("How we will use the information you provide", policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/information_provided.html.erb
+++ b/app/views/claims/information_provided.html.erb
@@ -1,4 +1,4 @@
-<% page_title("How we will use the information you provide", show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title("How we will use the information you provide", show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/information_provided.html.erb
+++ b/app/views/claims/information_provided.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("How we will use the information you provide", show_error: current_claim.errors.any?) %>
+<% page_title("How we will use the information you provide", show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/national_insurance_number.html.erb
+++ b/app/views/claims/national_insurance_number.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.national_insurance_number"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.national_insurance_number"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/national_insurance_number.html.erb
+++ b/app/views/claims/national_insurance_number.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.national_insurance_number"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.national_insurance_number"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/national_insurance_number.html.erb
+++ b/app/views/claims/national_insurance_number.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.national_insurance_number"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.national_insurance_number"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.has_student_loan"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.has_student_loan"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.has_student_loan"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.has_student_loan"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.has_student_loan"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.has_student_loan"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan_country.html.erb
+++ b/app/views/claims/student_loan_country.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.student_loan_country"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.student_loan_country"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan_country.html.erb
+++ b/app/views/claims/student_loan_country.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.student_loan_country"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.student_loan_country"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan_country.html.erb
+++ b/app/views/claims/student_loan_country.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.student_loan_country"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.student_loan_country"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.student_loan_how_many_courses"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.student_loan_how_many_courses"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.student_loan_how_many_courses"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.student_loan_how_many_courses"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.student_loan_how_many_courses"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.student_loan_how_many_courses"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.student_loan_start_date.#{current_claim.student_loan_courses}"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.student_loan_start_date.#{current_claim.student_loan_courses}"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.student_loan_start_date.#{current_claim.student_loan_courses}"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.student_loan_start_date.#{current_claim.student_loan_courses}"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.student_loan_start_date.#{current_claim.student_loan_courses}"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.student_loan_start_date.#{current_claim.student_loan_courses}"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("questions.teacher_reference_number"), show_error: current_claim.errors.any?) %>
+<% page_title(t("questions.teacher_reference_number"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("questions.teacher_reference_number"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.teacher_reference_number"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("questions.teacher_reference_number"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("questions.teacher_reference_number"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/timeout.html.erb
+++ b/app/views/claims/timeout.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("Your session has ended due to inactivity") %>
+<% page_title("Your session has ended due to inactivity") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/timeout.html.erb
+++ b/app/views/claims/timeout.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Your session has ended due to inactivity")) %>
+<% content_for(:page_title, page_title("Your session has ended due to inactivity", policy: current_policy_routing_name,)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/timeout.html.erb
+++ b/app/views/claims/timeout.html.erb
@@ -1,4 +1,4 @@
-<% page_title("Your session has ended due to inactivity") %>
+<% content_for(:page_title, page_title("Your session has ended due to inactivity")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/verified.html.erb
+++ b/app/views/claims/verified.html.erb
@@ -1,4 +1,4 @@
-<% page_title("We have verified your identity") %>
+<% content_for(:page_title, page_title("We have verified your identity")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/verified.html.erb
+++ b/app/views/claims/verified.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("We have verified your identity")) %>
+<% content_for(:page_title, page_title("We have verified your identity", policy: current_policy_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/claims/verified.html.erb
+++ b/app/views/claims/verified.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("We have verified your identity") %>
+<% page_title("We have verified your identity") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Accessibility statement for #{policy_service_name(current_policy_routing_name)}")) %>
+<% content_for(:page_title, page_title("Accessibility statement for #{policy_service_name(current_policy_routing_name)}",  policy: current_policy_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -1,4 +1,4 @@
-<% page_title("Accessibility statement for #{policy_service_name(current_policy_routing_name)}") %>
+<% content_for(:page_title, page_title("Accessibility statement for #{policy_service_name(current_policy_routing_name)}")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("Accessibility statement for #{policy_service_name(current_policy_routing_name)}") %>
+<% page_title("Accessibility statement for #{policy_service_name(current_policy_routing_name)}") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/contact_us.html.erb
+++ b/app/views/static_pages/contact_us.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Contact us")) %>
+<% content_for(:page_title, page_title("Contact us", policy: current_policy_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/contact_us.html.erb
+++ b/app/views/static_pages/contact_us.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("Contact us") %>
+<% page_title("Contact us") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/contact_us.html.erb
+++ b/app/views/static_pages/contact_us.html.erb
@@ -1,4 +1,4 @@
-<% page_title("Contact us") %>
+<% content_for(:page_title, page_title("Contact us")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -1,4 +1,4 @@
-<% page_title("Cookies") %>
+<% content_for(:page_title, page_title("Cookies")) %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("Cookies") %>
+<% page_title("Cookies") %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Cookies")) %>
+<% content_for(:page_title, page_title("Cookies", policy: current_policy_routing_name)) %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/static_pages/maintenance.html.erb
+++ b/app/views/static_pages/maintenance.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Sorry, the service is unavailable")) %>
+<% content_for(:page_title, page_title("Sorry, the service is unavailable", policy: current_policy_routing_name)) %>
 
 <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
 

--- a/app/views/static_pages/maintenance.html.erb
+++ b/app/views/static_pages/maintenance.html.erb
@@ -1,4 +1,4 @@
-<% page_title("Sorry, the service is unavailable") %>
+<% content_for(:page_title, page_title("Sorry, the service is unavailable")) %>
 
 <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
 

--- a/app/views/static_pages/maintenance.html.erb
+++ b/app/views/static_pages/maintenance.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("Sorry, the service is unavailable") %>
+<% page_title("Sorry, the service is unavailable") %>
 
 <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
 

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Privacy Notice: #{policy_service_name(current_policy_routing_name)}")) %>
+<% content_for(:page_title, page_title("Privacy Notice", policy: current_policy_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("Privacy Notice: #{policy_service_name(current_policy_routing_name)}") %>
+<% page_title("Privacy Notice: #{policy_service_name(current_policy_routing_name)}") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -1,4 +1,4 @@
-<% page_title("Privacy Notice: #{policy_service_name(current_policy_routing_name)}") %>
+<% content_for(:page_title, page_title("Privacy Notice: #{policy_service_name(current_policy_routing_name)}")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/terms_conditions.html.erb
+++ b/app/views/static_pages/terms_conditions.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Terms and Conditions")) %>
+<% content_for(:page_title, page_title("Terms and Conditions", policy: current_policy_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/terms_conditions.html.erb
+++ b/app/views/static_pages/terms_conditions.html.erb
@@ -1,4 +1,4 @@
-<% page_title("Terms and Conditions") %>
+<% content_for(:page_title, page_title("Terms and Conditions")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/static_pages/terms_conditions.html.erb
+++ b/app/views/static_pages/terms_conditions.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("Terms and Conditions") %>
+<% page_title("Terms and Conditions") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/claim_school.html.erb
+++ b/app/views/student_loans/claims/claim_school.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(school_search_question(params[:additional_school]), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(school_search_question(params[:additional_school]), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/claim_school.html.erb
+++ b/app/views/student_loans/claims/claim_school.html.erb
@@ -1,4 +1,4 @@
-<% page_title(school_search_question(params[:additional_school]), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(school_search_question(params[:additional_school]), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/claim_school.html.erb
+++ b/app/views/student_loans/claims/claim_school.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(school_search_question(params[:additional_school]), show_error: current_claim.errors.any?) %>
+<% page_title(school_search_question(params[:additional_school]), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/eligibility_confirmed.html.erb
+++ b/app/views/student_loans/claims/eligibility_confirmed.html.erb
@@ -1,4 +1,4 @@
-<% page_title("You are eligible to claim back student loan repayments", show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title("You are eligible to claim back student loan repayments", show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/eligibility_confirmed.html.erb
+++ b/app/views/student_loans/claims/eligibility_confirmed.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("You are eligible to claim back student loan repayments", show_error: current_claim.errors.any?) %>
+<% page_title("You are eligible to claim back student loan repayments", show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/eligibility_confirmed.html.erb
+++ b/app/views/student_loans/claims/eligibility_confirmed.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("You are eligible to claim back student loan repayments", show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title("You are eligible to claim back student loan repayments", policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/leadership_position.html.erb
+++ b/app/views/student_loans/claims/leadership_position.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("student_loans.questions.leadership_position"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.leadership_position"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/leadership_position.html.erb
+++ b/app/views/student_loans/claims/leadership_position.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.leadership_position"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.leadership_position"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/leadership_position.html.erb
+++ b/app/views/student_loans/claims/leadership_position.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("student_loans.questions.leadership_position"), show_error: current_claim.errors.any?) %>
+<% page_title(t("student_loans.questions.leadership_position"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
+++ b/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("student_loans.questions.mostly_performed_leadership_duties"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.mostly_performed_leadership_duties"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
+++ b/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("student_loans.questions.mostly_performed_leadership_duties"), show_error: current_claim.errors.any?) %>
+<% page_title(t("student_loans.questions.mostly_performed_leadership_duties"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
+++ b/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.mostly_performed_leadership_duties"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.mostly_performed_leadership_duties"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/qts_year.html.erb
+++ b/app/views/student_loans/claims/qts_year.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.qts_award_year"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.qts_award_year"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 <% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
 
 <div class="govuk-grid-row">

--- a/app/views/student_loans/claims/qts_year.html.erb
+++ b/app/views/student_loans/claims/qts_year.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("student_loans.questions.qts_award_year"), show_error: current_claim.errors.any?) %>
+<% page_title(t("student_loans.questions.qts_award_year"), show_error: current_claim.errors.any?) %>
 <% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
 
 <div class="govuk-grid-row">

--- a/app/views/student_loans/claims/qts_year.html.erb
+++ b/app/views/student_loans/claims/qts_year.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("student_loans.questions.qts_award_year"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.qts_award_year"), show_error: current_claim.errors.any?)) %>
 <% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
 
 <div class="govuk-grid-row">

--- a/app/views/student_loans/claims/still_teaching.html.erb
+++ b/app/views/student_loans/claims/still_teaching.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.employment_status"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.employment_status"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/still_teaching.html.erb
+++ b/app/views/student_loans/claims/still_teaching.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("student_loans.questions.employment_status"), show_error: current_claim.errors.any?) %>
+<% page_title(t("student_loans.questions.employment_status"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/still_teaching.html.erb
+++ b/app/views/student_loans/claims/still_teaching.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("student_loans.questions.employment_status"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.employment_status"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/student_loan_amount.html.erb
+++ b/app/views/student_loans/claims/student_loan_amount.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.student_loan_amount"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.student_loan_amount"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/student_loan_amount.html.erb
+++ b/app/views/student_loans/claims/student_loan_amount.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("student_loans.questions.student_loan_amount"), show_error: current_claim.errors.any?) %>
+<% page_title(t("student_loans.questions.student_loan_amount"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/student_loan_amount.html.erb
+++ b/app/views/student_loans/claims/student_loan_amount.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("student_loans.questions.student_loan_amount"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.student_loan_amount"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/subjects_taught.html.erb
+++ b/app/views/student_loans/claims/subjects_taught.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("student_loans.questions.subjects_taught"), show_error: current_claim.errors.any?) %>
+<% page_title(t("student_loans.questions.subjects_taught"), show_error: current_claim.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/subjects_taught.html.erb
+++ b/app/views/student_loans/claims/subjects_taught.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.subjects_taught"), show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.subjects_taught"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/student_loans/claims/subjects_taught.html.erb
+++ b/app/views/student_loans/claims/subjects_taught.html.erb
@@ -1,4 +1,4 @@
-<% page_title(t("student_loans.questions.subjects_taught"), show_error: current_claim.errors.any?) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.subjects_taught"), show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title("Claim submitted") %>
+<% content_for(:page_title, page_title("Claim submitted")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_title("Claim submitted") %>
+<% page_title("Claim submitted") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title("Claim submitted")) %>
+<% content_for(:page_title, page_title("Claim submitted", policy: current_policy_routing_name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -19,13 +19,20 @@ describe ApplicationHelper do
 
   describe "page_title" do
     it "returns a title for the page that follows the guidance of the design system" do
-      expect(page_title("Some Title")).to eq("Some Title - #{I18n.t("student_loans.policy_name")} - GOV.UK")
+      expected_title = page_title("Title", policy: "student-loans")
+      expect(expected_title).to eq("Title - Teachers: claim back your student loan repayments - GOV.UK")
+
+      expected_title = page_title("Title", policy: "maths-and-physics")
+      expect(expected_title).to eq("Title - Claim a payment for teaching maths or physics - GOV.UK")
+    end
+
+    it "uses the generic service name if a specific policy isn't available" do
+      expect(page_title("Some Title", policy: nil)).to eq("Some Title - Claim additional payments for teaching - GOV.UK")
     end
 
     it "includes an optional error prefix" do
-      title = page_title("Some Title", show_error: true)
-
-      expect(title).to eq("Error - Some Title - #{I18n.t("student_loans.policy_name")} - GOV.UK")
+      expected_title = page_title("Some Title", show_error: true, policy: "student-loans")
+      expect(expected_title).to eq("Error - Some Title - Teachers: claim back your student loan repayments - GOV.UK")
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -20,19 +20,19 @@ describe ApplicationHelper do
   describe "page_title" do
     it "returns a title for the page that follows the guidance of the design system" do
       expected_title = page_title("Title", policy: "student-loans")
-      expect(expected_title).to eq("Title - Teachers: claim back your student loan repayments - GOV.UK")
+      expect(expected_title).to eq("Title — Teachers: claim back your student loan repayments — GOV.UK")
 
       expected_title = page_title("Title", policy: "maths-and-physics")
-      expect(expected_title).to eq("Title - Claim a payment for teaching maths or physics - GOV.UK")
+      expect(expected_title).to eq("Title — Claim a payment for teaching maths or physics — GOV.UK")
     end
 
     it "uses the generic service name if a specific policy isn't available" do
-      expect(page_title("Some Title", policy: nil)).to eq("Some Title - Claim additional payments for teaching - GOV.UK")
+      expect(page_title("Some Title", policy: nil)).to eq("Some Title — Claim additional payments for teaching — GOV.UK")
     end
 
     it "includes an optional error prefix" do
       expected_title = page_title("Some Title", show_error: true, policy: "student-loans")
-      expect(expected_title).to eq("Error - Some Title - Teachers: claim back your student loan repayments - GOV.UK")
+      expect(expected_title).to eq("Error — Some Title — Teachers: claim back your student loan repayments — GOV.UK")
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,16 +18,12 @@ describe ApplicationHelper do
   end
 
   describe "page_title" do
-    it "Returns a title without an error prefix" do
-      page_title("Some Title", show_error: false)
-      title = content_for(:page_title)
-
-      expect(title).to eq("Some Title - #{I18n.t("student_loans.policy_name")} - GOV.UK")
+    it "returns a title for the page that follows the guidance of the design system" do
+      expect(page_title("Some Title")).to eq("Some Title - #{I18n.t("student_loans.policy_name")} - GOV.UK")
     end
 
-    it "Returns an error prefix" do
-      page_title("Some Title", show_error: true)
-      title = content_for(:page_title)
+    it "includes an optional error prefix" do
+      title = page_title("Some Title", show_error: true)
 
       expect(title).to eq("Error - Some Title - #{I18n.t("student_loans.policy_name")} - GOV.UK")
     end


### PR DESCRIPTION
In readiness for introducing the Maths & Physics policy, this updates the service so that the page's meta title will be policy-appropriate.