### PR TITLE
The "claim submitted" page should not link to the done page for Maths and Physics

### DIFF
--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -20,4 +20,8 @@ module MathsAndPhysics
   def feedback_url
     "https://docs.google.com/forms/d/e/1FAIpQLSeJcp50-eA5H_twIFKTUX8Z1ATDnj63wZaSlcnBCN-idJ7Ztg/viewform?usp=sf_link"
   end
+
+  def done_page_url
+    nil
+  end
 end

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -26,4 +26,8 @@ module StudentLoans
   def feedback_url
     "https://docs.google.com/forms/d/e/1FAIpQLSdAyOxHme39E8lMnD2qY029mmk4Lpn84soYg2vLrT5BV9IUSg/viewform?usp=sf_link"
   end
+
+  def done_page_url
+    "https://www.gov.uk/done/claim-additional-teaching-payment"
+  end
 end

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -41,7 +41,7 @@
     </div>
 
     <p class="govuk-body">
-      <%= link_to "What did you think of this service?", "https://www.gov.uk/done/claim-additional-teaching-payment", class: "govuk-link" %>
+      <%= link_to "What did you think of this service?", current_claim.policy.done_page_url, class: "govuk-link" %>
       (takes 30 seconds)
     </p>
   </div>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -40,9 +40,11 @@
       make the payment into your account.
     </div>
 
-    <p class="govuk-body">
-      <%= link_to "What did you think of this service?", current_claim.policy.done_page_url, class: "govuk-link" %>
-      (takes 30 seconds)
-    </p>
+    <% if current_claim.policy.done_page_url %>
+      <p class="govuk-body">
+        <%= link_to "What did you think of this service?", current_claim.policy.done_page_url, class: "govuk-link" %>
+        (takes 30 seconds)
+      </p>
+    <% end %>
   </div>
 </div>

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Submissions", type: :request do
   describe "#create" do
     let(:in_progress_claim) { Claim.order(:created_at).last }
 
-    context "with a submittable claim" do
+    context "with a submittable student loans claim" do
       before do
         @dataset_post_stub = stub_geckoboard_dataset_update
 
@@ -20,6 +20,11 @@ RSpec.describe "Submissions", type: :request do
         expect(response).to redirect_to(claim_confirmation_path(StudentLoans.routing_name))
 
         expect(in_progress_claim.reload.submitted_at).to be_present
+
+        follow_redirect!
+
+        expect(response.body).to include("What did you think of this service?")
+        expect(response.body).to include(in_progress_claim.policy.done_page_url)
 
         email = ActionMailer::Base.deliveries.first
         expect(email.to).to eql([in_progress_claim.email_address])

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -43,6 +43,27 @@ RSpec.describe "Submissions", type: :request do
       end
     end
 
+    context "with a submittable maths and physics claim" do
+      before do
+        start_maths_and_physics_claim
+        # Make the claim submittable
+        in_progress_claim.update!(attributes_for(:claim, :submittable))
+        in_progress_claim.eligibility.update!(attributes_for(:maths_and_physics_eligibility, :eligible))
+
+        post claim_submission_path(MathsAndPhysics.routing_name)
+      end
+
+      it "does not show a done page link" do
+        expect(response).to redirect_to(claim_confirmation_path(MathsAndPhysics.routing_name))
+
+        expect(in_progress_claim.reload.submitted_at).to be_present
+
+        follow_redirect!
+
+        expect(response.body).to_not include("What did you think of this service?")
+      end
+    end
+
     context "with an unsubmittable claim" do
       before :each do
         start_student_loans_claim

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -9,6 +9,16 @@ module RequestHelpers
     }
   end
 
+  def start_maths_and_physics_claim
+    post claims_path(MathsAndPhysics.routing_name), params: {
+      claim: {
+        eligibility_attributes: {
+          teaching_maths_or_physics: 1,
+        },
+      },
+    }
+  end
+
   def sign_in_to_admin_with_role(*args)
     stub_dfe_sign_in_with_role(*args)
     post admin_dfe_sign_in_path


### PR DESCRIPTION
This does two things:

* Moves the done page URL to a method in each policy (Maths and Physics currently has none, so returns `nil`)
* Only link to a done page on the confirmation page if it exists for that particular policy
