### PR TITLE
Make education.gov.uk domain canonical for now

### DIFF
--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -7,10 +7,10 @@
     },
     "appServiceHostNames": {
       "value": [
-        "claim-additional-teaching-payment.service.gov.uk",
-        "www.claim-additional-teaching-payment.service.gov.uk",
         "additional-teaching-payment.education.gov.uk",
-        "www.additional-teaching-payment.education.gov.uk"
+        "www.additional-teaching-payment.education.gov.uk",
+        "claim-additional-teaching-payment.service.gov.uk",
+        "www.claim-additional-teaching-payment.service.gov.uk"
       ]
     },
     "appServiceCertificateSecretNames": {


### PR DESCRIPTION
Rather than going big bang and making the service domain canonical, we're going to play it safe and keep the education.gov.uk as the canonical domain for now, until we've verified that the certificate for the service domain is in place and working as expected.
