### PR TITLE
Add a script to allow access to the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add script to get a console on a container instance
 - Stop running workers in the same instance as the web app
 - Show policy next to claims in admin view
 - Allow admins to filter list of claims by policy

--- a/README.md
+++ b/README.md
@@ -106,6 +106,46 @@ bundle exec rake
 
 To run the feature specs you will need Chrome installed.
 
+### Running a live console
+
+**Accessing a live console is very risky and should only be done as a last
+resort. This should only be done in pairs, and mutating any live data is
+STRONGLY discouraged.**
+
+The console will be ran inside a container instance and won't be on one of the
+web servers, however it will have access to the database.
+
+#### Through the Azure UI
+
+- Navigate to the
+  [container instance](https://portal.azure.com/#blade/HubsExtension/BrowseResourceBlade/resourceType/Microsoft.ContainerInstance%2FcontainerGroups)
+  resource (eg. `s118d01-app-worker-aci`)
+- Then go to 'Containers' under 'Settings'
+- With the container selected go to the 'Connect' tab
+- Choose the start up command (`/bin/bash` is recommended) and connect
+
+#### Through the Azure CLI
+
+We have a helpful script you can run that will connect you to the right resource
+(you will need the [Azure CLI](https://docs.microsoft.com/en-gb/cli) installed
+first):
+
+```bash
+bin/azure-console $ENVIRONMENT # (development/production)
+```
+
+#### Usage
+
+If you don't need to modify the data and only need to do queries it is
+recommended that you run rails console in sandbox mode
+`rails console --sandbox`.
+
+In exceptional circumstances you may want to modify the data, this should only
+be done with approval from the Service Owner and is to be carried out in pairs.
+
+Accessing a live console on production requires a
+[PIM (Privileged Identity Management) request](https://dfedigital.atlassian.net/wiki/spaces/TP/pages/1192624202/Privileged+Identity+Management+requests).
+
 ### Code linting rules
 
 Code linting is performed using:

--- a/bin/azure-console
+++ b/bin/azure-console
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+ENVIRONMENT_NAME=$1
+
+case $ENVIRONMENT_NAME in
+  "development")
+    SUBSCRIPTION_ID="8655985a-2f87-44d7-a541-0be9a8c2779d"
+    RESOURCE_GROUP_PREFIX="s118d01"
+    ;;
+  "production")
+    SUBSCRIPTION_ID="88bd392f-df19-458b-a100-22b4429060ed"
+    RESOURCE_GROUP_PREFIX="s118p01"
+    ;;
+  *)
+    echo "Could not find a known environment with the name: $ENVIRONMENT_NAME"
+    exit 1
+    ;;
+esac
+
+if [[ $ENVIRONMENT_NAME == "production" ]]; then
+  echo "**********************************************************************************************************************"
+  echo "You will need to make a PIM request to access the console"
+  echo "Visit https://portal.azure.com/#blade/Microsoft_Azure_PIMCommon/ActivationMenuBlade/azurerbac"
+  echo "and activate the 'Contributor' role for the 's118-teacherpaymentsservice-production' environment."
+  echo "Once this has been approved, press enter to continue"
+  echo "**********************************************************************************************************************"
+
+  read -p "" -r
+
+  echo "Logging out of Azure and back in to grab new tokens"
+  if az account show > /dev/null; then
+    az logout > /dev/null
+  fi
+fi
+
+if ! az account show > /dev/null; then
+  az login > /dev/null
+fi
+
+echo "**********************************************************************************************************************"
+echo "IMPORTANT: Accessing the $ENVIRONMENT_NAME console in this way is VERY risky and should only be done as a last resort"
+echo "This should only be done in pairs, and mutating any live data is STRONGLY discouraged."
+echo "**********************************************************************************************************************"
+
+echo
+
+read -p "Are you sure you want to continue? (y/n)" -n 1 -r
+echo
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  az account set --subscription "$SUBSCRIPTION_ID"
+
+  az container exec \
+    --name=$RESOURCE_GROUP_PREFIX-app-worker-aci \
+    --resource-group=$RESOURCE_GROUP_PREFIX-app \
+    --exec-command="/bin/bash"
+
+  exit 0
+else
+  echo "Quitting"
+  exit 0
+fi


### PR DESCRIPTION
This gives us bash console access to the worker container, which, in turn will allow us to access the Rails console, with appropriate warnings as to the severity and last-resort nature of running this command. I did consider dropping the user straight into the Rails console for this, but `az container exec` doesn't support this (https://docs.microsoft.com/en-us/azure/container-instances/container-instances-exec#restrictions)
