### PR TITLE
Make transactional emails work with any policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog]
 - Update transational emails with improved content
 - Clear claim session before view path gets calculated
 - Add some copy to make it clear why we ask about a user's student loan
+- Update transactional emails to support the two different policy types
 
 ## [Release 032] - 2019-11-19
 

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -26,12 +26,13 @@ class ClaimMailer < Mail::Notify::Mailer
   def view_mail_with_claim_and_subject(claim, subject)
     @claim = claim
     @display_name = [claim.first_name, claim.surname].join(" ")
+    @policy = claim.policy
 
     view_mail(
       ENV["NOTIFY_TEMPLATE_ID"],
       to: @claim.email_address,
       subject: subject,
-      reply_to_id: claim.policy.notify_reply_to_id
+      reply_to_id: @policy.notify_reply_to_id
     )
   end
 end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -2,26 +2,34 @@ class ClaimMailer < Mail::Notify::Mailer
   helper :application
 
   def submitted(claim)
-    view_mail_with_claim_and_subject(claim, "Your claim to get back your student loan repayments has been received")
+    @claim_description = claim_description(claim)
+    view_mail_with_claim_and_subject(claim, "Your #{@claim_description} has been received")
   end
 
   def approved(claim)
-    view_mail_with_claim_and_subject(claim, "Your claim to get back your student loan repayments has been approved, reference number: #{claim.reference}")
+    @claim_description = claim_description(claim)
+    view_mail_with_claim_and_subject(claim, "Your #{@claim_description} has been approved, reference number: #{claim.reference}")
   end
 
   def rejected(claim)
-    view_mail_with_claim_and_subject(claim, "Your claim to get back your student loan repayments has been rejected, reference number: #{claim.reference}")
+    @claim_description = claim_description(claim)
+    view_mail_with_claim_and_subject(claim, "Your #{@claim_description} has been rejected, reference number: #{claim.reference}")
   end
 
   def payment_confirmation(claim, payment_date_timestamp)
+    @claim_description = claim_description(claim)
     @reference = claim.reference
     @payment = claim.payment
     @payment_date = Time.at(payment_date_timestamp).to_date
 
-    view_mail_with_claim_and_subject(claim, "We’re paying your claim to get back your student loan repayments, reference number: #{claim.reference}")
+    view_mail_with_claim_and_subject(claim, "We’re paying your #{@claim_description}, reference number: #{claim.reference}")
   end
 
   private
+
+  def claim_description(claim)
+    I18n.t("#{claim.policy.routing_name.underscore}.claim_description")
+  end
 
   def view_mail_with_claim_and_subject(claim, subject)
     @claim = claim

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -13,6 +13,7 @@ class ClaimMailer < Mail::Notify::Mailer
 
   def rejected(claim)
     @claim_description = claim_description(claim)
+    @possible_rejection_reasons = I18n.t("#{claim.policy.routing_name.underscore}.possible_rejection_reasons")
     view_mail_with_claim_and_subject(claim, "Your #{@claim_description} has been rejected, reference number: #{claim.reference}")
   end
 

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -3,7 +3,7 @@ class ClaimMailer < Mail::Notify::Mailer
 
   def submitted(claim)
     @claim_description = claim_description(claim)
-    view_mail_with_claim_and_subject(claim, "Your #{@claim_description} has been received")
+    view_mail_with_claim_and_subject(claim, "Your #{@claim_description} has been received, reference number: #{claim.reference}")
   end
 
   def approved(claim)

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -10,4 +10,8 @@ module MathsAndPhysics
   def self.routing_name
     "maths-and-physics"
   end
+
+  def self.notify_reply_to_id
+    "29493350-ceec-4142-bd29-34ee363d5f62"
+  end
 end

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -3,6 +3,10 @@ module MathsAndPhysics
     "/maths-and-physics/start" # Temporary start page during private beta
   end
 
+  def self.eligibility_page_url
+    "https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details/claim-a-payment-for-teaching-maths-or-physics-eligibility-and-payment-details"
+  end
+
   def self.routing_name
     "maths-and-physics"
   end

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -9,6 +9,10 @@ module StudentLoans
     end
   end
 
+  def self.eligibility_page_url
+    "https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details/teachers-claim-back-your-student-loan-repayments-eligibility-and-payment-details"
+  end
+
   def self.routing_name
     "student-loans"
   end

--- a/app/views/claim_mailer/approved.text.erb
+++ b/app/views/claim_mailer/approved.text.erb
@@ -9,4 +9,4 @@ When we contact you we will include a breakdown of your payment and confirm the 
 * Income Tax and Employee National Insurance (NIC), which we pay on your behalf
 * student loan contribution, which is deducted from your claim payment if applicable
 
-If you have any questions about your claim, please contact <%= support_email_address("student-loans") %> giving your reference: <%= @claim.reference %>.
+If you have any questions about your claim, please contact <%= support_email_address(@policy.routing_name) %> giving your reference: <%= @claim.reference %>.

--- a/app/views/claim_mailer/approved.text.erb
+++ b/app/views/claim_mailer/approved.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-Your claim to get back your student loan repayments has been approved.
+Your <%= @claim_description %> has been approved.
 
 We will send you another email when we have processed your payment, which may take up to 6 weeks.
 

--- a/app/views/claim_mailer/payment_confirmation.text.erb
+++ b/app/views/claim_mailer/payment_confirmation.text.erb
@@ -35,7 +35,7 @@ The ‘earnings period’ used to set the thresholds for student loan and Nation
 
 # Contact us
 
-Email <%= support_email_address("student-loans") %> giving your reference: <%= @reference %>, if you have any questions.
+Email <%= support_email_address(@policy.routing_name) %> giving your reference: <%= @reference %>, if you have any questions.
 
 ----
 

--- a/app/views/claim_mailer/payment_confirmation.text.erb
+++ b/app/views/claim_mailer/payment_confirmation.text.erb
@@ -2,7 +2,9 @@ Dear <%= @display_name %>,
 
 We’re paying your <%= @claim_description %>.
 
+<% if @policy == StudentLoans -%>
 This payment does not change the amount that was credited to your Student Loans Company (SLC) account in the last financial year.
+<% end -%>
 
 ^ You will receive <%=number_to_currency(@payment.net_pay) %> on or after <%= l(@payment_date) %>.
 

--- a/app/views/claim_mailer/payment_confirmation.text.erb
+++ b/app/views/claim_mailer/payment_confirmation.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-We’re paying your claim to get back your student loan repayments.
+We’re paying your <%= @claim_description %>.
 
 This payment does not change the amount that was credited to your Student Loans Company (SLC) account in the last financial year.
 

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -11,4 +11,4 @@ Your claim has not been approved because our records show one of the following:
 
 You can find more information about the eligibility criteria for this service at https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details/teachers-claim-back-your-student-loan-repayments-eligibility-and-payment-details
 
-If you have any questions about your claim, please contact <%= support_email_address("student-loans") %> giving your reference: <%= @claim.reference %>.
+If you have any questions about your claim, please contact <%= support_email_address(@policy.routing_name) %> giving your reference: <%= @claim.reference %>.

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -4,10 +4,7 @@ We have not been able to approve your <%= @claim_description %>.
 
 Your claim has not been approved because our records show one of the following:
 
-* you completed your initial teacher training before September 2013
-* you did not teach at an eligible school during the financial year 2018 to 2019
-* you are not currently employed to teach at a state-funded secondary school
-* you did not teach an eligible subject for at least half of your contracted hours
+<%= @possible_rejection_reasons %>
 
 You can find more information about the eligibility criteria for this service at <%= @policy.eligibility_page_url %>
 

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-We have not been able to approve your claim to get back your student loan repayments.
+We have not been able to approve your <%= @claim_description %>.
 
 Your claim has not been approved because our records show one of the following:
 

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -9,6 +9,6 @@ Your claim has not been approved because our records show one of the following:
 * you are not currently employed to teach at a state-funded secondary school
 * you did not teach an eligible subject for at least half of your contracted hours
 
-You can find more information about the eligibility criteria for this service at https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details/teachers-claim-back-your-student-loan-repayments-eligibility-and-payment-details
+You can find more information about the eligibility criteria for this service at <%= @policy.eligibility_page_url %>
 
 If you have any questions about your claim, please contact <%= support_email_address(@policy.routing_name) %> giving your reference: <%= @claim.reference %>.

--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -14,4 +14,4 @@ This service is in development. If we cannot make the payment within 18 weeks we
 
 # Contact us
 
-Reply to this email or send an email to <%= support_email_address("student-loans") %> with your unique reference and your query.
+Reply to this email or send an email to <%= support_email_address(@policy.routing_name) %> with your unique reference and your query.

--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-We've received your claim to get back your student loan repayments.
+We've received your <%= @claim_description %>.
 
 Your unique reference is <%= @claim.reference %>. You will need this if you contact us about your claim.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,7 @@ en:
     full_name: "Full name"
   maths_and_physics:
     policy_name: "Claim a payment for teaching maths or physics"
+    claim_description: "claim for a payment for teaching maths and physics"
     support_email_address: "mathsphysicsteacherpayment@digital.education.gov.uk"
     questions:
       teaching_maths_or_physics: "Do you currently teach any maths or physics?"
@@ -105,6 +106,7 @@ en:
       has_uk_maths_or_physics_degree: "Do you have a UK undergraduate or postgraduate degree in maths or physics?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
+    claim_description: "claim to get back your student loan repayments"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
       qts_award_year: "When did you complete your initial teacher training?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,12 @@ en:
     policy_name: "Claim a payment for teaching maths or physics"
     claim_description: "claim for a payment for teaching maths and physics"
     support_email_address: "mathsphysicsteacherpayment@digital.education.gov.uk"
+    possible_rejection_reasons: |
+      * you are not employed to teach maths or physics at an eligible state-funded secondary school
+      * you did not complete your initial teacher training in maths or physics and you do not have a degree in maths or physics
+      * you completed your initial teacher training before September 2014
+      * you’re a supply teacher contracted by a private agency or for less than a full term
+      * you are currently subject to formal capability proceedings or disciplinary action
     questions:
       teaching_maths_or_physics: "Do you currently teach any maths or physics?"
       initial_teacher_training_specialised_in_maths_or_physics: "Did your initial teacher training specialise in maths or physics?"
@@ -107,6 +113,11 @@ en:
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     claim_description: "claim to get back your student loan repayments"
+    possible_rejection_reasons: |
+      * you completed your initial teacher training before September 2013
+      * you did not teach at an eligible school during the financial year 2018 to 2019
+      * you are not currently employed to teach at a state-funded secondary school
+      * you did not teach an eligible subject for at least half of your contracted hours
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
       qts_award_year: "When did you complete your initial teacher training?"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -1,6 +1,13 @@
 FactoryBot.define do
   factory :claim do
-    association(:eligibility, factory: :student_loans_eligibility)
+    transient do
+      policy { StudentLoans }
+      eligibility_factory { "#{policy.to_s.underscore}_eligibility".to_sym }
+    end
+
+    after(:build) do |claim, evaluator|
+      claim.eligibility = build(*evaluator.eligibility_factory) unless claim.eligibility
+    end
 
     trait :submittable do
       first_name { "Jo" }
@@ -19,9 +26,9 @@ FactoryBot.define do
       banking_name { "Jo Bloggs" }
       bank_sort_code { 123456 }
       bank_account_number { 12345678 }
-
-      association(:eligibility, factory: [:student_loans_eligibility, :eligible])
       payroll_gender { :female }
+
+      eligibility_factory { ["#{policy.to_s.underscore}_eligibility".to_sym, :eligible] }
     end
 
     trait :submitted do
@@ -42,7 +49,8 @@ FactoryBot.define do
 
     trait :ineligible do
       submittable
-      association(:eligibility, factory: [:student_loans_eligibility, :ineligible])
+
+      eligibility_factory { ["#{policy.to_s.underscore}_eligibility".to_sym, :ineligible] }
     end
   end
 end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association(:claim, factory: [:claim, :approved])
     association(:payroll_run, factory: :payroll_run)
 
-    award_amount { claim.award_amount }
+    award_amount { 123.45 }
 
     trait :with_figures do
       gross_value { 487.48 }

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
-RSpec.shared_examples "a claim mailer" do |policy|
-  it "sets the correct to address" do
+RSpec.shared_examples "an email related to a claim" do |policy|
+  it "sets the to address to the claimant's email address" do
     expect(mail.to).to eq([claim.email_address])
   end
 
-  it "sets the correct GOV.UK Notify reply to id" do
+  it "sets the GOV.UK Notify reply_to_id according to the policy" do
     expect(mail["reply_to_id"].value).to eql(policy.notify_reply_to_id)
   end
 end
@@ -15,7 +15,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:claim) { create(:claim, :submittable, first_name: "Abraham", surname: "Lincoln") }
     let(:mail) { ClaimMailer.submitted(claim) }
 
-    it_behaves_like "a claim mailer", StudentLoans
+    it_behaves_like "an email related to a claim", StudentLoans
 
     it "renders the subject" do
       expect(mail.subject).to match("been received")
@@ -32,7 +32,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
     let(:mail) { ClaimMailer.approved(claim) }
 
-    it_behaves_like "a claim mailer", StudentLoans
+    it_behaves_like "an email related to a claim", StudentLoans
 
     it "renders the subject" do
       expect(mail.subject).to match("approved")
@@ -49,7 +49,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
     let(:mail) { ClaimMailer.rejected(claim) }
 
-    it_behaves_like "a claim mailer", StudentLoans
+    it_behaves_like "an email related to a claim", StudentLoans
 
     it "renders the subject" do
       expect(mail.subject).to match("rejected")
@@ -68,7 +68,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     let(:payment_date_timestamp) { Time.new(2019, 1, 1).to_i }
     let(:mail) { ClaimMailer.payment_confirmation(payment.claim, payment_date_timestamp) }
 
-    it_behaves_like "a claim mailer", StudentLoans
+    it_behaves_like "an email related to a claim", StudentLoans
 
     it "renders the subject" do
       expect(mail.subject).to match("paying")

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -21,7 +21,7 @@ end
 
 RSpec.describe ClaimMailer, type: :mailer do
   describe "#submitted" do
-    let(:claim) { create(:claim, :submittable, first_name: "Abraham", surname: "Lincoln") }
+    let(:claim) { build(:claim, :submittable, first_name: "Abraham", surname: "Lincoln") }
     let(:mail) { ClaimMailer.submitted(claim) }
 
     it_behaves_like "an email related to a claim", StudentLoans
@@ -38,7 +38,7 @@ RSpec.describe ClaimMailer, type: :mailer do
   end
 
   describe "#approved" do
-    let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
+    let(:claim) { build(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
     let(:mail) { ClaimMailer.approved(claim) }
 
     it_behaves_like "an email related to a claim", StudentLoans
@@ -54,7 +54,7 @@ RSpec.describe ClaimMailer, type: :mailer do
   end
 
   describe "#rejected" do
-    let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
+    let(:claim) { build(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
     let(:mail) { ClaimMailer.rejected(claim) }
 
     it_behaves_like "an email related to a claim", StudentLoans
@@ -70,8 +70,8 @@ RSpec.describe ClaimMailer, type: :mailer do
   end
 
   describe "#payment_confirmation" do
-    let(:payment) { create(:payment, :with_figures, net_pay: 500.00, student_loan_repayment: 60, claim: claim) }
-    let(:claim) { create(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
+    let(:payment) { build(:payment, :with_figures, net_pay: 500.00, student_loan_repayment: 60, claim: claim) }
+    let(:claim) { build(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
     let(:payment_date_timestamp) { Time.new(2019, 1, 1).to_i }
     let(:mail) { ClaimMailer.payment_confirmation(payment.claim, payment_date_timestamp) }
 
@@ -89,7 +89,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     end
 
     context "when user does not currently have a student loan" do
-      let(:payment) { create(:payment, :with_figures, student_loan_repayment: nil, claim: claim) }
+      let(:payment) { build(:payment, :with_figures, student_loan_repayment: nil, claim: claim) }
 
       it "shows the right content" do
         expect(mail.body.encoded).to_not include("student loan contribution")
@@ -98,7 +98,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     end
 
     context "when user has a student loan, but has not made a contribution" do
-      let(:payment) { create(:payment, :with_figures, student_loan_repayment: 0, claim: claim) }
+      let(:payment) { build(:payment, :with_figures, student_loan_repayment: 0, claim: claim) }
 
       it "shows the right content" do
         expect(mail.body.encoded).to include("If you have made a student loan contribution, this is deducted from your payment amount and credited to SLC.")

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -13,6 +13,10 @@ RSpec.shared_examples "an email related to a claim" do |policy|
     claim_description = I18n.t("#{policy.routing_name.underscore}.claim_description")
     expect(mail.subject).to include(claim_description)
   end
+
+  it "includes the claim reference in the subject" do
+    expect(mail.subject).to include("reference number: #{claim.reference}")
+  end
 end
 
 RSpec.describe ClaimMailer, type: :mailer do
@@ -41,7 +45,6 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it "renders the subject" do
       expect(mail.subject).to match("approved")
-      expect(mail.subject).to match("reference number: #{claim.reference}")
     end
 
     it "renders the body" do
@@ -58,7 +61,6 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it "renders the subject" do
       expect(mail.subject).to match("rejected")
-      expect(mail.subject).to match("reference number: #{claim.reference}")
     end
 
     it "renders the body" do
@@ -77,7 +79,6 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it "renders the subject" do
       expect(mail.subject).to match("paying")
-      expect(mail.subject).to match("reference number: #{claim.reference}")
     end
 
     it "renders the body" do

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -16,8 +16,9 @@ RSpec.shared_examples "an email related to a claim" do |policy|
     expect(mail.body.encoded).to include(claim_description)
   end
 
-  it "includes the claim reference in the subject" do
+  it "includes the claim reference in the subject and body" do
     expect(mail.subject).to include("reference number: #{claim.reference}")
+    expect(mail.body.encoded).to include(claim.reference)
   end
 
   it "greets the claimant in the body" do
@@ -38,7 +39,6 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match("We've received your claim to get back your student loan repayments.")
-      expect(mail.body.encoded).to match("Your unique reference is #{claim.reference}. You will need this if you contact us about your claim.")
     end
   end
 

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -33,12 +33,9 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it_behaves_like "an email related to a claim", StudentLoans
 
-    it "mentions that claim has been received in the subject" do
-      expect(mail.subject).to match("been received")
-    end
-
-    it "renders the body" do
-      expect(mail.body.encoded).to match("We've received your claim to get back your student loan repayments.")
+    it "mentions that claim has been received in the subject and body" do
+      expect(mail.subject).to include("been received")
+      expect(mail.body.encoded).to include("We've received your claim")
     end
   end
 
@@ -48,12 +45,9 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it_behaves_like "an email related to a claim", StudentLoans
 
-    it "mentions that claim has been approved in the subject" do
-      expect(mail.subject).to match("approved")
-    end
-
-    it "renders the body" do
-      expect(mail.body.encoded).to match("been approved")
+    it "mentions that claim has been approved in the subject and body" do
+      expect(mail.subject).to include("approved")
+      expect(mail.body.encoded).to include("been approved")
     end
   end
 
@@ -63,12 +57,9 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it_behaves_like "an email related to a claim", StudentLoans
 
-    it "mentions that claim has been rejected in the subject" do
-      expect(mail.subject).to match("rejected")
-    end
-
-    it "renders the body" do
-      expect(mail.body.encoded).to match("not been able to approve")
+    it "mentions that claim has been rejected in the subject and body" do
+      expect(mail.subject).to include("rejected")
+      expect(mail.body.encoded).to include("not been able to approve")
     end
   end
 
@@ -80,12 +71,12 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it_behaves_like "an email related to a claim", StudentLoans
 
-    it "mentions that claim is being paid in the subject" do
-      expect(mail.subject).to match("paying")
+    it "mentions that claim is being paid in the subject and body" do
+      expect(mail.subject).to include("paying")
+      expect(mail.body.encoded).to include("We’re paying your claim")
     end
 
-    it "renders the body" do
-      expect(mail.body.encoded).to include("We’re paying your claim")
+    it "includes the NET pay amount and the student loan deduction in the body" do
       expect(mail.body.encoded).to include("You will receive £500.00 on or after 1 January 2019")
       expect(mail.body.encoded).to include("Student loan (deducted): £60.00")
     end
@@ -93,7 +84,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     context "when user does not currently have a student loan" do
       let(:payment) { build(:payment, :with_figures, student_loan_repayment: nil, claim: claim) }
 
-      it "shows the right content" do
+      it "does not mention the content relating to student loan dedictions" do
         expect(mail.body.encoded).to_not include("student loan contribution")
         expect(mail.body.encoded).to_not include("Student loan (deducted)")
       end
@@ -102,7 +93,7 @@ RSpec.describe ClaimMailer, type: :mailer do
     context "when user has a student loan, but has not made a contribution" do
       let(:payment) { build(:payment, :with_figures, student_loan_repayment: 0, claim: claim) }
 
-      it "shows the right content" do
+      it "mentions the student loan deduction content and lists their contribution as zero" do
         expect(mail.body.encoded).to include("If you have made a student loan contribution, this is deducted from your payment amount and credited to SLC.")
         expect(mail.body.encoded).to include("Student loan: £0.00")
       end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -8,6 +8,11 @@ RSpec.shared_examples "an email related to a claim" do |policy|
   it "sets the GOV.UK Notify reply_to_id according to the policy" do
     expect(mail["reply_to_id"].value).to eql(policy.notify_reply_to_id)
   end
+
+  it "mentions the type of claim in the subject" do
+    claim_description = I18n.t("#{policy.routing_name.underscore}.claim_description")
+    expect(mail.subject).to include(claim_description)
+  end
 end
 
 RSpec.describe ClaimMailer, type: :mailer do

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -19,11 +19,15 @@ RSpec.shared_examples "an email related to a claim" do |policy|
   it "includes the claim reference in the subject" do
     expect(mail.subject).to include("reference number: #{claim.reference}")
   end
+
+  it "greets the claimant in the body" do
+    expect(mail.body.encoded).to start_with("Dear #{claim.first_name} #{claim.surname},")
+  end
 end
 
 RSpec.describe ClaimMailer, type: :mailer do
   describe "#submitted" do
-    let(:claim) { build(:claim, :submittable, first_name: "Abraham", surname: "Lincoln") }
+    let(:claim) { build(:claim, :submittable) }
     let(:mail) { ClaimMailer.submitted(claim) }
 
     it_behaves_like "an email related to a claim", StudentLoans
@@ -33,14 +37,13 @@ RSpec.describe ClaimMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("Dear Abraham Lincoln,")
       expect(mail.body.encoded).to match("We've received your claim to get back your student loan repayments.")
       expect(mail.body.encoded).to match("Your unique reference is #{claim.reference}. You will need this if you contact us about your claim.")
     end
   end
 
   describe "#approved" do
-    let(:claim) { build(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
+    let(:claim) { build(:claim, :submitted) }
     let(:mail) { ClaimMailer.approved(claim) }
 
     it_behaves_like "an email related to a claim", StudentLoans
@@ -50,13 +53,12 @@ RSpec.describe ClaimMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("Dear John Kennedy,")
       expect(mail.body.encoded).to match("been approved")
     end
   end
 
   describe "#rejected" do
-    let(:claim) { build(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
+    let(:claim) { build(:claim, :submitted) }
     let(:mail) { ClaimMailer.rejected(claim) }
 
     it_behaves_like "an email related to a claim", StudentLoans
@@ -66,14 +68,13 @@ RSpec.describe ClaimMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("Dear John Kennedy,")
       expect(mail.body.encoded).to match("not been able to approve")
     end
   end
 
   describe "#payment_confirmation" do
     let(:payment) { build(:payment, :with_figures, net_pay: 500.00, student_loan_repayment: 60, claim: claim) }
-    let(:claim) { build(:claim, :submitted, first_name: "John", middle_name: "Fitzgerald", surname: "Kennedy") }
+    let(:claim) { build(:claim, :submitted) }
     let(:payment_date_timestamp) { Time.new(2019, 1, 1).to_i }
     let(:mail) { ClaimMailer.payment_confirmation(payment.claim, payment_date_timestamp) }
 
@@ -84,7 +85,6 @@ RSpec.describe ClaimMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to include("Dear John Kennedy,")
       expect(mail.body.encoded).to include("We’re paying your claim")
       expect(mail.body.encoded).to include("You will receive £500.00 on or after 1 January 2019")
       expect(mail.body.encoded).to include("Student loan (deducted): £60.00")

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.shared_examples "an email related to a claim" do |policy|
+  let(:claim_description) { I18n.t("#{policy.routing_name.underscore}.claim_description") }
+
   it "sets the to address to the claimant's email address" do
     expect(mail.to).to eq([claim.email_address])
   end
@@ -9,9 +11,9 @@ RSpec.shared_examples "an email related to a claim" do |policy|
     expect(mail["reply_to_id"].value).to eql(policy.notify_reply_to_id)
   end
 
-  it "mentions the type of claim in the subject" do
-    claim_description = I18n.t("#{policy.routing_name.underscore}.claim_description")
+  it "mentions the type of claim in the subject and body" do
     expect(mail.subject).to include(claim_description)
+    expect(mail.body.encoded).to include(claim_description)
   end
 
   it "includes the claim reference in the subject" do

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -27,7 +27,7 @@ end
 
 RSpec.describe ClaimMailer, type: :mailer do
   describe "#submitted" do
-    let(:claim) { build(:claim, :submittable) }
+    let(:claim) { build(:claim, :submitted) }
     let(:mail) { ClaimMailer.submitted(claim) }
 
     it_behaves_like "an email related to a claim", StudentLoans

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -27,6 +27,7 @@ RSpec.shared_examples "an email related to a claim" do |policy|
 end
 
 RSpec.describe ClaimMailer, type: :mailer do
+  # Characteristics common to all policies
   Policies.all.each do |policy|
     context "with a #{policy} claim" do
       describe "#submitted" do
@@ -100,6 +101,28 @@ RSpec.describe ClaimMailer, type: :mailer do
             expect(mail.body.encoded).to include("Student loan: £0.00")
           end
         end
+      end
+    end
+  end
+
+  # Policy-specific characteristics
+  describe "#payment_confirmation" do
+    let(:student_loan_account_credit_fragment) { "This payment does not change the amount that was credited to your Student Loans" }
+
+    it "includes a sentence about the amount credited to their student loans when given a StudentLoans claim" do
+      claim = build(:payment, :with_figures).claim
+      mail = ClaimMailer.payment_confirmation(claim, Time.new(2019, 1, 1).to_i)
+
+      expect(mail.body.encoded).to include(student_loan_account_credit_fragment)
+    end
+
+    it "does not include the student loans credit sentence" do
+      Policies.all.excluding(StudentLoans).each do |policy|
+        claim = create(:claim, :approved, policy: policy)
+        build(:payment, :with_figures, claim: claim)
+        mail = ClaimMailer.payment_confirmation(claim, Time.new(2019, 1, 1).to_i)
+
+        expect(mail.body.encoded).not_to include(student_loan_account_credit_fragment)
       end
     end
   end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it_behaves_like "an email related to a claim", StudentLoans
 
-    it "renders the subject" do
+    it "mentions that claim has been received in the subject" do
       expect(mail.subject).to match("been received")
     end
 
@@ -48,7 +48,7 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it_behaves_like "an email related to a claim", StudentLoans
 
-    it "renders the subject" do
+    it "mentions that claim has been approved in the subject" do
       expect(mail.subject).to match("approved")
     end
 
@@ -63,7 +63,7 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it_behaves_like "an email related to a claim", StudentLoans
 
-    it "renders the subject" do
+    it "mentions that claim has been rejected in the subject" do
       expect(mail.subject).to match("rejected")
     end
 
@@ -80,7 +80,7 @@ RSpec.describe ClaimMailer, type: :mailer do
 
     it_behaves_like "an email related to a claim", StudentLoans
 
-    it "renders the subject" do
+    it "mentions that claim is being paid in the subject" do
       expect(mail.subject).to match("paying")
     end
 


### PR DESCRIPTION
This updates the transactional claim emails so that they will work with any policy. There are a lot of commits here, but it's not as bad as it looks:

- The first half dozen update the mailer and the views such that they will handle either type of claim
- The rest are small iterative steps that rework the mailer specs until the point where they can all be run with a claim for either policy

**NOTE: the rejection reasons for Maths & Physics are currently being reviewed and I'll be fixing them up in the translation file once the final content has been agreed**