### PR TITLE
Correct schema.rb and currently failing migration

### DIFF
--- a/db/migrate/20191203103255_add_created_at_indexes_for_implicit_ordering.rb
+++ b/db/migrate/20191203103255_add_created_at_indexes_for_implicit_ordering.rb
@@ -4,7 +4,6 @@ class AddCreatedAtIndexesForImplicitOrdering < ActiveRecord::Migration[6.0]
     add_index :claims, :created_at
     add_index :maths_and_physics_eligibilities, :created_at
     add_index :payments, :created_at
-    add_index :payroll_runs, :created_at
     add_index :policy_configurations, :created_at
     add_index :schools, :created_at
     add_index :student_loans_eligibilities, :created_at

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,11 +133,12 @@ ActiveRecord::Schema.define(version: 2019_12_03_103255) do
   end
 
   create_table "payroll_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "created_by"
+    t.string "created_by", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "confirmation_report_uploaded_by"
     t.index ["created_at"], name: "index_payroll_runs_on_created_at"
+    t.index ["updated_at"], name: "index_payroll_runs_on_updated_at"
   end
 
   create_table "policy_configurations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Turns out our schema.rb file was not an accurate reflection of the
actual database schema: it was missing indexes for created_at and
updated_at on the payroll_runs table. This corrects the schema.rb file
and also updates the most recent migration, which is currently failing
to run because it tries to add an index that already exists.

The problem stems from this commit: https://github.com/DFE-Digital/dfe-teachers-payment-service/commit/39ca7bfa30144ff3c2a0671de42b984ad55d322b

It added the payroll_runs table with `t.timestamps index: true`, which
would have added indexes for `created_at` and `updated_at`, but for whatever
reason those indexes were not reflected in the schema.rb changes. The
result of this was our local versions of the database were likely to get
out of sync after running db:reset or similar commands that load the
schema. Same with the null constraint on the `created_by` column. What
probably happened is the migration was edited after it was intially run
during local development but wasn't subsequently re-run to update the
schema.rb file accordingly.

Note: developers will want to rebuild and reseed their local databases
after this is merged to get everything back in sync and avoid similar
problems in the future:

    rails db:reset

<!-- Do you need to update CHANGELOG.md? -->
