### PR TITLE
Add question about maths or physics degree

### DIFF
--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -4,29 +4,46 @@ module MathsAndPhysics
       :teaching_maths_or_physics,
       :current_school_id,
       :initial_teacher_training_specialised_in_maths_or_physics,
+      :has_uk_maths_or_physics_degree,
     ].freeze
+    ATTRIBUTE_DEPENDENCIES = {
+      "initial_teacher_training_specialised_in_maths_or_physics" => ["has_uk_maths_or_physics_degree"],
+    }.freeze
     self.table_name = "maths_and_physics_eligibilities"
+
+    enum has_uk_maths_or_physics_degree: {
+      yes: 0,
+      no: 1,
+      has_non_uk: 2,
+    }
 
     belongs_to :current_school, optional: true, class_name: "School"
 
     validates :teaching_maths_or_physics, on: [:"teaching-maths-or-physics", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
     validates :current_school, on: [:"current-school", :submit], presence: {message: "Select a school from the list"}
     validates :initial_teacher_training_specialised_in_maths_or_physics, on: [:"initial-teacher-training-specialised-in-maths-or-physics", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
+    validates :has_uk_maths_or_physics_degree, on: [:"has-uk-maths-or-physics-degree", :submit], presence: {message: "Select whether you have a UK maths or physics degree."}, unless: :initial_teacher_training_specialised_in_maths_or_physics?
 
     delegate :name, to: :current_school, prefix: true, allow_nil: true
 
     def ineligible?
-      not_teaching_maths_or_physics? || ineligible_current_school?
+      not_teaching_maths_or_physics? || ineligible_current_school? || no_maths_or_physics_qualification?
     end
 
     def ineligibility_reason
       [
         :not_teaching_maths_or_physics,
         :ineligible_current_school,
+        :no_maths_or_physics_qualification,
       ].find { |eligibility_check| send("#{eligibility_check}?") }
     end
 
     def reset_dependent_answers
+      ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
+        dependent_attribute_names.each do |dependent_attribute_name|
+          write_attribute(dependent_attribute_name, nil) if changed.include?(attribute_name)
+        end
+      end
     end
 
     private
@@ -37,6 +54,10 @@ module MathsAndPhysics
 
     def ineligible_current_school?
       current_school.present? && !current_school.eligible_for_maths_and_physics?
+    end
+
+    def no_maths_or_physics_qualification?
+      initial_teacher_training_specialised_in_maths_or_physics == false && has_uk_maths_or_physics_degree == "no"
     end
   end
 end

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -13,6 +13,7 @@ module MathsAndPhysics
       "teaching-maths-or-physics",
       "current-school",
       "initial-teacher-training-specialised-in-maths-or-physics",
+      "has-uk-maths-or-physics-degree",
       "eligibility-confirmed",
       "information-provided",
       "verified",
@@ -38,6 +39,7 @@ module MathsAndPhysics
 
     def slugs
       SLUGS.dup.tap do |sequence|
+        sequence.delete("has-uk-maths-or-physics-degree") if claim.eligibility.initial_teacher_training_specialised_in_maths_or_physics?
         sequence.delete("student-loan-country") if claim.no_student_loan?
         sequence.delete("student-loan-how-many-courses") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
         sequence.delete("student-loan-start-date") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_no_maths_or_physics_qualification.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_no_maths_or_physics_qualification.html.erb
@@ -1,0 +1,14 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
+<p class="govuk-body">
+  You can only get this payment if you completed a degree specialising
+  in maths or physics or you specialised in maths and physics for your
+  initial teacher training.
+</p>
+
+<p class="govuk-body">
+  If you trained to teach physics as part of science but specialised in a
+  subject other than physics, you are not eligible to claim.
+</p>

--- a/app/views/maths_and_physics/claims/has_uk_maths_or_physics_degree.html.erb
+++ b/app/views/maths_and_physics/claims/has_uk_maths_or_physics_degree.html.erb
@@ -1,0 +1,61 @@
+<% content_for(:page_title, page_title(t("maths_and_physics.questions.has_uk_maths_or_physics_degree"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.has_uk_maths_or_physics_degree": "claim_eligibility_attributes_has_uk_maths_or_physics_degree_yes" }) if current_claim.errors.any? %>
+
+    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+      <%= form_group_tag current_claim do %>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+
+          <%= fields.hidden_field :has_uk_maths_or_physics_degree %>
+
+          <fieldset class="govuk-fieldset">
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("maths_and_physics.questions.has_uk_maths_or_physics_degree") %>
+              </h1>
+            </legend>
+
+            <span class="govuk-hint">
+              <p>You must have specialised in maths or physics to be able to
+              claim. If you studied maths or physics for less than 50% of your
+              degree, please select No.</p>
+
+              <p>For more information on which subjects are eligible, see the
+              <%= link_to "qualifications criteria", "https://www.gov.uk/guidance/apply-for-mathematics-and-physics-teacher-retention-payments#opportinity-area", class: "govuk-link" %> for this service.</p>
+            </span>
+
+            <%= errors_tag current_claim.eligibility, :has_uk_maths_or_physics_degree %>
+
+            <div class="govuk-radios">
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:has_uk_maths_or_physics_degree, :yes, class: "govuk-radios__input") %>
+                <%= fields.label :has_uk_maths_or_physics_degree_yes, "Yes", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:has_uk_maths_or_physics_degree, :no, class: "govuk-radios__input") %>
+                <%= fields.label :has_uk_maths_or_physics_degree_no, "No", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__divider">or</div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:has_uk_maths_or_physics_degree, :has_non_uk, class: "govuk-radios__input") %>
+                <%= fields.label :has_uk_maths_or_physics_degree_has_non_uk, "I have a non-UK degree in Maths or Physics", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+            </div>
+
+          </fieldset>
+
+        <% end %>
+      <% end %>
+
+      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
     questions:
       teaching_maths_or_physics: "Do you currently teach any maths or physics?"
       initial_teacher_training_specialised_in_maths_or_physics: "Did your initial teacher training specialise in maths or physics?"
+      has_uk_maths_or_physics_degree: "Do you have a UK undergraduate or postgraduate degree in maths or physics?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"

--- a/db/migrate/20191119115400_add_has_uk_maths_or_physics_degree_to_maths_and_physics_eligibilities.rb
+++ b/db/migrate/20191119115400_add_has_uk_maths_or_physics_degree_to_maths_and_physics_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddHasUkMathsOrPhysicsDegreeToMathsAndPhysicsEligibilities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :maths_and_physics_eligibilities, :has_uk_maths_or_physics_degree, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 2019_11_20_081451) do
     t.datetime "updated_at", null: false
     t.uuid "current_school_id"
     t.boolean "initial_teacher_training_specialised_in_maths_or_physics"
+    t.integer "has_uk_maths_or_physics_degree"
     t.index ["current_school_id"], name: "index_maths_and_physics_eligibilities_on_current_school_id"
   end
 

--- a/spec/features/ineligible_maths_and_physics_claims_spec.rb
+++ b/spec/features/ineligible_maths_and_physics_claims_spec.rb
@@ -21,4 +21,16 @@ RSpec.feature "Ineligible Maths and Physics claims" do
     expect(page).to have_text("This school is not eligible")
     expect(page).to have_text("You can only get this payment if you are employed to teach at an eligible state-funded secondary school.")
   end
+
+  scenario "chooses no degree in maths or physics" do
+    claim = start_maths_and_physics_claim
+
+    choose_school schools(:penistone_grammar_school)
+    choose_initial_teacher_training_specialised_in_maths_or_physics("No")
+    choose_maths_and_physics_degree("No")
+
+    expect(claim.eligibility.reload.has_uk_maths_or_physics_degree).to eq "no"
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You can only get this payment if you completed a degree specialising in maths or physics")
+  end
 end

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -91,6 +91,76 @@ RSpec.feature "Maths & Physics claims" do
     end
   end
 
+  scenario "Teacher claims for Maths and Physics, without maths or physics ITT and with a UK degree in maths or physics" do
+    # This test was initially written for the purpose of building out this
+    # alternative journey. It may evolve to not test the whole claims journey
+    # but only this part of it. Not sure of the best approach.
+    visit "maths-and-physics/start"
+    expect(page).to have_text "Claim a payment for teaching maths or physics"
+
+    click_on "Start"
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    claim = Claim.order(:created_at).last
+    eligibility = claim.eligibility
+
+    expect(eligibility.teaching_maths_or_physics).to eql true
+
+    expect(page).to have_text(I18n.t("questions.current_school"))
+    choose_school schools(:penistone_grammar_school)
+    expect(claim.eligibility.reload.current_school).to eql schools(:penistone_grammar_school)
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.initial_teacher_training_specialised_in_maths_or_physics"))
+    choose "No"
+    click_on "Continue"
+    expect(claim.eligibility.reload.initial_teacher_training_specialised_in_maths_or_physics).to eql false
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.has_uk_maths_or_physics_degree"))
+    choose "Yes"
+    click_on "Continue"
+    expect(claim.eligibility.reload.has_uk_maths_or_physics_degree).to eql "yes"
+
+    expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
+  end
+
+  scenario "Teacher claims for Maths and Physics, without maths or physics ITT and with a non-UK degree in maths or physics" do
+    # This test was initially written for the purpose of building out this
+    # alternative journey. It may evolve to not test the whole claims journey
+    # but only this part of it. Not sure of the best approach.
+    visit "maths-and-physics/start"
+    expect(page).to have_text "Claim a payment for teaching maths or physics"
+
+    click_on "Start"
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    claim = Claim.order(:created_at).last
+    eligibility = claim.eligibility
+
+    expect(eligibility.teaching_maths_or_physics).to eql true
+
+    expect(page).to have_text(I18n.t("questions.current_school"))
+    choose_school schools(:penistone_grammar_school)
+    expect(claim.eligibility.reload.current_school).to eql schools(:penistone_grammar_school)
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.initial_teacher_training_specialised_in_maths_or_physics"))
+    choose "No"
+    click_on "Continue"
+    expect(claim.eligibility.reload.initial_teacher_training_specialised_in_maths_or_physics).to eql false
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.has_uk_maths_or_physics_degree"))
+    choose "I have a non-UK degree in Maths or Physics"
+    click_on "Continue"
+    expect(claim.eligibility.reload.has_uk_maths_or_physics_degree).to eql "has_non_uk"
+
+    expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
+  end
+
   scenario "A teacher is ineligible for Maths & Physics" do
     visit new_claim_path(MathsAndPhysics.routing_name)
 

--- a/spec/models/maths_and_physics/slug_sequence_spec.rb
+++ b/spec/models/maths_and_physics/slug_sequence_spec.rb
@@ -1,11 +1,17 @@
 require "rails_helper"
 
 RSpec.describe MathsAndPhysics::SlugSequence do
-  let(:claim) { build(:claim) }
+  let(:claim) { build(:claim, eligibility: build(:maths_and_physics_eligibility)) }
 
   subject(:slug_sequence) { MathsAndPhysics::SlugSequence.new(claim) }
 
   describe "The sequence as defined by #slugs" do
+    it "excludes “has-uk-maths-or-physics-degree” if the claimant's initial teacher training specialised in maths or physics" do
+      claim.eligibility.initial_teacher_training_specialised_in_maths_or_physics = true
+
+      expect(slug_sequence.slugs).not_to include("has-uk-maths-or-physics-degree")
+    end
+
     it "excludes the “address” slug if any address fields were acquired from GOV.UK Verify" do
       claim.verified_fields = []
       expect(slug_sequence.slugs).to include("address")

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -10,6 +10,16 @@ module FeatureHelpers
     click_on "Continue"
   end
 
+  def choose_initial_teacher_training_specialised_in_maths_or_physics(response = "Yes")
+    choose response
+    click_on "Continue"
+  end
+
+  def choose_maths_and_physics_degree(response = "Yes")
+    choose response
+    click_on "Continue"
+  end
+
   def start_student_loans_claim
     visit new_claim_path(StudentLoans.routing_name)
     choose_qts_year


### PR DESCRIPTION
This is the first maths and physics question with a question which is
displayed conditionally.
MathsAndPhysics::Eligibility#reset_dependent_answers is a copy-and-paste
of the same method from StudentLoans::Eligibility.

![image](https://user-images.githubusercontent.com/53756884/69231069-59e32800-0b80-11ea-89b0-6c728671bb0d.png)

![image](https://user-images.githubusercontent.com/53756884/69231161-8303b880-0b80-11ea-8061-38f38eb5cb25.png)
