### PR TITLE
Improvements to the generate payroll interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog]
   interface. Closing the service prevents users from making claims. As part of
   this, we remove the global maintenance mode, and the default maintenance mode
   availability message.
+- Only allow payroll runs to be created if none exist already for the current
+  month
 
 ## [Release 031] - 2019-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog]
   interface. Closing the service prevents users from making claims. As part of
   this, we remove the global maintenance mode, and the default maintenance mode
   availability message.
+- Service operators are shown when the next payroll run file is due to be sent
+  to Cantium
 - Only allow payroll runs to be created if none exist already for the current
   month
 

--- a/app/helpers/admin/payroll_run_helper.rb
+++ b/app/helpers/admin/payroll_run_helper.rb
@@ -1,0 +1,14 @@
+module Admin
+  module PayrollRunHelper
+    def next_payroll_file_to_cantium_due_date
+      next_payrollable_month = PayrollRun.this_month.exists? ? Date.today.next_month.all_month : Date.today.all_month
+      all_fridays_in_month(next_payrollable_month)[-3]
+    end
+
+    private
+
+    def all_fridays_in_month(month)
+      month.select { |day| day.friday? }
+    end
+  end
+end

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -4,6 +4,10 @@ class PayrollRun < ApplicationRecord
 
   validates :created_by, presence: true
 
+  validate :ensure_no_payroll_run_this_month, on: :create
+
+  scope :this_month, -> { where(created_at: DateTime.now.all_month) }
+
   def total_award_amount
     claims.sum(&:award_amount)
   end
@@ -16,5 +20,11 @@ class PayrollRun < ApplicationRecord
         end
       end
     end
+  end
+
+  private
+
+  def ensure_no_payroll_run_this_month
+    errors.add(:base, "There has already been a payroll run for #{Date.today.strftime("%B")}") if PayrollRun.this_month.any?
   end
 end

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -5,9 +5,13 @@
     </h1>
   </div>
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Make a payroll file containing all the relevant information for approved claims to be paid by a payroll provider.</p>
+    <p class="govuk-body">Make a payroll file containing all the relevant information for approved claims to be paid by Cantium.</p>
 
-    <%= link_to 'Prepare payroll', new_admin_payroll_run_path, class: "govuk-button", data: {module: "govuk-button"} if PayrollRun.this_month.empty? %>
+    <div class="govuk-inset-text">
+      The next payroll file must be with Cantium on or before <%= l(next_payroll_file_to_cantium_due_date) %>
+    </div>
+
+    <%= link_to 'Prepare payroll file', new_admin_payroll_run_path, class: "govuk-button", data: {module: "govuk-button"} if PayrollRun.this_month.empty? %>
   </div>
   <div class="govuk-grid-column-full">
     <table class="govuk-table">

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -15,7 +15,7 @@
       </strong>
     </div>
 
-    <%= link_to 'Prepare payroll', new_admin_payroll_run_path, class: "govuk-button", data: {module: "govuk-button"} %></li>
+    <%= link_to 'Prepare payroll', new_admin_payroll_run_path, class: "govuk-button", data: {module: "govuk-button"} if PayrollRun.this_month.empty? %>
   </div>
   <div class="govuk-grid-column-full">
     <table class="govuk-table">

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -7,14 +7,6 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">Make a payroll file containing all the relevant information for approved claims to be paid by a payroll provider.</p>
 
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        Only one payroll file should be generated and submitted per calendar month
-      </strong>
-    </div>
-
     <%= link_to 'Prepare payroll', new_admin_payroll_run_path, class: "govuk-button", data: {module: "govuk-button"} if PayrollRun.this_month.empty? %>
   </div>
   <div class="govuk-grid-column-full">

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -27,6 +27,17 @@ RSpec.feature "Payroll" do
     expect(csv.count).to eq(3)
   end
 
+  context "when a payroll run already exists for the month" do
+    scenario "Service operator cannot create a new payroll run" do
+      create(:payroll_run, claims_count: 2, created_at: 5.minutes.ago)
+      sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+
+      visit admin_payroll_runs_path
+
+      expect(page).not_to have_link("Prepare payroll")
+    end
+  end
+
   scenario "Any claims approved in the meantime are not included" do
     sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
 
@@ -49,7 +60,7 @@ RSpec.feature "Payroll" do
   scenario "Service operator can view a list of previous payroll runs" do
     sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
 
-    first_payroll_run = create(:payroll_run, created_at: Time.zone.now - 1.week)
+    first_payroll_run = create(:payroll_run, created_at: Time.zone.now - 1.month)
     last_payroll_run = create(:payroll_run, created_at: Time.zone.now)
 
     click_on "Payroll"

--- a/spec/helpers/admin/payroll_run_helper_spec.rb
+++ b/spec/helpers/admin/payroll_run_helper_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Admin::PayrollRunHelper, type: :helper do
+  describe "#next_payroll_file_to_cantium_due_date" do
+    context "when there has not been a payroll run this month" do
+      let(:third_friday_of_january_2020) { Date.new(2020, 1, 17) }
+
+      it "returns the third to last Friday of the current month" do
+        travel_to Date.new(2020, 1, 1) do
+          expect(helper.next_payroll_file_to_cantium_due_date).to eql(third_friday_of_january_2020)
+        end
+      end
+    end
+
+    context "when the payroll run has already happended this month" do
+      let(:third_friday_of_november_2019) { Date.new(2019, 11, 15) }
+      let!(:payroll_run_this_month) { create(:payroll_run, created_at: Date.new(2019, 10, 1)) }
+
+      it "returns the third to last Friday of the following month" do
+        travel_to Date.new(2019, 10, 10) do
+          expect(helper.next_payroll_file_to_cantium_due_date).to eql(third_friday_of_november_2019)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -1,6 +1,34 @@
 require "rails_helper"
 
 RSpec.describe PayrollRun, type: :model do
+  it "cannot be created when another PayrollRun has occurred in same month" do
+    create(:payroll_run)
+    another_payroll_run = build(:payroll_run)
+
+    expect(another_payroll_run.valid?).to be false
+    expect { another_payroll_run.save! }.to raise_error(ActiveRecord::RecordInvalid)
+
+    travel_to Time.zone.now.next_month do
+      next_month_payroll_run = build(:payroll_run)
+
+      expect(next_month_payroll_run.valid?).to be true
+      expect { next_month_payroll_run.save! }.not_to raise_error
+    end
+  end
+
+  it "can be updated in the same month as it was created" do
+    payroll_run = create(:payroll_run)
+    confirmation_report_uploaded_time = Time.zone.now.end_of_month
+    service_operator_id = "service_operator_id"
+
+    travel_to confirmation_report_uploaded_time do
+      payroll_run.confirmation_report_uploaded_by = service_operator_id
+
+      expect(payroll_run.save!).to be true
+      expect(payroll_run.confirmation_report_uploaded_by).eql? service_operator_id
+    end
+  end
+
   describe "#total_award_amount" do
     it "returns the sum of the award amounts of its claims" do
       claim_1 = build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 1500))
@@ -25,6 +53,15 @@ RSpec.describe PayrollRun, type: :model do
       expect(payroll_run.claims).to match_array(claims)
       expect(claims[0].payment.award_amount).to eq(300)
       expect(claims[1].payment.award_amount).to eq(600)
+    end
+  end
+
+  describe ".this_month" do
+    it "only includes payroll runs created in this calendar month" do
+      create(:payroll_run, created_at: 1.month.ago)
+      created_this_month = create(:payroll_run, created_at: 5.minutes.ago)
+
+      expect(PayrollRun.this_month).to eq([created_this_month])
     end
   end
 end


### PR DESCRIPTION
- Service operators are shown when the next payroll run file is expected to be uploaded by
- Only allow payroll runs to be created if none exist already for the current month

## Screenshots

<img width="1120" alt="Screenshot 2019-11-12 at 16 31 38" src="https://user-images.githubusercontent.com/2804149/68690475-ffd3d880-0569-11ea-8f3f-b9b6b0d019a4.png">
<img width="1099" alt="Screenshot 2019-11-12 at 16 32 05" src="https://user-images.githubusercontent.com/2804149/68690476-ffd3d880-0569-11ea-9544-0610a0daf93e.png">
