### PR TITLE
Introduce the Maths & Physics journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
-- Introduce the beginnings of the Maths & Physics journey
+- Introduce the beginnings of the Maths & Physics journey, protected with basic
+  auth
 
 ## [Release 030] - 2019-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Introduce the beginnings of the Maths & Physics journey
+
 ## [Release 030] - 2019-11-12
 
 - Add policy specific "Reply-to" address for claim emails

--- a/app/controllers/base_public_controller.rb
+++ b/app/controllers/base_public_controller.rb
@@ -2,6 +2,7 @@ class BasePublicController < ApplicationController
   CLAIM_TIMEOUT_LENGTH_IN_MINUTES = 30
 
   helper_method :current_policy_routing_name, :claim_timeout_in_minutes
+  before_action :authenticate_with_basic_auth, if: :part_of_maths_and_physics_journey
   before_action :end_expired_claim_sessions
 
   private
@@ -29,5 +30,18 @@ class BasePublicController < ApplicationController
     session.delete(:claim_id)
     session.delete(:verify_request_id)
     @current_claim = nil
+  end
+
+  def authenticate_with_basic_auth
+    if ENV["BASIC_AUTH_USERNAME"].present?
+      authenticate_or_request_with_http_basic("Maths & Physics private beta") do |username, password|
+        ActiveSupport::SecurityUtils.secure_compare(username, ENV["BASIC_AUTH_USERNAME"]) &&
+          ActiveSupport::SecurityUtils.secure_compare(password, ENV["BASIC_AUTH_PASSWORD"])
+      end
+    end
+  end
+
+  def part_of_maths_and_physics_journey
+    current_policy_routing_name == MathsAndPhysics.routing_name
   end
 end

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -9,7 +9,7 @@ module PartOfClaimJourney
   private
 
   def current_policy_routing_name
-    current_claim.policy.routing_name
+    current_claim.policy&.routing_name
   end
 
   def send_unstarted_claiments_to_the_start

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -8,6 +8,9 @@ class StaticPagesController < BasePublicController
   def cookies
   end
 
+  def maths_and_physics
+  end
+
   def privacy_notice
   end
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -209,7 +209,7 @@ class Claim < ApplicationRecord
   end
 
   def policy
-    eligibility.class.module_parent
+    eligibility&.class&.module_parent
   end
 
   private

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -1,0 +1,9 @@
+module MathsAndPhysics
+  def self.start_page_url
+    "/maths-and-physics/start" # Temporary start page during private beta
+  end
+
+  def self.routing_name
+    "maths-and-physics"
+  end
+end

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -1,0 +1,26 @@
+module MathsAndPhysics
+  class Eligibility < ApplicationRecord
+    self.table_name = "maths_and_physics_eligibilities"
+
+    validates :teaching_maths_or_physics, on: [:"teaching-maths-or-physics", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
+
+    def ineligible?
+      not_teaching_maths_or_physics?
+    end
+
+    def ineligibility_reason
+      [
+        :not_teaching_maths_or_physics,
+      ].find { |eligibility_check| send("#{eligibility_check}?") }
+    end
+
+    def reset_dependent_answers
+    end
+
+    private
+
+    def not_teaching_maths_or_physics?
+      teaching_maths_or_physics == false
+    end
+  end
+end

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -1,5 +1,8 @@
 module MathsAndPhysics
   class Eligibility < ApplicationRecord
+    EDITABLE_ATTRIBUTES = [
+      :teaching_maths_or_physics,
+    ].freeze
     self.table_name = "maths_and_physics_eligibilities"
 
     validates :teaching_maths_or_physics, on: [:"teaching-maths-or-physics", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -1,0 +1,25 @@
+module MathsAndPhysics
+  # Determines the slugs that make up the claim process for a Maths & Physics
+  # claim. Based on the existing answers on the claim, the sequence of slugs
+  # will change. For example, if the claimant has said they are not paying off a
+  # student loan, the questions to determine their loan plan will not be part of
+  # the sequence.
+  #
+  # Note that the sequence is recalculated on each call to `slugs` so that it
+  # accounts for any changes that may have been made to the claim and always
+  # reflects the sequence based on the claim's current state.
+  class SlugSequence
+    SLUGS = [].freeze
+
+    attr_reader :claim
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def slugs
+      SLUGS.dup.tap do |sequence|
+      end
+    end
+  end
+end

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -9,7 +9,11 @@ module MathsAndPhysics
   # accounts for any changes that may have been made to the claim and always
   # reflects the sequence based on the claim's current state.
   class SlugSequence
-    SLUGS = [].freeze
+    SLUGS = [
+      "teaching-maths-or-physics",
+      "eligibility-confirmed",
+      "ineligible",
+    ].freeze
 
     attr_reader :claim
 

--- a/app/models/policies.rb
+++ b/app/models/policies.rb
@@ -2,6 +2,7 @@
 module Policies
   POLICIES = [
     StudentLoans,
+    MathsAndPhysics,
   ].freeze
 
   def self.all

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_not_teaching_maths_or_physics.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_not_teaching_maths_or_physics.html.erb
@@ -1,0 +1,7 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
+<p class="govuk-body">
+  You can only get this payment if you teach maths or physics.
+</p>

--- a/app/views/maths_and_physics/claims/eligibility_confirmed.html.erb
+++ b/app/views/maths_and_physics/claims/eligibility_confirmed.html.erb
@@ -1,0 +1,8 @@
+<% content_for(:page_title, page_title("You are eligible to claim for teaching maths or physics", policy: current_policy_routing_name)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You are eligible to claim a payment for teaching maths or physics</h1>
+    <p class="govuk-body">Based on your answers you can claim £2,000 for teaching maths or physics.</p>
+  </div>
+</div>

--- a/app/views/maths_and_physics/claims/teaching_maths_or_physics.html.erb
+++ b/app/views/maths_and_physics/claims/teaching_maths_or_physics.html.erb
@@ -1,0 +1,45 @@
+<% content_for(:page_title, page_title(t("maths_and_physics.questions.teaching_maths_or_physics"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.teaching_maths_or_physics": "claim_eligibility_attributes_teaching_maths_or_physics_true" }) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: path_for_form  do |form| %>
+      <%= form_group_tag current_claim do %>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+
+          <%= fields.hidden_field :teaching_maths_or_physics %>
+
+          <fieldset class="govuk-fieldset">
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("maths_and_physics.questions.teaching_maths_or_physics") %>
+              </h1>
+            </legend>
+
+            <%= errors_tag current_claim.eligibility, :teaching_maths_or_physics %>
+
+            <div class="govuk-radios govuk-radios--inline">
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:teaching_maths_or_physics, true, class: "govuk-radios__input") %>
+                <%= fields.label :teaching_maths_or_physics_true, "Yes", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:teaching_maths_or_physics, false, class: "govuk-radios__input") %>
+                <%= fields.label :teaching_maths_or_physics_false, "No", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+            </div>
+
+          </fieldset>
+
+        <% end %>
+      <% end %>
+
+      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/static_pages/maths_and_physics.html.erb
+++ b/app/views/static_pages/maths_and_physics.html.erb
@@ -1,0 +1,52 @@
+<% content_for(:page_title, t("maths_and_physics.policy_name")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= policy_service_name("maths-and-physics") %>
+    </h1>
+
+    <p class="govuk-body">
+      Claim £2,000 after tax if you:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>are a maths or physics teacher or teach maths or physics sometimes</li>
+      <li>
+        have a degree or teaching qualification specialising in maths or physics —
+        <%= link_to "check which qualifications are eligible", "https://www.gov.uk/guidance/apply-for-mathematics-and-physics-teacher-retention-payments#opportinity-area", class: "govuk-link" %>
+      </li>
+      <li>
+        teach at a state-funded secondary school in certain places —
+        <%= link_to "check which places are eligible", "https://www.gov.uk/guidance/apply-for-mathematics-and-physics-teacher-retention-payments#regional-eligibility-criteria", class: "govuk-link" %>
+      </li>
+      <li>completed your initial teacher training (ITT) course in or after the 2013 to 2014 academic year</li>
+    </ul>
+
+    <p class="govuk-body">
+      The application takes around 15 to 45 minutes to complete.
+    </p>
+
+    <h2 class="govuk-heading-m">Before you apply</h2>
+
+    <p class="govuk-body">You'll need:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>your National Insurance Number</li>
+      <li>your bank account details</li>
+      <li>
+        your 7-digit teacher reference number – you can get this from your
+        school, the certificate you got when you qualified, or from the
+        <%= link_to "teacher qualifications helpdesk", "https://www.gov.uk/guidance/individual-teacher-records-information-for-teachers#contact", class: "govuk-link" %>
+      </li>
+      <li>the date you completed your initial teacher training</li>
+      <li>
+        sign in details for ‘Verify’ — the government’s secure way of proving
+        who you are, if you do not have a Verify account, you’ll need your
+        passport or photocard driving licence to sign up
+      </li>
+    </ul>
+
+    <%= link_to "Start now", new_claim_path("maths-and-physics"), class: "govuk-button govuk-button--start", role: "button", data: {module: "govuk-button"} %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,8 @@ en:
   maths_and_physics:
     policy_name: "Claim a payment for teaching maths or physics"
     support_email_address: "mathsphysicsteacherpayment@digital.education.gov.uk"
+    questions:
+      teaching_maths_or_physics: "Do you currently teach any maths or physics?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,8 @@ Rails.application.routes.draw do
       resources :school_search, only: [:create]
     end
   end
+  # Temporary start page for Maths & Physics
+  get "maths-and-physics/start", to: "static_pages#maths_and_physics", defaults: {policy: "maths-and-physics"}
 
   namespace :verify do
     resource :authentications, only: [:new, :create] do

--- a/db/migrate/20191106160514_create_maths_and_physics_eligibilities.rb
+++ b/db/migrate/20191106160514_create_maths_and_physics_eligibilities.rb
@@ -1,0 +1,8 @@
+class CreateMathsAndPhysicsEligibilities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :maths_and_physics_eligibilities, id: :uuid do |t|
+      t.boolean :teaching_maths_or_physics
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_24_151831) do
+ActiveRecord::Schema.define(version: 2019_11_06_160514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -91,6 +91,12 @@ ActiveRecord::Schema.define(version: 2019_10_24_151831) do
     t.string "name"
     t.string "code"
     t.index ["code"], name: "index_local_authority_districts_on_code", unique: true
+  end
+
+  create_table "maths_and_physics_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "teaching_maths_or_physics"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/maths_and_physics/eligibilities.rb
+++ b/spec/factories/maths_and_physics/eligibilities.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :maths_and_physics_eligibility, class: "MathsAndPhysics::Eligibility" do
+    trait :eligible do
+      teaching_maths_or_physics { true }
+    end
+  end
+end

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.feature "Maths & Physics claims" do
+  [true, false].each do |javascript_enabled|
+    js_status = javascript_enabled ? "enabled" : "disabled"
+    scenario "Teacher claims for Maths & Physics payment with JavaScript #{js_status}", js: javascript_enabled do
+      visit "maths-and-physics/start"
+
+      expect(page).to have_text "Claim a payment for teaching maths or physics"
+    end
+  end
+end

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -5,8 +5,31 @@ RSpec.feature "Maths & Physics claims" do
     js_status = javascript_enabled ? "enabled" : "disabled"
     scenario "Teacher claims for Maths & Physics payment with JavaScript #{js_status}", js: javascript_enabled do
       visit "maths-and-physics/start"
-
       expect(page).to have_text "Claim a payment for teaching maths or physics"
+
+      click_on "Start"
+      expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))
+
+      choose "Yes"
+      click_on "Continue"
+
+      claim = Claim.order(:created_at).last
+      eligibility = claim.eligibility
+
+      expect(eligibility.teaching_maths_or_physics).to eql true
+      expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
     end
+  end
+
+  scenario "A teacher is ineligible for Maths & Physics" do
+    visit new_claim_path(MathsAndPhysics.routing_name)
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))
+
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text("You’re not eligible for this payment")
+    expect(page).to have_text("You can only get this payment if you teach maths or physics")
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -315,6 +315,10 @@ RSpec.describe Claim, type: :model do
     it "returns the claim’s policy namespace" do
       expect(Claim.new(eligibility: StudentLoans::Eligibility.new).policy).to eq StudentLoans
     end
+
+    it "returns nil if no eligibility is set" do
+      expect(Claim.new.policy).to be_nil
+    end
   end
 
   describe "#submit!" do

--- a/spec/models/maths_and_physics/eligibility_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe MathsAndPhysics::Eligibility, type: :model do
+  describe "#ineligible?" do
+    it "returns false when the eligibility cannot be determined" do
+      expect(MathsAndPhysics::Eligibility.new.ineligible?).to eql false
+    end
+
+    it "returns true when not teaching maths or physics" do
+      expect(MathsAndPhysics::Eligibility.new(teaching_maths_or_physics: false).ineligible?).to eql true
+      expect(MathsAndPhysics::Eligibility.new(teaching_maths_or_physics: true).ineligible?).to eql false
+    end
+  end
+
+  describe "#ineligibility_reason" do
+    it "returns nil when the reason for ineligibility cannot be determined" do
+      expect(MathsAndPhysics::Eligibility.new.ineligibility_reason).to be_nil
+    end
+
+    it "returns a symbol indicating the reason for ineligibility" do
+      expect(MathsAndPhysics::Eligibility.new(teaching_maths_or_physics: false).ineligibility_reason).to eq :not_teaching_maths_or_physics
+    end
+  end
+
+  # Validation contexts
+  context "when saving in the “teaching-maths-or-physics” context" do
+    it "is not valid without a value for teaching_maths_or_physics" do
+      expect(MathsAndPhysics::Eligibility.new).not_to be_valid(:"teaching-maths-or-physics")
+      expect(MathsAndPhysics::Eligibility.new(teaching_maths_or_physics: true)).to be_valid(:"teaching-maths-or-physics")
+      expect(MathsAndPhysics::Eligibility.new(teaching_maths_or_physics: false)).to be_valid(:"teaching-maths-or-physics")
+    end
+  end
+
+  context "when saving in the “submit” context" do
+    it "is valid when all attributes are present" do
+      expect(build(:maths_and_physics_eligibility, :eligible)).to be_valid(:submit)
+    end
+
+    it "is not valid without a value for teaching_maths_or_physics" do
+      expect(build(:maths_and_physics_eligibility, :eligible, teaching_maths_or_physics: nil)).not_to be_valid(:submit)
+      expect(build(:maths_and_physics_eligibility, :eligible, teaching_maths_or_physics: true)).to be_valid(:submit)
+    end
+  end
+end

--- a/spec/requests/basic_auth_protects_maths_and_physics_spec.rb
+++ b/spec/requests/basic_auth_protects_maths_and_physics_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Requests when basic auth environment variables are present", type: :request do
+  around do |example|
+    ClimateControl.modify BASIC_AUTH_USERNAME: "username", BASIC_AUTH_PASSWORD: "password" do
+      example.run
+    end
+  end
+
+  it "doesn't require basic for student-loan requests" do
+    get new_claim_path(StudentLoans.routing_name)
+    expect(response).to be_successful
+
+    get privacy_notice_path(StudentLoans.routing_name)
+    expect(response).to be_successful
+  end
+
+  it "requires basic auth for maths-and-physics requests" do
+    authorised_headers = {
+      "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials("username", "password"),
+    }
+
+    get new_claim_path(MathsAndPhysics.routing_name)
+    expect(response).to be_unauthorized
+
+    get privacy_notice_path(MathsAndPhysics.routing_name)
+    expect(response).to be_unauthorized
+
+    get new_claim_path(MathsAndPhysics.routing_name), params: {}, headers: authorised_headers
+    expect(response).to be_successful
+  end
+end

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -4,6 +4,7 @@ describe "Routes", type: :routing do
   describe "Claims routing" do
     it "routes GET requests to pages in the policies’ page sequences" do
       expect(get: "student-loans/qts-year").to route_to "claims#show", slug: "qts-year", policy: "student-loans"
+      expect(get: "maths-and-physics/teaching-maths-or-physics").to route_to "claims#show", slug: "teaching-maths-or-physics", policy: "maths-and-physics"
     end
 
     it "routes GET /:policy/claim to the new action" do
@@ -18,6 +19,7 @@ describe "Routes", type: :routing do
 
     it "routes policy page sequence slugs to the update action" do
       expect(put: "student-loans/claim-school").to route_to "claims#update", slug: "claim-school", policy: "student-loans"
+      expect(put: "maths-and-physics/teaching-maths-or-physics").to route_to "claims#update", slug: "teaching-maths-or-physics", policy: "maths-and-physics"
     end
 
     it "does not route for unrecognised policies" do
@@ -28,10 +30,12 @@ describe "Routes", type: :routing do
 
     it "does not route to pages not in a policy’s page sequences" do
       expect(get: "student-loans/teaching-maths-or-physics").not_to be_routable
+      expect(get: "maths-and-physics/qts-year").not_to be_routable
     end
 
     it "allows positionable routing parameters in the URL helpers" do
       expect(claim_path("student-loans", "claim-school")).to eq "/student-loans/claim-school"
+      expect(claim_path("maths-and-physics", "teaching-maths-or-physics")).to eq "/maths-and-physics/teaching-maths-or-physics"
     end
   end
 end

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -6,8 +6,14 @@ describe "Routes", type: :routing do
       expect(get: "student-loans/qts-year").to route_to "claims#show", slug: "qts-year", policy: "student-loans"
     end
 
-    it "routes /:policy/claim to the create action" do
+    it "routes GET /:policy/claim to the new action" do
+      expect(get: "student-loans/claim").to route_to "claims#new", policy: "student-loans"
+      expect(get: "maths-and-physics/claim").to route_to "claims#new", policy: "maths-and-physics"
+    end
+
+    it "routes POST /:policy/claim to the create action" do
       expect(post: "student-loans/claim").to route_to "claims#create", policy: "student-loans"
+      expect(post: "maths-and-physics/claim").to route_to "claims#create", policy: "maths-and-physics"
     end
 
     it "routes policy page sequence slugs to the update action" do


### PR DESCRIPTION
Finally, after the many preparatory PRs, here is the beginnings of the Maths & Physics journey.

It introduces the beginnings of the `Eligibility` model and`SlugSequence` as well as a temporary start page that can be used during private beta. Only the first question is implemented in the PR, the rest of the journey can be implemented iteratively from this base.

The Maths & Physics journey will be protected using basic auth; all that needs to happen is to set the appropriate environment variables.