### PR TITLE
Drop unused claim school name param in I18n calls

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -48,7 +48,7 @@ module ClaimsHelper
       a << [t("questions.student_loan_country"), claim.student_loan_country.titleize, "student-loan-country"] if claim.student_loan_country.present?
       a << [t("questions.student_loan_how_many_courses"), claim.student_loan_courses.humanize, "student-loan-how-many-courses"] if claim.student_loan_courses.present?
       a << [t("questions.student_loan_start_date.#{claim.student_loan_courses}"), t("answers.student_loan_start_date.#{claim.student_loan_courses}.#{claim.student_loan_start_date}"), "student-loan-start-date"] if claim.student_loan_courses.present?
-      a << [t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), number_to_currency(claim.eligibility.student_loan_repayment_amount), "student-loan-amount"]
+      a << [t("student_loans.questions.student_loan_amount"), number_to_currency(claim.eligibility.student_loan_repayment_amount), "student-loan-amount"]
     end
   end
 

--- a/app/views/student_loans/claims/student_loan_amount.html.erb
+++ b/app/views/student_loans/claims/student_loan_amount.html.erb
@@ -9,7 +9,7 @@
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
 
           <h1 class="govuk-form-wrapper">
-            <%= fields.label :student_loan_repayment_amount, t("student_loans.questions.student_loan_amount", claim_school_name: current_claim.eligibility.claim_school_name), class: "govuk-label govuk-label--xl" %>
+            <%= fields.label :student_loan_repayment_amount, t("student_loans.questions.student_loan_amount"), class: "govuk-label govuk-label--xl" %>
           </h1>
 
           <p class="govuk-hint">

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -276,7 +276,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     find("a[href='#{claim_path(StudentLoans.routing_name, "student-loan-amount")}']").click
 
     expect(find("#claim_eligibility_attributes_student_loan_repayment_amount").value).to eq("100.10")
-    fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), with: "150.20"
+    fill_in I18n.t("student_loans.questions.student_loan_amount"), with: "150.20"
     click_on "Continue"
 
     expect(page).to have_content("£150.20")

--- a/spec/features/missing_verify_information_spec.rb
+++ b/spec/features/missing_verify_information_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Missing information from GOV.UK Verify" do
 
     answer_student_loan_plan_questions
 
-    fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), with: "1100"
+    fill_in I18n.t("student_loans.questions.student_loan_amount"), with: "1100"
     click_on "Continue"
 
     fill_in I18n.t("questions.email_address"), with: "name@example.tld"
@@ -86,7 +86,7 @@ RSpec.feature "Missing information from GOV.UK Verify" do
 
     answer_student_loan_plan_questions
 
-    fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), with: "1100"
+    fill_in I18n.t("student_loans.questions.student_loan_amount"), with: "1100"
     click_on "Continue"
 
     fill_in I18n.t("questions.email_address"), with: "name@example.tld"

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -86,8 +86,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(claim.student_loan_start_date).to eq(StudentLoan::BEFORE_1_SEPT_2012)
       expect(claim.student_loan_plan).to eq(StudentLoan::PLAN_1)
 
-      expect(page).to have_text(I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name))
-      fill_in I18n.t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), with: "1100"
+      expect(page).to have_text(I18n.t("student_loans.questions.student_loan_amount"))
+      fill_in I18n.t("student_loans.questions.student_loan_amount"), with: "1100"
       click_on "Continue"
 
       expect(claim.eligibility.reload.student_loan_repayment_amount).to eql(1100.00)

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -174,7 +174,7 @@ describe ClaimsHelper do
         [t("questions.student_loan_country"), "England", "student-loan-country"],
         [t("questions.student_loan_how_many_courses"), "One course", "student-loan-how-many-courses"],
         [t("questions.student_loan_start_date.one_course"), t("answers.student_loan_start_date.one_course.on_or_after_first_september_2012"), "student-loan-start-date"],
-        [t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), "£1,987.65", "student-loan-amount"],
+        [t("student_loans.questions.student_loan_amount"), "£1,987.65", "student-loan-amount"],
       ]
 
       expect(helper.student_loan_answers(claim)).to eq expected_answers
@@ -195,7 +195,7 @@ describe ClaimsHelper do
         [t("questions.student_loan_country"), "England", "student-loan-country"],
         [t("questions.student_loan_how_many_courses"), "Two or more courses", "student-loan-how-many-courses"],
         [t("questions.student_loan_start_date.two_or_more_courses"), t("answers.student_loan_start_date.two_or_more_courses.before_first_september_2012"), "student-loan-start-date"],
-        [t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), "£1,987.65", "student-loan-amount"],
+        [t("student_loans.questions.student_loan_amount"), "£1,987.65", "student-loan-amount"],
       ]
 
       expect(helper.student_loan_answers(claim)).to eq expected_answers
@@ -212,7 +212,7 @@ describe ClaimsHelper do
       expected_answers = [
         [t("questions.has_student_loan"), "Yes", "student-loan"],
         [t("questions.student_loan_country"), "Scotland", "student-loan-country"],
-        [t("student_loans.questions.student_loan_amount", claim_school_name: claim.eligibility.claim_school_name), "£1,987.65", "student-loan-amount"],
+        [t("student_loans.questions.student_loan_amount"), "£1,987.65", "student-loan-amount"],
       ]
 
       expect(helper.student_loan_answers(claim)).to eq expected_answers


### PR DESCRIPTION
The student_loans.questions.student_loan_amount question no longer
refers to the claim school, as of d2afc57.