### PR TITLE
Use Canonical Hostname for DfE Signin base URL

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -124,14 +124,6 @@
         "secretName": "DfeSignInSecret"
       }
     },
-    "DFE_SIGN_IN_REDIRECT_BASE_URL": {
-      "reference": {
-        "keyVault": {
-          "id": "${keyVaultId}"
-        },
-        "secretName": "DfeSignInRedirectBaseUrl"
-      }
-    },
     "DFE_SIGN_IN_API_CLIENT_ID": {
       "reference": {
         "keyVault": {

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -108,14 +108,6 @@
         "secretName": "DfeSignInSecret"
       }
     },
-    "DFE_SIGN_IN_REDIRECT_BASE_URL": {
-      "reference": {
-        "keyVault": {
-          "id": "${keyVaultId}"
-        },
-        "secretName": "DfeSignInRedirectBaseUrl"
-      }
-    },
     "DFE_SIGN_IN_API_CLIENT_ID": {
       "reference": {
         "keyVault": {

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -114,9 +114,6 @@
     "DFE_SIGN_IN_ISSUER": {
       "type": "string"
     },
-    "DFE_SIGN_IN_REDIRECT_BASE_URL": {
-      "type": "string"
-    },
     "DFE_SIGN_IN_IDENTIFIER": {
       "type": "securestring"
     },
@@ -229,6 +226,8 @@
     "appServiceRuntimeStack": "[concat('COMPOSE|', base64(parameters('appServiceDockerCompose')))]",
 
     "appServiceWebTestName": "[concat(variables('appServiceName'), '-webtest')]",
+
+    "canonicalHostname": "[if(parameters('useAppServiceHostNames'), first(parameters('appServiceHostNames')), concat(variables('appServiceName'), '.azurewebsites.net'))]",
 
     "vspAppServicePlanName": "[concat(parameters('resourceNamePrefix'), '-vsp-asp')]",
     "vspAppServiceName": "[concat(parameters('resourceNamePrefix'), '-vsp-as')]",
@@ -358,7 +357,7 @@
               },
               {
                 "name": "CANONICAL_HOSTNAME",
-                "value": "[if(parameters('useAppServiceHostNames'), first(parameters('appServiceHostNames')), concat(variables('appServiceName'), '.azurewebsites.net'))]"
+                "value": "[variables('canonicalHostname')]"
               },
               {
                 "name": "DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME",
@@ -398,7 +397,7 @@
               },
               {
                 "name": "DFE_SIGN_IN_REDIRECT_BASE_URL",
-                "value": "[parameters('DFE_SIGN_IN_REDIRECT_BASE_URL')]"
+                "value": "[concat('https://', variables('canonicalHostname'))]"
               },
               {
                 "name": "DFE_SIGN_IN_IDENTIFIER",


### PR DESCRIPTION
This will always be whatever hostname is the canonical one, so, in case we move domain again, this will ensure the redirect URL is set correctly. We'll still need to get DfE Signin to whitelist the URL, but it's one less thing for us to think about
