### PR TITLE
Add config to Dockerfile to make sassc portable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY Gemfile ${DEPS_HOME}/Gemfile
 COPY Gemfile.lock ${DEPS_HOME}/Gemfile.lock
 
 RUN gem install bundler
+ENV BUNDLE_BUILD__SASSC=--disable-march-tune-native
 
 RUN if [ ${RAILS_ENV} = "production" ]; then \
   bundle install --frozen --retry 3 --without development test; \


### PR DESCRIPTION
We had some issues in staging that meant the Docker image fell over during boot. The solution outlined in https://github.com/sass/sassc-ruby/issues/146#issuecomment-534197168 should fix it so we're not relying on the underlying system that built the image
