### PR TITLE
Hardcode the VSP entity ID

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -221,6 +221,9 @@
     },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "value": "true"
+    },
+    "VSP.VERIFY_ENTITY_ID": {
+      "value": "development.additional-teaching-payment.education.gov.uk"
     }
   }
 }

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -210,6 +210,9 @@
     },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "value": "true"
+    },
+    "VSP.VERIFY_ENTITY_ID": {
+      "value": "additional-teaching-payment.education.gov.uk"
     }
   }
 }

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -167,6 +167,9 @@
     },
     "VSP.EUROPEAN_IDENTITY_ENABLED": {
       "type": "string"
+    },
+    "VSP.VERIFY_ENTITY_ID": {
+      "type": "string"
     }
   },
   "variables": {
@@ -564,7 +567,7 @@
               },
               {
                 "name": "SERVICE_ENTITY_IDS",
-                "value": "[string(createArray(concat('https://', reference(resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))).outputs.appServiceCanonicalHostName.value)))]"
+                "value": "[string(createArray(parameters('VSP.VERIFY_ENTITY_ID')))]"
               },
               {
                 "name": "SAML_SIGNING_KEY",


### PR DESCRIPTION
Since we switched to the service domain, we accidentally switched the VSP entity ID too, as it's tied to the canonical domain. This hardcodes the ID, so it's no longer tied to the domain, as Verify don't really care if it's related to the domain (it's a abitary string)
