### PR TITLE
Add new domains and certificates to template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog]
 - Add the eligibility questions for the Maths and Physics journey
 - Show a different feedback URL depending on the policy being used
 - Maths & Physics claims will work with the payroll process
+- Start using the GOV.UK service domain
 
 ## [Release 033] - 2019-11-21
 

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -6,15 +6,25 @@
       "value": "${dockerCompose}"
     },
     "appServiceHostNames": {
-      "value": ["additional-teaching-payment.education.gov.uk", "www.additional-teaching-payment.education.gov.uk"]
+      "value": [
+        "claim-additional-teaching-payment.service.gov.uk",
+        "www.claim-additional-teaching-payment.service.gov.uk",
+        "additional-teaching-payment.education.gov.uk",
+        "www.additional-teaching-payment.education.gov.uk"
+      ]
     },
     "appServiceCertificateSecretNames": {
-      "value": ["sslCertificate-additional-teaching-payment-education-gov-uk"]
+      "value": [
+        "sslCertificate-additional-teaching-payment-education-gov-uk",
+        "sslCertificate-claim-additional-teaching-payment-service-gov-uk"
+      ]
     },
     "appServiceHostNameToCertificateSecretNameIndexMap": {
       "value": {
+        "www.additional-teaching-payment.education.gov.uk": 0,
         "additional-teaching-payment.education.gov.uk": 0,
-        "www.additional-teaching-payment.education.gov.uk": 0
+        "claim-additional-teaching-payment.service.gov.uk": 1,
+        "www.claim-additional-teaching-payment.service.gov.uk": 1
       }
     },
     "vspAppServiceDockerImage": {


### PR DESCRIPTION
This adds the GOV.UK service domains (with the canonical one first), as well as the certificate names and mapings to the template. With these in place we will be able to start serving requests from the service domain, and any requests to the old domain will be redirected to the new one.
