### PR TITLE
Maths & Physics content snags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog]
 - Allow admins to filter list of claims by policy
 - Update Maths & Physics sequence with new ITT specialism questions
 - Adjust Maths & Physics private beta start page content
+- Correct wording in Maths & Physics claim emails
 
 ## [Release 036] - 2019-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog]
 - Adjust Maths & Physics private beta start page content
 - Correct wording in Maths & Physics claim emails
 - Remove explicit mention of Student Loans policy on accessibility statement
+- Update re-apply date on performance/disciplinary ineligibility pages
 
 ## [Release 036] - 2019-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog]
 - Update Maths & Physics sequence with new ITT specialism questions
 - Adjust Maths & Physics private beta start page content
 - Correct wording in Maths & Physics claim emails
+- Remove explicit mention of Student Loans policy on accessibility statement
 
 ## [Release 036] - 2019-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog]
 - Show policy next to claims in admin view
 - Allow admins to filter list of claims by policy
 - Update Maths & Physics sequence with new ITT specialism questions
+- Adjust Maths & Physics private beta start page content
 
 ## [Release 036] - 2019-11-26
 

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_subject_to_disciplinary_action.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_subject_to_disciplinary_action.html.erb
@@ -8,6 +8,6 @@
 </p>
 
 <div class="govuk-inset-text">
-  If you’re cleared, or your warning expires by 31 January 2020 you
+  If you’re cleared, or your warning expires by 28 February 2020 you
   can apply again.
 </div>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_subject_to_formal_performance_action.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_subject_to_formal_performance_action.html.erb
@@ -8,6 +8,6 @@
 </p>
 
 <div class="govuk-inset-text">
-  If the action has ended and any warnings have expired by 31 January 2020 you
+  If the action has ended and any warnings have expired by 28 February 2020 you
   can apply again.
 </div>

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -100,16 +100,6 @@
     </p>
 
     <p class="govuk-body">
-      We tested:
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        the ‘<%= policy_service_name(current_policy_routing_name) %> service’
-      </li>
-    </ul>
-
-    <p class="govuk-body">
       This statement was prepared on 31 July 2019. It was last updated on 18 September 2019.
     </p>
 

--- a/app/views/static_pages/maths_and_physics.html.erb
+++ b/app/views/static_pages/maths_and_physics.html.erb
@@ -42,9 +42,9 @@
       </li>
       <li>the date you completed your initial teacher training</li>
       <li>
-        sign in details for ‘Verify’ — the government’s secure way of proving
-        who you are, if you do not have a Verify account, you’ll need your
-        passport or photocard driving licence to sign up
+        your passport or photocard driving licence to prove your identity
+        using GOV.UK Verify — if you’ve used GOV.UK Verify before, you’ll just
+        need your sign-in details
       </li>
     </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,7 @@ en:
   maths_and_physics:
     policy_name: "Claim a payment for teaching maths or physics"
     policy_short_name: "Maths and Physics"
-    claim_description: "claim for a payment for teaching maths and physics"
+    claim_description: "claim for a payment for teaching maths or physics"
     support_email_address: "mathsphysicsteacherpayment@digital.education.gov.uk"
     possible_rejection_reasons: |
       * you are not employed to teach maths or physics at an eligible state-funded secondary school


### PR DESCRIPTION
Just the simple stuff for now:

- Adjust Maths & Physics private beta start page content
- Correct wording in Maths & Physics claim emails
- Remove explicit mention of Student Loans policy on accessibility statement
- Update re-apply date on performance/disciplinary ineligibility pages