### PR TITLE
Reinstate production basic auth env vars

### DIFF
--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -59,10 +59,20 @@
       }
     },
     "BASIC_AUTH_USERNAME": {
-      "value": ""
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "BasicAuthUsername"
+      }
     },
     "BASIC_AUTH_PASSWORD": {
-      "value": ""
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "BasicAuthPassword"
+      }
     },
     "DFE_SIGN_IN_ISSUER": {
       "reference": {


### PR DESCRIPTION
These were hardcoded to blank values to disable basic auth when we went into public beta. Instead of doing that in the template we should load the value from the key vault, that way we can enable/disable basic auth without having to do a full release.

We're currently making use of basic auth to protect the new Maths & Physics journey. Re-instating these environment variables will mean basic auth will be active when we ship the beginning of the Maths & Physics journey.