### PR TITLE
Make sure payroll process works with a Maths & Physics claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Show a different feedback URL depending on the policy being used
+- Maths & Physics claims will work with the payroll process
 
 ## [Release 033] - 2019-11-21
 

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -60,6 +60,10 @@ module MathsAndPhysics
       ].find { |eligibility_check| send("#{eligibility_check}?") }
     end
 
+    def award_amount
+      BigDecimal("2000.00")
+    end
+
     def reset_dependent_answers
       ATTRIBUTE_DEPENDENCIES.each do |attribute_name, dependent_attribute_names|
         dependent_attribute_names.each do |dependent_attribute_name|

--- a/app/models/payroll/claim_csv_row.rb
+++ b/app/models/payroll/claim_csv_row.rb
@@ -132,7 +132,7 @@ module Payroll
     end
 
     def scheme_amount
-      model.eligibility.student_loan_repayment_amount.to_s
+      model.payment.award_amount.to_s
     end
 
     def roll_number

--- a/app/models/payroll/claims_csv.rb
+++ b/app/models/payroll/claims_csv.rb
@@ -44,7 +44,7 @@ module Payroll
     def file
       Tempfile.new.tap do |file|
         file.write(header_row)
-        payroll_run.claims.each do |claim|
+        payroll_run.claims.includes(:payment).each do |claim|
           file.write(Payroll::ClaimCsvRow.new(claim).to_s)
         end
         file.rewind

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -8,18 +8,19 @@ RSpec.feature "Payroll" do
 
     click_on "Payroll"
 
-    create_list(:claim, 3, :approved)
-    create_list(:claim, 1, :submitted)
+    create(:claim, :approved, policy: MathsAndPhysics)
+    create(:claim, :approved, policy: StudentLoans)
+    create(:claim, :approved, policy: StudentLoans)
 
     click_on "Prepare payroll"
 
     expect(page).to have_content("Approved claims 3")
-    expect(page).to have_content("Total award amount £3,000")
+    expect(page).to have_content("Total award amount £4,000")
 
     click_on "Create payroll file"
 
     expect(page).to have_content("Approved claims 3")
-    expect(page).to have_content("Total award amount £3,000")
+    expect(page).to have_content("Total award amount £4,000")
 
     click_on "Download file"
 

--- a/spec/models/maths_and_physics/eligibility_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
     end
   end
 
+  describe "#award_amount" do
+    it "returns the £2,000 amount that Maths & Physics claimants are eligible for" do
+      expect(MathsAndPhysics::Eligibility.new.award_amount).to eq(BigDecimal("2000"))
+    end
+  end
+
   describe "#current_school_name" do
     it "returns the name of the current school" do
       eligibility = MathsAndPhysics::Eligibility.new(current_school: schools(:penistone_grammar_school))

--- a/spec/models/payroll/claim_csv_row_spec.rb
+++ b/spec/models/payroll/claim_csv_row_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe Payroll::ClaimCsvRow do
         banking_name: "Jo Bloggs",
         building_society_roll_number: "1234/12345678",
         address_line_1: "1 Test Road",
-        postcode: "AB1 2CD",
-        eligibility: build(:student_loans_eligibility, :eligible))
+        postcode: "AB1 2CD")
     end
 
     it "generates a csv row" do

--- a/spec/models/payroll/claim_csv_row_spec.rb
+++ b/spec/models/payroll/claim_csv_row_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Payroll::ClaimCsvRow do
   subject { described_class.new(claim) }
   let(:claim) { build(:claim) }
 
-  describe "to_s" do
+  describe "to_s with an approved claim that has a payment" do
     let(:row) { CSV.parse(subject.to_s).first }
-
+    let(:payment_award_amount) { BigDecimal("1234.56") }
     let(:claim) do
-      build(:claim, :submittable,
+      build(:payment, award_amount: payment_award_amount, claim: build(:claim, :approved,
         payroll_gender: :female,
         date_of_birth: Date.new(1980, 12, 1),
         student_loan_plan: StudentLoan::PLAN_2,
@@ -17,7 +17,7 @@ RSpec.describe Payroll::ClaimCsvRow do
         banking_name: "Jo Bloggs",
         building_society_roll_number: "1234/12345678",
         address_line_1: "1 Test Road",
-        postcode: "AB1 2CD")
+        postcode: "AB1 2CD")).claim
     end
 
     it "generates a csv row" do
@@ -51,7 +51,7 @@ RSpec.describe Payroll::ClaimCsvRow do
           claim.bank_account_number,
           claim.building_society_roll_number,
           "Student Loans",
-          claim.eligibility.student_loan_repayment_amount.to_s,
+          payment_award_amount.to_s,
           claim.reference,
         ])
       end

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -41,18 +41,15 @@ RSpec.describe PayrollRun, type: :model do
   end
 
   describe ".create_with_claims!" do
-    let(:claims) { create_list(:claim, 2, :approved) }
+    let(:claims) { Policies.all.map { |policy| create(:claim, :approved, policy: policy) } }
 
     it "creates a payroll run with payments and populates the award_amount" do
-      claims[0].eligibility.update(student_loan_repayment_amount: 300)
-      claims[1].eligibility.update(student_loan_repayment_amount: 600)
-
       payroll_run = PayrollRun.create_with_claims!(claims, created_by: "creator-id")
 
       expect(payroll_run.reload.created_by).to eq("creator-id")
       expect(payroll_run.claims).to match_array(claims)
-      expect(claims[0].payment.award_amount).to eq(300)
-      expect(claims[1].payment.award_amount).to eq(600)
+      expect(claims[0].payment.award_amount).to eq(claims[0].award_amount)
+      expect(claims[1].payment.award_amount).to eq(claims[1].award_amount)
     end
   end
 


### PR DESCRIPTION
Prior to this things would have blown up if a payroll run was attempted with an approved Maths & Physics claim.

This doesn't deal with the bigger issue of when there is a claim for each policy from the same person in the same payroll run, but that is being tackled elsewhere in another story. This at least means we can approve and pay Maths & Physics claims, as long as the person doesn't have an approved Student Loans claim in the same run.