### PR TITLE
Send payment stats to Geckoboard

### DIFF
--- a/app/jobs/record_payment_job.rb
+++ b/app/jobs/record_payment_job.rb
@@ -1,0 +1,5 @@
+class RecordPaymentJob < ApplicationJob
+  def perform(claim)
+    Claim::GeckoboardEvent.new(claim, :paid, claim.payment.updated_at).record
+  end
+end

--- a/app/models/payment_confirmation.rb
+++ b/app/models/payment_confirmation.rb
@@ -26,6 +26,7 @@ class PaymentConfirmation
       if errors.empty?
         payroll_run.claims.each do |claim|
           ClaimMailer.payment_confirmation(claim, payment_date_timestamp).deliver_later
+          RecordPaymentJob.perform_later(claim)
         end
       else
         raise ActiveRecord::Rollback

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Payroll" do
+  let!(:dataset_post_stub) { stub_geckoboard_dataset_update("claims.paid.test") }
+
   scenario "Service operator creates a payroll run" do
     sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
 
@@ -101,5 +103,7 @@ RSpec.feature "Payroll" do
 
     expect(first_email.subject).to eq("We’re paying your claim to get back your student loan repayments, reference number: #{payroll_run.claims[0].reference}")
     expect(second_email.subject).to eq("We’re paying your claim to get back your student loan repayments, reference number: #{payroll_run.claims[1].reference}")
+
+    expect(dataset_post_stub).to have_been_requested.twice
   end
 end

--- a/spec/features/missing_verify_information_spec.rb
+++ b/spec/features/missing_verify_information_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Missing information from GOV.UK Verify" do
-  before { stub_geckoboard_submitted_event }
+  before { stub_geckoboard_dataset_update }
 
   scenario "Claimant is asked a payroll gender question when Verify doesn’t provide their gender" do
     claim = start_claim

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Teacher Student Loan Repayments claims" do
-  before { stub_geckoboard_submitted_event }
+  before { stub_geckoboard_dataset_update }
 
   [
     true,

--- a/spec/jobs/record_payment_job_spec.rb
+++ b/spec/jobs/record_payment_job_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+require "geckoboard"
+
+RSpec.describe RecordPaymentJob do
+  let(:claim) { build(:claim) }
+  let(:payment) { build(:payment, :with_figures, updated_at: DateTime.now, claim: claim) }
+
+  subject { described_class.new }
+
+  it "sends the claim reference, policy and payment date to claims.submitted.ENV dataset" do
+    ClimateControl.modify ENVIRONMENT_NAME: "environment_name" do
+      claim_data = {
+        reference: claim.reference,
+        policy: claim.policy.to_s,
+        performed_at: payment.updated_at.strftime("%Y-%m-%dT%H:%M:%S%:z"),
+      }
+
+      stub_geckoboard_dataset_find_or_create("claims.paid.environment_name")
+
+      dataset_post_stub = stub_geckoboard_dataset_post("claims.paid.environment_name")
+
+      subject.perform(claim)
+
+      expect(dataset_post_stub.with(body: {data: [claim_data]})).to have_been_requested
+    end
+  end
+end

--- a/spec/jobs/record_payment_job_spec.rb
+++ b/spec/jobs/record_payment_job_spec.rb
@@ -15,9 +15,7 @@ RSpec.describe RecordPaymentJob do
         performed_at: payment.updated_at.strftime("%Y-%m-%dT%H:%M:%S%:z"),
       }
 
-      stub_geckoboard_dataset_find_or_create("claims.paid.environment_name")
-
-      dataset_post_stub = stub_geckoboard_dataset_post("claims.paid.environment_name")
+      dataset_post_stub = stub_geckoboard_dataset_update("claims.paid.environment_name")
 
       subject.perform(claim)
 

--- a/spec/jobs/record_submitted_claim_job_spec.rb
+++ b/spec/jobs/record_submitted_claim_job_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe RecordSubmittedClaimJob do
         performed_at: claim.submitted_at.strftime("%Y-%m-%dT%H:%M:%S%:z"),
       }
 
-      stub_geckoboard_dataset_find_or_create("claims.submitted.environment_name")
-
-      dataset_post_stub = stub_geckoboard_dataset_post("claims.submitted.environment_name")
+      dataset_post_stub = stub_geckoboard_dataset_update("claims.submitted.environment_name")
 
       subject.perform(claim)
 

--- a/spec/models/claim/geckoboard_event_spec.rb
+++ b/spec/models/claim/geckoboard_event_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe Claim::GeckoboardEvent, type: :model do
     ClimateControl.modify ENVIRONMENT_NAME: "test" do
       event = Claim::GeckoboardEvent.new(claim, event_name, datetime)
 
-      stub_geckoboard_dataset_find_or_create("claims.#{event_name}.test")
-      dataset_post_stub = stub_geckoboard_dataset_post("claims.#{event_name}.test")
+      dataset_post_stub = stub_geckoboard_dataset_update("claims.#{event_name}.test")
 
       event.record
 

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Submissions", type: :request do
 
     context "with a submittable claim" do
       before do
-        @dataset_post_stub = stub_geckoboard_submitted_event
+        @dataset_post_stub = stub_geckoboard_dataset_update
 
         start_claim
         # Make the claim submittable

--- a/spec/support/geckoboard_helpers.rb
+++ b/spec/support/geckoboard_helpers.rb
@@ -1,10 +1,10 @@
 module GeckoboardHelpers
-  # Use this to stub out the API calls that will be made to Geckoboard when a
-  # Claim is submitted. It will return the webmock POST request, which can be
-  # used to write expectations about the request being made.
-  def stub_geckoboard_submitted_event
-    stub_geckoboard_dataset_find_or_create("claims.submitted.test")
-    stub_geckoboard_dataset_post("claims.submitted.test")
+  # Use this to stub out the API calls that will be made to Geckoboard.
+  # It will return the webmock POST request, which can be used to write
+  # expectations about the request being made.
+  def stub_geckoboard_dataset_update(dataset_id = "claims.submitted.test")
+    stub_geckoboard_dataset_find_or_create(dataset_id)
+    stub_geckoboard_dataset_post(dataset_id)
   end
 
   def stub_geckoboard_dataset_find_or_create(dataset_id)


### PR DESCRIPTION
This is a follow-up PR to send data about claims that have been paid to Geckoboard. It uses the same class introduced in #617 to give us a record of all the claims that have been paid, which will allow us to get a count of claims that have been paid during a particular time period, as well as track activity over time. This is updated every time a claim is paid.