### PR TITLE
Set cache headers so pages are refreshed each time

### DIFF
--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -2,6 +2,7 @@ module PartOfClaimJourney
   extend ActiveSupport::Concern
 
   included do
+    before_action :set_cache_headers
     before_action :check_whether_closed_for_submissions, if: :current_policy_routing_name
     before_action :send_unstarted_claiments_to_the_start
     helper_method :current_claim
@@ -43,5 +44,11 @@ module PartOfClaimJourney
 
   def routing_eligibility
     routing_policy && routing_policy::Eligibility.new
+  end
+
+  def set_cache_headers
+    response.headers["Cache-Control"] = "no-cache, no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 end

--- a/spec/features/claim_journey_does_not_get_cached_spec.rb
+++ b/spec/features/claim_journey_does_not_get_cached_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.feature "Claim journey does not get cached", js: true do
+  it "redirects the user to the start of the claim journey if they go back after the claim is completed" do
+    claim = start_student_loans_claim
+    claim.update!(attributes_for(:claim, :submittable))
+    claim.eligibility.update!(attributes_for(:student_loans_eligibility, :eligible))
+    visit claim_path(claim.policy.routing_name, "check-your-answers")
+
+    expect(page).to have_text(claim.first_name)
+
+    click_on "Confirm and send"
+
+    expect(current_path).to eq(claim_confirmation_path(claim.policy.routing_name))
+
+    page.evaluate_script("window.history.back()")
+
+    expect(page).to_not have_text(claim.first_name)
+    expect(current_path).to eq(new_claim_path(claim.policy.routing_name))
+  end
+end

--- a/spec/requests/verify_authentications_spec.rb
+++ b/spec/requests/verify_authentications_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :reque
       it "stores the request_id in the user’s session" do
         expect(session[:verify_request_id]).to eql(stubbed_auth_request_response["requestId"])
       end
+
+      it "returns cache headers so the page gives a newly minted VSP request on every visit" do
+        expect(response.headers["Cache-Control"]).to eq("no-cache, no-store")
+        expect(response.headers["Pragma"]).to eq("no-cache")
+        expect(response.headers["Expires"]).to eq("Fri, 01 Jan 1990 00:00:00 GMT")
+      end
     end
 
     describe "POST verify/authentications (i.e. the verify callback handler)" do


### PR DESCRIPTION
This fixes two issues - the first being an issue where a user who has finished, or was part way through their claim and has navigated away, can have their personal data surfaced by someone using the back button, even after the session has expired.

The second issue is if a user starts the Verify journey and then uses the back button, clicking continues results in an error, because the browser sends the same authentication request, rather than a newly minted one. This is slightly harder to test, because we stub out a lot of the Verify stuff in feature tests (and we  don't even see the error in the development version of the VSP), so the only thing we can test is that the cache headers get successfully set in the part of the journey where the authentication request is made.
