### PR TITLE
Allow admin to filter by policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Show policy next to claims in admin view
+- Allow admins to filter list of claims by policy
+
 ## [Release 036] - 2019-11-26
 
 - Hardcode VSP entity ID to fix our GOV.UK Verify journey

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -3,6 +3,8 @@ class Admin::ClaimsController < Admin::BaseAdminController
 
   def index
     @claims = Claim.includes(:check, eligibility: [:claim_school, :current_school]).awaiting_checking.order(:submitted_at)
+    @claims = @claims.by_policy(filtered_policy) if filtered_policy
+
     respond_to do |format|
       format.html
       format.csv {
@@ -28,5 +30,11 @@ class Admin::ClaimsController < Admin::BaseAdminController
     else
       flash.now[:notice] = "Cannot find a claim with reference \"#{params[:reference]}\""
     end
+  end
+
+  private
+
+  def filtered_policy
+    Policies[params[:policy]]
   end
 end

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -25,10 +25,10 @@ module Admin
     end
 
     def admin_student_loan_details(claim)
-      [
-        [t("student_loans.admin.student_loan_repayment_amount"), number_to_currency(claim.eligibility.student_loan_repayment_amount)],
-        [t("student_loans.admin.student_loan_repayment_plan"), claim.student_loan_plan&.humanize],
-      ]
+      [].tap do |a|
+        a << [t("student_loans.admin.student_loan_repayment_amount"), number_to_currency(claim.eligibility.student_loan_repayment_amount)] if claim.eligibility.respond_to?(:student_loan_repayment_amount)
+        a << [t("student_loans.admin.student_loan_repayment_plan"), claim.student_loan_plan&.humanize]
+      end
     end
 
     def admin_submission_details(claim)

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -144,6 +144,7 @@ class Claim < ApplicationRecord
   scope :approaching_check_deadline, -> { awaiting_checking.where("submitted_at < ? AND submitted_at > ?", CHECK_DEADLINE.ago + CHECK_DEADLINE_WARNING_POINT, CHECK_DEADLINE.ago) }
   scope :passed_check_deadline, -> { awaiting_checking.where("submitted_at < ?", CHECK_DEADLINE.ago) }
   scope :payrollable, -> { approved.left_joins(:payment).where(payments: {id: nil}) }
+  scope :by_policy, ->(policy) { where(eligibility_type: policy::Eligibility.to_s) }
 
   delegate :award_amount, to: :eligibility
 

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -24,4 +24,8 @@ module MathsAndPhysics
   def done_page_url
     nil
   end
+
+  def short_name
+    I18n.t("maths_and_physics.policy_short_name")
+  end
 end

--- a/app/models/policies.rb
+++ b/app/models/policies.rb
@@ -9,6 +9,10 @@ module Policies
     POLICIES
   end
 
+  def self.options_for_select
+    all.collect { |c| [c.short_name, c.routing_name] }
+  end
+
   # Returns a policy that matches the provided routing name
   # For example:
   #

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -30,4 +30,8 @@ module StudentLoans
   def done_page_url
     "https://www.gov.uk/done/claim-additional-teaching-payment"
   end
+
+  def short_name
+    I18n.t("student_loans.policy_short_name")
+  end
 end

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -15,6 +15,7 @@
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Reference</th>
             <th scope="col" class="govuk-table__header">Applicant Name</th>
+            <th scope="col" class="govuk-table__header">Service</th>
             <% if claims_with_warning.nonzero? %>
               <th scope="col" class="govuk-table__header">Check warning</th>
             <% end %>
@@ -27,6 +28,7 @@
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header"><%= claim.reference %></th>
               <td class="govuk-table__cell"><%= claim.full_name %></td>
+              <td class="govuk-table__cell"><%= claim.policy.short_name %></td>
               <% if claims_with_warning.nonzero? %>
                 <td class="govuk-table__cell"><%= check_deadline_warning(claim) %></td>
               <% end %>

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -5,6 +5,16 @@
       Claims
     </h1>
 
+    <%= form_with url: admin_claims_path, method: :get do |form| %>
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="policy">
+          Filter by service:
+        </label>
+        <%= form.select :policy, options_for_select(Policies.options_for_select, params[:policy]), {include_blank: "All"}, class: "govuk-select" %>
+        <%= form.submit "Go", class: "govuk-button govuk-button--secondary" %>
+      </div>
+    <% end %>
+
     <% if @claims.any? %>
       <% claims_with_warning = Claim.approaching_check_deadline.count + Claim.passed_check_deadline.count %>
 

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -22,7 +22,9 @@
 
     <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
 
-    <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim.eligibility)} %>
+    <% if @claim.policy == StudentLoans %>
+      <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim.eligibility)} %>
+    <% end %>
 
     <%= render "admin/claims/answer_section", {heading: "Student loan details", answers: admin_student_loan_details(@claim)} %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,7 @@ en:
     full_name: "Full name"
   maths_and_physics:
     policy_name: "Claim a payment for teaching maths or physics"
+    policy_short_name: "Maths and Physics"
     claim_description: "claim for a payment for teaching maths and physics"
     support_email_address: "mathsphysicsteacherpayment@digital.education.gov.uk"
     possible_rejection_reasons: |
@@ -121,6 +122,7 @@ en:
       formal_performance_action: "Are you currently subject to formal action for poor performance at work?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
+    policy_short_name: "Student Loans"
     claim_description: "claim to get back your student loan repayments"
     possible_rejection_reasons: |
       * you completed your initial teacher training before September 2013

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -95,8 +95,22 @@ RSpec.feature "Admin checks a claim" do
       it "shows the policy types on the index page" do
         click_on "View claims"
 
-        expect(page).to have_content("Maths and Physics").exactly(3).times
-        expect(page).to have_content("Student Loans").exactly(2).times
+        expect(page.find("table")).to have_content("Maths and Physics").exactly(3).times
+        expect(page.find("table")).to have_content("Student Loans").exactly(2).times
+      end
+
+      it "can filter by claim type" do
+        click_on "View claims"
+        select "Maths and Physics", from: "policy"
+        click_on "Go"
+
+        maths_and_physics_claims.each do |c|
+          expect(page).to have_content(c.reference)
+        end
+
+        student_loan_claims.each do |c|
+          expect(page).to_not have_content(c.reference)
+        end
       end
     end
   end

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -87,6 +87,18 @@ RSpec.feature "Admin checks a claim" do
         expect(page).to have_content("This claim cannot be approved, the payroll gender is missing")
       end
     end
+
+    context "with a mixture of policy types" do
+      let!(:maths_and_physics_claims) { create_list(:claim, 3, :submitted, policy: MathsAndPhysics) }
+      let!(:student_loan_claims) { create_list(:claim, 2, :submitted, policy: StudentLoans) }
+
+      it "shows the policy types on the index page" do
+        click_on "View claims"
+
+        expect(page).to have_content("Maths and Physics").exactly(3).times
+        expect(page).to have_content("Student Loans").exactly(2).times
+      end
+    end
   end
 
   context "User is logged in as a support user" do

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -17,6 +17,33 @@ RSpec.describe "Admin claims", type: :request do
       end
       expect(response.body).not_to include(checked_claim.reference)
     end
+
+    it "can filter by policy" do
+      maths_and_physics_claims = create_list(:claim, 3, :submitted, policy: MathsAndPhysics)
+      get admin_claims_path, params: {policy: "maths-and-physics"}
+
+      maths_and_physics_claims.each do |c|
+        expect(response.body).to include(c.reference)
+      end
+
+      claims.each do |c|
+        expect(response.body).to_not include(c.reference)
+      end
+    end
+
+    it "returns all claims if a policy does not exist" do
+      maths_and_physics_claims = create_list(:claim, 3, :submitted, policy: MathsAndPhysics)
+
+      get admin_claims_path, params: {policy: "non-existent-policy"}
+
+      maths_and_physics_claims.each do |c|
+        expect(response.body).to include(c.reference)
+      end
+
+      claims.each do |c|
+        expect(response.body).to include(c.reference)
+      end
+    end
   end
 
   describe "claims#show" do


### PR DESCRIPTION
This shows the policy in the admin view against each claim, and also allows users to filter by policy.

There will be some further work needed on this story, once the Check Your Answers work is done.

![image](https://user-images.githubusercontent.com/109774/69613370-5e4c8c80-1029-11ea-8d12-04f34a657d6f.png)

![image](https://user-images.githubusercontent.com/109774/69613390-67d5f480-1029-11ea-81e2-749be28be2b2.png)
