### PR TITLE
Change feedback link depending on policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Show a different feedback URL depending on the policy being used
+
 ## [Release 033] - 2019-11-21
 
 - Display the gross pay instead of the gross value in the payment confirmation

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,10 +28,14 @@ module ApplicationHelper
   end
 
   def feedback_url
-    "https://docs.google.com/forms/d/e/1FAIpQLSdAyOxHme39E8lMnD2qY029mmk4Lpn84soYg2vLrT5BV9IUSg/viewform?usp=sf_link"
+    current_policy.feedback_url
   end
 
   def start_page_url
-    Policies[current_policy_routing_name].start_page_url
+    current_policy.start_page_url
+  end
+
+  def current_policy
+    Policies[current_policy_routing_name]
   end
 end

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -1,17 +1,19 @@
 module MathsAndPhysics
-  def self.start_page_url
+  extend self
+
+  def start_page_url
     "/maths-and-physics/start" # Temporary start page during private beta
   end
 
-  def self.eligibility_page_url
+  def eligibility_page_url
     "https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details/claim-a-payment-for-teaching-maths-or-physics-eligibility-and-payment-details"
   end
 
-  def self.routing_name
+  def routing_name
     "maths-and-physics"
   end
 
-  def self.notify_reply_to_id
+  def notify_reply_to_id
     "29493350-ceec-4142-bd29-34ee363d5f62"
   end
 end

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -16,4 +16,8 @@ module MathsAndPhysics
   def notify_reply_to_id
     "29493350-ceec-4142-bd29-34ee363d5f62"
   end
+
+  def feedback_url
+    "https://docs.google.com/forms/d/e/1FAIpQLSeJcp50-eA5H_twIFKTUX8Z1ATDnj63wZaSlcnBCN-idJ7Ztg/viewform?usp=sf_link"
+  end
 end

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module StudentLoans
-  def self.start_page_url
+  extend self
+
+  def start_page_url
     if Rails.env.production?
       "https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments"
     else
@@ -9,15 +11,15 @@ module StudentLoans
     end
   end
 
-  def self.eligibility_page_url
+  def eligibility_page_url
     "https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details/teachers-claim-back-your-student-loan-repayments-eligibility-and-payment-details"
   end
 
-  def self.routing_name
+  def routing_name
     "student-loans"
   end
 
-  def self.notify_reply_to_id
+  def notify_reply_to_id
     "962b3044-cdd4-4dbe-b6ea-c461530b3dc6"
   end
 end

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -22,4 +22,8 @@ module StudentLoans
   def notify_reply_to_id
     "962b3044-cdd4-4dbe-b6ea-c461530b3dc6"
   end
+
+  def feedback_url
+    "https://docs.google.com/forms/d/e/1FAIpQLSdAyOxHme39E8lMnD2qY029mmk4Lpn84soYg2vLrT5BV9IUSg/viewform?usp=sf_link"
+  end
 end

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Maths & Physics claims" do
     scenario "Teacher claims for Maths & Physics payment with JavaScript #{js_status}", js: javascript_enabled do
       visit "maths-and-physics/start"
       expect(page).to have_text "Claim a payment for teaching maths or physics"
+      expect(page).to have_link(href: MathsAndPhysics.feedback_url)
 
       click_on "Start"
       expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     scenario "Teacher claims back student loan repayments with javascript #{js_status}", js: javascript_enabled do
       visit new_claim_path(StudentLoans.routing_name)
       expect(page).to have_text(I18n.t("questions.qts_award_year"))
+      expect(page).to have_link(href: StudentLoans.feedback_url)
 
       choose_qts_year
       claim = Claim.order(:created_at).last


### PR DESCRIPTION
This adds a helper method to get the feedback link for each policy. I've also refactored the `ApplicationHelper` to get the current policy based on the routing name given that we're using it in two places now. 

I've also updated the StudentLoans and Maths and Physics modules to extend from themselves, to avoid the repetition of typing `self` at the beginning of every method name, and given that we're unlikely to be including these modules in any other classes.

I've also added a simple test in the Student Loan and Maths and Physics happy paths to give us the confidence that the correct feedback URLs are being returned for each journey.
