### PR TITLE
Make headless Chrome screen size bigger

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -10,7 +10,7 @@ Capybara.register_driver :headless_chrome do |app|
     app,
     browser: :chrome,
     options: Selenium::WebDriver::Chrome::Options.new(
-      args: %w[headless disable-dev-shm-usage no-sandbox]
+      args: %w[headless disable-dev-shm-usage no-sandbox window-size=1280x1280]
     )
   )
 end


### PR DESCRIPTION
We're having some issues with tests failing on Headless Chrome occasionally when forms have hints that make the screen size a specific height. Working theory is that Chromedriver isn't taking account of the margin/padding of the span element and causing it to click in the wrong place. An easy fix for this is to increase the screen size to make sure Chromedriver doesn't have to scroll for most cases.

# What headless Chrome sees before:

![capybara-201911251214425431935296](https://user-images.githubusercontent.com/109774/69539906-5a633080-0f7d-11ea-9055-4f9b5cff483f.png)

# What headless Chrome sees after:

![capybara-201911251214529610193277](https://user-images.githubusercontent.com/109774/69539916-60f1a800-0f7d-11ea-9773-27a87b71973a.png)


