### PR TITLE
Wire in the post-eligiblity Qs for Maths & Physics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog]
   to Cantium
 - Only allow payroll runs to be created if none exist already for the current
   month
+- Added post-eligibility questions to the Maths & Physics journey
 
 ## [Release 031] - 2019-11-18
 

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -12,6 +12,19 @@ module MathsAndPhysics
     SLUGS = [
       "teaching-maths-or-physics",
       "eligibility-confirmed",
+      "information-provided",
+      "verified",
+      "address",
+      "gender",
+      "teacher-reference-number",
+      "national-insurance-number",
+      "student-loan",
+      "student-loan-country",
+      "student-loan-how-many-courses",
+      "student-loan-start-date",
+      "email-address",
+      "bank-details",
+      "check-your-answers",
       "ineligible",
     ].freeze
 
@@ -23,6 +36,11 @@ module MathsAndPhysics
 
     def slugs
       SLUGS.dup.tap do |sequence|
+        sequence.delete("student-loan-country") if claim.no_student_loan?
+        sequence.delete("student-loan-how-many-courses") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
+        sequence.delete("student-loan-start-date") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
+        sequence.delete("address") if claim.address_verified?
+        sequence.delete("gender") if claim.payroll_gender_verified?
       end
     end
   end

--- a/app/views/maths_and_physics/claims/check_your_answers.html.erb
+++ b/app/views/maths_and_physics/claims/check_your_answers.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:page_title, page_title("Check your answers before sending your application", policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      Check your answers before sending your application
+    </h1>
+
+    <p>
+      Note this is a temporary view. A future story is planned that will
+      update the existing generic <pre>views/claims/check_your_answers</pre>
+      such that it will work for any claim type. At that point this template
+      should be deleted.
+    </p>
+  </div>
+</div>

--- a/app/views/maths_and_physics/claims/eligibility_confirmed.html.erb
+++ b/app/views/maths_and_physics/claims/eligibility_confirmed.html.erb
@@ -4,5 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">You are eligible to claim a payment for teaching maths or physics</h1>
     <p class="govuk-body">Based on your answers you can claim £2,000 for teaching maths or physics.</p>
+
+    <%= link_to "Continue", claim_path(current_policy_routing_name, next_slug), class: "govuk-button", role: "button", data: { module: "govuk-button" } %>
   </div>
 </div>

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -18,6 +18,66 @@ RSpec.feature "Maths & Physics claims" do
 
       expect(eligibility.teaching_maths_or_physics).to eql true
       expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
+
+      click_on "Continue"
+
+      expect(page).to have_text("How we will use the information you provide")
+      perform_verify_step
+      click_on "Continue"
+
+      expect(claim.reload.first_name).to eql("Isambard")
+      expect(claim.reload.middle_name).to eql("Kingdom")
+      expect(claim.reload.surname).to eql("Brunel")
+      expect(claim.address_line_1).to eq("Verified Building")
+      expect(claim.address_line_2).to eq("Verified Street")
+      expect(claim.address_line_3).to eq("Verified Town")
+      expect(claim.address_line_4).to eq("Verified County")
+      expect(claim.postcode).to eql("M12 345")
+      expect(claim.date_of_birth).to eq(Date.new(1806, 4, 9))
+      expect(claim.payroll_gender).to eq("male")
+
+      expect(page).to have_text(I18n.t("questions.teacher_reference_number"))
+      fill_in :claim_teacher_reference_number, with: "1234567"
+      click_on "Continue"
+
+      expect(claim.reload.teacher_reference_number).to eql("1234567")
+
+      expect(page).to have_text(I18n.t("questions.national_insurance_number"))
+      fill_in "National Insurance number", with: "QQ123456C"
+      click_on "Continue"
+
+      expect(claim.reload.national_insurance_number).to eq("QQ123456C")
+
+      expect(page).to have_text(I18n.t("questions.has_student_loan"))
+
+      answer_student_loan_plan_questions
+
+      expect(claim.reload).to have_student_loan
+      expect(claim.student_loan_country).to eq("england")
+      expect(claim.student_loan_courses).to eq("one_course")
+      expect(claim.student_loan_start_date).to eq(StudentLoan::BEFORE_1_SEPT_2012)
+      expect(claim.student_loan_plan).to eq(StudentLoan::PLAN_1)
+
+      expect(page).to have_text(I18n.t("questions.email_address"))
+      fill_in I18n.t("questions.email_address"), with: "name@example.com"
+      click_on "Continue"
+
+      expect(claim.reload.email_address).to eq("name@example.com")
+
+      expect(page).to have_text(I18n.t("questions.bank_details"))
+
+      fill_in "Name on the account", with: "Jo Bloggs"
+      fill_in "Sort code", with: "123456"
+      fill_in "Account number", with: "87654321"
+      fill_in "Building society roll number (if you have one)", with: "1234/123456789"
+      click_on "Continue"
+
+      expect(claim.reload.banking_name).to eq("Jo Bloggs")
+      expect(claim.reload.bank_sort_code).to eq("123456")
+      expect(claim.bank_account_number).to eq("87654321")
+      expect(claim.building_society_roll_number).to eq("1234/123456789")
+
+      expect(page).to have_text("Check your answers before sending your application")
     end
   end
 

--- a/spec/models/maths_and_physics/slug_sequence_spec.rb
+++ b/spec/models/maths_and_physics/slug_sequence_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe MathsAndPhysics::SlugSequence do
+  let(:claim) { build(:claim) }
+
+  subject(:slug_sequence) { MathsAndPhysics::SlugSequence.new(claim) }
+
+  describe "The sequence as defined by #slugs" do
+    it "excludes the “address” slug if any address fields were acquired from GOV.UK Verify" do
+      claim.verified_fields = []
+      expect(slug_sequence.slugs).to include("address")
+
+      claim.verified_fields = ["postcode"]
+      expect(slug_sequence.slugs).to_not include("address")
+    end
+
+    it "excludes the “gender” slug if the claim's payroll_gender were acquired supplied by GOV.UK Verify" do
+      claim.verified_fields = []
+      expect(slug_sequence.slugs).to include("gender")
+
+      claim.verified_fields = ["payroll_gender"]
+      expect(slug_sequence.slugs).to_not include("gender")
+    end
+
+    it "excludes student loan plan slugs if the claimant is not paying off a student loan" do
+      claim.has_student_loan = false
+      expect(slug_sequence.slugs).not_to include("student-loan-country")
+      expect(slug_sequence.slugs).not_to include("student-loan-how-many-courses")
+      expect(slug_sequence.slugs).not_to include("student-loan-start-date")
+
+      claim.has_student_loan = true
+      expect(slug_sequence.slugs).to include("student-loan-country")
+      expect(slug_sequence.slugs).to include("student-loan-how-many-courses")
+      expect(slug_sequence.slugs).to include("student-loan-start-date")
+    end
+
+    it "excludes the remaining student loan plan slugs if the claimant received their student loan in a Plan 1 country" do
+      claim.has_student_loan = true
+
+      StudentLoan::PLAN_1_COUNTRIES.each do |plan_1_country|
+        claim.student_loan_country = plan_1_country
+        expect(slug_sequence.slugs).to include("student-loan-country")
+        expect(slug_sequence.slugs).not_to include("student-loan-how-many-courses")
+        expect(slug_sequence.slugs).not_to include("student-loan-start-date")
+      end
+
+      %w[england wales].each do |variable_plan_country|
+        claim.student_loan_country = variable_plan_country
+        expect(slug_sequence.slugs).to include("student-loan-country")
+        expect(slug_sequence.slugs).to include("student-loan-how-many-courses")
+        expect(slug_sequence.slugs).to include("student-loan-start-date")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will get the user as far as the check-your-answers page. For now,
the check-your-answers page is just a holding page as the real thing
is planned to be implemented as a separate story.

This commit adds a temporary check-your-answers template as the existing
one will break if given a Maths & Physics claim. A separate story is
planned that will make check-your-answers work with any type of claim.

Note that there is now a fair amount of commonality/duplication between
the two SlugSequence classes but it feels too early to try and extract
any kind of abstraction.