### PR TITLE
Add missing local authority district to fixtures

### DIFF
--- a/spec/fixtures/local_authority_districts.yml
+++ b/spec/fixtures/local_authority_districts.yml
@@ -2,6 +2,9 @@
 barnsley:
   code: E08000016
   name: Barnsley
+bradford:
+  code: E08000032
+  name: Bradford
 #Maths and Physics Ineligible
 camden:
   code: E09000007


### PR DESCRIPTION
"bradford" is referred to but there isn't actually a fixture for it.
Noticed this whilst trying to test Meyric's maths and physics school
question PR in local development.