### PR TITLE
Introduce DfE Sign-in role for payroll operators

### DIFF
--- a/app/models/admin_session.rb
+++ b/app/models/admin_session.rb
@@ -3,6 +3,7 @@
 class AdminSession < DfeSignIn::AuthenticatedSession
   SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_access"
   SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_support"
+  PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE = "teacher_payments_payroll"
 
   def is_service_operator?
     role_codes.include?(SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
@@ -12,7 +13,11 @@ class AdminSession < DfeSignIn::AuthenticatedSession
     role_codes.include?(SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
   end
 
+  def is_payroll_operator?
+    role_codes.include?(PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+  end
+
   def has_admin_access?
-    is_service_operator? || is_support_agent?
+    is_service_operator? || is_support_agent? || is_payroll_operator?
   end
 end

--- a/spec/models/admin_session_spec.rb
+++ b/spec/models/admin_session_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe AdminSession, type: :model do
       expect(admin_session.has_admin_access?).to eq true
     end
 
+    it "returns true when user is a payroll operator" do
+      admin_session = AdminSession.new("user-id", "organisation-id", [AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
+      expect(admin_session.has_admin_access?).to eq true
+    end
+
     it "returns true when user has both roles" do
       admin_session = AdminSession.new("user-id", "organisation-id", [
         AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE,


### PR DESCRIPTION
We'll use this to grant restricted access to Cantium employees so that they can sign-in and download the monthly payroll file.

This new role has been set up on pre-production and is scoped to a new "Cantium Business Solutions" organisation. That way, the approver for this organisation will be able to grant and revoke access to users themselves without the need for intervention from us. For now, I have been set up as the approver on pre-production so that we can test the behaviour whilst we build out the new functionality.
