### PR TITLE
Signed-out admin users redirected to orginal request url after signing in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Make www.claim-additional-teaching-payment.service.gov.uk the canonical domain
+- Admin users are redirected to their original request path after sign in
 
 ## [Release 034] - 2019-11-25
 

--- a/app/controllers/admin/auth_controller.rb
+++ b/app/controllers/admin/auth_controller.rb
@@ -17,7 +17,8 @@ module Admin
         session[:user_id] = admin_session.user_id
         session[:organisation_id] = admin_session.organisation_id
         session[:role_codes] = admin_session.role_codes
-        redirect_to admin_root_path
+
+        redirect_to session.delete(:requested_admin_path) || admin_root_path
       else
         render "failure", status: :unauthorized
       end

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -31,7 +31,10 @@ module Admin
     end
 
     def ensure_authenticated_user
-      redirect_to admin_sign_in_path unless admin_signed_in?
+      unless admin_signed_in?
+        session[:requested_admin_path] = request.fullpath
+        redirect_to admin_sign_in_path
+      end
     end
 
     def admin_session

--- a/spec/features/admin_sessions_spec.rb
+++ b/spec/features/admin_sessions_spec.rb
@@ -1,16 +1,18 @@
 require "rails_helper"
 
-RSpec.feature "Admin sessions" do
-  before do
+RSpec.feature "Admin session management" do
+  scenario "A user is redirected to the admin root path after sign in" do
     sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
-  end
 
-  scenario "Redirected to admin page after signing in" do
     expect(page).to have_link("Sign out")
+    expect(current_path).to eql(admin_root_path)
   end
 
-  scenario "Signing out" do
+  scenario "A signed in user can sign out" do
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+
     click_on "Sign out"
     expect(page).to have_content("You've been signed out")
+    expect(current_path).to eql(admin_sign_in_path)
   end
 end

--- a/spec/features/admin_sessions_spec.rb
+++ b/spec/features/admin_sessions_spec.rb
@@ -15,4 +15,14 @@ RSpec.feature "Admin session management" do
     expect(page).to have_content("You've been signed out")
     expect(current_path).to eql(admin_sign_in_path)
   end
+
+  scenario "A user is redirected to their original url after sign in" do
+    visit admin_claims_path
+
+    expect(current_path).to eql(admin_sign_in_path)
+
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+
+    expect(current_path).to eql(admin_claims_path)
+  end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -97,7 +97,7 @@ module FeatureHelpers
 
   def sign_in_to_admin_with_role(*args)
     stub_dfe_sign_in_with_role(*args)
-    visit admin_root_path
+    visit admin_sign_in_path
     click_on "Sign in"
   end
 


### PR DESCRIPTION
Not only is this a better user experience in general, Cantium users will only be
given a single endpoint to download the payroll run file. By redirecting them
after sign in we save them from having to navigate to the right place.