### PR TITLE
Add qts-year question to Maths and Physics

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -4,7 +4,7 @@ module Admin
 
     def admin_eligibility_answers(eligibility)
       [].tap do |a|
-        a << [t("student_loans.admin.qts_award_year"), I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}")]
+        a << [t("student_loans.admin.qts_award_year"), I18n.t("questions.qts_award_years.#{eligibility.qts_award_year}")]
         a << [t("student_loans.admin.claim_school"), display_school(eligibility.claim_school)]
         a << [t("admin.current_school"), display_school(eligibility.current_school)]
         a << [t("student_loans.admin.subjects_taught"), subject_list(eligibility.subjects_taught)]

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -12,7 +12,7 @@ module ClaimsHelper
 
   def eligibility_answers(eligibility)
     [].tap do |a|
-      a << [t("student_loans.questions.qts_award_year"), I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}"), "qts-year"]
+      a << [t("questions.qts_award_year"), I18n.t("questions.qts_award_years.#{eligibility.qts_award_year}"), "qts-year"]
       a << [t("student_loans.questions.claim_school"), eligibility.claim_school_name, "claim-school"]
       a << [t("questions.current_school"), eligibility.current_school_name, "still-teaching"]
       a << [t("student_loans.questions.subjects_taught", school: eligibility.claim_school_name), subject_list(eligibility.subjects_taught), "subjects-taught"]

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -14,6 +14,7 @@ module MathsAndPhysics
       "current-school",
       "initial-teacher-training-specialised-in-maths-or-physics",
       "has-uk-maths-or-physics-degree",
+      "qts-year",
       "eligibility-confirmed",
       "information-provided",
       "verified",

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -18,7 +18,7 @@
 
             <div class="govuk-radios">
               <%= fields.hidden_field :qts_award_year %>
-              <% StudentLoans::Eligibility.qts_award_years.each_key do |option| %>
+              <% current_claim.eligibility.class.qts_award_years.each_key do |option| %>
                 <div class="govuk-radios__item">
                   <%= fields.radio_button(:qts_award_year, option, class: "govuk-radios__input") %>
                   <%= fields.label "qts_award_year_#{option}", t("questions.qts_award_years.#{option}"), class: "govuk-label govuk-radios__label" %>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -1,0 +1,8 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
+<p class="govuk-body">
+  You can only get this payment if you completed your initial teacher training
+  on or after 1 September 2013.
+</p>

--- a/app/views/student_loans/claims/qts_year.html.erb
+++ b/app/views/student_loans/claims/qts_year.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.qts_award_year"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("questions.qts_award_year"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 <% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
 
 <div class="govuk-grid-row">
@@ -9,7 +9,7 @@
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">
-              <%= t("student_loans.questions.qts_award_year") %>
+              <%= t("questions.qts_award_year") %>
             </h1>
           </legend>
 
@@ -21,7 +21,7 @@
               <% StudentLoans::Eligibility.qts_award_years.each_key do |option| %>
                 <div class="govuk-radios__item">
                   <%= fields.radio_button(:qts_award_year, option, class: "govuk-radios__input") %>
-                  <%= fields.label "qts_award_year_#{option}", t("student_loans.questions.qts_award_years.#{option}"), class: "govuk-label govuk-radios__label" %>
+                  <%= fields.label "qts_award_year_#{option}", t("questions.qts_award_years.#{option}"), class: "govuk-label govuk-radios__label" %>
                 </div>
               <% end %>
             </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,10 @@ en:
   support_email_address: "additionalteachingpayment@digital.education.gov.uk"
   questions:
     current_school: "Which school are you currently employed to teach at?"
+    qts_award_year: "When did you complete your initial teacher training?"
+    qts_award_years:
+      before_september_2013: "Before 1 September 2013"
+      on_or_after_september_2013: "On or after 1 September 2013"
     address: "What is your address?"
     teacher_reference_number: "What's your teacher reference number?"
     national_insurance_number: "What's your National Insurance number?"
@@ -107,10 +111,6 @@ en:
     policy_name: "Teachers: claim back your student loan repayments"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
-      qts_award_year: "When did you complete your initial teacher training?"
-      qts_award_years:
-        before_september_2013: "Before 1 September 2013"
-        on_or_after_september_2013: "On or after 1 September 2013"
       claim_school: "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
       additional_school: "Which additional school were you employed to teach at between 6 April 2018 and 5 April 2019?"
       employment_status: "Are you still employed to teach at a school in England?"

--- a/db/migrate/20191120120237_add_qts_award_year_to_maths_and_physics_eligibilities.rb
+++ b/db/migrate/20191120120237_add_qts_award_year_to_maths_and_physics_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddQtsAwardYearToMathsAndPhysicsEligibilities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :maths_and_physics_eligibilities, :qts_award_year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_081451) do
+ActiveRecord::Schema.define(version: 2019_11_20_120237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 2019_11_20_081451) do
     t.uuid "current_school_id"
     t.boolean "initial_teacher_training_specialised_in_maths_or_physics"
     t.integer "has_uk_maths_or_physics_degree"
+    t.integer "qts_award_year"
     t.index ["current_school_id"], name: "index_maths_and_physics_eligibilities_on_current_school_id"
   end
 

--- a/spec/factories/maths_and_physics/eligibilities.rb
+++ b/spec/factories/maths_and_physics/eligibilities.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
       teaching_maths_or_physics { true }
       current_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
       initial_teacher_training_specialised_in_maths_or_physics { true }
+      qts_award_year { "on_or_after_september_2013" }
     end
   end
 end

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     expect(find("#claim_eligibility_attributes_qts_award_year_on_or_after_september_2013").checked?).to eq(true)
 
-    choose I18n.t("student_loans.questions.qts_award_years.before_september_2013")
+    choose I18n.t("questions.qts_award_years.before_september_2013")
     click_on "Continue"
 
     expect(eligibility.reload.qts_award_year).to eq("before_september_2013")

--- a/spec/features/ineligible_maths_and_physics_claims_spec.rb
+++ b/spec/features/ineligible_maths_and_physics_claims_spec.rb
@@ -33,4 +33,16 @@ RSpec.feature "Ineligible Maths and Physics claims" do
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you completed a degree specialising in maths or physics")
   end
+
+  scenario "qualified before the first eligible year" do
+    claim = start_maths_and_physics_claim
+
+    choose_school schools(:penistone_grammar_school)
+    choose_initial_teacher_training_specialised_in_maths_or_physics("Yes")
+    choose_qts_year("Before 1 September 2013")
+
+    expect(claim.eligibility.reload.qts_award_year).to eql("before_september_2013")
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You can only get this payment if you completed your initial teacher training on or after 1 September 2013.")
+  end
 end

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -27,6 +27,10 @@ RSpec.feature "Maths & Physics claims" do
       click_on "Continue"
       expect(claim.eligibility.reload.initial_teacher_training_specialised_in_maths_or_physics).to eql true
 
+      expect(page).to have_text(I18n.t("questions.qts_award_year"))
+      choose_qts_year
+      expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_september_2013")
+
       expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
 
       click_on "Continue"
@@ -93,8 +97,8 @@ RSpec.feature "Maths & Physics claims" do
 
   scenario "Teacher claims for Maths and Physics, without maths or physics ITT and with a UK degree in maths or physics" do
     # This test was initially written for the purpose of building out this
-    # alternative journey. It may evolve to not test the whole claims journey
-    # but only this part of it. Not sure of the best approach.
+    # alternative journey. It does not test the whole claims journey but only
+    # this part of it. Not sure of the best approach.
     visit "maths-and-physics/start"
     expect(page).to have_text "Claim a payment for teaching maths or physics"
 
@@ -123,13 +127,13 @@ RSpec.feature "Maths & Physics claims" do
     click_on "Continue"
     expect(claim.eligibility.reload.has_uk_maths_or_physics_degree).to eql "yes"
 
-    expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
+    expect(page).to have_text(I18n.t("questions.qts_award_year"))
   end
 
   scenario "Teacher claims for Maths and Physics, without maths or physics ITT and with a non-UK degree in maths or physics" do
     # This test was initially written for the purpose of building out this
-    # alternative journey. It may evolve to not test the whole claims journey
-    # but only this part of it. Not sure of the best approach.
+    # alternative journey. It does not test the whole claims journey but only
+    # this part of it. Not sure of the best approach.
     visit "maths-and-physics/start"
     expect(page).to have_text "Claim a payment for teaching maths or physics"
 
@@ -158,7 +162,7 @@ RSpec.feature "Maths & Physics claims" do
     click_on "Continue"
     expect(claim.eligibility.reload.has_uk_maths_or_physics_degree).to eql "has_non_uk"
 
-    expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
+    expect(page).to have_text(I18n.t("questions.qts_award_year"))
   end
 
   scenario "A teacher is ineligible for Maths & Physics" do

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     js_status = javascript_enabled ? "enabled" : "disabled"
     scenario "Teacher claims back student loan repayments with javascript #{js_status}", js: javascript_enabled do
       visit new_claim_path(StudentLoans.routing_name)
-      expect(page).to have_text(I18n.t("student_loans.questions.qts_award_year"))
+      expect(page).to have_text(I18n.t("questions.qts_award_year"))
 
       choose_qts_year
       claim = Claim.order(:created_at).last

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -19,7 +19,7 @@ describe ClaimsHelper do
 
     it "returns an array of questions and answers for displaying to the user for review" do
       expected_answers = [
-        [I18n.t("student_loans.questions.qts_award_year"), "On or after 1 September 2013", "qts-year"],
+        [I18n.t("questions.qts_award_year"), "On or after 1 September 2013", "qts-year"],
         [I18n.t("student_loans.questions.claim_school"), school.name, "claim-school"],
         [I18n.t("questions.current_school"), school.name, "still-teaching"],
         [I18n.t("student_loans.questions.subjects_taught", school: school.name), "Chemistry and Physics", "subjects-taught"],

--- a/spec/models/maths_and_physics/eligibility_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
       expect(MathsAndPhysics::Eligibility.new(initial_teacher_training_specialised_in_maths_or_physics: false, has_uk_maths_or_physics_degree: "yes").ineligible?).to eql false
       expect(MathsAndPhysics::Eligibility.new(initial_teacher_training_specialised_in_maths_or_physics: false, has_uk_maths_or_physics_degree: "has_non_uk").ineligible?).to eql false
     end
+
+    it "returns true when the qts_award_year is before 2013" do
+      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_september_2013").ineligible?).to eql true
+      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "on_or_after_september_2013").ineligible?).to eql false
+    end
   end
 
   describe "#ineligibility_reason" do
@@ -32,6 +37,7 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
       expect(MathsAndPhysics::Eligibility.new(teaching_maths_or_physics: false).ineligibility_reason).to eq :not_teaching_maths_or_physics
       expect(MathsAndPhysics::Eligibility.new(current_school: schools(:hampstead_school)).ineligibility_reason).to eq :ineligible_current_school
       expect(MathsAndPhysics::Eligibility.new(initial_teacher_training_specialised_in_maths_or_physics: false, has_uk_maths_or_physics_degree: "no").ineligibility_reason).to eq :no_maths_or_physics_qualification
+      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_september_2013").ineligibility_reason).to eq :ineligible_qts_award_year
     end
   end
 
@@ -97,6 +103,13 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
     end
   end
 
+  context "when saving in the “qts-year” context" do
+    it "validates the presence of qts_award_year" do
+      expect(MathsAndPhysics::Eligibility.new).not_to be_valid(:"qts-year")
+      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_september_2013")).to be_valid(:"qts-year")
+    end
+  end
+
   context "when saving in the “submit” context" do
     it "is valid when all attributes are present" do
       expect(build(:maths_and_physics_eligibility, :eligible)).to be_valid(:submit)
@@ -120,6 +133,11 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
     it "is not valid without a value for has_uk_maths_or_physics_degree, when initial_teacher_training_specialised_in_maths_or_physics is false" do
       expect(build(:maths_and_physics_eligibility, :eligible, initial_teacher_training_specialised_in_maths_or_physics: false, has_uk_maths_or_physics_degree: nil)).not_to be_valid(:submit)
       expect(build(:maths_and_physics_eligibility, :eligible, initial_teacher_training_specialised_in_maths_or_physics: false, has_uk_maths_or_physics_degree: "no")).to be_valid(:submit)
+    end
+
+    it "is not valid without a value for qts_award_year" do
+      expect(build(:maths_and_physics_eligibility, :eligible, qts_award_year: nil)).not_to be_valid(:submit)
+      expect(build(:maths_and_physics_eligibility, :eligible, qts_award_year: "before_september_2013")).to be_valid(:submit)
     end
   end
 end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Claims", type: :request do
     context "the user has not already started a claim" do
       it "renders the first page in the sequence" do
         get new_claim_path(StudentLoans.routing_name)
-        expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
+        expect(response.body).to include(I18n.t("questions.qts_award_year"))
       end
     end
 
@@ -15,7 +15,7 @@ RSpec.describe "Claims", type: :request do
       it "clears the current claim from the session, and renders the first page in the sequence" do
         expect { get new_claim_path(StudentLoans.routing_name) }.to change { session[:claim_id] }.from(String).to(nil)
 
-        expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
+        expect(response.body).to include(I18n.t("questions.qts_award_year"))
       end
     end
   end
@@ -39,7 +39,7 @@ RSpec.describe "Claims", type: :request do
 
       it "renders the requested page in the sequence" do
         get claim_path(StudentLoans.routing_name, "qts-year")
-        expect(response.body).to include(I18n.t("student_loans.questions.qts_award_year"))
+        expect(response.body).to include(I18n.t("questions.qts_award_year"))
 
         get claim_path(StudentLoans.routing_name, "claim-school")
         expect(response.body).to include("Which school were you employed to teach at")

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -30,7 +30,7 @@ describe "Routes", type: :routing do
 
     it "does not route to pages not in a policy’s page sequences" do
       expect(get: "student-loans/teaching-maths-or-physics").not_to be_routable
-      expect(get: "maths-and-physics/qts-year").not_to be_routable
+      expect(get: "maths-and-physics/subjects-taught").not_to be_routable
     end
 
     it "allows positionable routing parameters in the URL helpers" do


### PR DESCRIPTION
This adds the question and the eligibility logic. It's a couple of small refactors, to be able to reuse a template and some strings, and then pretty much a copy and paste from Student Loans (which seems like the right thing to do, at the moment).

![image](https://user-images.githubusercontent.com/53756884/69246133-0ed90d00-0ba0-11ea-9058-4da6019e7c56.png)

![image](https://user-images.githubusercontent.com/53756884/69246169-1b5d6580-0ba0-11ea-8037-1bf6aa7d309b.png)