### PR TITLE
Redirect root url to an all-encompassing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog]
 - Service operators can see Maths and Physics claim eligibility
 - Fix a bug that would occassionally redirect users even after they'd continued
   their session
+- Redirect requests to the root URL to a GOV.UK page about teacher payments
 
 ## [Release 037] - 2019-11-28
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Architecture decision records can be found in the
 2. Run `bundle install` and `yarn install` to install the dependencies
 3. Run `bundle exec rails db:setup` to set up the database development
 4. Run `bundle exec foreman start` to launch the app on https://localhost:3000/
+5. Visit one of the following urls in your browser to access the relevant
+   policy:
+
+- **Student Loans:** https://localhost:3000/student-loans/claim
+- **Maths and Physics:** https://localhost:3000/maths-and-physics/claim
 
 ### DfE Sign In credentials
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,7 @@ module DfeTeachersPaymentService
     # Make sure the `form_with` helper generates local forms, instead of defaulting
     # to remote and unobtrusive XHR forms
     config.action_view.form_with_generates_remote_forms = false
+
+    config.guidance_url = "https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root to: redirect(StudentLoans.start_page_url)
+  root to: redirect(Rails.application.config.guidance_url)
 
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that
   # hostname, redirect us to the canonical hostname with the path and query string present


### PR DESCRIPTION
Now Maths and Physics is in private beta, it no longer makes sense to redirect requests to the root url to the Maths and Physics start page. There is now a [generic page on GOV.UK](https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details) about teacher payments, so we're now redirecting to that. I've stored it as a config var in the Rails application.rb, rather than exposing it in the routes file, as it a) may be useful in other places and b) I'm not a huge fan of having a big URL like that in the routes.rb file itself.