### PR TITLE
Add supply teacher questions to Maths and Physics journey

### DIFF
--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -8,10 +8,11 @@ module MathsAndPhysics
       :qts_award_year,
       :employed_as_supply_teacher,
       :has_entire_term_contract,
+      :employed_directly,
     ].freeze
     ATTRIBUTE_DEPENDENCIES = {
       "initial_teacher_training_specialised_in_maths_or_physics" => ["has_uk_maths_or_physics_degree"],
-      "employed_as_supply_teacher" => ["has_entire_term_contract"],
+      "employed_as_supply_teacher" => ["has_entire_term_contract", "employed_directly"],
     }.freeze
     self.table_name = "maths_and_physics_eligibilities"
 
@@ -35,6 +36,7 @@ module MathsAndPhysics
     validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select the academic year you were awarded qualified teacher status"}
     validates :employed_as_supply_teacher, on: [:"supply-teacher", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
     validates :has_entire_term_contract, on: [:"entire-term-contract", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}, if: :employed_as_supply_teacher?
+    validates :employed_directly, on: [:"employed-directly", :submit], inclusion: {in: [true, false], message: "Select whether you are employed directly by your school."}, if: :employed_as_supply_teacher?
 
     delegate :name, to: :current_school, prefix: true, allow_nil: true
 
@@ -43,7 +45,8 @@ module MathsAndPhysics
         ineligible_current_school? ||
         no_maths_or_physics_qualification? ||
         ineligible_qts_award_year? ||
-        no_entire_term_contract?
+        no_entire_term_contract? ||
+        not_employed_directly?
     end
 
     def ineligibility_reason
@@ -53,6 +56,7 @@ module MathsAndPhysics
         :no_maths_or_physics_qualification,
         :ineligible_qts_award_year,
         :no_entire_term_contract,
+        :not_employed_directly,
       ].find { |eligibility_check| send("#{eligibility_check}?") }
     end
 
@@ -84,6 +88,10 @@ module MathsAndPhysics
 
     def no_entire_term_contract?
       employed_as_supply_teacher? && has_entire_term_contract == false
+    end
+
+    def not_employed_directly?
+      employed_as_supply_teacher? && employed_directly == false
     end
   end
 end

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -7,9 +7,11 @@ module MathsAndPhysics
       :has_uk_maths_or_physics_degree,
       :qts_award_year,
       :employed_as_supply_teacher,
+      :has_entire_term_contract,
     ].freeze
     ATTRIBUTE_DEPENDENCIES = {
       "initial_teacher_training_specialised_in_maths_or_physics" => ["has_uk_maths_or_physics_degree"],
+      "employed_as_supply_teacher" => ["has_entire_term_contract"],
     }.freeze
     self.table_name = "maths_and_physics_eligibilities"
 
@@ -32,6 +34,7 @@ module MathsAndPhysics
     validates :has_uk_maths_or_physics_degree, on: [:"has-uk-maths-or-physics-degree", :submit], presence: {message: "Select whether you have a UK maths or physics degree."}, unless: :initial_teacher_training_specialised_in_maths_or_physics?
     validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select the academic year you were awarded qualified teacher status"}
     validates :employed_as_supply_teacher, on: [:"supply-teacher", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
+    validates :has_entire_term_contract, on: [:"entire-term-contract", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}, if: :employed_as_supply_teacher?
 
     delegate :name, to: :current_school, prefix: true, allow_nil: true
 
@@ -39,7 +42,8 @@ module MathsAndPhysics
       not_teaching_maths_or_physics? ||
         ineligible_current_school? ||
         no_maths_or_physics_qualification? ||
-        ineligible_qts_award_year?
+        ineligible_qts_award_year? ||
+        no_entire_term_contract?
     end
 
     def ineligibility_reason
@@ -48,6 +52,7 @@ module MathsAndPhysics
         :ineligible_current_school,
         :no_maths_or_physics_qualification,
         :ineligible_qts_award_year,
+        :no_entire_term_contract,
       ].find { |eligibility_check| send("#{eligibility_check}?") }
     end
 
@@ -75,6 +80,10 @@ module MathsAndPhysics
 
     def ineligible_qts_award_year?
       awarded_qualified_status_before_september_2014?
+    end
+
+    def no_entire_term_contract?
+      employed_as_supply_teacher? && has_entire_term_contract == false
     end
   end
 end

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -6,6 +6,7 @@ module MathsAndPhysics
       :initial_teacher_training_specialised_in_maths_or_physics,
       :has_uk_maths_or_physics_degree,
       :qts_award_year,
+      :employed_as_supply_teacher,
     ].freeze
     ATTRIBUTE_DEPENDENCIES = {
       "initial_teacher_training_specialised_in_maths_or_physics" => ["has_uk_maths_or_physics_degree"],
@@ -30,6 +31,7 @@ module MathsAndPhysics
     validates :initial_teacher_training_specialised_in_maths_or_physics, on: [:"initial-teacher-training-specialised-in-maths-or-physics", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
     validates :has_uk_maths_or_physics_degree, on: [:"has-uk-maths-or-physics-degree", :submit], presence: {message: "Select whether you have a UK maths or physics degree."}, unless: :initial_teacher_training_specialised_in_maths_or_physics?
     validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select the academic year you were awarded qualified teacher status"}
+    validates :employed_as_supply_teacher, on: [:"supply-teacher", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
 
     delegate :name, to: :current_school, prefix: true, allow_nil: true
 

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -17,6 +17,7 @@ module MathsAndPhysics
       "qts-year",
       "supply-teacher",
       "entire-term-contract",
+      "employed-directly",
       "eligibility-confirmed",
       "information-provided",
       "verified",
@@ -44,6 +45,7 @@ module MathsAndPhysics
       SLUGS.dup.tap do |sequence|
         sequence.delete("has-uk-maths-or-physics-degree") if claim.eligibility.initial_teacher_training_specialised_in_maths_or_physics?
         sequence.delete("entire-term-contract") unless claim.eligibility.employed_as_supply_teacher?
+        sequence.delete("employed-directly") unless claim.eligibility.employed_as_supply_teacher?
         sequence.delete("student-loan-country") if claim.no_student_loan?
         sequence.delete("student-loan-how-many-courses") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
         sequence.delete("student-loan-start-date") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -16,6 +16,7 @@ module MathsAndPhysics
       "has-uk-maths-or-physics-degree",
       "qts-year",
       "supply-teacher",
+      "entire-term-contract",
       "eligibility-confirmed",
       "information-provided",
       "verified",
@@ -42,6 +43,7 @@ module MathsAndPhysics
     def slugs
       SLUGS.dup.tap do |sequence|
         sequence.delete("has-uk-maths-or-physics-degree") if claim.eligibility.initial_teacher_training_specialised_in_maths_or_physics?
+        sequence.delete("entire-term-contract") unless claim.eligibility.employed_as_supply_teacher?
         sequence.delete("student-loan-country") if claim.no_student_loan?
         sequence.delete("student-loan-how-many-courses") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
         sequence.delete("student-loan-start-date") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?

--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -15,6 +15,7 @@ module MathsAndPhysics
       "initial-teacher-training-specialised-in-maths-or-physics",
       "has-uk-maths-or-physics-degree",
       "qts-year",
+      "supply-teacher",
       "eligibility-confirmed",
       "information-provided",
       "verified",

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_no_entire_term_contract.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_no_entire_term_contract.html.erb
@@ -1,0 +1,8 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
+<p class="govuk-body">
+  You can only get this payment if you are employed directly by your school for
+  at least one term.
+</p>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_not_employed_directly.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_not_employed_directly.html.erb
@@ -1,0 +1,7 @@
+<h1 class="govuk-heading-xl">
+  You’re not eligible for this payment
+</h1>
+
+<p class="govuk-body">
+  You can only get this payment if you are employed directly by the school.
+</p>

--- a/app/views/maths_and_physics/claims/employed_directly.html.erb
+++ b/app/views/maths_and_physics/claims/employed_directly.html.erb
@@ -1,0 +1,44 @@
+<% content_for(:page_title, page_title(t("maths_and_physics.questions.employed_directly"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.employed_directly": "claim_eligibility_attributes_employed_directly_true" }) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+      <%= form_group_tag current_claim do %>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+
+          <%= fields.hidden_field :employed_directly %>
+
+          <fieldset class="govuk-fieldset">
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("maths_and_physics.questions.employed_directly") %>
+              </h1>
+            </legend>
+
+            <%= errors_tag current_claim.eligibility, :employed_directly %>
+
+            <div class="govuk-radios">
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:employed_directly, true, class: "govuk-radios__input") %>
+                <%= fields.label :employed_directly_true, "Yes, I’m employed by my school", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:employed_directly, false, class: "govuk-radios__input") %>
+                <%= fields.label :employed_directly_false, "No, I’m employed by a private agency", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+            </div>
+
+          </fieldset>
+
+        <% end %>
+      <% end %>
+
+      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/maths_and_physics/claims/entire_term_contract.html.erb
+++ b/app/views/maths_and_physics/claims/entire_term_contract.html.erb
@@ -1,0 +1,44 @@
+<% content_for(:page_title, page_title(t("maths_and_physics.questions.has_entire_term_contract"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.has_entire_term_contract": "claim_eligibility_attributes_has_entire_term_contract_true" }) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
+      <%= form_group_tag current_claim do %>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+
+          <%= fields.hidden_field :has_entire_term_contract %>
+
+          <fieldset class="govuk-fieldset">
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("maths_and_physics.questions.has_entire_term_contract") %>
+              </h1>
+            </legend>
+
+            <%= errors_tag current_claim.eligibility, :has_entire_term_contract %>
+
+            <div class="govuk-radios govuk-radios--inline">
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:has_entire_term_contract, true, class: "govuk-radios__input") %>
+                <%= fields.label :has_entire_term_contract_true, "Yes", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:has_entire_term_contract, false, class: "govuk-radios__input") %>
+                <%= fields.label :has_entire_term_contract_false, "No", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+            </div>
+
+          </fieldset>
+
+        <% end %>
+      <% end %>
+
+      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/maths_and_physics/claims/supply_teacher.html.erb
+++ b/app/views/maths_and_physics/claims/supply_teacher.html.erb
@@ -1,10 +1,9 @@
 <% content_for(:page_title, page_title(t("maths_and_physics.questions.employed_as_supply_teacher"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
-<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.employed_as_supply_teacher": "claim_eligibility_attributes_employed_as_supply_teacher_true" }) if current_claim.errors.any? %>
-    <%= form_for current_claim, url: path_for_form  do |form| %>
+    <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
       <%= form_group_tag current_claim do %>
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
 

--- a/app/views/maths_and_physics/claims/supply_teacher.html.erb
+++ b/app/views/maths_and_physics/claims/supply_teacher.html.erb
@@ -1,0 +1,45 @@
+<% content_for(:page_title, page_title(t("maths_and_physics.questions.employed_as_supply_teacher"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% path_for_form = current_claim.persisted? ? claim_path(current_policy_routing_name) : claims_path(current_policy_routing_name) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { "eligibility.employed_as_supply_teacher": "claim_eligibility_attributes_employed_as_supply_teacher_true" }) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: path_for_form  do |form| %>
+      <%= form_group_tag current_claim do %>
+        <%= form.fields_for :eligibility, include_id: false do |fields| %>
+
+          <%= fields.hidden_field :employed_as_supply_teacher %>
+
+          <fieldset class="govuk-fieldset">
+
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                <%= t("maths_and_physics.questions.employed_as_supply_teacher") %>
+              </h1>
+            </legend>
+
+            <%= errors_tag current_claim.eligibility, :employed_as_supply_teacher %>
+
+            <div class="govuk-radios govuk-radios--inline">
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:employed_as_supply_teacher, true, class: "govuk-radios__input") %>
+                <%= fields.label :employed_as_supply_teacher_true, "Yes", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:employed_as_supply_teacher, false, class: "govuk-radios__input") %>
+                <%= fields.label :employed_as_supply_teacher_false, "No", class: "govuk-label govuk-radios__label" %>
+              </div>
+
+            </div>
+
+          </fieldset>
+
+        <% end %>
+      <% end %>
+
+      <%= form.submit "Continue", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,6 +115,7 @@ en:
         before_september_2014: "Before 1 September 2014"
         on_or_after_september_2014: "On or after 1 September 2014"
       employed_as_supply_teacher: "Are you currently employed as a supply teacher?"
+      has_entire_term_contract: "Do you have a contract to teach at the same school for an entire term or longer?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     claim_description: "claim to get back your student loan repayments"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,7 @@ en:
       qts_award_years:
         before_september_2014: "Before 1 September 2014"
         on_or_after_september_2014: "On or after 1 September 2014"
+      employed_as_supply_teacher: "Are you currently employed as a supply teacher?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     claim_description: "claim to get back your student loan repayments"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,7 @@ en:
         on_or_after_september_2014: "On or after 1 September 2014"
       employed_as_supply_teacher: "Are you currently employed as a supply teacher?"
       has_entire_term_contract: "Do you have a contract to teach at the same school for an entire term or longer?"
+      employed_directly: "Are you employed directly by your school?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     claim_description: "claim to get back your student loan repayments"

--- a/db/migrate/20191120161044_add_employed_as_supply_teacher_to_maths_and_physics_eligibilities.rb
+++ b/db/migrate/20191120161044_add_employed_as_supply_teacher_to_maths_and_physics_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddEmployedAsSupplyTeacherToMathsAndPhysicsEligibilities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :maths_and_physics_eligibilities, :employed_as_supply_teacher, :boolean
+  end
+end

--- a/db/migrate/20191120171540_add_has_entire_term_contract_to_maths_and_physics_eligibilities.rb
+++ b/db/migrate/20191120171540_add_has_entire_term_contract_to_maths_and_physics_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddHasEntireTermContractToMathsAndPhysicsEligibilities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :maths_and_physics_eligibilities, :has_entire_term_contract, :boolean
+  end
+end

--- a/db/migrate/20191121081842_add_employed_directly_to_maths_and_physics_eligibilities.rb
+++ b/db/migrate/20191121081842_add_employed_directly_to_maths_and_physics_eligibilities.rb
@@ -1,0 +1,5 @@
+class AddEmployedDirectlyToMathsAndPhysicsEligibilities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :maths_and_physics_eligibilities, :employed_directly, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_161044) do
+ActiveRecord::Schema.define(version: 2019_11_20_171540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 2019_11_20_161044) do
     t.integer "has_uk_maths_or_physics_degree"
     t.integer "qts_award_year"
     t.boolean "employed_as_supply_teacher"
+    t.boolean "has_entire_term_contract"
     t.index ["current_school_id"], name: "index_maths_and_physics_eligibilities_on_current_school_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_171540) do
+ActiveRecord::Schema.define(version: 2019_11_21_081842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 2019_11_20_171540) do
     t.integer "qts_award_year"
     t.boolean "employed_as_supply_teacher"
     t.boolean "has_entire_term_contract"
+    t.boolean "employed_directly"
     t.index ["current_school_id"], name: "index_maths_and_physics_eligibilities_on_current_school_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_142322) do
+ActiveRecord::Schema.define(version: 2019_11_20_161044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 2019_11_20_142322) do
     t.boolean "initial_teacher_training_specialised_in_maths_or_physics"
     t.integer "has_uk_maths_or_physics_degree"
     t.integer "qts_award_year"
+    t.boolean "employed_as_supply_teacher"
     t.index ["current_school_id"], name: "index_maths_and_physics_eligibilities_on_current_school_id"
   end
 

--- a/spec/factories/maths_and_physics/eligibilities.rb
+++ b/spec/factories/maths_and_physics/eligibilities.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
       current_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
       initial_teacher_training_specialised_in_maths_or_physics { true }
       qts_award_year { "on_or_after_september_2014" }
+      employed_as_supply_teacher { false }
     end
   end
 end

--- a/spec/features/ineligible_maths_and_physics_claims_spec.rb
+++ b/spec/features/ineligible_maths_and_physics_claims_spec.rb
@@ -62,4 +62,23 @@ RSpec.feature "Ineligible Maths and Physics claims" do
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you are employed directly by your school for at least one term")
   end
+
+  scenario "supply teacher isn't employed directly by school" do
+    claim = start_maths_and_physics_claim
+
+    choose_school schools(:penistone_grammar_school)
+    choose_initial_teacher_training_specialised_in_maths_or_physics("Yes")
+    choose_qts_year("On or after 1 September 2014")
+
+    choose "Yes"
+    click_on "Continue"
+    choose "Yes"
+    click_on "Continue"
+    choose "No, I’m employed by a private agency"
+    click_on "Continue"
+
+    expect(claim.eligibility.reload.employed_directly).to eql false
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You can only get this payment if you are employed directly by the school.")
+  end
 end

--- a/spec/features/ineligible_maths_and_physics_claims_spec.rb
+++ b/spec/features/ineligible_maths_and_physics_claims_spec.rb
@@ -45,4 +45,21 @@ RSpec.feature "Ineligible Maths and Physics claims" do
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you completed your initial teacher training on or after 1 September 2014.")
   end
+
+  scenario "supply teacher doesn't have a contract for a whole term" do
+    claim = start_maths_and_physics_claim
+
+    choose_school schools(:penistone_grammar_school)
+    choose_initial_teacher_training_specialised_in_maths_or_physics("Yes")
+    choose_qts_year("On or after 1 September 2014")
+
+    choose "Yes"
+    click_on "Continue"
+    choose "No"
+    click_on "Continue"
+
+    expect(claim.eligibility.reload.has_entire_term_contract).to eql false
+    expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You can only get this payment if you are employed directly by your school for at least one term")
+  end
 end

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -31,6 +31,11 @@ RSpec.feature "Maths & Physics claims" do
       choose_qts_year "On or after 1 September 2014"
       expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_september_2014")
 
+      expect(page).to have_text(I18n.t("maths_and_physics.questions.employed_as_supply_teacher"))
+      choose "No"
+      click_on "Continue"
+      expect(claim.eligibility.reload.employed_as_supply_teacher).to eql false
+
       expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
 
       click_on "Continue"

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -170,7 +170,7 @@ RSpec.feature "Maths & Physics claims" do
     expect(page).to have_text(I18n.t("questions.qts_award_year"))
   end
 
-  scenario "Supply teacher claims for Maths and Physics, with a contract to teach for an entire term" do
+  scenario "Supply teacher claims for Maths and Physics, employed directly by school with a contract to teach for an entire term" do
     # This test was initially written for the purpose of building out this
     # alternative journey. It does not test the whole claims journey but only
     # this part of it. Not sure of the best approach.
@@ -210,6 +210,11 @@ RSpec.feature "Maths & Physics claims" do
     choose "Yes"
     click_on "Continue"
     expect(claim.eligibility.reload.has_entire_term_contract).to eql true
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.employed_directly"))
+    choose "Yes, I’m employed by my school"
+    click_on "Continue"
+    expect(claim.eligibility.reload.employed_directly).to eql true
 
     expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
   end

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -170,6 +170,50 @@ RSpec.feature "Maths & Physics claims" do
     expect(page).to have_text(I18n.t("questions.qts_award_year"))
   end
 
+  scenario "Supply teacher claims for Maths and Physics, with a contract to teach for an entire term" do
+    # This test was initially written for the purpose of building out this
+    # alternative journey. It does not test the whole claims journey but only
+    # this part of it. Not sure of the best approach.
+    visit "maths-and-physics/start"
+    expect(page).to have_text "Claim a payment for teaching maths or physics"
+
+    click_on "Start"
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))
+
+    choose "Yes"
+    click_on "Continue"
+
+    claim = Claim.order(:created_at).last
+    eligibility = claim.eligibility
+
+    expect(eligibility.teaching_maths_or_physics).to eql true
+
+    expect(page).to have_text(I18n.t("questions.current_school"))
+    choose_school schools(:penistone_grammar_school)
+    expect(claim.eligibility.reload.current_school).to eql schools(:penistone_grammar_school)
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.initial_teacher_training_specialised_in_maths_or_physics"))
+    choose "Yes"
+    click_on "Continue"
+    expect(claim.eligibility.reload.initial_teacher_training_specialised_in_maths_or_physics).to eql true
+
+    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+    choose_qts_year "On or after 1 September 2014"
+    expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_september_2014")
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.employed_as_supply_teacher"))
+    choose "Yes"
+    click_on "Continue"
+    expect(claim.eligibility.reload.employed_as_supply_teacher).to eql true
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.has_entire_term_contract"))
+    choose "Yes"
+    click_on "Continue"
+    expect(claim.eligibility.reload.has_entire_term_contract).to eql true
+
+    expect(page).to have_text("You are eligible to claim a payment for teaching maths or physics")
+  end
+
   scenario "A teacher is ineligible for Maths & Physics" do
     visit new_claim_path(MathsAndPhysics.routing_name)
 

--- a/spec/models/maths_and_physics/eligibility_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_spec.rb
@@ -110,6 +110,14 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
     end
   end
 
+  context "when saving in the “supply-teacher” context" do
+    it "is not valid without a value for employed_as_supply_teacher" do
+      expect(MathsAndPhysics::Eligibility.new).not_to be_valid(:"supply-teacher")
+      expect(MathsAndPhysics::Eligibility.new(employed_as_supply_teacher: true)).to be_valid(:"supply-teacher")
+      expect(MathsAndPhysics::Eligibility.new(employed_as_supply_teacher: false)).to be_valid(:"supply-teacher")
+    end
+  end
+
   context "when saving in the “submit” context" do
     it "is valid when all attributes are present" do
       expect(build(:maths_and_physics_eligibility, :eligible)).to be_valid(:submit)
@@ -138,6 +146,11 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
     it "is not valid without a value for qts_award_year" do
       expect(build(:maths_and_physics_eligibility, :eligible, qts_award_year: nil)).not_to be_valid(:submit)
       expect(build(:maths_and_physics_eligibility, :eligible, qts_award_year: "before_september_2014")).to be_valid(:submit)
+    end
+
+    it "is not valid without a value for employed_as_supply_teacher" do
+      expect(build(:maths_and_physics_eligibility, :eligible, employed_as_supply_teacher: nil)).not_to be_valid(:submit)
+      expect(build(:maths_and_physics_eligibility, :eligible, employed_as_supply_teacher: false)).to be_valid(:submit)
     end
   end
 end

--- a/spec/models/maths_and_physics/eligibility_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
       expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_september_2014").ineligible?).to eql true
       expect(MathsAndPhysics::Eligibility.new(qts_award_year: "on_or_after_september_2014").ineligible?).to eql false
     end
+
+    it "returns true when claimant is a supply teacher without a contract of at least one term" do
+      expect(MathsAndPhysics::Eligibility.new(employed_as_supply_teacher: true, has_entire_term_contract: false).ineligible?).to eql true
+      expect(MathsAndPhysics::Eligibility.new(employed_as_supply_teacher: true, has_entire_term_contract: true).ineligible?).to eql false
+    end
   end
 
   describe "#ineligibility_reason" do
@@ -38,6 +43,7 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
       expect(MathsAndPhysics::Eligibility.new(current_school: schools(:hampstead_school)).ineligibility_reason).to eq :ineligible_current_school
       expect(MathsAndPhysics::Eligibility.new(initial_teacher_training_specialised_in_maths_or_physics: false, has_uk_maths_or_physics_degree: "no").ineligibility_reason).to eq :no_maths_or_physics_qualification
       expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_september_2014").ineligibility_reason).to eq :ineligible_qts_award_year
+      expect(MathsAndPhysics::Eligibility.new(employed_as_supply_teacher: true, has_entire_term_contract: false).ineligibility_reason).to eql :no_entire_term_contract
     end
   end
 
@@ -59,6 +65,8 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
         :eligible,
         initial_teacher_training_specialised_in_maths_or_physics: false,
         has_uk_maths_or_physics_degree: "no",
+        employed_as_supply_teacher: true,
+        has_entire_term_contract: false,
       )
     end
 
@@ -70,6 +78,16 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
       expect { eligibility.reset_dependent_answers }
         .to change { eligibility.has_uk_maths_or_physics_degree }
         .from("no").to(nil)
+    end
+
+    it "resets has_entire_term_contract when the value of employed_as_supply_teacher changes" do
+      eligibility.employed_as_supply_teacher = true
+      expect { eligibility.reset_dependent_answers }.not_to change { eligibility.attributes }
+
+      eligibility.employed_as_supply_teacher = false
+      expect { eligibility.reset_dependent_answers }
+        .to change { eligibility.has_entire_term_contract }
+        .from(false).to(nil)
     end
   end
 
@@ -118,6 +136,13 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
     end
   end
 
+  context "when saving in the “entire-term-contract” context, with employed_as_supply_teacher true" do
+    it "validates the presence of has_entire_term_contract" do
+      expect(MathsAndPhysics::Eligibility.new(employed_as_supply_teacher: true)).not_to be_valid(:"entire-term-contract")
+      expect(MathsAndPhysics::Eligibility.new(employed_as_supply_teacher: true, has_entire_term_contract: false)).to be_valid(:"entire-term-contract")
+    end
+  end
+
   context "when saving in the “submit” context" do
     it "is valid when all attributes are present" do
       expect(build(:maths_and_physics_eligibility, :eligible)).to be_valid(:submit)
@@ -151,6 +176,11 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
     it "is not valid without a value for employed_as_supply_teacher" do
       expect(build(:maths_and_physics_eligibility, :eligible, employed_as_supply_teacher: nil)).not_to be_valid(:submit)
       expect(build(:maths_and_physics_eligibility, :eligible, employed_as_supply_teacher: false)).to be_valid(:submit)
+    end
+
+    it "is not valid without a value for has_entire_term_contract, when employed_as_supply_teacher is true" do
+      expect(build(:maths_and_physics_eligibility, :eligible, employed_as_supply_teacher: true, has_entire_term_contract: nil)).not_to be_valid(:submit)
+      expect(build(:maths_and_physics_eligibility, :eligible, employed_as_supply_teacher: true, has_entire_term_contract: false)).to be_valid(:submit)
     end
   end
 end

--- a/spec/models/maths_and_physics/slug_sequence_spec.rb
+++ b/spec/models/maths_and_physics/slug_sequence_spec.rb
@@ -12,10 +12,11 @@ RSpec.describe MathsAndPhysics::SlugSequence do
       expect(slug_sequence.slugs).not_to include("has-uk-maths-or-physics-degree")
     end
 
-    it "excludes “entire-term-contract” if the claimant is not employed as a supply teacher" do
+    it "excludes the remaining supply teacher slugs if the claimant is not employed as a supply teacher" do
       claim.eligibility.employed_as_supply_teacher = false
 
       expect(slug_sequence.slugs).not_to include("entire-term-contract")
+      expect(slug_sequence.slugs).not_to include("employed-directly")
     end
 
     it "excludes the “address” slug if any address fields were acquired from GOV.UK Verify" do

--- a/spec/models/maths_and_physics/slug_sequence_spec.rb
+++ b/spec/models/maths_and_physics/slug_sequence_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe MathsAndPhysics::SlugSequence do
       expect(slug_sequence.slugs).not_to include("has-uk-maths-or-physics-degree")
     end
 
+    it "excludes “entire-term-contract” if the claimant is not employed as a supply teacher" do
+      claim.eligibility.employed_as_supply_teacher = false
+
+      expect(slug_sequence.slugs).not_to include("entire-term-contract")
+    end
+
     it "excludes the “address” slug if any address fields were acquired from GOV.UK Verify" do
       claim.verified_fields = []
       expect(slug_sequence.slugs).to include("address")


### PR DESCRIPTION
This adds the "Are you currently employed as a supply teacher?" question, which acts as a branching point in the Maths and Physics eligibility journey. It then adds all the questions for this branch of the journey. (After these questions, the main journey will resume.)

![image](https://user-images.githubusercontent.com/53756884/69329266-ab56ea00-0c48-11ea-9a87-cc0e63b00af1.png)

![image](https://user-images.githubusercontent.com/53756884/69329288-b3af2500-0c48-11ea-95b1-0e92a56f3417.png)

![image](https://user-images.githubusercontent.com/53756884/69329302-bb6ec980-0c48-11ea-8da5-3d50fc5b3419.png)

![image](https://user-images.githubusercontent.com/53756884/69329680-71d2ae80-0c49-11ea-9dad-8fd62a8bc3fe.png)

![image](https://user-images.githubusercontent.com/53756884/69329699-7a2ae980-0c49-11ea-8b07-6d45c6937b6d.png)