### PR TITLE
Update employment-related copy to clarify policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Update employment-related copy to clarify that the policy cares about the
+  location that the teacher _taught_ at, not where their employer is based.
 - A service operator can open or close an individual service from the admin
   interface. Closing the service prevents users from making claims. As part of
   this, we remove the global maintenance mode, and the default maintenance mode

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -35,7 +35,7 @@
 
       <% if school_id_param == :claim_school_id && !params.has_key?(:additional_school) %>
         <span class="govuk-hint">
-          If you worked at multiple schools during this period, enter the first school you think might be eligible.
+          If you taught at multiple schools during this period, enter the first school you think might be eligible.
         </span>
       <% end %>
     <% end %>

--- a/app/views/student_loans/claims/_ineligibility_reason_employed_at_no_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_employed_at_no_school.html.erb
@@ -3,5 +3,5 @@
 </h1>
 
 <p class="govuk-body">
-  You can only get this payment if you’re still employed at a school.
+  You can only get this payment if you’re still employed to teach at a school.
 </p>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -7,14 +7,14 @@
 
   <p class="govuk-body">
     <%= current_claim.eligibility.claim_school_name %> is not an eligible school. You can only get this
-    payment if you  were employed at an eligible school between 6 April 2018
+    payment if you were employed to teach at an eligible school between 6 April 2018
     and 5 April 2019.
   </p>
 
   <p class="govuk-body">
     If you taught at more than one school during this period, you can
     search again with the next school.
-    You only need to have worked at one eligible school to claim.
+    You only need to have taught at one eligible school to claim.
   </p>
 
   <%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button" %>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_current_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_current_school.html.erb
@@ -3,7 +3,7 @@
 </h1>
 
 <p class="govuk-body">
-  You must be employed at a state-funded secondary school to be eligible for
-  this payment. <%= current_claim.eligibility.current_school_name %>, where you are currently employed,
+  You must be employed to teach at a state-funded secondary school to be eligible for
+  this payment. <%= current_claim.eligibility.current_school_name %>, where you are currently employed to teach,
   is not a state-funded secondary school.
 </p>

--- a/app/views/student_loans/claims/_ineligibility_reason_no_more_schools.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_no_more_schools.erb
@@ -3,5 +3,5 @@
 </h1>
 
 <p class="govuk-body">
-  You must have been employed by at least one eligible school and taught eligible subjects to claim between 6 April 2018 and 5 April 2019.
+  You must have been employed to teach an eligible subject at an eligible school for a period of time between 6 April 2018 and 5 April 2019 to claim.
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
   service_name: "Claim additional payments for teaching"
   support_email_address: "additionalteachingpayment@digital.education.gov.uk"
   questions:
-    current_school: "Which school are you currently employed at?"
+    current_school: "Which school are you currently employed to teach at?"
     address: "What is your address?"
     teacher_reference_number: "What's your teacher reference number?"
     national_insurance_number: "What's your National Insurance number?"
@@ -109,8 +109,8 @@ en:
       qts_award_years:
         before_september_2013: "Before 1 September 2013"
         on_or_after_september_2013: "On or after 1 September 2013"
-      claim_school: "Which school were you employed at between 6 April 2018 and 5 April 2019?"
-      additional_school: "Which additional school were you employed at between 6 April 2018 and 5 April 2019?"
+      claim_school: "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
+      additional_school: "Which additional school were you employed to teach at between 6 April 2018 and 5 April 2019?"
       employment_status: "Are you still employed to teach at a school in England?"
       subjects_taught: "Which of the following subjects did you teach at %{school} between 6 April 2018 and 5 April 2019?"
       leadership_position: "Were you employed in a leadership position between 6 April 2018 and 5 April 2019?"

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -171,7 +171,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
       expect(eligibility.reload.employment_status).to eq("no_school")
       expect(page).to have_text("You’re not eligible")
-      expect(page).to have_text("You can only get this payment if you’re still employed at a school.")
+      expect(page).to have_text("You can only get this payment if you’re still employed to teach at a school.")
     end
   end
 

--- a/spec/features/ineligible_tslr_claims_spec.rb
+++ b/spec/features/ineligible_tslr_claims_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     click_on "Continue"
 
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("Bradford Grammar School, where you are currently employed, is not a state-funded secondary school.")
+    expect(page).to have_text("Bradford Grammar School, where you are currently employed to teach, is not a state-funded secondary school.")
   end
 
   scenario "no longer teaching" do
@@ -47,7 +47,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.employment_status).to eq("no_school")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you’re still employed at a school.")
+    expect(page).to have_text("You can only get this payment if you’re still employed to teach at a school.")
   end
 
   scenario "did not teach an eligible subject" do

--- a/spec/features/multiple_claim_schools_spec.rb
+++ b/spec/features/multiple_claim_schools_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Applicant worked at multiple schools" do
 
     expect(page).to_not have_css("input[value=\"Hampstead School\"]")
     expect(page).to have_text(I18n.t("student_loans.questions.additional_school"))
-    expect(page).to_not have_text("If you worked at multiple schools")
+    expect(page).to_not have_text("If you taught at multiple schools")
 
     choose_school schools(:penistone_grammar_school)
     expect(claim.eligibility.reload.claim_school).to eq schools(:penistone_grammar_school)

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Claims", type: :request do
         expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
 
         get claim_path(StudentLoans.routing_name, "claim-school")
-        expect(response.body).to include("Which school were you employed at")
+        expect(response.body).to include("Which school were you employed to teach at")
       end
 
       context "when searching for a school on the claim-school page" do
@@ -88,7 +88,7 @@ RSpec.describe "Claims", type: :request do
         get claim_path(StudentLoans.routing_name, "ineligible")
 
         expect(response.body).to include("You’re not eligible")
-        expect(response.body).to include("You can only get this payment if you’re still employed at a school.")
+        expect(response.body).to include("You can only get this payment if you’re still employed to teach at a school.")
       end
     end
 


### PR DESCRIPTION
The intent of the policy is to consider the location of the school where
the claimant _taught_, not the location of their employer (these may be
different in the case of, e.g. a multi-academy trust).

I've checked these changes with Faye, our content designer.