### PR TITLE
Don't include ineligible slug when not appropriate

### DIFF
--- a/app/models/maths_and_physics/slug_sequence.rb
+++ b/app/models/maths_and_physics/slug_sequence.rb
@@ -55,6 +55,7 @@ module MathsAndPhysics
         sequence.delete("student-loan-start-date") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
         sequence.delete("address") if claim.address_verified?
         sequence.delete("gender") if claim.payroll_gender_verified?
+        sequence.delete("ineligible") unless claim.eligibility.ineligible?
       end
     end
   end

--- a/app/models/student_loans/slug_sequence.rb
+++ b/app/models/student_loans/slug_sequence.rb
@@ -50,6 +50,7 @@ module StudentLoans
         sequence.delete("student-loan-start-date") if claim.no_student_loan? || claim.student_loan_country_with_one_plan?
         sequence.delete("address") if claim.address_verified?
         sequence.delete("gender") if claim.payroll_gender_verified?
+        sequence.delete("ineligible") unless claim.eligibility.ineligible?
       end
     end
   end

--- a/spec/models/maths_and_physics/slug_sequence_spec.rb
+++ b/spec/models/maths_and_physics/slug_sequence_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe MathsAndPhysics::SlugSequence do
   subject(:slug_sequence) { MathsAndPhysics::SlugSequence.new(claim) }
 
   describe "The sequence as defined by #slugs" do
+    it "excludes the “ineligible” slug if the claim is not actually ineligible" do
+      expect(claim.eligibility).not_to be_ineligible
+      expect(slug_sequence.slugs).not_to include("ineligible")
+
+      claim.eligibility.teaching_maths_or_physics = false
+      expect(claim.eligibility).to be_ineligible
+      expect(slug_sequence.slugs).to include("ineligible")
+    end
+
     it "excludes the “initial-teacher-training-subject-specialism” and “has-uk-maths-or-physics-degree” slug if the claimant’s ITT subject was Maths or Physics" do
       claim.eligibility.initial_teacher_training_subject = "maths"
       expect(slug_sequence.slugs).not_to include("initial-teacher-training-subject-specialism")

--- a/spec/models/student_loans/slug_sequence_spec.rb
+++ b/spec/models/student_loans/slug_sequence_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe StudentLoans::SlugSequence do
   subject(:slug_sequence) { StudentLoans::SlugSequence.new(claim) }
 
   describe "The sequence as defined by #slugs" do
+    it "excludes the “ineligible” slug if the claim is not actually ineligible" do
+      expect(claim.eligibility).not_to be_ineligible
+      expect(slug_sequence.slugs).not_to include("ineligible")
+
+      claim.eligibility.qts_award_year = "before_september_2013"
+      expect(claim.eligibility).to be_ineligible
+      expect(slug_sequence.slugs).to include("ineligible")
+    end
+
     it "excludes “current-school” if the claimant still works at the school they are claiming against" do
       claim.eligibility.employment_status = :claim_school
 


### PR DESCRIPTION
Instead of a raising a 500 error if a user visits the ineligible screen
with an claim that isn't actually ineligible we raise a 404.

We had an exception raised for the ineligible screen because a partial
for the ineligibility reason couldn't be found: `"...Missing partial
claims/_ineligibility_reason_"`. Based on the code in the partial this
is likely to have happened because the claim eligibility didn't report
an `ineligibility_reason`. which would only happen if the claim wasn't
actually ineligible. This is probably a weird edge case and caused by
the user navigating outside of the normal UI interface, but in any case
Returning a 404 feels more appropriate and will reduce the rollbar
noise.

If we find more users ending up on the ineligible screen
unexpectedly we might want to consider handling things differently and
helping the user get back to their in-progress claim.