### PR TITLE
Add current school question to maths and physics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog]
 - Only allow payroll runs to be created if none exist already for the current
   month
 - Added post-eligibility questions to the Maths & Physics journey
+- Add the current school question to the maths and physics claim journey
 
 ## [Release 031] - 2019-11-18
 

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -2,6 +2,7 @@ module MathsAndPhysics
   class Eligibility < ApplicationRecord
     EDITABLE_ATTRIBUTES = [
       :teaching_maths_or_physics,
+      :current_school_id,
     ].freeze
     self.table_name = "maths_and_physics_eligibilities"
 

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -6,15 +6,21 @@ module MathsAndPhysics
     ].freeze
     self.table_name = "maths_and_physics_eligibilities"
 
+    belongs_to :current_school, optional: true, class_name: "School"
+
     validates :teaching_maths_or_physics, on: [:"teaching-maths-or-physics", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
+    validates :current_school, on: [:"current-school", :submit], presence: {message: "Select a school from the list"}
+
+    delegate :name, to: :current_school, prefix: true, allow_nil: true
 
     def ineligible?
-      not_teaching_maths_or_physics?
+      not_teaching_maths_or_physics? || ineligible_current_school?
     end
 
     def ineligibility_reason
       [
         :not_teaching_maths_or_physics,
+        :ineligible_current_school,
       ].find { |eligibility_check| send("#{eligibility_check}?") }
     end
 
@@ -25,6 +31,10 @@ module MathsAndPhysics
 
     def not_teaching_maths_or_physics?
       teaching_maths_or_physics == false
+    end
+
+    def ineligible_current_school?
+      current_school.present? && !current_school.eligible_for_maths_and_physics?
     end
   end
 end

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -11,6 +11,7 @@ module MathsAndPhysics
   class SlugSequence
     SLUGS = [
       "teaching-maths-or-physics",
+      "current-school",
       "eligibility-confirmed",
       "information-provided",
       "verified",

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_current_school.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_current_school.html.erb
@@ -1,0 +1,7 @@
+<h1 class="govuk-heading-xl">
+  This school is not eligible
+</h1>
+
+<p class="govuk-body">
+  You can only get this payment if you are employed to teach at an eligible state-funded secondary school.
+</p>

--- a/db/migrate/20191114141607_add_current_school_to_maths_and_physics_eligibilities.rb
+++ b/db/migrate/20191114141607_add_current_school_to_maths_and_physics_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddCurrentSchoolToMathsAndPhysicsEligibilities < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :maths_and_physics_eligibilities, :current_school, type: :uuid, foreign_key: {to_table: :schools}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_07_131220) do
+ActiveRecord::Schema.define(version: 2019_11_14_141607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -97,6 +97,8 @@ ActiveRecord::Schema.define(version: 2019_11_07_131220) do
     t.boolean "teaching_maths_or_physics"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "current_school_id"
+    t.index ["current_school_id"], name: "index_maths_and_physics_eligibilities_on_current_school_id"
   end
 
   create_table "payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -174,6 +176,7 @@ ActiveRecord::Schema.define(version: 2019_11_07_131220) do
     t.index ["current_school_id"], name: "index_student_loans_eligibilities_on_current_school_id"
   end
 
+  add_foreign_key "maths_and_physics_eligibilities", "schools", column: "current_school_id"
   add_foreign_key "payments", "claims"
   add_foreign_key "payments", "payroll_runs"
   add_foreign_key "schools", "local_authority_districts"

--- a/spec/factories/maths_and_physics/eligibilities.rb
+++ b/spec/factories/maths_and_physics/eligibilities.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :maths_and_physics_eligibility, class: "MathsAndPhysics::Eligibility" do
     trait :eligible do
       teaching_maths_or_physics { true }
+      current_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
     end
   end
 end

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
   let(:eligibility) { claim.eligibility }
 
   before do
-    claim = start_claim
+    claim = start_student_loans_claim
     claim.update!(attributes_for(:claim, :submittable))
     claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible))
     visit claim_path(StudentLoans.routing_name, "check-your-answers")

--- a/spec/features/current_school_with_closed_claim_school_spec.rb
+++ b/spec/features/current_school_with_closed_claim_school_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Current school with closed claim school" do
   let(:claim_school) { schools(:the_samuel_lister_academy) }
 
   scenario "Still teaching only has two options" do
-    start_claim
+    start_student_loans_claim
     choose_school claim_school
     check "Physics"
     click_on "Continue"
@@ -16,7 +16,7 @@ RSpec.feature "Current school with closed claim school" do
   end
 
   scenario "Choosing yes to still teaching prompts to search for a school" do
-    claim = start_claim
+    claim = start_student_loans_claim
     choose_school claim_school
     check "Physics"
     click_on "Continue"

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
   before do
     stub_vsp_generate_request
 
-    @claim = start_claim
+    @claim = start_student_loans_claim
     choose_school schools(:penistone_grammar_school)
     choose_subjects_taught
     choose_still_teaching

--- a/spec/features/ineligible_maths_and_physics_claims_spec.rb
+++ b/spec/features/ineligible_maths_and_physics_claims_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.feature "Ineligible Maths and Physics claims" do
+  scenario "not teaching maths or physics" do
+    visit new_claim_path(MathsAndPhysics.routing_name)
+    choose "No"
+    click_on "Continue"
+    claim = Claim.order(:created_at).last
+
+    expect(claim.eligibility.teaching_maths_or_physics).to eql false
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You can only get this payment if you teach maths or physics.")
+  end
+
+  scenario "chooses an ineligible current school" do
+    visit new_claim_path(MathsAndPhysics.routing_name)
+    choose "Yes"
+    click_on "Continue"
+
+    choose_school schools(:hampstead_school)
+    claim = Claim.order(:created_at).last
+
+    expect(claim.eligibility.reload.current_school).to eq schools(:hampstead_school)
+    expect(page).to have_text("This school is not eligible")
+    expect(page).to have_text("You can only get this payment if you are employed to teach at an eligible state-funded secondary school.")
+  end
+end

--- a/spec/features/ineligible_maths_and_physics_claims_spec.rb
+++ b/spec/features/ineligible_maths_and_physics_claims_spec.rb
@@ -13,12 +13,9 @@ RSpec.feature "Ineligible Maths and Physics claims" do
   end
 
   scenario "chooses an ineligible current school" do
-    visit new_claim_path(MathsAndPhysics.routing_name)
-    choose "Yes"
-    click_on "Continue"
+    claim = start_maths_and_physics_claim
 
     choose_school schools(:hampstead_school)
-    claim = Claim.order(:created_at).last
 
     expect(claim.eligibility.reload.current_school).to eq schools(:hampstead_school)
     expect(page).to have_text("This school is not eligible")

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   end
 
   scenario "chooses an ineligible claim school" do
-    claim = start_claim
+    claim = start_student_loans_claim
     choose_school schools(:hampstead_school)
 
     expect(claim.eligibility.reload.claim_school).to eq schools(:hampstead_school)
@@ -21,7 +21,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   end
 
   scenario "chooses an ineligible current school" do
-    start_claim
+    start_student_loans_claim
 
     choose_school schools(:penistone_grammar_school)
     choose_subjects_taught
@@ -39,7 +39,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   end
 
   scenario "no longer teaching" do
-    claim = start_claim
+    claim = start_student_loans_claim
     choose_school schools(:penistone_grammar_school)
     choose_subjects_taught
 
@@ -51,7 +51,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   end
 
   scenario "did not teach an eligible subject" do
-    claim = start_claim
+    claim = start_student_loans_claim
     choose_school schools(:penistone_grammar_school)
 
     choose I18n.t("student_loans.questions.eligible_subjects.none_taught")
@@ -63,7 +63,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   end
 
   scenario "was in a leadership position and performed leadership duties for more than half of their time" do
-    claim = start_claim
+    claim = start_student_loans_claim
     choose_school schools(:penistone_grammar_school)
     check "Biology"
     click_on "Continue"
@@ -82,7 +82,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
   end
 
   scenario "claimant can start a fresh claim after being told they are ineligible, by visiting the start page" do
-    start_claim
+    start_student_loans_claim
     choose_school schools(:hampstead_school)
     expect(page).to have_text("This school is not eligible")
 

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -17,6 +17,11 @@ RSpec.feature "Maths & Physics claims" do
       eligibility = claim.eligibility
 
       expect(eligibility.teaching_maths_or_physics).to eql true
+
+      expect(page).to have_text(I18n.t("questions.current_school"))
+      choose_school schools(:penistone_grammar_school)
+      expect(claim.eligibility.reload.current_school).to eql schools(:penistone_grammar_school)
+
       expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
 
       click_on "Continue"

--- a/spec/features/missing_verify_information_spec.rb
+++ b/spec/features/missing_verify_information_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Missing information from GOV.UK Verify" do
   before { stub_geckoboard_dataset_update }
 
   scenario "Claimant is asked a payroll gender question when Verify doesn’t provide their gender" do
-    claim = start_claim
+    claim = start_student_loans_claim
     choose_school schools(:penistone_grammar_school)
     choose_subjects_taught
     choose_still_teaching
@@ -56,7 +56,7 @@ RSpec.feature "Missing information from GOV.UK Verify" do
   end
 
   scenario "Claimant is asked an address question when Verify doesn’t provide their address" do
-    claim = start_claim
+    claim = start_student_loans_claim
     choose_school schools(:penistone_grammar_school)
     choose_subjects_taught
     choose_still_teaching

--- a/spec/features/multiple_claim_schools_spec.rb
+++ b/spec/features/multiple_claim_schools_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Applicant worked at multiple schools" do
   let!(:eligible_school) { create(:school, :student_loan_eligible) }
 
-  let!(:claim) { start_claim }
+  let!(:claim) { start_student_loans_claim }
 
   scenario "first claim school is ineligible and subsequent school is eligible" do
     choose_school schools(:hampstead_school)

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Searching for school during Teacher Student Loan Repayments claims" do
   scenario "doesn't select a school from the search results the first time around" do
-    claim = start_claim
+    claim = start_student_loans_claim
 
     fill_in :school_search, with: "Penistone"
     click_on "Search"
@@ -20,7 +20,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   end
 
   scenario "searches again to find school" do
-    claim = start_claim
+    claim = start_student_loans_claim
 
     fill_in :school_search, with: "hamp"
     click_on "Search"
@@ -38,7 +38,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   end
 
   scenario "Claim school search with autocomplete", js: true do
-    start_claim
+    start_student_loans_claim
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
@@ -54,7 +54,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   end
 
   scenario "Current school search with autocomplete", js: true do
-    start_claim
+    start_student_loans_claim
 
     choose_school schools(:penistone_grammar_school)
     choose_subjects_taught
@@ -75,7 +75,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   end
 
   scenario "School search form still works like a normal form if submitted", js: true do
-    start_claim
+    start_student_loans_claim
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
@@ -92,7 +92,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   end
 
   scenario "Editing school search after autocompletion clears last selection", js: true do
-    start_claim
+    start_student_loans_claim
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
@@ -114,7 +114,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   end
 
   scenario "Claim school search includes closed schools" do
-    start_claim
+    start_student_loans_claim
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
@@ -126,7 +126,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   end
 
   scenario "Current school search excludes closed schools" do
-    start_claim
+    start_student_loans_claim
     choose_school schools(:penistone_grammar_school)
     choose_subjects_taught
     choose_still_teaching "Yes, at another school"
@@ -141,7 +141,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   end
 
   scenario "Claim school search with autocomplete includes closed schools", js: true do
-    start_claim
+    start_student_loans_claim
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
     expect(page).to have_button("Search")
@@ -151,7 +151,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   end
 
   scenario "Current school search with autocomplete excludes closed schools", js: true do
-    start_claim
+    start_student_loans_claim
 
     choose_school schools(:penistone_grammar_school)
     choose_subjects_taught

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -131,7 +131,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
   end
 
   scenario "currently works at a different school to the claim school" do
-    claim = start_claim
+    claim = start_student_loans_claim
 
     choose_school schools(:penistone_grammar_school)
     choose_subjects_taught

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments claims" do
   before do
-    start_claim
+    start_student_loans_claim
     choose_school schools(:penistone_grammar_school)
   end
 

--- a/spec/features/timeout_spec.rb
+++ b/spec/features/timeout_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Teacher Student Loan Repayments claims", js: true do
   before do
     allow_any_instance_of(BasePublicController).to receive(:claim_timeout_in_minutes) { two_seconds_in_minutes }
     allow_any_instance_of(BasePublicController).to receive(:timeout_warning_in_minutes) { one_second_in_minutes }
-    start_claim
+    start_student_loans_claim
   end
 
   scenario "Dialog warns claimants their session will timeout" do

--- a/spec/models/maths_and_physics/eligibility_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
     end
   end
 
+  context "when saving in the “current-school” context" do
+    it "validates the presence of the current_school" do
+      expect(MathsAndPhysics::Eligibility.new).not_to be_valid(:"current-school")
+      expect(MathsAndPhysics::Eligibility.new(current_school: schools(:penistone_grammar_school))).to be_valid(:"current-school")
+    end
+  end
+
   context "when saving in the “submit” context" do
     it "is valid when all attributes are present" do
       expect(build(:maths_and_physics_eligibility, :eligible)).to be_valid(:submit)
@@ -39,6 +46,11 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
     it "is not valid without a value for teaching_maths_or_physics" do
       expect(build(:maths_and_physics_eligibility, :eligible, teaching_maths_or_physics: nil)).not_to be_valid(:submit)
       expect(build(:maths_and_physics_eligibility, :eligible, teaching_maths_or_physics: true)).to be_valid(:submit)
+    end
+
+    it "is not valid without a value for current_school" do
+      expect(build(:maths_and_physics_eligibility, :eligible, current_school: nil)).not_to be_valid(:submit)
+      expect(build(:maths_and_physics_eligibility, :eligible, current_school: schools(:penistone_grammar_school))).to be_valid(:submit)
     end
   end
 end

--- a/spec/models/maths_and_physics/eligibility_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
       expect(MathsAndPhysics::Eligibility.new(teaching_maths_or_physics: false).ineligible?).to eql true
       expect(MathsAndPhysics::Eligibility.new(teaching_maths_or_physics: true).ineligible?).to eql false
     end
+
+    it "returns true when teaching at an ineligble school" do
+      expect(MathsAndPhysics::Eligibility.new(current_school: schools(:hampstead_school)).ineligible?).to eql true
+      expect(MathsAndPhysics::Eligibility.new(current_school: schools(:penistone_grammar_school)).ineligible?).to eql false
+    end
   end
 
   describe "#ineligibility_reason" do
@@ -19,6 +24,18 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
 
     it "returns a symbol indicating the reason for ineligibility" do
       expect(MathsAndPhysics::Eligibility.new(teaching_maths_or_physics: false).ineligibility_reason).to eq :not_teaching_maths_or_physics
+      expect(MathsAndPhysics::Eligibility.new(current_school: schools(:hampstead_school)).ineligibility_reason).to eq :ineligible_current_school
+    end
+  end
+
+  describe "#current_school_name" do
+    it "returns the name of the claim school" do
+      eligibility = MathsAndPhysics::Eligibility.new(current_school: schools(:penistone_grammar_school))
+      expect(eligibility.current_school_name).to eq schools(:penistone_grammar_school).name
+    end
+
+    it "does not error if the claim school is not set" do
+      expect(MathsAndPhysics::Eligibility.new.current_school_name).to be_nil
     end
   end
 

--- a/spec/models/maths_and_physics/eligibility_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
   end
 
   describe "#current_school_name" do
-    it "returns the name of the claim school" do
+    it "returns the name of the current school" do
       eligibility = MathsAndPhysics::Eligibility.new(current_school: schools(:penistone_grammar_school))
       expect(eligibility.current_school_name).to eq schools(:penistone_grammar_school).name
     end
 
-    it "does not error if the claim school is not set" do
+    it "does not error if the current school is not set" do
       expect(MathsAndPhysics::Eligibility.new.current_school_name).to be_nil
     end
   end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Claims", type: :request do
     end
 
     context "the user has already started a claim" do
-      before { start_claim }
+      before { start_student_loans_claim }
 
       it "clears the current claim from the session, and renders the first page in the sequence" do
         expect { get new_claim_path(StudentLoans.routing_name) }.to change { session[:claim_id] }.from(String).to(nil)
@@ -22,7 +22,7 @@ RSpec.describe "Claims", type: :request do
 
   describe "claims#create request" do
     it "creates a new Claim and redirects to the QTS question" do
-      expect { start_claim }.to change { Claim.count }.by(1)
+      expect { start_student_loans_claim }.to change { Claim.count }.by(1)
 
       expect(response).to redirect_to(claim_path(StudentLoans.routing_name, "claim-school"))
     end
@@ -35,7 +35,7 @@ RSpec.describe "Claims", type: :request do
 
   describe "claims#show request" do
     context "when a claim is already in progress" do
-      before { start_claim }
+      before { start_student_loans_claim }
 
       it "renders the requested page in the sequence" do
         get claim_path(StudentLoans.routing_name, "qts-year")
@@ -80,7 +80,7 @@ RSpec.describe "Claims", type: :request do
 
   describe "the claims ineligible page" do
     context "when a claim is already in progress" do
-      before { start_claim }
+      before { start_student_loans_claim }
 
       it "renders a static ineligibility page" do
         Claim.order(:created_at).last.eligibility.update(employment_status: "no_school")
@@ -111,7 +111,7 @@ RSpec.describe "Claims", type: :request do
     context "when a claim is already in progress" do
       let(:in_progress_claim) { Claim.order(:created_at).last }
 
-      before { start_claim }
+      before { start_student_loans_claim }
 
       it "updates the claim with the submitted form data" do
         put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_september_2013"}}}

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Submissions", type: :request do
       before do
         @dataset_post_stub = stub_geckoboard_dataset_update
 
-        start_claim
+        start_student_loans_claim
         # Make the claim submittable
         in_progress_claim.update!(attributes_for(:claim, :submittable))
         in_progress_claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible))
@@ -40,7 +40,7 @@ RSpec.describe "Submissions", type: :request do
 
     context "with an unsubmittable claim" do
       before :each do
-        start_claim
+        start_student_loans_claim
         # Make the claim _almost_ submittable
         in_progress_claim.update!(attributes_for(:claim, :submittable, email_address: nil))
 
@@ -62,7 +62,7 @@ RSpec.describe "Submissions", type: :request do
   end
 
   describe "#show" do
-    before { start_claim }
+    before { start_student_loans_claim }
 
     context "with a submitted claim" do
       it "renders the claim confirmation screen and clears the session" do

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Claim session timing out", type: :request do
 
   context "no actions performed for more than the timeout period" do
     before do
-      start_claim
+      start_student_loans_claim
       start_verify_authentication_process
     end
 
@@ -28,7 +28,7 @@ RSpec.describe "Claim session timing out", type: :request do
 
   context "no action performed just within the timeout period" do
     before do
-      start_claim
+      start_student_loans_claim
       start_verify_authentication_process
     end
 

--- a/spec/requests/verify_authentications_spec.rb
+++ b/spec/requests/verify_authentications_spec.rb
@@ -3,7 +3,7 @@ require "verify/fake_sso"
 
 RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :request do
   context "when a claim is in progress" do
-    before { start_claim }
+    before { start_student_loans_claim }
 
     describe "verify/authentications/new" do
       before do
@@ -23,7 +23,7 @@ RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :reque
 
     describe "POST verify/authentications (i.e. the verify callback handler)" do
       before do
-        start_claim
+        start_student_loans_claim
 
         stub_vsp_generate_request
         get new_verify_authentications_path # sets the authentication request request_id in the session
@@ -97,7 +97,7 @@ RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :reque
   end
 
   describe "GET verify/authentications/failed" do
-    before { start_claim }
+    before { start_student_loans_claim }
 
     it "renders the failure content" do
       get failed_verify_authentications_path
@@ -108,7 +108,7 @@ RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :reque
   end
 
   describe "GET verify/authentications/no_auth" do
-    before { start_claim }
+    before { start_student_loans_claim }
 
     it "renders the no-auth content" do
       get no_auth_verify_authentications_path

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,4 +1,15 @@
 module FeatureHelpers
+  def start_maths_and_physics_claim
+    visit new_claim_path(MathsAndPhysics.routing_name)
+    choose_teaching_maths_or_physics
+    Claim.order(:created_at).last
+  end
+
+  def choose_teaching_maths_or_physics(response = "Yes")
+    choose response
+    click_on "Continue"
+  end
+
   def start_student_loans_claim
     visit new_claim_path(StudentLoans.routing_name)
     choose_qts_year

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,5 +1,5 @@
 module FeatureHelpers
-  def start_claim
+  def start_student_loans_claim
     visit new_claim_path(StudentLoans.routing_name)
     choose_qts_year
     Claim.order(:created_at).last

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,5 +1,5 @@
 module RequestHelpers
-  def start_claim
+  def start_student_loans_claim
     post claims_path(StudentLoans.routing_name), params: {
       claim: {
         eligibility_attributes: {


### PR DESCRIPTION
This is the first PR in a series for maths and physics eligibility.

Obtains the `current_school` using the existing school search. Although I looked at the specs around the school search, I decided not to add additional tests for maths and physics as the school search is independant of which journey, but let me know if that was a bad call. 

Most of this is taken straight from student loans.