### PR TITLE
Remove global basic auth check

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,6 @@
 class ApplicationController < ActionController::Base
   TIMEOUT_WARNING_LENGTH_IN_MINUTES = 2
 
-  http_basic_authenticate_with(
-    name: ENV["BASIC_AUTH_USERNAME"],
-    password: ENV["BASIC_AUTH_PASSWORD"],
-    if: -> { ENV["BASIC_AUTH_USERNAME"].present? },
-  )
-
   after_action :update_last_seen_at
 
   helper_method :timeout_warning_in_minutes


### PR DESCRIPTION
We don't ever expect to use basic auth to disable the entire application so this no longer makes sense here. The config for the environment variables is hanging around though as we can still use those for adding basic auth for individual policies, i.e. the upcoming Maths & Physics private beta.