### PR TITLE
Cantium can download the payroll file themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Service operators can see Maths and Physics claim eligibility
-- Fix a bug that would occassionally redirect users even after they'd continued
+- Fix a bug that would occasionally redirect users even after they'd continued
   their session
 - Redirect requests to the root URL to a GOV.UK page about teacher payments
+- Service operators can create and view a payroll run and provide a link to
+  payroll operators (Cantium users) to download a file
+- Payroll operators can download the payroll run file using a link
 
 ## [Release 037] - 2019-11-28
 

--- a/app/assets/javascripts/components/auto_click_link.js
+++ b/app/assets/javascripts/components/auto_click_link.js
@@ -1,0 +1,10 @@
+"use strict";
+
+document.addEventListener("DOMContentLoaded", function() {
+  var linkElement = document.querySelector("[data-auto-follow-link=true]");
+
+  if (linkElement)
+    window.setTimeout(function() {
+      linkElement.click();
+    }, 3 * 1000);
+});

--- a/app/assets/javascripts/components/copy_to_clipboard.js
+++ b/app/assets/javascripts/components/copy_to_clipboard.js
@@ -1,0 +1,26 @@
+"use strict";
+
+document.addEventListener("DOMContentLoaded", function() {
+  var fields = document.querySelectorAll("[data-copy-to-clipboard=true]");
+
+  fields.forEach(function(field) {
+    field.parentNode.appendChild(copyLinkBuilder(field));
+  });
+
+  function copyToClipboard(fieldToCopy) {
+    fieldToCopy.select();
+    document.execCommand("copy");
+  }
+
+  function copyLinkBuilder(fieldToCopy) {
+    var copyButton = document.createElement("button");
+    copyButton.innerHTML = "Copy to clipboard";
+    copyButton.className = "govuk-button govuk-!-margin-top-2";
+    copyButton.setAttribute("data-module", "govuk-button");
+    copyButton.addEventListener("click", function() {
+      copyToClipboard(fieldToCopy);
+    });
+
+    return copyButton;
+  }
+});

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -45,8 +45,24 @@ module Admin
       admin_session.is_service_operator?
     end
 
+    def payroll_operator_signed_in?
+      admin_session.is_payroll_operator?
+    end
+
+    def support_agent_signed_in?
+      admin_session.is_support_agent?
+    end
+
+    def ensure_service_team
+      render "admin/auth/failure", status: :unauthorized unless service_operator_signed_in? || support_agent_signed_in?
+    end
+
     def ensure_service_operator
       render "admin/auth/failure", status: :unauthorized unless service_operator_signed_in?
+    end
+
+    def ensure_payroll_operator
+      render "admin/auth/failure", status: :unauthorized unless payroll_operator_signed_in?
     end
   end
 end

--- a/app/controllers/admin/page_controller.rb
+++ b/app/controllers/admin/page_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class PageController < BaseAdminController
+    before_action :ensure_service_team
+
     def index
     end
   end

--- a/app/controllers/admin/payroll_run_downloads_controller.rb
+++ b/app/controllers/admin/payroll_run_downloads_controller.rb
@@ -1,5 +1,5 @@
 class Admin::PayrollRunDownloadsController < Admin::BaseAdminController
-  before_action :ensure_service_operator, :find_payroll_run
+  before_action :ensure_payroll_operator, :find_payroll_run
 
   before_action :ensure_download_has_been_triggered, only: :show
   before_action :ensure_download_is_available, only: :show

--- a/app/controllers/admin/payroll_run_downloads_controller.rb
+++ b/app/controllers/admin/payroll_run_downloads_controller.rb
@@ -1,5 +1,45 @@
 class Admin::PayrollRunDownloadsController < Admin::BaseAdminController
+  before_action :ensure_service_operator, :find_payroll_run
+
+  before_action :ensure_download_has_been_triggered, only: :show
+  before_action :ensure_download_is_available, only: :show
+  before_action :ensure_download_not_already_triggered, only: [:new, :create]
+
   def new
+  end
+
+  def create
+    @payroll_run.update!(downloaded_at: Time.zone.now, downloaded_by: admin_session.user_id)
+
+    redirect_to admin_payroll_run_download_path(@payroll_run)
+  end
+
+  def show
+    respond_to do |format|
+      format.html
+      format.csv do
+        csv = Payroll::ClaimsCsv.new(@payroll_run)
+        send_file csv.file, type: "text/csv", filename: csv.filename
+      end
+    end
+  end
+
+  private
+
+  def find_payroll_run
     @payroll_run = PayrollRun.find(params[:payroll_run_id])
+  end
+
+  def ensure_download_not_already_triggered
+    redirect_to admin_payroll_run_download_path(@payroll_run) if @payroll_run.download_triggered?
+  end
+
+  def ensure_download_has_been_triggered
+    redirect_to new_admin_payroll_run_download_path(@payroll_run) unless @payroll_run.download_triggered?
+  end
+
+  def ensure_download_is_available
+    return unless request.format.csv?
+    redirect_to admin_payroll_run_download_path(@payroll_run, format: :html) unless @payroll_run.download_available?
   end
 end

--- a/app/controllers/admin/payroll_run_downloads_controller.rb
+++ b/app/controllers/admin/payroll_run_downloads_controller.rb
@@ -1,0 +1,5 @@
+class Admin::PayrollRunDownloadsController < Admin::BaseAdminController
+  def new
+    @payroll_run = PayrollRun.find(params[:payroll_run_id])
+  end
+end

--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -20,14 +20,6 @@ module Admin
 
     def show
       @payroll_run = PayrollRun.find(params[:id])
-
-      respond_to do |format|
-        format.html
-        format.csv do
-          csv = Payroll::ClaimsCsv.new(@payroll_run)
-          send_file csv.file, type: "text/csv", filename: csv.filename
-        end
-      end
     end
   end
 end

--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -15,7 +15,7 @@ module Admin
 
       payroll_run = PayrollRun.create_with_claims!(claims, created_by: admin_session.user_id)
 
-      redirect_to [:admin, payroll_run]
+      redirect_to [:admin, payroll_run], notice: "Payroll run created"
     end
 
     def show

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -1,4 +1,6 @@
 class PayrollRun < ApplicationRecord
+  DOWNLOAD_FILE_TIMEOUT = 30
+
   has_many :payments
   has_many :claims, through: :payments
 
@@ -20,6 +22,14 @@ class PayrollRun < ApplicationRecord
         end
       end
     end
+  end
+
+  def download_triggered?
+    downloaded_at.present? && downloaded_by.present?
+  end
+
+  def download_available?
+    download_triggered? && Time.zone.now - downloaded_at < DOWNLOAD_FILE_TIMEOUT.seconds
   end
 
   private

--- a/app/views/admin/payroll_run_downloads/new.html.erb
+++ b/app/views/admin/payroll_run_downloads/new.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= @payroll_run.created_at.strftime("%B") %> payroll file
+    </h1>
+
+    <p class="govuk-body">
+      This month's payroll file is ready for processing.
+    </p>
+
+    <p class="govuk-body govuk-!-font-weight-bold">
+      NOTE: You will only be able to download this file once.
+    </p>
+  </div>
+</div>

--- a/app/views/admin/payroll_run_downloads/new.html.erb
+++ b/app/views/admin/payroll_run_downloads/new.html.erb
@@ -11,5 +11,9 @@
     <p class="govuk-body govuk-!-font-weight-bold">
       NOTE: You will only be able to download this file once.
     </p>
+
+    <%= form_with url: admin_payroll_run_download_path(@payroll_run) do %>
+      <%= submit_tag "Download payroll file", class: "govuk-button" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/payroll_run_downloads/show.html.erb
+++ b/app/views/admin/payroll_run_downloads/show.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= @payroll_run.created_at.strftime("%B") %> payroll file
+    </h1>
+
+    <% if @payroll_run.download_available? %>
+      <p class="govuk-body">
+        The payroll run file is available for 30 seconds. If the download does not start automatically, click on the link below
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        This month's payroll file was downloaded on
+        <%= l(@payroll_run.downloaded_at) %> by
+        <%= @payroll_run.downloaded_by %>.
+      </p>
+      <p class="govuk-body">
+        For security and privacy, this payroll file can only be downloaded once.
+      </p>
+    <% end %>
+
+  </div>
+  <div class="govuk-grid-column-full">
+    <%= link_to "Download #{@payroll_run.created_at.strftime("%B")} payroll file", admin_payroll_run_download_path(@payroll_run, format: :csv), class: ["govuk-body", "govuk-link"] if @payroll_run.download_available? %>
+  </div>
+</div>

--- a/app/views/admin/payroll_run_downloads/show.html.erb
+++ b/app/views/admin/payroll_run_downloads/show.html.erb
@@ -21,6 +21,6 @@
 
   </div>
   <div class="govuk-grid-column-full">
-    <%= link_to "Download #{@payroll_run.created_at.strftime("%B")} payroll file", admin_payroll_run_download_path(@payroll_run, format: :csv), class: ["govuk-body", "govuk-link"] if @payroll_run.download_available? %>
+    <%= link_to "Download #{@payroll_run.created_at.strftime("%B")} payroll file", admin_payroll_run_download_path(@payroll_run, format: :csv), class: ["govuk-body", "govuk-link"], data: { "auto-follow-link": "true" } if @payroll_run.download_available? %>
   </div>
 </div>

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -3,15 +3,17 @@
     <h1 class="govuk-heading-xl">
       Payroll
     </h1>
-  </div>
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Make a payroll file containing all the relevant information for approved claims to be paid by Cantium.</p>
 
     <div class="govuk-inset-text">
-      The next payroll file must be with Cantium on or before <%= l(next_payroll_file_to_cantium_due_date) %>
+      The next payroll run must be with Cantium on or before <%= l(next_payroll_file_to_cantium_due_date) %>
     </div>
 
-    <%= link_to 'Prepare payroll file', new_admin_payroll_run_path, class: "govuk-button", data: {module: "govuk-button"} if PayrollRun.this_month.empty? %>
+    <%= link_to(
+          "Run #{Date.today.strftime("%B")} payroll",
+          new_admin_payroll_run_path,
+          class: "govuk-button",
+          data: {module: "govuk-button"}
+        ) if PayrollRun.this_month.empty? %>
   </div>
   <div class="govuk-grid-column-full">
     <table class="govuk-table">

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -23,6 +23,7 @@
           <th scope="col" class="govuk-table__header">Date</th>
           <th scope="col" class="govuk-table__header">Approved claims</th>
           <th scope="col" class="govuk-table__header">Payment Confirmation Report</th>
+          <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Payroll actions</span></th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -35,6 +36,11 @@
                 Uploaded
               <% else %>
                 <%= link_to("Upload", new_admin_payroll_run_payment_confirmation_report_upload_path(payroll_run), class: "govuk-link") %>
+              <% end %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= link_to admin_payroll_run_path(payroll_run), class: "govuk-link" do %>
+                View <span class="govuk-visually-hidden"> <%= payroll_run.created_at.strftime("%B") %> payroll run</span>
               <% end %>
             </td>
           </tr>

--- a/app/views/admin/payroll_runs/new.html.erb
+++ b/app/views/admin/payroll_runs/new.html.erb
@@ -1,10 +1,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Create payroll file
+      Run <%= Date.today.strftime("%B") %> payroll
     </h1>
 
-    <p class="govuk-body">Below is a preview of the payroll file, you can see how many approved claims will be included and the total award amount.</p>
+    <p class="govuk-body">
+      Below is a preview of the payroll run for <%= Date.today.strftime("%B") %>.
+      You can see how many approved claims will be included and the total award amount.
+    </p>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
       <div class="govuk-summary-list__row">
@@ -33,5 +36,5 @@
   <% @payroll_run.claims.each do |claim| %>
     <%= hidden_field_tag "claim_ids[]", claim.id %>
   <% end %>
-  <%= form.submit "Create payroll file", class: "govuk-button", data: {module: "govuk-button"} %>
+  <%= form.submit "Confirm and submit", class: "govuk-button", data: {module: "govuk-button"} %>
 <% end %>

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -23,6 +23,15 @@
           <%= number_to_currency(@payroll_run.total_award_amount) %>
         </dd>
       </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Downloaded
+        </dt>
+
+        <dd class="govuk-summary-list__value">
+          <%= @payroll_run.download_triggered? ? l(@payroll_run.downloaded_at) : "No" %>
+        </dd>
+      </div>
     </dl>
   </div>
   <% unless @payroll_run.download_triggered? %>

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -4,8 +4,6 @@
       <%= @payroll_run.created_at.strftime("%B") %> payroll run
     </h1>
 
-    <p class="govuk-body">The payroll file has been created and can be downloaded.</p>
-
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -27,6 +25,14 @@
       </div>
     </dl>
   </div>
+  <% unless @payroll_run.download_triggered? %>
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">
+        You can now send this link to Cantium for processing.
+      </p>
+    </div>
+    <div class="govuk-grid-column-full">
+      <%= text_field_tag "payroll_run_download_link", new_admin_payroll_run_download_url(@payroll_run), readonly: true, class: ["govuk-input"] %>
+    </div>
+  <% end %>
 </div>
-
-<%= link_to 'Download payroll file', { model: [:admin, @payroll_run], format: :csv }, class: "govuk-button", data: {module: "govuk-button"} %>

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Download payroll file
+      <%= @payroll_run.created_at.strftime("%B") %> payroll run
     </h1>
 
     <p class="govuk-body">The payroll file has been created and can be downloaded.</p>
@@ -29,4 +29,4 @@
   </div>
 </div>
 
-<%= link_to 'Download file', { model: [:admin, @payroll_run], format: :csv }, class: "govuk-button", data: {module: "govuk-button"} %>
+<%= link_to 'Download payroll file', { model: [:admin, @payroll_run], format: :csv }, class: "govuk-button", data: {module: "govuk-button"} %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,31 +3,11 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "088b9c30d95759306b85565ec31d51856b7e8c37f8ea8ee74f85debc608f2ca8",
-      "check_name": "SendFile",
-      "message": "Model attribute used in file name",
-      "file": "app/controllers/admin/payroll_runs_controller.rb",
-      "line": 28,
-      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(Payroll::ClaimsCsv.new(PayrollRun.find(params[:id])).file, :type => \"text/csv\", :filename => Payroll::ClaimsCsv.new(PayrollRun.find(params[:id])).filename)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Admin::PayrollRunsController",
-        "method": "show"
-      },
-      "user_input": "Payroll::ClaimsCsv.new(PayrollRun.find(params[:id])).file",
-      "confidence": "Medium",
-      "note": "We generate the filename based on non-user input so we can ignore this"
-    },
-    {
-      "warning_type": "File Access",
-      "warning_code": 16,
       "fingerprint": "13cc1ba0eab122ed9ac8800c10cc642df54a9dcef897fc4c0e5c3fadaf1c680e",
       "check_name": "SendFile",
       "message": "Model attribute used in file name",
       "file": "app/controllers/admin/payroll_run_downloads_controller.rb",
-      "line": 18,
+      "line": 22,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "send_file(Payroll::ClaimsCsv.new(PayrollRun.find(params[:payroll_run_id])).file, :type => \"text/csv\", :filename => Payroll::ClaimsCsv.new(PayrollRun.find(params[:payroll_run_id])).filename)",
       "render_path": null,
@@ -41,6 +21,6 @@
       "note": "We generate the filename based on non-user input so we can ignore this"
     }
   ],
-  "updated": "2019-12-04 12:02:54 +0000",
+  "updated": "2019-12-04 13:06:34 +0000",
   "brakeman_version": "4.7.2"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "SendFile",
       "message": "Model attribute used in file name",
       "file": "app/controllers/admin/payroll_runs_controller.rb",
-      "line": 25,
+      "line": 28,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "send_file(Payroll::ClaimsCsv.new(PayrollRun.find(params[:id])).file, :type => \"text/csv\", :filename => Payroll::ClaimsCsv.new(PayrollRun.find(params[:id])).filename)",
       "render_path": null,
@@ -19,8 +19,28 @@
       "user_input": "Payroll::ClaimsCsv.new(PayrollRun.find(params[:id])).file",
       "confidence": "Medium",
       "note": "We generate the filename based on non-user input so we can ignore this"
+    },
+    {
+      "warning_type": "File Access",
+      "warning_code": 16,
+      "fingerprint": "13cc1ba0eab122ed9ac8800c10cc642df54a9dcef897fc4c0e5c3fadaf1c680e",
+      "check_name": "SendFile",
+      "message": "Model attribute used in file name",
+      "file": "app/controllers/admin/payroll_run_downloads_controller.rb",
+      "line": 18,
+      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
+      "code": "send_file(Payroll::ClaimsCsv.new(PayrollRun.find(params[:payroll_run_id])).file, :type => \"text/csv\", :filename => Payroll::ClaimsCsv.new(PayrollRun.find(params[:payroll_run_id])).filename)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Admin::PayrollRunDownloadsController",
+        "method": "show"
+      },
+      "user_input": "Payroll::ClaimsCsv.new(PayrollRun.find(params[:payroll_run_id])).file",
+      "confidence": "Medium",
+      "note": "We generate the filename based on non-user input so we can ignore this"
     }
   ],
-  "updated": "2019-10-15 09:59:23 +0100",
-  "brakeman_version": "4.6.1"
+  "updated": "2019-12-04 12:02:54 +0000",
+  "brakeman_version": "4.7.2"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,7 @@ Rails.application.routes.draw do
 
     resources :payroll_runs, only: [:index, :new, :create, :show] do
       resources :payment_confirmation_report_uploads, only: [:new, :create]
-      resource :download, only: [:new], controller: "payroll_run_downloads"
+      resource :download, only: [:new, :create, :show], controller: "payroll_run_downloads"
     end
 
     resources :policy_configurations, only: [:index, :edit, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
 
     resources :payroll_runs, only: [:index, :new, :create, :show] do
       resources :payment_confirmation_report_uploads, only: [:new, :create]
+      resource :download, only: [:new], controller: "payroll_run_downloads"
     end
 
     resources :policy_configurations, only: [:index, :edit, :update]

--- a/db/migrate/20191126083258_add_downloaded_at_and_by_to_payroll_runs.rb
+++ b/db/migrate/20191126083258_add_downloaded_at_and_by_to_payroll_runs.rb
@@ -1,0 +1,6 @@
+class AddDownloadedAtAndByToPayrollRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_column :payroll_runs, :downloaded_at, :datetime
+    add_column :payroll_runs, :downloaded_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -137,6 +137,8 @@ ActiveRecord::Schema.define(version: 2019_12_03_103255) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "confirmation_report_uploaded_by"
+    t.datetime "downloaded_at"
+    t.string "downloaded_by"
     t.index ["created_at"], name: "index_payroll_runs_on_created_at"
   end
 
@@ -167,6 +169,7 @@ ActiveRecord::Schema.define(version: 2019_12_03_103255) do
     t.uuid "local_authority_district_id"
     t.date "close_date"
     t.integer "establishment_number"
+    t.integer "statutory_high_age"
     t.index ["created_at"], name: "index_schools_on_created_at"
     t.index ["local_authority_district_id"], name: "index_schools_on_local_authority_district_id"
     t.index ["local_authority_id"], name: "index_schools_on_local_authority_id"

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -115,18 +115,18 @@ RSpec.feature "Admin checks a claim" do
     end
   end
 
-  context "User is logged in as a support user" do
-    before do
-      sign_in_to_admin_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
-    end
+  context "User is logged in as a payroll operator or a support user" do
+    [AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
+      scenario "User cannot view claims to check" do
+        sign_in_to_admin_with_role(role)
 
-    scenario "User cannot view claims to check" do
-      expect(page).to_not have_link(nil, href: admin_claims_path)
+        expect(page).to_not have_link(nil, href: admin_claims_path)
 
-      visit admin_claims_path
+        visit admin_claims_path
 
-      expect(page.status_code).to eq(401)
-      expect(page).to have_content("Not authorised")
+        expect(page.status_code).to eq(401)
+        expect(page).to have_content("Not authorised")
+      end
     end
   end
 end

--- a/spec/features/admin_payroll_run_download_spec.rb
+++ b/spec/features/admin_payroll_run_download_spec.rb
@@ -9,5 +9,14 @@ RSpec.feature "Payroll run download" do
     visit new_admin_payroll_run_download_path(payroll_run)
 
     expect(page).to have_content "This month's payroll file is ready for processing."
+
+    click_on "Download payroll file"
+
+    click_on "Download #{payroll_run.created_at.strftime("%B")} payroll file"
+
+    expect(page.response_headers["Content-Type"]).to eq("text/csv")
+
+    csv = CSV.parse(body, headers: true)
+    expect(csv.count).to eq(3)
   end
 end

--- a/spec/features/admin_payroll_run_download_spec.rb
+++ b/spec/features/admin_payroll_run_download_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.feature "Payroll run download" do
+  scenario "User can download a payroll run file" do
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+
+    payroll_run = create(:payroll_run, claims_counts: {StudentLoans: 2, MathsAndPhysics: 1})
+
+    visit new_admin_payroll_run_download_path(payroll_run)
+
+    expect(page).to have_content "This month's payroll file is ready for processing."
+  end
+end

--- a/spec/features/admin_payroll_run_download_spec.rb
+++ b/spec/features/admin_payroll_run_download_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Payroll run download" do
   scenario "User can download a payroll run file" do
-    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_to_admin_with_role(AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
 
     payroll_run = create(:payroll_run, claims_counts: {StudentLoans: 2, MathsAndPhysics: 1})
 

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -72,6 +72,22 @@ RSpec.feature "Payroll" do
 
     expect(page).to have_content(I18n.l(first_payroll_run.created_at.to_date))
     expect(page).to have_content(I18n.l(last_payroll_run.created_at.to_date))
+
+    expect(page).to have_link "View", href: admin_payroll_run_path(first_payroll_run)
+    expect(page).to have_link "View", href: admin_payroll_run_path(last_payroll_run)
+  end
+
+  scenario "Service operator can view a payroll run" do
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+
+    payroll_run = create(:payroll_run, created_at: Time.zone.now)
+
+    click_on "Payroll"
+    click_on "View #{payroll_run.created_at.strftime("%B")} payroll run"
+
+    expect(page).to have_content payroll_run.claims.count
+    expect(page).to have_content "Downloaded No"
+    expect(page).to have_field("payroll_run_download_link", with: new_admin_payroll_run_download_url(payroll_run))
   end
 
   scenario "Service operator can upload a Payment Confirmation Report against a payroll run" do

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -12,17 +12,18 @@ RSpec.feature "Payroll" do
     create(:claim, :approved, policy: StudentLoans)
     create(:claim, :approved, policy: StudentLoans)
 
-    click_on "Prepare payroll"
+    month_name = Date.today.strftime("%B")
+    click_on "Run #{month_name} payroll"
 
     expect(page).to have_content("Approved claims 3")
     expect(page).to have_content("Total award amount £4,000")
 
-    click_on "Create payroll file"
+    click_on "Confirm and submit"
 
     expect(page).to have_content("Approved claims 3")
     expect(page).to have_content("Total award amount £4,000")
 
-    click_on "Download file"
+    click_on "Download payroll file"
 
     expect(page.response_headers["Content-Type"]).to eq("text/csv")
 
@@ -48,11 +49,12 @@ RSpec.feature "Payroll" do
 
     expected_claims = create_list(:claim, 3, :approved)
 
-    click_on "Prepare payroll"
+    month_name = Date.today.strftime("%B")
+    click_on "Run #{month_name} payroll"
 
     create_list(:claim, 3, :approved)
 
-    click_on "Create payroll file"
+    click_on "Confirm and submit"
 
     expect(page).to have_content("Approved claims 3")
 

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature "Payroll" do
 
     expect(page).to have_content("Approved claims 3")
     expect(page).to have_content("Total award amount £4,000")
+    expect(page).to have_content("Payroll run created")
 
     click_on "Download payroll file"
 

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature "Payroll" do
     create(:claim, :approved, policy: StudentLoans)
 
     month_name = Date.today.strftime("%B")
+
     click_on "Run #{month_name} payroll"
 
     expect(page).to have_content("Approved claims 3")
@@ -20,16 +21,12 @@ RSpec.feature "Payroll" do
 
     click_on "Confirm and submit"
 
+    payroll_run = PayrollRun.order(:created_at).last
+
     expect(page).to have_content("Approved claims 3")
     expect(page).to have_content("Total award amount £4,000")
     expect(page).to have_content("Payroll run created")
-
-    click_on "Download payroll file"
-
-    expect(page.response_headers["Content-Type"]).to eq("text/csv")
-
-    csv = CSV.parse(body, headers: true)
-    expect(csv.count).to eq(3)
+    expect(page).to have_field("payroll_run_download_link", with: new_admin_payroll_run_download_url(payroll_run))
   end
 
   context "when a payroll run already exists for the month" do

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -61,4 +61,33 @@ RSpec.describe PayrollRun, type: :model do
       expect(PayrollRun.this_month).to eq([created_this_month])
     end
   end
+
+  describe "#download_available?" do
+    it "returns true when the download was triggered within the time limit" do
+      payroll_run = create(:payroll_run, downloaded_at: Time.zone.now, downloaded_by: "admin_user_id")
+      expect(payroll_run.download_available?).to eql true
+
+      travel_to 31.seconds.from_now do
+        expect(payroll_run.download_available?).to eql false
+      end
+    end
+
+    it "returns false when the download has not been tirggered" do
+      payroll_run = create(:payroll_run)
+
+      expect(payroll_run.download_available?).to eql false
+    end
+  end
+
+  describe "#download_triggered?" do
+    it "returns true when downloaded_at and downloaded_by are present" do
+      payroll_run = create(:payroll_run)
+
+      expect(payroll_run.download_triggered?).to eql false
+
+      payroll_run.update!(downloaded_at: Time.zone.now, downloaded_by: "admin_user_id")
+
+      expect(payroll_run.download_triggered?).to eql true
+    end
+  end
 end

--- a/spec/requests/admin_claim_checks_spec.rb
+++ b/spec/requests/admin_claim_checks_spec.rb
@@ -77,18 +77,17 @@ RSpec.describe "Admin claim checks", type: :request do
     end
   end
 
-  context "when signed in as a support user" do
-    before do
-      sign_in_to_admin_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
-    end
-
+  context "when signed in as a payroll operator or a support agent" do
     describe "claim_checks#create" do
       let(:claim) { create(:claim, :submitted) }
 
-      it "does not allow a claim to be approved" do
-        post admin_claim_checks_path(claim_id: claim.id, result: "approved")
+      [AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
+        it "does not allow a claim to be approved" do
+          sign_in_to_admin_with_role(role)
+          post admin_claim_checks_path(claim_id: claim.id, result: "approved")
 
-        expect(response.code).to eq("401")
+          expect(response.code).to eq("401")
+        end
       end
     end
   end

--- a/spec/requests/admin_configure_services_spec.rb
+++ b/spec/requests/admin_configure_services_spec.rb
@@ -21,16 +21,16 @@ RSpec.describe "Service configuration" do
     end
   end
 
-  context "when signed in as a support user" do
-    before do
-      sign_in_to_admin_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
-    end
-
+  context "when signed in as a payroll operator or a support agent" do
     describe "admin_policy_configurations#update" do
-      it "returns a unauthorized response" do
-        patch admin_policy_configuration_path(policy_configuration, policy_configuration: {open_for_submissions: false, availability_message: "Test message"})
+      [AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
+        it "returns a unauthorized response" do
+          sign_in_to_admin_with_role(role)
 
-        expect(response).to have_http_status(:unauthorized)
+          patch admin_policy_configuration_path(policy_configuration, policy_configuration: {open_for_submissions: false, availability_message: "Test message"})
+
+          expect(response).to have_http_status(:unauthorized)
+        end
       end
     end
   end

--- a/spec/requests/admin_page_spec.rb
+++ b/spec/requests/admin_page_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "Admin page" do
+  context "when signed in as a payroll operator" do
+    it "returns a unauthorized response" do
+      sign_in_to_admin_with_role(AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+
+      get admin_root_path
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/admin_payment_confirmation_report_upload_spec.rb
+++ b/spec/requests/admin_payment_confirmation_report_upload_spec.rb
@@ -82,16 +82,16 @@ RSpec.describe "Admin Payment Confirmation Report upload" do
     end
   end
 
-  context "when signed in as a support user" do
-    before do
-      sign_in_to_admin_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
-    end
-
+  context "when signed in as a payroll operator or a support agent" do
     describe "payment_confirmation_report_uploads#new" do
-      it "returns an unauthorized response" do
-        get new_admin_payroll_run_payment_confirmation_report_upload_path(payroll_run)
+      [AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
+        it "returns an unauthorized response" do
+          sign_in_to_admin_with_role(role)
 
-        expect(response).to have_http_status(:unauthorized)
+          get new_admin_payroll_run_payment_confirmation_report_upload_path(payroll_run)
+
+          expect(response).to have_http_status(:unauthorized)
+        end
       end
     end
   end

--- a/spec/requests/admin_payroll_run_downloads_spec.rb
+++ b/spec/requests/admin_payroll_run_downloads_spec.rb
@@ -1,16 +1,117 @@
 require "rails_helper"
 
 RSpec.describe "Admin payroll run downloads" do
+  let(:admin_session_id) { "some_user_id" }
+
+  before do
+    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin_session_id)
+  end
+
   describe "downloads#new" do
     it "shows a form to download a payroll_run file" do
-      sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
-
       payroll_run = create(:payroll_run)
 
       get new_admin_payroll_run_download_path(payroll_run)
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("#{Date.today.strftime("%B")} payroll file")
+    end
+
+    it "redirects to the show action if the download has already been triggered for the payroll run" do
+      payroll_run = create(:payroll_run, downloaded_at: Time.zone.now, downloaded_by: admin_session_id)
+
+      expect(get(new_admin_payroll_run_download_path(payroll_run))).to redirect_to admin_payroll_run_download_path(payroll_run)
+    end
+  end
+
+  describe "downloads#show" do
+    it "redirects to the new action when payroll run download has not been triggered" do
+      payroll_run = create(:payroll_run)
+
+      [:html, :csv].each do |format|
+        expect(get(admin_payroll_run_download_path(payroll_run, format: format))).to redirect_to new_admin_payroll_run_download_path(payroll_run)
+      end
+    end
+
+    context "when requesting html" do
+      context "and it is within the timeout" do
+        it "shows a link to download the payroll run file" do
+          payroll_run = create(:payroll_run, downloaded_at: Time.zone.now, downloaded_by: admin_session_id)
+
+          get admin_payroll_run_download_path(payroll_run)
+
+          expect(response.body).to include admin_payroll_run_download_path(payroll_run, format: :csv)
+
+          travel_to 31.seconds.from_now do
+            get admin_payroll_run_download_path(payroll_run)
+
+            expect(response.body).not_to include admin_payroll_run_download_path(payroll_run, format: :csv)
+          end
+        end
+      end
+
+      context "and the timeout has been reached" do
+        it "shows who triggered the download and when" do
+          payroll_run = create(:payroll_run, downloaded_at: 31.seconds.ago, downloaded_by: "admin_user_id")
+
+          get admin_payroll_run_download_path(payroll_run)
+
+          expect(response.body).to include payroll_run.downloaded_by
+          expect(response.body).to include I18n.l(payroll_run.downloaded_at)
+        end
+      end
+    end
+
+    context "when requesting csv" do
+      context "and it is within the timeout" do
+        it "allows the payroll run file to be downloaded within the time limit" do
+          payroll_run = create(:payroll_run, downloaded_at: Time.zone.now, downloaded_by: "admin_user_id")
+          get admin_payroll_run_download_path(payroll_run, format: :csv)
+
+          expect(response.headers["Content-Type"]).to eq("text/csv")
+        end
+      end
+
+      context "and the timeout has been reached" do
+        it "redirects a request for the file once the timeout has been reached" do
+          payroll_run = create(:payroll_run, downloaded_at: 31.seconds.ago, downloaded_by: "admin_user_id")
+
+          expect(get(admin_payroll_run_download_path(payroll_run, format: :csv))).to redirect_to admin_payroll_run_download_path(payroll_run, format: :html)
+        end
+      end
+    end
+  end
+
+  describe "downloads#create" do
+    context "when the payroll run has not been triggered already" do
+      let(:payroll_run) { create(:payroll_run) }
+
+      it "sets the downloaded_at and downloaded_by attributes on the payroll_run" do
+        downloaded_at = Time.zone.now
+
+        travel_to downloaded_at do
+          post admin_payroll_run_download_path(payroll_run)
+
+          expect(payroll_run.reload.downloaded_by).to eql admin_session_id
+          expect(payroll_run.downloaded_at.to_s).to eql downloaded_at.to_s
+        end
+      end
+
+      it "redirects to the show action" do
+        expect(post(admin_payroll_run_download_path(payroll_run))).to redirect_to admin_payroll_run_download_path(payroll_run)
+      end
+    end
+
+    context "when the payroll run download has already been triggered" do
+      let(:payroll_run) { create(:payroll_run) }
+
+      it "does not set the downloaded_at and downloaded_by attributes on the payroll_run" do
+        expect { post(admin_payroll_run_download_path(payroll_run)) }.not_to change { payroll_run.attributes }
+      end
+
+      it "redirects to the show action" do
+        expect(post(admin_payroll_run_download_path(payroll_run))).to redirect_to admin_payroll_run_download_path(payroll_run)
+      end
     end
   end
 end

--- a/spec/requests/admin_payroll_run_downloads_spec.rb
+++ b/spec/requests/admin_payroll_run_downloads_spec.rb
@@ -114,4 +114,29 @@ RSpec.describe "Admin payroll run downloads" do
       end
     end
   end
+
+  describe "When signed in as a service operator or a support agent, download routes" do
+    [AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE].each do |role|
+      it "respond with not authorised" do
+        payroll_run = create(:payroll_run)
+
+        sign_in_to_admin_with_role(role)
+
+        get new_admin_payroll_run_download_path(payroll_run)
+
+        expect(response.code).to eq("401")
+        expect(response.body).to include("Not authorised")
+
+        get admin_payroll_run_download_path(payroll_run)
+
+        expect(response.code).to eq("401")
+        expect(response.body).to include("Not authorised")
+
+        post admin_payroll_run_download_path(payroll_run)
+
+        expect(response.code).to eq("401")
+        expect(response.body).to include("Not authorised")
+      end
+    end
+  end
 end

--- a/spec/requests/admin_payroll_run_downloads_spec.rb
+++ b/spec/requests/admin_payroll_run_downloads_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Admin payroll run downloads" do
+  describe "downloads#new" do
+    it "shows a form to download a payroll_run file" do
+      sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+
+      payroll_run = create(:payroll_run)
+
+      get new_admin_payroll_run_download_path(payroll_run)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("#{Date.today.strftime("%B")} payroll file")
+    end
+  end
+end

--- a/spec/requests/admin_payroll_run_downloads_spec.rb
+++ b/spec/requests/admin_payroll_run_downloads_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Admin payroll run downloads" do
   let(:admin_session_id) { "some_user_id" }
 
   before do
-    sign_in_to_admin_with_role(AdminSession::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin_session_id)
+    sign_in_to_admin_with_role(AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin_session_id)
   end
 
   describe "downloads#new" do

--- a/spec/requests/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin_payroll_runs_spec.rb
@@ -32,20 +32,6 @@ RSpec.describe "Admin payroll runs" do
         expect(response).to redirect_to(admin_payroll_run_path(payroll_run))
       end
     end
-
-    describe "admin_payroll_runs#show" do
-      it "returns a csv containing the claims from the given payroll run" do
-        payroll_run = create(:payroll_run, claims_counts: {StudentLoans => 3})
-
-        create_list(:claim, 2, :approved)
-
-        get admin_payroll_run_path(payroll_run, format: :csv)
-
-        csv = CSV.parse(body, headers: true)
-
-        expect(csv.map { |row| row["CLAIM_ID"] }).to match_array(payroll_run.claims.map(&:reference))
-      end
-    end
   end
 
   context "when signed in as a support user" do

--- a/spec/requests/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin_payroll_runs_spec.rb
@@ -54,34 +54,36 @@ RSpec.describe "Admin payroll runs" do
     end
   end
 
-  context "when signed in as a support user" do
-    before do
-      sign_in_to_admin_with_role(AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE)
-    end
-
-    describe "admin_payroll_runs#new" do
-      it "returns a unauthorized response" do
-        get new_admin_payroll_run_path
-
-        expect(response).to have_http_status(:unauthorized)
+  context "when signed in as a payroll operator or a support agent" do
+    [AdminSession::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
+      before do
+        sign_in_to_admin_with_role(role)
       end
-    end
 
-    describe "admin_payroll_runs#create" do
-      it "does not create a payroll run and returns a unauthorized response" do
-        expect { post admin_payroll_runs_path }.to_not change { PayrollRun.count }
+      describe "admin_payroll_runs#new" do
+        it "returns a unauthorized response" do
+          get new_admin_payroll_run_path
 
-        expect(response).to have_http_status(:unauthorized)
+          expect(response).to have_http_status(:unauthorized)
+        end
       end
-    end
 
-    describe "admin_payroll_runs#show" do
-      it "does not view a payroll run and returns a unauthorized response" do
-        payroll_run = create(:payroll_run)
+      describe "admin_payroll_runs#create" do
+        it "does not create a payroll run and returns a unauthorized response" do
+          expect { post admin_payroll_runs_path }.to_not change { PayrollRun.count }
 
-        get admin_payroll_run_path(payroll_run)
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
 
-        expect(response).to have_http_status(:unauthorized)
+      describe "admin_payroll_runs#show" do
+        it "does not view a payroll run and returns a unauthorized response" do
+          payroll_run = create(:payroll_run)
+
+          get admin_payroll_run_path(payroll_run)
+
+          expect(response).to have_http_status(:unauthorized)
+        end
       end
     end
   end

--- a/spec/requests/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin_payroll_runs_spec.rb
@@ -32,6 +32,26 @@ RSpec.describe "Admin payroll runs" do
         expect(response).to redirect_to(admin_payroll_run_path(payroll_run))
       end
     end
+
+    describe "admin_payroll_runs#show" do
+      it "displays a payroll run showing a link to the payroll run download" do
+        payroll_run = create(:payroll_run)
+
+        get admin_payroll_run_path(payroll_run)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include new_admin_payroll_run_download_url(payroll_run)
+      end
+
+      it "does not show the link to the payroll run download once the download has been triggered" do
+        payroll_run = create(:payroll_run, downloaded_at: Time.zone.now, downloaded_by: "admin_user_id")
+
+        get admin_payroll_run_path(payroll_run)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include new_admin_payroll_run_download_url(payroll_run)
+      end
+    end
   end
 
   context "when signed in as a support user" do
@@ -50,6 +70,16 @@ RSpec.describe "Admin payroll runs" do
     describe "admin_payroll_runs#create" do
       it "does not create a payroll run and returns a unauthorized response" do
         expect { post admin_payroll_runs_path }.to_not change { PayrollRun.count }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    describe "admin_payroll_runs#show" do
+      it "does not view a payroll run and returns a unauthorized response" do
+        payroll_run = create(:payroll_run)
+
+        get admin_payroll_run_path(payroll_run)
 
         expect(response).to have_http_status(:unauthorized)
       end

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -59,6 +59,23 @@ RSpec.describe "Admin", type: :request do
         end
       end
 
+      context "when the user is a payroll operator" do
+        before do
+          sign_in_to_admin_with_role(AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user_id, organisation_id)
+        end
+
+        it "renders the page and sets a session" do
+          payroll_run = create(:payroll_run)
+
+          get new_admin_payroll_run_download_path(payroll_run)
+
+          expect(response).to be_successful
+          expect(session[:user_id]).to eq(user_id)
+          expect(session[:organisation_id]).to eq(organisation_id)
+          expect(session[:role_codes]).to eq([AdminSession::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE])
+        end
+      end
+
       context "when the user is not authorised to access the service" do
         before do
           sign_in_to_admin_with_role("not-the-role-code-we-expect")


### PR DESCRIPTION
This PR allows Payroll operators (Cantium users) to sign in to the admin area of the service and download the payroll run file.

Serivce operators (DfE users) can no longer donwload a payroll run file but they must still create the payroll run at which point they are provided with a link to the file to send to Cantium, they cannot download the file from the link.  The link is not shown once the file has been downloaded.

This manual process will be replaced with a more automated one at a later date.

Because the payroll run file contains personally identifiable information, we want to limit the number of times it can be downloaded. To achieve this we chose to limit the time a Payroll user can download the file, currently set to 30 seconds. Once the timeout is reached the file cannot be accessed by anyone.

Should there be some kind of issue downloading the file, we will have to reset the `downloaded_at` and `downloaded_by` attributes in the database to allow the file to be available again – this is by design.

There are two small JavaScripts to enhance the experience:

- the donwload link is automatically clicked after 3 seconds
- the Service operator can click a button to copy the file url

I couldn't think of a way to test either of these easily – love to hear thoughts on that

## Documentation

Please take some time to also review the documentation for this on [confluence](https://dfedigital.atlassian.net/wiki/spaces/TP/pages/1193017348/Accessing+the+payroll+run+file)

## Service operator

View a service operator sees instead of being offered a download:
![Screenshot_2019-11-28 Claim additional payments for teaching – GOV UK(5)](https://user-images.githubusercontent.com/480578/69816171-c351df00-11ef-11ea-9a87-c9a7a0d39165.png)

View when the download has been trigggered:
![Screenshot_2019-11-28 Claim additional payments for teaching – GOV UK(6)](https://user-images.githubusercontent.com/480578/69817425-7a4f5a00-11f2-11ea-8886-e8ab65472dc9.png)

## Payroll operator

View of a Payroll operator asked to trigger the download:
![Screenshot_2019-11-28 Claim additional payments for teaching – GOV UK](https://user-images.githubusercontent.com/480578/69811116-4883c680-11e5-11ea-9cee-272beca92de3.png)

View of the download, users have 30 seconds to click the link and begin the download, JS clicks the link for them:
![Screenshot_2019-11-28 Claim additional payments for teaching – GOV UK(1)](https://user-images.githubusercontent.com/480578/69811120-4c174d80-11e5-11ea-9aaa-a69429a91dd9.png)

View once the timeout is reached:
![Screenshot_2019-11-28 Claim additional payments for teaching – GOV UK(2)](https://user-images.githubusercontent.com/480578/69811125-50436b00-11e5-11ea-82d6-fad67a1b424b.png)

