### PR TITLE
A service operator can download a csv file to generate a report from DQT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog]
 
 - Add policy specific "Reply-to" address for claim emails
 - Upgrade to Rails 6.0.1
+- A service operator can create and download a Database of qualified teachers
+  (DQT) report request csv file
 
 ## [Release 029] - 2019-11-07
 

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -3,6 +3,13 @@ class Admin::ClaimsController < Admin::BaseAdminController
 
   def index
     @claims = Claim.includes(:check, eligibility: [:claim_school, :current_school]).awaiting_checking.order(:submitted_at)
+    respond_to do |format|
+      format.html
+      format.csv {
+        send_data Claim::DatabaseOfQualifiedTeachersReportRequest.new(@claims).to_csv,
+          filename: "dqt_report_request_#{Date.today.iso8601}.csv"
+      }
+    end
   end
 
   def show

--- a/app/models/claim/database_of_qualified_teachers_report_request.rb
+++ b/app/models/claim/database_of_qualified_teachers_report_request.rb
@@ -1,0 +1,24 @@
+require "csv"
+
+class Claim
+  class DatabaseOfQualifiedTeachersReportRequest
+    ATTRIBUTES = {
+      reference: "Claim reference",
+      teacher_reference_number: "Teacher reference number",
+    }.freeze
+
+    def initialize(claims)
+      @claims = claims
+    end
+
+    def to_csv
+      CSV.generate do |csv|
+        csv << ATTRIBUTES.values
+
+        @claims.each do |claim|
+          csv << ATTRIBUTES.keys.map { |attribute| claim.read_attribute(attribute) }
+        end
+      end
+    end
+  end
+end

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -9,6 +9,7 @@
       <% claims_with_warning = Claim.approaching_check_deadline.count + Claim.passed_check_deadline.count %>
 
       <h2 class="govuk-heading-m"><%= pluralize(@claims.count, "claim") %> awaiting checking</h2>
+      <%= link_to "Download DQT report request file", admin_claims_path(format: :csv), class: "govuk-button", data: { module: "govuk-button" }, role: :button %>
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">

--- a/spec/features/admin_dqt_report_request_spec.rb
+++ b/spec/features/admin_dqt_report_request_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.feature "DQT Report request" do
+  scenario "Service operator can download CSV for the Database of Qualified Teachers report request" do
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+
+    claims = create_list(:claim, 3, :submitted)
+
+    click_on "View claims"
+
+    click_on "Download DQT report request file"
+
+    expect(page.response_headers["Content-Type"]).to eq("text/csv")
+
+    csv = CSV.parse(body, headers: true)
+
+    expect(csv.count).to eq(3)
+    expect(csv[2].fields("Claim reference")).to include(claims.last.reference)
+  end
+end

--- a/spec/models/claim/database_of_qualified_teachers_report_request_spec.rb
+++ b/spec/models/claim/database_of_qualified_teachers_report_request_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe Claim::DatabaseOfQualifiedTeachersReportRequest do
+  describe "#to_csv" do
+    let(:claims) { create_list :claim, 3, :submitted }
+    let(:report_request) { described_class.new(claims) }
+
+    subject(:report_request_csv) { CSV.parse(report_request.to_csv, headers: true) }
+
+    it "contains the correct headers" do
+      expect(report_request_csv.headers).to eql(Claim::DatabaseOfQualifiedTeachersReportRequest::ATTRIBUTES.values)
+    end
+
+    it "includes the claims reference number and teacher reference number" do
+      expect(report_request_csv[2].fields("Claim reference")).to include(claims.last.reference)
+      expect(report_request_csv[2].fields("Teacher reference number")).to include(claims.last.teacher_reference_number)
+    end
+  end
+end

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -7,13 +7,15 @@ RSpec.describe "Admin claims", type: :request do
 
   describe "claims#index" do
     let!(:claims) { create_list(:claim, 3, :submitted) }
+    let!(:checked_claim) { create :claim, :approved }
 
-    it "lists all claims" do
+    it "lists all claims awaiting checking" do
       get admin_claims_path
 
       claims.each do |c|
         expect(response.body).to include(c.reference)
       end
+      expect(response.body).not_to include(checked_claim.reference)
     end
   end
 


### PR DESCRIPTION
This PR adds a simple way for service operators to download a csv file that contains the `reference` and `teacher_reference_number` for claims that are `awaiting checking`.

The file is sent securely to the DQT team who return a report file with all the relevent details for claims checking, this saves a service operator from having to sign in to DQT and check each record manually as they can just reference the report.

There is the opportunity to extend this feature to ingest the report, but this is not part of this PR and would need to be scoped and prioritised.

I wanted this to be as simple as possible so I just used a new `format` on the admin#index action of the controller as this already loads the correct claims.

From there I introduced a new `Claim::DatabaseOfQualifiedTeachersReportRequest` class which converts `Claim` attributes to csv for exporting. I wanted to keep the knowledge for which attributes are exported inside this class as opposed to the controller as this felt more natural.

<!-- Do you need to update CHANGELOG.md? -->
## Screenshot
![Screenshot_2019-11-12 Claim additional payments for teaching – GOV UK](https://user-images.githubusercontent.com/480578/68672457-8d530080-0549-11ea-936d-76c0d0419091.png)

