### PR TITLE
Clear JS timeout redirect when session refreshed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix a bug that would occassionally redirect users even after they'd continued
+  their session
+
 ## [Release 037] - 2019-11-28
 
 - Redesign the layout of the payment confirmation email

--- a/app/assets/javascripts/components/timeout_dialog.js.erb
+++ b/app/assets/javascripts/components/timeout_dialog.js.erb
@@ -27,6 +27,7 @@
       type: "get",
       success: function() {
         clearInterval(window.sessionTimeoutTimer);
+        clearTimeout(window.sessionTimeout);
         window.sessionTimeoutTimer = setInterval(showTimeoutDialog, timeoutInMilliseconds);
       }
     });
@@ -40,7 +41,7 @@
   function showTimeoutDialog() {
     dialogElement.setAttribute("aria-hidden", "false");
     dialog.show();
-    setTimeout(sessionTimedOut, warningTimeInMinutes * 60 * 1000);
+    window.sessionTimeout = setTimeout(sessionTimedOut, warningTimeInMinutes * 60 * 1000);
   }
 
   window.sessionTimeoutTimer = setInterval(showTimeoutDialog, timeoutInMilliseconds);


### PR DESCRIPTION
This fixes a bug where a user that has dismissed the timeout dialog to
continue their session still gets redirected after the timeout dialog
warning period has expired. This was happening because the JS timeout
that gets initially set to redirect the user after the timeout period
has expired wasn't being cleared.

It's unlikely many users will have experienced this because the timeout
is naturally cleared when a new page is loaded.