### PR TITLE
Make service.gov.uk domain canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Make www.claim-additional-teaching-payment.service.gov.uk the canonical domain
+
 ## [Release 034] - 2019-11-25
 
 - Change wording of the student loan start date question for more than more

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -7,10 +7,10 @@
     },
     "appServiceHostNames": {
       "value": [
-        "additional-teaching-payment.education.gov.uk",
-        "www.additional-teaching-payment.education.gov.uk",
+        "www.claim-additional-teaching-payment.service.gov.uk",
         "claim-additional-teaching-payment.service.gov.uk",
-        "www.claim-additional-teaching-payment.service.gov.uk"
+        "additional-teaching-payment.education.gov.uk",
+        "www.additional-teaching-payment.education.gov.uk"
       ]
     },
     "appServiceCertificateSecretNames": {


### PR DESCRIPTION
Now the certificate is set up an confirmed working, we can now redirect all requests to the service domain.

**NOTE** Before this goes to production, we'll need to put the app into maintenance mode, as the sessions are stored by domain, so any in-progress claims will break.

<!-- Do you need to update CHANGELOG.md? -->
