### PR TITLE
Change computer science to computing

### DIFF
--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -6,7 +6,7 @@ module StudentLoans
       :biology_taught,
       :chemistry_taught,
       :physics_taught,
-      :computer_science_taught,
+      :computing_taught,
       :languages_taught,
     ].freeze
     EDITABLE_ATTRIBUTES = [

--- a/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -18,7 +18,7 @@
     <li>biology</li>
     <li>chemistry</li>
     <li>physics</li>
-    <li>computer science</li>
+    <li>computing</li>
     <li>languages (not including English)</li>
   </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
         biology_taught: "Biology"
         chemistry_taught: "Chemistry"
         physics_taught: "Physics"
-        computer_science_taught: "Computer Science"
+        computer_science_taught: "Computing"
         languages_taught: "Languages"
         none_taught: "No, I didn't teach any of these subjects"
       student_loan_amount:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
         biology_taught: "Biology"
         chemistry_taught: "Chemistry"
         physics_taught: "Physics"
-        computer_science_taught: "Computing"
+        computing_taught: "Computing"
         languages_taught: "Languages"
         none_taught: "No, I didn't teach any of these subjects"
       student_loan_amount:

--- a/db/migrate/20191120081451_change_computer_science_taught_to_computing_taught.rb
+++ b/db/migrate/20191120081451_change_computer_science_taught_to_computing_taught.rb
@@ -1,0 +1,5 @@
+class ChangeComputerScienceTaughtToComputingTaught < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :student_loans_eligibilities, :computer_science_taught, :computing_taught
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_14_141607) do
+ActiveRecord::Schema.define(version: 2019_11_20_081451) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -165,7 +165,7 @@ ActiveRecord::Schema.define(version: 2019_11_14_141607) do
     t.integer "employment_status"
     t.boolean "biology_taught"
     t.boolean "chemistry_taught"
-    t.boolean "computer_science_taught"
+    t.boolean "computing_taught"
     t.boolean "languages_taught"
     t.boolean "physics_taught"
     t.boolean "taught_eligible_subjects"

--- a/spec/models/claim/permitted_parameters_spec.rb
+++ b/spec/models/claim/permitted_parameters_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Claim::PermittedParameters do
         :biology_taught,
         :chemistry_taught,
         :physics_taught,
-        :computer_science_taught,
+        :computing_taught,
         :languages_taught,
       ],
     ]

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
         taught_eligible_subjects: true,
         chemistry_taught: true,
         physics_taught: true,
-        computer_science_taught: true,
+        computing_taught: true,
         languages_taught: true,
         employment_status: :different_school,
         had_leadership_position: true,
@@ -183,7 +183,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       expect(eligibility.physics_taught).to eq(nil)
       expect(eligibility.chemistry_taught).to eq(nil)
       expect(eligibility.physics_taught).to eq(nil)
-      expect(eligibility.computer_science_taught).to eq(nil)
+      expect(eligibility.computing_taught).to eq(nil)
       expect(eligibility.languages_taught).to eq(nil)
     end
 
@@ -267,7 +267,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
 
     it "is valid when one or more of the subjects-taught attributes are true" do
       expect(StudentLoans::Eligibility.new(biology_taught: true)).to be_valid(:"subjects-taught")
-      expect(StudentLoans::Eligibility.new(biology_taught: true, computer_science_taught: false)).to be_valid(:"subjects-taught")
+      expect(StudentLoans::Eligibility.new(biology_taught: true, computing_taught: false)).to be_valid(:"subjects-taught")
       expect(StudentLoans::Eligibility.new(chemistry_taught: true, languages_taught: true)).to be_valid(:"subjects-taught")
     end
 


### PR DESCRIPTION
This changes all references of "Computer Science" to "Computing". I've also changed the name of the column to `computing_taught`. I considered not doing this to save added complication, but given that `change_column` is a non-destructive action, it makes sense to do this, so we don't have legacy naming flying around.
