### PR TITLE
Refactor check-your-answers helper for multiple policies and add answer formatting for Maths and Physics

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -1,6 +1,6 @@
 module Admin
   module ClaimsHelper
-    include ::ClaimsHelper
+    include StudentLoans::PresenterMethods
 
     def admin_eligibility_answers(eligibility)
       [].tap do |a|

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -10,15 +10,8 @@ module ClaimsHelper
     fields.to_sentence
   end
 
-  def eligibility_answers(eligibility)
-    [].tap do |a|
-      a << [t("questions.qts_award_year"), I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}"), "qts-year"]
-      a << [t("student_loans.questions.claim_school"), eligibility.claim_school_name, "claim-school"]
-      a << [t("questions.current_school"), eligibility.current_school_name, "still-teaching"]
-      a << [t("student_loans.questions.subjects_taught", school: eligibility.claim_school_name), subject_list(eligibility.subjects_taught), "subjects-taught"]
-      a << [t("student_loans.questions.leadership_position"), (eligibility.had_leadership_position? ? "Yes" : "No"), "leadership-position"]
-      a << [t("student_loans.questions.mostly_performed_leadership_duties"), (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No"), "mostly-performed-leadership-duties"] if eligibility.had_leadership_position?
-    end
+  def eligibility_answers(claim)
+    claim.policy::EligibilityAnswersPresenter.new(claim.eligibility).answers
   end
 
   def verify_answers(claim)
@@ -59,15 +52,6 @@ module ClaimsHelper
       a << ["Bank account number", claim.bank_account_number, "bank-details"]
       a << ["Building society roll number", claim.building_society_roll_number, "bank-details"] if claim.building_society_roll_number.present?
     end
-  end
-
-  def subject_list(subjects)
-    connector = " and "
-    translated_subjects = subjects.map { |subject| I18n.t("student_loans.questions.eligible_subjects.#{subject}") }
-    translated_subjects.sort.to_sentence(
-      last_word_connector: connector,
-      two_words_connector: connector
-    )
   end
 
   def school_search_question(searching_for_additional_school)

--- a/app/presenters/maths_and_physics/eligibility_answers_presenter.rb
+++ b/app/presenters/maths_and_physics/eligibility_answers_presenter.rb
@@ -1,0 +1,43 @@
+module MathsAndPhysics
+  class EligibilityAnswersPresenter
+    attr_reader :eligibility
+
+    def initialize(eligibility)
+      @eligibility = eligibility
+    end
+
+    # Formats the eligibility as a list of questions and answers, each
+    # accompanied by a slug for changing the answer. Suitable for playback to
+    # the claimant for them to review on the check-your-answers page.
+    #
+    # Returns an array. Each element of this an array is an array of three
+    # elements:
+    # [0]: question text;
+    # [1]: answer text;
+    # [2]: slug for changing the answer.
+    def answers
+      [].tap do |a|
+        a << [I18n.t("maths_and_physics.questions.teaching_maths_or_physics"), (eligibility.teaching_maths_or_physics? ? "Yes" : "No"), "teaching-maths-or-physics"]
+        a << [I18n.t("questions.current_school"), eligibility.current_school_name, "current-school"]
+        a << [I18n.t("maths_and_physics.questions.initial_teacher_training_specialised_in_maths_or_physics"), (eligibility.initial_teacher_training_specialised_in_maths_or_physics? ? "Yes" : "No"), "initial-teacher-training-specialised-in-maths-or-physics"]
+        a << [I18n.t("maths_and_physics.questions.has_uk_maths_or_physics_degree"), degree_answer, "has-uk-maths-or-physics-degree"] unless eligibility.initial_teacher_training_specialised_in_maths_or_physics?
+        a << [I18n.t("questions.qts_award_year"), I18n.t("maths_and_physics.questions.qts_award_years.#{eligibility.qts_award_year}"), "qts-year"]
+        a << [I18n.t("maths_and_physics.questions.employed_as_supply_teacher"), (eligibility.employed_as_supply_teacher? ? "Yes" : "No"), "supply-teacher"]
+        a << [I18n.t("maths_and_physics.questions.has_entire_term_contract"), (eligibility.has_entire_term_contract? ? "Yes" : "No"), "entire-term-contract"] if eligibility.employed_as_supply_teacher?
+        a << [I18n.t("maths_and_physics.questions.employed_directly"), I18n.t("maths_and_physics.answers.employed_directly.#{eligibility.employed_directly? ? "yes" : "no"}"), "employed-directly"] if eligibility.employed_as_supply_teacher?
+        a << [I18n.t("maths_and_physics.questions.disciplinary_action"), (eligibility.subject_to_disciplinary_action? ? "Yes" : "No"), "disciplinary-action"]
+        a << [I18n.t("maths_and_physics.questions.formal_performance_action"), (eligibility.subject_to_formal_performance_action? ? "Yes" : "No"), "formal-performance-action"]
+      end
+    end
+
+    private
+
+    def degree_answer
+      case eligibility.has_uk_maths_or_physics_degree
+      when "yes" then "Yes"
+      when "no" then "No"
+      else I18n.t("maths_and_physics.answers.has_uk_maths_or_physics_degree.#{eligibility.has_uk_maths_or_physics_degree}")
+      end
+    end
+  end
+end

--- a/app/presenters/student_loans/eligibility_answers_presenter.rb
+++ b/app/presenters/student_loans/eligibility_answers_presenter.rb
@@ -1,0 +1,31 @@
+module StudentLoans
+  class EligibilityAnswersPresenter
+    include StudentLoans::PresenterMethods
+
+    attr_reader :eligibility
+
+    def initialize(eligibility)
+      @eligibility = eligibility
+    end
+
+    # Formats the eligibility as a list of questions and answers, each
+    # accompanied by a slug for changing the answer. Suitable for playback to
+    # the claimant for them to review on the check-your-answers page.
+    #
+    # Returns an array. Each element of this an array is an array of three
+    # elements:
+    # [0]: question text;
+    # [1]: answer text;
+    # [2]: slug for changing the answer.
+    def answers
+      [].tap do |a|
+        a << [I18n.t("questions.qts_award_year"), I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}"), "qts-year"]
+        a << [I18n.t("student_loans.questions.claim_school"), eligibility.claim_school_name, "claim-school"]
+        a << [I18n.t("questions.current_school"), eligibility.current_school_name, "still-teaching"]
+        a << [I18n.t("student_loans.questions.subjects_taught", school: eligibility.claim_school_name), subject_list(eligibility.subjects_taught), "subjects-taught"]
+        a << [I18n.t("student_loans.questions.leadership_position"), (eligibility.had_leadership_position? ? "Yes" : "No"), "leadership-position"]
+        a << [I18n.t("student_loans.questions.mostly_performed_leadership_duties"), (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No"), "mostly-performed-leadership-duties"] if eligibility.had_leadership_position?
+      end
+    end
+  end
+end

--- a/app/presenters/student_loans/presenter_methods.rb
+++ b/app/presenters/student_loans/presenter_methods.rb
@@ -1,0 +1,12 @@
+module StudentLoans
+  module PresenterMethods
+    def subject_list(subjects)
+      connector = " and "
+      translated_subjects = subjects.map { |subject| I18n.t("student_loans.questions.eligible_subjects.#{subject}") }
+      translated_subjects.sort.to_sentence(
+        last_word_connector: connector,
+        two_words_connector: connector
+      )
+    end
+  end
+end

--- a/app/views/claims/check_your_answers.html.erb
+++ b/app/views/claims/check_your_answers.html.erb
@@ -8,7 +8,7 @@
       Check your answers before sending your application
     </h1>
 
-    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Eligibility details", answers: eligibility_answers(current_claim.eligibility)} %>
+    <%= render partial: "claims/check_your_answers_section", locals: {heading: "Eligibility details", answers: eligibility_answers(current_claim)} %>
 
     <%= render partial: "claims/check_your_answers_section", locals: {heading: "GOV.UK Verify details", answers: verify_answers(current_claim)} %>
 

--- a/app/views/maths_and_physics/claims/employed_directly.html.erb
+++ b/app/views/maths_and_physics/claims/employed_directly.html.erb
@@ -23,12 +23,12 @@
 
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:employed_directly, true, class: "govuk-radios__input") %>
-                <%= fields.label :employed_directly_true, "Yes, I’m employed by my school", class: "govuk-label govuk-radios__label" %>
+                <%= fields.label :employed_directly_true, t("maths_and_physics.answers.employed_directly.yes"), class: "govuk-label govuk-radios__label" %>
               </div>
 
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:employed_directly, false, class: "govuk-radios__input") %>
-                <%= fields.label :employed_directly_false, "No, I’m employed by a private agency", class: "govuk-label govuk-radios__label" %>
+                <%= fields.label :employed_directly_false, t("maths_and_physics.answers.employed_directly.no"), class: "govuk-label govuk-radios__label" %>
               </div>
 
             </div>

--- a/app/views/maths_and_physics/claims/has_uk_maths_or_physics_degree.html.erb
+++ b/app/views/maths_and_physics/claims/has_uk_maths_or_physics_degree.html.erb
@@ -45,7 +45,7 @@
 
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:has_uk_maths_or_physics_degree, :has_non_uk, class: "govuk-radios__input") %>
-                <%= fields.label :has_uk_maths_or_physics_degree_has_non_uk, "I have a non-UK degree in Maths or Physics", class: "govuk-label govuk-radios__label" %>
+                <%= fields.label :has_uk_maths_or_physics_degree_has_non_uk, t("maths_and_physics.answers.has_uk_maths_or_physics_degree.has_non_uk"), class: "govuk-label govuk-radios__label" %>
               </div>
 
             </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,6 +120,12 @@ en:
       employed_directly: "Are you employed directly by your school?"
       disciplinary_action: "Are you currently subject to disciplinary action?"
       formal_performance_action: "Are you currently subject to formal action for poor performance at work?"
+    answers:
+      has_uk_maths_or_physics_degree:
+        has_non_uk: "I have a non-UK degree in Maths or Physics"
+      employed_directly:
+        "yes": "Yes, I’m employed by my school"
+        "no": "No, I’m employed by a private agency"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     policy_short_name: "Student Loans"

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -6,34 +6,17 @@ describe ClaimsHelper do
     let(:eligibility) do
       build(
         :student_loans_eligibility,
+        :eligible,
         qts_award_year: "on_or_after_september_2013",
-        claim_school: school,
-        current_school: school,
-        chemistry_taught: true,
-        physics_taught: true,
-        had_leadership_position: true,
-        mostly_performed_leadership_duties: false,
-        student_loan_repayment_amount: 1987.65,
       )
     end
-
-    it "returns an array of questions and answers for displaying to the user for review" do
-      expected_answers = [
-        [I18n.t("questions.qts_award_year"), "On or after 1 September 2013", "qts-year"],
-        [I18n.t("student_loans.questions.claim_school"), school.name, "claim-school"],
-        [I18n.t("questions.current_school"), school.name, "still-teaching"],
-        [I18n.t("student_loans.questions.subjects_taught", school: school.name), "Chemistry and Physics", "subjects-taught"],
-        [I18n.t("student_loans.questions.leadership_position"), "Yes", "leadership-position"],
-        [I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "No", "mostly-performed-leadership-duties"],
-      ]
-
-      expect(helper.eligibility_answers(eligibility)).to eq expected_answers
+    let(:claim) do
+      build(:claim, eligibility: eligibility)
     end
 
-    it "excludes questions skipped from the flow" do
-      eligibility.had_leadership_position = false
-      expect(helper.eligibility_answers(eligibility)).to_not include([I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "Yes", "mostly-performed-leadership-duties"])
-      expect(helper.eligibility_answers(eligibility)).to_not include([I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "No", "mostly-performed-leadership-duties"])
+    it "returns the correct answers for the eligibility's policy" do
+      answers = helper.eligibility_answers(claim)
+      expect(answers.first).to eq [I18n.t("questions.qts_award_year"), "On or after 1 September 2013", "qts-year"]
     end
   end
 
@@ -216,26 +199,6 @@ describe ClaimsHelper do
       ]
 
       expect(helper.student_loan_answers(claim)).to eq expected_answers
-    end
-  end
-
-  describe "subject_list" do
-    let(:list) { subject_list(subjects) }
-
-    context "with two subjects" do
-      let(:subjects) { [:biology_taught, :chemistry_taught] }
-
-      it "seperates the subjects with 'and" do
-        expect(list).to eq("Biology and Chemistry")
-      end
-    end
-
-    context "with three subjects" do
-      let(:subjects) { [:biology_taught, :chemistry_taught, :physics_taught] }
-
-      it "returns a comma separated list with a final 'and'" do
-        expect(list).to eq("Biology, Chemistry and Physics")
-      end
     end
   end
 end

--- a/spec/presenters/maths_and_physics/eligibility_answers_presenter_spec.rb
+++ b/spec/presenters/maths_and_physics/eligibility_answers_presenter_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
+  let(:eligibility) do
+    build(:maths_and_physics_eligibility,
+      teaching_maths_or_physics: true,
+      current_school: schools(:penistone_grammar_school),
+      initial_teacher_training_specialised_in_maths_or_physics: true,
+      qts_award_year: "on_or_after_september_2014",
+      employed_as_supply_teacher: false,
+      subject_to_disciplinary_action: false,
+      subject_to_formal_performance_action: false)
+  end
+  subject(:presenter) { described_class.new(eligibility) }
+
+  it "returns an array of questions and answers to be presented to the user for checking" do
+    expected_answers = [
+      [I18n.t("maths_and_physics.questions.teaching_maths_or_physics"), "Yes", "teaching-maths-or-physics"],
+      [I18n.t("questions.current_school"), "Penistone Grammar School", "current-school"],
+      [I18n.t("maths_and_physics.questions.initial_teacher_training_specialised_in_maths_or_physics"), "Yes", "initial-teacher-training-specialised-in-maths-or-physics"],
+      [I18n.t("questions.qts_award_year"), "On or after 1 September 2014", "qts-year"],
+      [I18n.t("maths_and_physics.questions.employed_as_supply_teacher"), "No", "supply-teacher"],
+      [I18n.t("maths_and_physics.questions.disciplinary_action"), "No", "disciplinary-action"],
+      [I18n.t("maths_and_physics.questions.formal_performance_action"), "No", "formal-performance-action"],
+    ]
+
+    expect(presenter.answers).to eq(expected_answers)
+  end
+
+  context "initial teacher training didn't specialise in maths or physics" do
+    let(:eligibility) do
+      build(:maths_and_physics_eligibility,
+        teaching_maths_or_physics: true,
+        current_school: schools(:penistone_grammar_school),
+        initial_teacher_training_specialised_in_maths_or_physics: false,
+        has_uk_maths_or_physics_degree: "has_non_uk",
+        qts_award_year: "on_or_after_september_2014",
+        employed_as_supply_teacher: false,
+        subject_to_disciplinary_action: false,
+        subject_to_formal_performance_action: false)
+    end
+
+    it "includes degree question" do
+      expected_answers = [
+        [I18n.t("maths_and_physics.questions.teaching_maths_or_physics"), "Yes", "teaching-maths-or-physics"],
+        [I18n.t("questions.current_school"), "Penistone Grammar School", "current-school"],
+        [I18n.t("maths_and_physics.questions.initial_teacher_training_specialised_in_maths_or_physics"), "No", "initial-teacher-training-specialised-in-maths-or-physics"],
+        [I18n.t("maths_and_physics.questions.has_uk_maths_or_physics_degree"), "I have a non-UK degree in Maths or Physics", "has-uk-maths-or-physics-degree"],
+        [I18n.t("questions.qts_award_year"), "On or after 1 September 2014", "qts-year"],
+        [I18n.t("maths_and_physics.questions.employed_as_supply_teacher"), "No", "supply-teacher"],
+        [I18n.t("maths_and_physics.questions.disciplinary_action"), "No", "disciplinary-action"],
+        [I18n.t("maths_and_physics.questions.formal_performance_action"), "No", "formal-performance-action"],
+      ]
+
+      expect(presenter.answers).to eq(expected_answers)
+    end
+  end
+
+  context "employed as supply teacher" do
+    let(:eligibility) do
+      build(:maths_and_physics_eligibility,
+        teaching_maths_or_physics: true,
+        current_school: schools(:penistone_grammar_school),
+        initial_teacher_training_specialised_in_maths_or_physics: true,
+        qts_award_year: "on_or_after_september_2014",
+        employed_as_supply_teacher: true,
+        has_entire_term_contract: true,
+        employed_directly: true,
+        subject_to_disciplinary_action: false,
+        subject_to_formal_performance_action: false)
+    end
+
+    it "includes supply teacher questions" do
+      expected_answers = [
+        [I18n.t("maths_and_physics.questions.teaching_maths_or_physics"), "Yes", "teaching-maths-or-physics"],
+        [I18n.t("questions.current_school"), "Penistone Grammar School", "current-school"],
+        [I18n.t("maths_and_physics.questions.initial_teacher_training_specialised_in_maths_or_physics"), "Yes", "initial-teacher-training-specialised-in-maths-or-physics"],
+        [I18n.t("questions.qts_award_year"), "On or after 1 September 2014", "qts-year"],
+        [I18n.t("maths_and_physics.questions.employed_as_supply_teacher"), "Yes", "supply-teacher"],
+        [I18n.t("maths_and_physics.questions.has_entire_term_contract"), "Yes", "entire-term-contract"],
+        [I18n.t("maths_and_physics.questions.employed_directly"), "Yes, I’m employed by my school", "employed-directly"],
+        [I18n.t("maths_and_physics.questions.disciplinary_action"), "No", "disciplinary-action"],
+        [I18n.t("maths_and_physics.questions.formal_performance_action"), "No", "formal-performance-action"],
+      ]
+
+      expect(presenter.answers).to eq(expected_answers)
+    end
+  end
+end

--- a/spec/presenters/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/presenters/student_loans/eligibility_answers_presenter_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
+  let(:school) { schools(:penistone_grammar_school) }
+  let(:eligibility_attributes) do
+    {
+      qts_award_year: "on_or_after_september_2013",
+      claim_school: school,
+      current_school: school,
+      had_leadership_position: true,
+      mostly_performed_leadership_duties: false,
+      student_loan_repayment_amount: 1987.65,
+    }.merge(subject_attributes)
+  end
+  let(:subject_attributes) { {chemistry_taught: true, physics_taught: true} }
+  let(:eligibility) do
+    build(
+      :student_loans_eligibility,
+      eligibility_attributes
+    )
+  end
+  subject(:presenter) { described_class.new(eligibility) }
+
+  it "returns an array of questions, answers, and slugs for displaying to the user for review" do
+    expected_answers = [
+      [I18n.t("questions.qts_award_year"), "On or after 1 September 2013", "qts-year"],
+      [I18n.t("student_loans.questions.claim_school"), school.name, "claim-school"],
+      [I18n.t("questions.current_school"), school.name, "still-teaching"],
+      [I18n.t("student_loans.questions.subjects_taught", school: school.name), "Chemistry and Physics", "subjects-taught"],
+      [I18n.t("student_loans.questions.leadership_position"), "Yes", "leadership-position"],
+      [I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "No", "mostly-performed-leadership-duties"],
+    ]
+
+    expect(presenter.answers).to eq expected_answers
+  end
+
+  it "excludes questions skipped from the flow" do
+    eligibility.had_leadership_position = false
+    expect(presenter.answers).to_not include([I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "Yes", "mostly-performed-leadership-duties"])
+    expect(presenter.answers).to_not include([I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "No", "mostly-performed-leadership-duties"])
+  end
+
+  context "with three subjects taught" do
+    let(:subject_attributes) { {chemistry_taught: true, physics_taught: true, biology_taught: true} }
+
+    it "separates the subjects with commas and a final 'and'" do
+      expect(presenter.answers[3][1]).to eq("Biology, Chemistry and Physics")
+    end
+  end
+end


### PR DESCRIPTION
This PR is the first step in building the `check-your-answers` page for Maths and Physics. There's a first refactor which lets us provide a per-policy class to format the answers for playback to the claimant. After that, I create this class for M&P.

I'm submitting this PR now, before building the whole `check-your-answers` feature, because:
1. I would like feedback on the approach (@tekin and I did talk about it a bit already though);
2. We will probably want to use a similar approach when [adapting the admin claims interface for M&P](https://trello.com/c/hgPHPmX4/991-admin-is-updated-to-accommodate-maths-physics-claims), so getting this in early means we can be consistent in our approach.