### PR TITLE
Release 37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+## [Release 037] - 2019-11-28
+
 - Redesign the layout of the payment confirmation email
 - Add script to get a console on a container instance
 - Stop running workers in the same instance as the web app
@@ -283,7 +285,9 @@ The format is based on [Keep a Changelog]
 - First release for student loan repayments private beta
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-036...HEAD
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-037...HEAD
+[release 037]:
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-036...release-037
 [release 036]:
   https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-035...release-036
 [release 035]:


### PR DESCRIPTION
- Redesign the layout of the payment confirmation email
- Add script to get a console on a container instance
- Stop running workers in the same instance as the web app
- Show policy next to claims in admin view
- Allow admins to filter list of claims by policy
- Update Maths & Physics sequence with new ITT specialism questions
- Adjust Maths & Physics private beta start page content
- Correct wording in Maths & Physics claim emails
- Remove explicit mention of Student Loans policy on accessibility statement
- Update re-apply date on performance/disciplinary ineligibility pages
- Increase the claim checking deadline date to 12 weeks
- Privacy notice wording works for Maths & Physics
- A teacher can submit a Maths and Physics claim
- "How we use the information you provided" content works for both policies
