### PR TITLE
Backfill claim data in Geckoboard

### DIFF
--- a/app/jobs/backfill_geckoboard_data_job.rb
+++ b/app/jobs/backfill_geckoboard_data_job.rb
@@ -1,0 +1,5 @@
+class BackfillGeckoboardDataJob < ApplicationJob
+  def perform(event_type, data)
+    Claim::BulkGeckoboardEvent.new(event_type, data).record
+  end
+end

--- a/app/models/claim/bulk_geckoboard_event.rb
+++ b/app/models/claim/bulk_geckoboard_event.rb
@@ -1,0 +1,14 @@
+class Claim
+  class BulkGeckoboardEvent < GeckoboardEvent
+    attr_reader :data
+
+    def initialize(event_type, data)
+      @event_type = event_type
+      @data = data
+    end
+
+    def record
+      dataset.post(data)
+    end
+  end
+end

--- a/db/data/20191118132534_backfill_geckoboard_data.rb
+++ b/db/data/20191118132534_backfill_geckoboard_data.rb
@@ -1,0 +1,28 @@
+class BackfillGeckoboardData < ActiveRecord::Migration[6.0]
+  def up
+    return unless defined?(BackfillGeckoboardDataJob)
+
+    submitted_claims = Claim.submitted.all.map { |claim|
+      {
+        reference: claim.reference,
+        policy: claim.policy.to_s,
+        performed_at: claim.submitted_at,
+      }
+    }
+
+    paid_claims = Payment.all.map { |payment|
+      {
+        reference: payment.claim.reference,
+        policy: payment.claim.policy.to_s,
+        performed_at: payment.updated_at,
+      }
+    }
+
+    BackfillGeckoboardDataJob.perform_later("submitted", submitted_claims)
+    BackfillGeckoboardDataJob.perform_later("paid", paid_claims)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20191111115415)
+DataMigrate::Data.define(version: 20191118132534)

--- a/spec/jobs/backfill_geckoboard_data_job_spec.rb
+++ b/spec/jobs/backfill_geckoboard_data_job_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+require "geckoboard"
+
+RSpec.describe BackfillGeckoboardDataJob do
+  let(:claims) { build_list(:claim, 5, :submitted) }
+
+  let(:datetime) { DateTime.now }
+  let(:event_name) { "some_event" }
+
+  let(:data) do
+    claims.map do |claim|
+      {
+        reference: claim.reference,
+        policy: claim.policy.to_s,
+        performed_at: datetime,
+      }
+    end
+  end
+
+  subject { described_class.new }
+
+  it "sends the expected data to the endpoint specified by the event name" do
+    ClimateControl.modify ENVIRONMENT_NAME: "environment_name" do
+      stub_geckoboard_dataset_find_or_create("claims.some_event.environment_name")
+
+      dataset_post_stub = stub_geckoboard_dataset_post("claims.some_event.environment_name")
+
+      subject.perform(event_name, data)
+
+      expected_data_payload = claims.map { |claim|
+        {
+          reference: claim.reference,
+          policy: claim.policy.to_s,
+          performed_at: datetime.strftime("%Y-%m-%dT%H:%M:%S%:z"),
+        }
+      }
+
+      expect(dataset_post_stub.with(body: {data: expected_data_payload})).to have_been_requested
+    end
+  end
+end

--- a/spec/models/claim/bulk_geckoboard_event_spec.rb
+++ b/spec/models/claim/bulk_geckoboard_event_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Claim::BulkGeckoboardEvent, type: :model do
+  let(:claims) { build_list(:claim, 4, :submitted) }
+
+  let(:datetime) { DateTime.now }
+  let(:event_name) { "some_event" }
+
+  let(:data) do
+    claims.map do |claim|
+      {
+        reference: claim.reference,
+        policy: claim.policy.to_s,
+        performed_at: datetime,
+      }
+    end
+  end
+
+  it "sends the expected data to the endpoint specified by the event name" do
+    ClimateControl.modify ENVIRONMENT_NAME: "test" do
+      event = Claim::BulkGeckoboardEvent.new(event_name, data)
+
+      stub_geckoboard_dataset_find_or_create("claims.#{event_name}.test")
+      dataset_post_stub = stub_geckoboard_dataset_post("claims.#{event_name}.test")
+
+      event.record
+
+      expected_data_payload = claims.map { |claim|
+        {
+          reference: claim.reference,
+          policy: claim.policy.to_s,
+          performed_at: datetime.strftime("%Y-%m-%dT%H:%M:%S%:z"),
+        }
+      }
+
+      expect(dataset_post_stub.with(body: {data: expected_data_payload})).to have_been_requested
+    end
+  end
+end


### PR DESCRIPTION
This follows up from #617 and #620 to backfill existing data about historic claims in Geckoboard. As we don't currently have a way of running arbitary rake tasks on production, I've used Data Migrations for this. I'm unsure if this is a misuse of tools, but as we're using this to update data (even though said data doesn't exist in the database), I think this is fine. Totally up to have a discussion about alternatives though!