### PR TITLE
Update approved/rejected email content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Update transational emails with improved content
+
 ## [Release 032] - 2019-11-19
 
 - Update employment-related copy to clarify that the policy cares about the

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -2,15 +2,15 @@ class ClaimMailer < Mail::Notify::Mailer
   helper :application
 
   def submitted(claim)
-    view_mail_with_claim_and_subject(claim, "Your claim was received")
+    view_mail_with_claim_and_subject(claim, "Your claim to get back your student loan repayments has been received")
   end
 
   def approved(claim)
-    view_mail_with_claim_and_subject(claim, "Your claim to get your student loan repayments back has been approved, reference number: #{claim.reference}")
+    view_mail_with_claim_and_subject(claim, "Your claim to get back your student loan repayments has been approved, reference number: #{claim.reference}")
   end
 
   def rejected(claim)
-    view_mail_with_claim_and_subject(claim, "Your claim to get your student loan repayments back has been rejected, reference number: #{claim.reference}")
+    view_mail_with_claim_and_subject(claim, "Your claim to get back your student loan repayments has been rejected, reference number: #{claim.reference}")
   end
 
   def payment_confirmation(claim, payment_date_timestamp)

--- a/app/views/claim_mailer/approved.text.erb
+++ b/app/views/claim_mailer/approved.text.erb
@@ -1,9 +1,12 @@
 Dear <%= @display_name %>,
 
-Your claim to get your student loan repayments back has been approved.
+Your claim to get back your student loan repayments has been approved.
 
-We will now calculate your payment.
+We will send you another email when we have processed your payment, which may take up to 6 weeks.
 
-We will email you confirming the amount when we are ready to make the payment.
+When we contact you we will include a breakdown of your payment and confirm the amount you will receive. Your payment is taxable and the breakdown will show the following deductions:
 
-Email <%= support_email_address("student-loans") %>  giving your reference number: <%= @claim.reference %> if you have any questions.
+* Income Tax and Employee National Insurance (NIC), which we pay on your behalf
+* student loan contribution, which is deducted from your claim payment if applicable
+
+If you have any questions about your claim, please contact <%= support_email_address("student-loans") %> giving your reference: <%= @claim.reference %>.

--- a/app/views/claim_mailer/payment_confirmation.text.erb
+++ b/app/views/claim_mailer/payment_confirmation.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-We’re paying your claim to get back the student loan repayments you made while employed as a teacher during the last financial year, claim reference: <%= @reference %>.
+We’re paying your claim to get back your student loan repayments.
 
 This payment does not change the amount that was credited to your Student Loans Company (SLC) account in the last financial year.
 

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -1,14 +1,14 @@
 Dear <%= @display_name %>,
 
+We have not been able to approve your claim to get back your student loan repayments.
 
-Unfortunately your claim to get your student loan payments back has been rejected.
+Your claim has not been approved because our records show one of the following:
 
-# Appeals process and support
+* you completed your initial teacher training before September 2013
+* you did not teach at an eligible school during the financial year 2018 to 2019
+* you are not currently employed to teach at a state-funded secondary school
+* you did not teach an eligible subject for at least half of your contracted hours
 
-If you feel that we have made a mistake in the processing of your application or something is incorrect please email <%= support_email_address("student-loans") %>  giving your reference number: <%= @claim.reference %> if you have any questions about your claim.
+You can find more information about the eligibility criteria for this service at https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details/teachers-claim-back-your-student-loan-repayments-eligibility-and-payment-details
 
-Regards,
-
-The claim additional payments for teaching team.
-
-
+If you have any questions about your claim, please contact <%= support_email_address("student-loans") %> giving your reference: <%= @claim.reference %>.

--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-We've received your application to claim back your student loan repayments for the time you spent at <%= @claim.eligibility.claim_school.name %>.
+We've received your claim to get back your student loan repayments.
 
 Your unique reference is <%= @claim.reference %>. You will need this if you contact us about your claim.
 

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature "Admin checks a claim" do
 
       expect(mail.subject).to match("been rejected")
       expect(mail.to).to eq([claim_to_reject.email_address])
-      expect(mail.body.raw_source).to match("been rejected.")
+      expect(mail.body.raw_source).to match("not been able to approve")
     end
 
     scenario "User can see existing check details" do

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe ClaimMailer, type: :mailer do
     it_behaves_like "a claim mailer", StudentLoans
 
     it "renders the subject" do
-      expect(mail.subject).to eq("Your claim was received")
+      expect(mail.subject).to match("been received")
     end
 
     it "renders the body" do
       expect(mail.body.encoded).to match("Dear Abraham Lincoln,")
-      expect(mail.body.encoded).to match("We've received your application to claim back your student loan repayments for the time you spent at #{claim.eligibility.claim_school.name}.")
+      expect(mail.body.encoded).to match("We've received your claim to get back your student loan repayments.")
       expect(mail.body.encoded).to match("Your unique reference is #{claim.reference}. You will need this if you contact us about your claim.")
     end
   end
@@ -58,7 +58,7 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match("Dear John Kennedy,")
-      expect(mail.body.encoded).to match("been rejected")
+      expect(mail.body.encoded).to match("not been able to approve")
     end
   end
 

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Submissions", type: :request do
 
         email = ActionMailer::Base.deliveries.first
         expect(email.to).to eql([in_progress_claim.email_address])
-        expect(email.subject).to eql("Your claim was received")
+        expect(email.subject).to match("been received")
         expect(email.body).to include("Your unique reference is #{in_progress_claim.reference}.")
       end
 


### PR DESCRIPTION
Updated based on feedback from Faye. As well as updating the content to be more helpful to the user, we're also now using a consistent sentence when referring to the claim, which will make it easier to adjust these emails based on the policy. We've also removed mention of the claim school from the emails as this is not really necessary, and also confusing for users that may have worked at multiple schools.