### PR TITLE
Clear claim session before prepending view path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Update transational emails with improved content
+- Clear claim session before view path gets calculated
 
 ## [Release 032] - 2019-11-19
 

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -3,10 +3,10 @@ class ClaimsController < BasePublicController
 
   skip_before_action :send_unstarted_claiments_to_the_start, only: [:new, :create, :timeout]
   before_action :check_page_is_in_sequence, only: [:show, :update]
+  before_action :clear_claim_session, only: [:new]
   before_action :prepend_view_path_for_policy
 
   def new
-    clear_claim_session
     render first_template_in_sequence
   end
 

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "A user can switch policies" do
+  it "a user can switch to maths and physics after starting a student loan claim" do
+    start_student_loans_claim
+    visit new_claim_path(MathsAndPhysics.routing_name)
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))
+  end
+
+  it "a user can switch to student loans after starting a maths and physics claim" do
+    start_maths_and_physics_claim
+    visit new_claim_path(StudentLoans.routing_name)
+
+    expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
+  end
+end


### PR DESCRIPTION
Currently, if a user starts a claim session for one policy, and then attempts to switch policies, they're confronted with a Template error. This is because `prepend_view_path_for_policy` runs before the claim session is cleared, so the view path is set for the old policy. This tweak changes this behaviour so `clear_claim_session` runs before the view path is set.
