### PR TITLE
Add school name to subjects-taught page title

### DIFF
--- a/app/views/student_loans/claims/subjects_taught.html.erb
+++ b/app/views/student_loans/claims/subjects_taught.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.subjects_taught"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(t("student_loans.questions.subjects_taught", school: current_claim.eligibility.claim_school_name), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
(I noticed that the page title was showing a %{school} placeholder.)