### PR TITLE
Bug: fix special school age range and add Alternative provision schools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog]
 
 - Restore uptime alerting to alert when the App / VSP are down
 - Don't match bank account sort code when identifying potentially similar claims
+- Alternative provisions schools and special schools that teach students who are
+  over 11 are eligible
 
 ## [Release 040] - 2019-12-09
 

--- a/app/models/maths_and_physics/school_eligibility.rb
+++ b/app/models/maths_and_physics/school_eligibility.rb
@@ -54,17 +54,13 @@ module MathsAndPhysics
       @school.open? &&
         eligible_local_authority_district? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (@school.secondary_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
+        (@school.secondary_phase? || @school.secondary_equivalent_special? || secondary_equivalent_alternative_provision_school?)
     end
 
     private
 
     def eligible_local_authority_district?
       ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES.include?(@school.local_authority_district.code)
-    end
-
-    def secondary_equivalent_special_school?
-      @school.special? && @school.school_type != "special_post_16_institutions" && @school.has_statutory_high_age_over_eleven?
     end
 
     def secondary_equivalent_alternative_provision_school?

--- a/app/models/maths_and_physics/school_eligibility.rb
+++ b/app/models/maths_and_physics/school_eligibility.rb
@@ -1,6 +1,5 @@
 module MathsAndPhysics
   class SchoolEligibility
-    ELIGIBLE_PHASES = %w[secondary middle_deemed_secondary all_through].freeze
     ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES = [
       "E08000016", # Barnsley
       "E06000009", # Blackpool
@@ -55,17 +54,13 @@ module MathsAndPhysics
       @school.open? &&
         eligible_local_authority_district? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (eligible_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
+        (@school.secondary_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
     end
 
     private
 
     def eligible_local_authority_district?
       ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES.include?(@school.local_authority_district.code)
-    end
-
-    def eligible_phase?
-      ELIGIBLE_PHASES.include?(@school.phase)
     end
 
     def secondary_equivalent_special_school?

--- a/app/models/maths_and_physics/school_eligibility.rb
+++ b/app/models/maths_and_physics/school_eligibility.rb
@@ -51,7 +51,7 @@ module MathsAndPhysics
       @school = school
     end
 
-    def check
+    def eligible_current_school?
       @school.open? &&
         eligible_local_authority_district? &&
         @school.state_funded? &&

--- a/app/models/maths_and_physics/school_eligibility.rb
+++ b/app/models/maths_and_physics/school_eligibility.rb
@@ -55,7 +55,7 @@ module MathsAndPhysics
       @school.open? &&
         eligible_local_authority_district? &&
         @school.state_funded? &&
-        (eligible_phase? || eligible_special_school?)
+        (eligible_phase? || secondary_equivalent_special_school?)
     end
 
     private
@@ -68,8 +68,8 @@ module MathsAndPhysics
       ELIGIBLE_PHASES.include?(@school.phase)
     end
 
-    def eligible_special_school?
-      @school.phase == "not_applicable" && @school.special? && @school.school_type != "special_post_16_institutions"
+    def secondary_equivalent_special_school?
+      @school.special? && @school.school_type != "special_post_16_institutions" && @school.has_statutory_high_age_over_eleven?
     end
   end
 end

--- a/app/models/maths_and_physics/school_eligibility.rb
+++ b/app/models/maths_and_physics/school_eligibility.rb
@@ -54,8 +54,8 @@ module MathsAndPhysics
     def eligible_current_school?
       @school.open? &&
         eligible_local_authority_district? &&
-        @school.state_funded? &&
-        (eligible_phase? || secondary_equivalent_special_school?)
+        (@school.state_funded? || @school.secure_unit?) &&
+        (eligible_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
     end
 
     private
@@ -70,6 +70,10 @@ module MathsAndPhysics
 
     def secondary_equivalent_special_school?
       @school.special? && @school.school_type != "special_post_16_institutions" && @school.has_statutory_high_age_over_eleven?
+    end
+
+    def secondary_equivalent_alternative_provision_school?
+      @school.alternative_provision? && @school.has_statutory_high_age_over_eleven?
     end
   end
 end

--- a/app/models/maths_and_physics/school_eligibility.rb
+++ b/app/models/maths_and_physics/school_eligibility.rb
@@ -54,7 +54,7 @@ module MathsAndPhysics
       @school.open? &&
         eligible_local_authority_district? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (@school.secondary_phase? || @school.secondary_equivalent_special? || @school.secondary_equivalent_alternative_provision?)
+        @school.secondary_or_equivalent?
     end
 
     private

--- a/app/models/maths_and_physics/school_eligibility.rb
+++ b/app/models/maths_and_physics/school_eligibility.rb
@@ -54,17 +54,13 @@ module MathsAndPhysics
       @school.open? &&
         eligible_local_authority_district? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (@school.secondary_phase? || @school.secondary_equivalent_special? || secondary_equivalent_alternative_provision_school?)
+        (@school.secondary_phase? || @school.secondary_equivalent_special? || @school.secondary_equivalent_alternative_provision?)
     end
 
     private
 
     def eligible_local_authority_district?
       ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES.include?(@school.local_authority_district.code)
-    end
-
-    def secondary_equivalent_alternative_provision_school?
-      @school.alternative_provision? && @school.has_statutory_high_age_over_eleven?
     end
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -136,24 +136,16 @@ class School < ApplicationRecord
     (STATE_FUNDED_SCHOOL_TYPE_GROUPS.include?(school_type_group) && school_type != "other_independent_special_school") || secure_unit?
   end
 
-  def special?
-    SPECIAL_SCHOOL_TYPES.include?(school_type)
-  end
-
-  def alternative_provision?
-    ALTERNATIVE_PROVISION_TYPES.include?(school_type)
-  end
-
-  def has_statutory_high_age_over_eleven?
-    statutory_high_age.present? && statutory_high_age > 11
-  end
-
   def secondary_phase?
     SECONDARY_PHASES.include?(phase)
   end
 
   def secondary_equivalent_special?
     special? && school_type != "special_post_16_institutions" && has_statutory_high_age_over_eleven?
+  end
+
+  def secondary_equivalent_alternative_provision?
+    alternative_provision? && has_statutory_high_age_over_eleven?
   end
 
   def open?
@@ -169,5 +161,17 @@ class School < ApplicationRecord
 
   def secure_unit?
     school_type == "secure_unit"
+  end
+
+  def alternative_provision?
+    ALTERNATIVE_PROVISION_TYPES.include?(school_type)
+  end
+
+  def has_statutory_high_age_over_eleven?
+    statutory_high_age.present? && statutory_high_age > 11
+  end
+
+  def special?
+    SPECIAL_SCHOOL_TYPES.include?(school_type)
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -152,6 +152,10 @@ class School < ApplicationRecord
     SECONDARY_PHASES.include?(phase)
   end
 
+  def secondary_equivalent_special?
+    special? && school_type != "special_post_16_institutions" && has_statutory_high_age_over_eleven?
+  end
+
   def open?
     close_date.nil?
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -93,6 +93,14 @@ class School < ApplicationRecord
     academy_special_converter
   ].freeze
 
+  ALTERNATIVE_PROVISION_TYPES = %w[
+    pupil_referral_unit
+    secure_unit
+    free_school_alternative_provider
+    academy_alternative_provision_converter
+    academy_alternative_provision_sponsor_led
+  ].freeze
+
   enum phase: PHASES
   enum school_type_group: SCHOOL_TYPE_GROUPS
   enum school_type: SCHOOL_TYPES
@@ -123,11 +131,15 @@ class School < ApplicationRecord
   end
 
   def state_funded?
-    STATE_FUNDED_SCHOOL_TYPE_GROUPS.include?(school_type_group) && school_type != "other_independent_special_school"
+    (STATE_FUNDED_SCHOOL_TYPE_GROUPS.include?(school_type_group) && school_type != "other_independent_special_school") || secure_unit?
   end
 
   def special?
     SPECIAL_SCHOOL_TYPES.include?(school_type)
+  end
+
+  def alternative_provision?
+    ALTERNATIVE_PROVISION_TYPES.include?(school_type)
   end
 
   def has_statutory_high_age_over_eleven?
@@ -143,5 +155,9 @@ class School < ApplicationRecord
       local_authority.code,
       establishment_number,
     ].join("/")
+  end
+
+  def secure_unit?
+    school_type == "secure_unit"
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -22,6 +22,8 @@ class School < ApplicationRecord
     all_through: 7,
   }.freeze
 
+  SECONDARY_PHASES = %w[secondary middle_deemed_secondary all_through].freeze
+
   SCHOOL_TYPE_GROUPS = {
     colleges: 1,
     universities: 2,
@@ -144,6 +146,10 @@ class School < ApplicationRecord
 
   def has_statutory_high_age_over_eleven?
     statutory_high_age.present? && statutory_high_age > 11
+  end
+
+  def secondary_phase?
+    SECONDARY_PHASES.include?(phase)
   end
 
   def open?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -119,7 +119,7 @@ class School < ApplicationRecord
   end
 
   def eligible_for_maths_and_physics?
-    MathsAndPhysics::SchoolEligibility.new(self).check
+    MathsAndPhysics::SchoolEligibility.new(self).eligible_current_school?
   end
 
   def state_funded?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -136,18 +136,6 @@ class School < ApplicationRecord
     (STATE_FUNDED_SCHOOL_TYPE_GROUPS.include?(school_type_group) && school_type != "other_independent_special_school") || secure_unit?
   end
 
-  def secondary_phase?
-    SECONDARY_PHASES.include?(phase)
-  end
-
-  def secondary_equivalent_special?
-    special? && school_type != "special_post_16_institutions" && has_statutory_high_age_over_eleven?
-  end
-
-  def secondary_equivalent_alternative_provision?
-    alternative_provision? && has_statutory_high_age_over_eleven?
-  end
-
   def open?
     close_date.nil?
   end
@@ -163,12 +151,30 @@ class School < ApplicationRecord
     school_type == "secure_unit"
   end
 
+  def secondary_or_equivalent?
+    secondary_phase? || secondary_equivalent_special? || secondary_equivalent_alternative_provision?
+  end
+
+  private
+
   def alternative_provision?
     ALTERNATIVE_PROVISION_TYPES.include?(school_type)
   end
 
   def has_statutory_high_age_over_eleven?
     statutory_high_age.present? && statutory_high_age > 11
+  end
+
+  def secondary_phase?
+    SECONDARY_PHASES.include?(phase)
+  end
+
+  def secondary_equivalent_special?
+    special? && school_type != "special_post_16_institutions" && has_statutory_high_age_over_eleven?
+  end
+
+  def secondary_equivalent_alternative_provision?
+    alternative_provision? && has_statutory_high_age_over_eleven?
   end
 
   def special?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -130,6 +130,10 @@ class School < ApplicationRecord
     SPECIAL_SCHOOL_TYPES.include?(school_type)
   end
 
+  def has_statutory_high_age_over_eleven?
+    statutory_high_age.present? && statutory_high_age > 11
+  end
+
   def open?
     close_date.nil?
   end

--- a/app/models/school_data_importer.rb
+++ b/app/models/school_data_importer.rb
@@ -45,6 +45,7 @@ class SchoolDataImporter
     school.local_authority_district = local_authority_district
     school.close_date = row.fetch("CloseDate")
     school.establishment_number = row.fetch("EstablishmentNumber")
+    school.statutory_high_age = row.fetch("StatutoryHighAge")
     school
   end
 

--- a/app/models/student_loans/school_eligibility.rb
+++ b/app/models/student_loans/school_eligibility.rb
@@ -38,13 +38,13 @@ module StudentLoans
       !closed_before_policy_start? &&
         eligible_local_authority? &&
         @school.state_funded? &&
-        (eligible_phase? || eligible_special_school?)
+        (eligible_phase? || secondary_equivalent_special_school?)
     end
 
     def eligible_current_school?
       @school.open? &&
         @school.state_funded? &&
-        (eligible_phase? || eligible_special_school?)
+        (eligible_phase? || secondary_equivalent_special_school?)
     end
 
     private
@@ -57,8 +57,8 @@ module StudentLoans
       ELIGIBLE_PHASES.include?(@school.phase)
     end
 
-    def eligible_special_school?
-      @school.phase == "not_applicable" && @school.special? && @school.school_type != "special_post_16_institutions"
+    def secondary_equivalent_special_school?
+      @school.special? && @school.school_type != "special_post_16_institutions" && @school.has_statutory_high_age_over_eleven?
     end
 
     def closed_before_policy_start?

--- a/app/models/student_loans/school_eligibility.rb
+++ b/app/models/student_loans/school_eligibility.rb
@@ -1,7 +1,6 @@
 module StudentLoans
   class SchoolEligibility
     POLICY_START_DATE = Date.new(2018, 4, 6)
-    ELIGIBLE_PHASES = %w[secondary middle_deemed_secondary all_through].freeze
     ELIGIBLE_LOCAL_AUTHORITY_CODES = [
       370, # Barnsley
       890, # Blackpool
@@ -38,23 +37,19 @@ module StudentLoans
       !closed_before_policy_start? &&
         eligible_local_authority? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (eligible_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
+        (@school.secondary_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
     end
 
     def eligible_current_school?
       @school.open? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (eligible_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
+        (@school.secondary_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
     end
 
     private
 
     def eligible_local_authority?
       ELIGIBLE_LOCAL_AUTHORITY_CODES.include?(@school.local_authority.code)
-    end
-
-    def eligible_phase?
-      ELIGIBLE_PHASES.include?(@school.phase)
     end
 
     def secondary_equivalent_special_school?

--- a/app/models/student_loans/school_eligibility.rb
+++ b/app/models/student_loans/school_eligibility.rb
@@ -37,14 +37,14 @@ module StudentLoans
     def eligible_claim_school?
       !closed_before_policy_start? &&
         eligible_local_authority? &&
-        @school.state_funded? &&
-        (eligible_phase? || secondary_equivalent_special_school?)
+        (@school.state_funded? || @school.secure_unit?) &&
+        (eligible_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
     end
 
     def eligible_current_school?
       @school.open? &&
-        @school.state_funded? &&
-        (eligible_phase? || secondary_equivalent_special_school?)
+        (@school.state_funded? || @school.secure_unit?) &&
+        (eligible_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
     end
 
     private
@@ -59,6 +59,10 @@ module StudentLoans
 
     def secondary_equivalent_special_school?
       @school.special? && @school.school_type != "special_post_16_institutions" && @school.has_statutory_high_age_over_eleven?
+    end
+
+    def secondary_equivalent_alternative_provision_school?
+      @school.alternative_provision? && @school.has_statutory_high_age_over_eleven?
     end
 
     def closed_before_policy_start?

--- a/app/models/student_loans/school_eligibility.rb
+++ b/app/models/student_loans/school_eligibility.rb
@@ -37,13 +37,13 @@ module StudentLoans
       !closed_before_policy_start? &&
         eligible_local_authority? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (@school.secondary_phase? || @school.secondary_equivalent_special? || @school.secondary_equivalent_alternative_provision?)
+        @school.secondary_or_equivalent?
     end
 
     def eligible_current_school?
       @school.open? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (@school.secondary_phase? || @school.secondary_equivalent_special? || @school.secondary_equivalent_alternative_provision?)
+        @school.secondary_or_equivalent?
     end
 
     private

--- a/app/models/student_loans/school_eligibility.rb
+++ b/app/models/student_loans/school_eligibility.rb
@@ -37,23 +37,19 @@ module StudentLoans
       !closed_before_policy_start? &&
         eligible_local_authority? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (@school.secondary_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
+        (@school.secondary_phase? || @school.secondary_equivalent_special? || secondary_equivalent_alternative_provision_school?)
     end
 
     def eligible_current_school?
       @school.open? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (@school.secondary_phase? || secondary_equivalent_special_school? || secondary_equivalent_alternative_provision_school?)
+        (@school.secondary_phase? || @school.secondary_equivalent_special? || secondary_equivalent_alternative_provision_school?)
     end
 
     private
 
     def eligible_local_authority?
       ELIGIBLE_LOCAL_AUTHORITY_CODES.include?(@school.local_authority.code)
-    end
-
-    def secondary_equivalent_special_school?
-      @school.special? && @school.school_type != "special_post_16_institutions" && @school.has_statutory_high_age_over_eleven?
     end
 
     def secondary_equivalent_alternative_provision_school?

--- a/app/models/student_loans/school_eligibility.rb
+++ b/app/models/student_loans/school_eligibility.rb
@@ -37,23 +37,19 @@ module StudentLoans
       !closed_before_policy_start? &&
         eligible_local_authority? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (@school.secondary_phase? || @school.secondary_equivalent_special? || secondary_equivalent_alternative_provision_school?)
+        (@school.secondary_phase? || @school.secondary_equivalent_special? || @school.secondary_equivalent_alternative_provision?)
     end
 
     def eligible_current_school?
       @school.open? &&
         (@school.state_funded? || @school.secure_unit?) &&
-        (@school.secondary_phase? || @school.secondary_equivalent_special? || secondary_equivalent_alternative_provision_school?)
+        (@school.secondary_phase? || @school.secondary_equivalent_special? || @school.secondary_equivalent_alternative_provision?)
     end
 
     private
 
     def eligible_local_authority?
       ELIGIBLE_LOCAL_AUTHORITY_CODES.include?(@school.local_authority.code)
-    end
-
-    def secondary_equivalent_alternative_provision_school?
-      @school.alternative_provision? && @school.has_statutory_high_age_over_eleven?
     end
 
     def closed_before_policy_start?

--- a/db/migrate/20191202123242_add_statutory_high_age_to_schools.rb
+++ b/db/migrate/20191202123242_add_statutory_high_age_to_schools.rb
@@ -1,0 +1,5 @@
+class AddStatutoryHighAgeToSchools < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :statutory_high_age, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -172,6 +172,7 @@ ActiveRecord::Schema.define(version: 2019_12_03_103255) do
     t.uuid "local_authority_district_id"
     t.date "close_date"
     t.integer "establishment_number"
+    t.integer "statutory_high_age"
     t.index ["created_at"], name: "index_schools_on_created_at"
     t.index ["local_authority_district_id"], name: "index_schools_on_local_authority_district_id"
     t.index ["local_authority_id"], name: "index_schools_on_local_authority_id"

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -11,13 +11,13 @@ FactoryBot.define do
     trait :student_loan_eligible do
       local_authority { LocalAuthority.find(ActiveRecord::FixtureSet.identify(:barnsley, :uuid)) }
       school_type_group { School::STATE_FUNDED_SCHOOL_TYPE_GROUPS.sample }
-      phase { StudentLoans::SchoolEligibility::ELIGIBLE_PHASES.sample }
+      phase { School::SECONDARY_PHASES.sample }
     end
 
     trait :maths_and_physics_eligible do
       local_authority_district { LocalAuthorityDistrict.find(ActiveRecord::FixtureSet.identify(:barnsley, :uuid)) }
       school_type_group { School::STATE_FUNDED_SCHOOL_TYPE_GROUPS.sample }
-      phase { StudentLoans::SchoolEligibility::ELIGIBLE_PHASES.sample }
+      phase { School::SECONDARY_PHASES.sample }
     end
   end
 end

--- a/spec/models/maths_and_physics/school_eligibility_spec.rb
+++ b/spec/models/maths_and_physics/school_eligibility_spec.rb
@@ -2,172 +2,117 @@ require "rails_helper"
 
 RSpec.describe MathsAndPhysics::SchoolEligibility do
   describe "#eligible_current_school?" do
-    subject { MathsAndPhysics::SchoolEligibility.new(school).eligible_current_school? }
-    let(:school) { build(:school, school_attributes.merge({local_authority_district: local_authority_district})) }
+    context "with a secondary school" do
+      let(:secondary_school) {
+        School.new(
+          school_type_group: :la_maintained,
+          phase: :secondary,
+          close_date: nil,
+          local_authority_district: local_authority_districts(:barnsley)
+        )
+      }
 
-    context "when it is in an eligible local authority district" do
-      let(:local_authority_district) { local_authority_districts(:barnsley) }
-
-      context "and it is a college" do
-        let(:college_attributes) { {school_type_group: :colleges} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { college_attributes.merge({phase: :middle_deemed_secondary}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { college_attributes.merge({phase: :sixteen_plus}) }
-          it { is_expected.to be false }
-        end
+      it "returns true with an open, state funded secondary school in an eligible local authority district" do
+        expect(MathsAndPhysics::SchoolEligibility.new(secondary_school).eligible_current_school?).to eql true
       end
 
-      context "and it is an academy" do
-        let(:academy_school_attributes) { {school_type_group: :academies} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { academy_school_attributes.merge({phase: :secondary}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { academy_school_attributes.merge({phase: :primary}) }
-          it { is_expected.to be false }
-        end
+      it "returns false when closed" do
+        secondary_school.assign_attributes(close_date: Date.new)
+        expect(MathsAndPhysics::SchoolEligibility.new(secondary_school).eligible_current_school?).to eql false
       end
 
-      context "and it is a free school" do
-        let(:free_school_attributes) { {school_type_group: :free_schools} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { free_school_attributes.merge({phase: :secondary}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { free_school_attributes.merge({phase: :middle_deemed_primary}) }
-          it { is_expected.to be false }
-        end
+      it "returns false when not in an eligible local authority district" do
+        secondary_school.assign_attributes(local_authority_district: local_authority_districts(:camden))
+        expect(MathsAndPhysics::SchoolEligibility.new(secondary_school).eligible_current_school?).to eql false
       end
 
-      context "and it is a LA maintained school" do
-        let(:la_maintained_attributes) { {school_type_group: :la_maintained} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { la_maintained_attributes.merge({phase: :all_through}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { la_maintained_attributes.merge({phase: :nursery}) }
-          it { is_expected.to be false }
-        end
-      end
-
-      context "and it is a state funded special school" do
-        let(:special_school_attributes) { {school_type: :community_special_school, school_type_group: :special_schools} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :secondary}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :nursery}) }
-          it { is_expected.to be false }
-        end
-
-        context "and it doesn't have an education phase" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :not_applicable}) }
-          it { is_expected.to be false }
-
-          context "and it has a statutory high age of 16" do
-            let(:school_attributes) { {statutory_high_age: 16} }
-            it { is_expected.to be(true) }
-          end
-        end
-      end
-
-      context "and it is a special free school" do
-        let(:special_free_school_attributes) { {school_type: :free_school_special, school_type_group: :free_schools} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { special_free_school_attributes.merge({phase: :secondary}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { special_free_school_attributes.merge({phase: :nursery}) }
-          it { is_expected.to be false }
-        end
-
-        context "and it doesn't have an education phase" do
-          let(:school_attributes) { special_free_school_attributes.merge({phase: :not_applicable}) }
-          it { is_expected.to be false }
-
-          context "and it has a statutory high age of 16" do
-            let(:school_attributes) { {statutory_high_age: 16} }
-            it { is_expected.to be(true) }
-          end
-        end
-      end
-
-      context "and it is an independent special school" do
-        let(:special_school_attributes) { {school_type: :other_independent_special_school, school_type_group: :special_schools} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :secondary}) }
-          it { is_expected.to be false }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :nursery}) }
-          it { is_expected.to be false }
-        end
-
-        context "and it doesn't have an education phase" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :not_applicable}) }
-          it { is_expected.to be false }
-        end
-      end
-
-      context "and it is a special post 16 institution" do
-        let(:school_attributes) { {school_type: :special_post_16_institutions, school_type_group: :special_schools, phase: :not_applicable} }
-        it { is_expected.to be false }
-      end
-
-      context "and it is not a state funded school" do
-        let(:school_attributes) { {school_type_group: :independent_schools} }
-        it { is_expected.to be false }
+      it "returns false when not state funded" do
+        secondary_school.assign_attributes(school_type_group: :independent_schools)
+        expect(MathsAndPhysics::SchoolEligibility.new(secondary_school).eligible_current_school?).to eql false
       end
     end
 
-    context "when it is not in an eligible local authority district" do
-      let(:local_authority_district) { local_authority_districts(:camden) }
-      let(:school_attributes) { {} }
-      it { is_expected.to be false }
-    end
+    context "with a special school" do
+      let(:special_school) {
+        School.new(
+          close_date: nil,
+          school_type: :community_special_school,
+          school_type_group: :special_schools,
+          statutory_high_age: 16,
+          local_authority_district: local_authority_districts(:barnsley)
+        )
+      }
 
-    context "when the school is otherwise eligible but is closed" do
-      let(:school) { build(:school, :maths_and_physics_eligible, close_date: Date.yesterday) }
-      it { is_expected.to be false }
+      it "returns true with an open, state funded secondary equivalent special school in an eligible local authority district" do
+        expect(MathsAndPhysics::SchoolEligibility.new(special_school).eligible_current_school?).to eql true
+      end
+
+      it "returns false when closed" do
+        special_school.assign_attributes(close_date: Date.new)
+        expect(MathsAndPhysics::SchoolEligibility.new(special_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not in an eligble local authority district" do
+        special_school.assign_attributes(local_authority_district: local_authority_districts(:camden))
+        expect(MathsAndPhysics::SchoolEligibility.new(special_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not state funded" do
+        special_school.assign_attributes(school_type_group: :independent_schools)
+        expect(MathsAndPhysics::SchoolEligibility.new(special_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        special_school.assign_attributes(statutory_high_age: 11)
+        expect(MathsAndPhysics::SchoolEligibility.new(special_school).eligible_current_school?).to eql false
+      end
     end
 
     context "with alternative provision school" do
-      it "returns true with a state funded secondary equivalent alternative provision school" do
-        alternative_provision_school = School.new(school_type_group: :la_maintained, school_type: :pupil_referral_unit, statutory_high_age: 19, local_authority_district: local_authority_districts(:barnsley))
+      let(:alternative_provision_school) {
+        School.new(
+          close_date: nil,
+          school_type_group: :la_maintained,
+          school_type: :pupil_referral_unit,
+          statutory_high_age: 19,
+          local_authority_district: local_authority_districts(:barnsley)
+        )
+      }
+
+      it "returns true with an open, state funded secondary equivalent alternative provision school in an eligible local authority district" do
         expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      end
+
+      it "returns false when closed" do
+        alternative_provision_school.assign_attributes(close_date: Date.new)
+        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not in an eligble local authority district" do
+        alternative_provision_school.assign_attributes(local_authority_district: local_authority_districts(:camden))
+        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        alternative_provision_school.assign_attributes(statutory_high_age: 11)
+        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq false
       end
 
       it "returns true with a secure unit" do
-        alternative_provision_school = School.new(school_type_group: :other, school_type: :secure_unit, statutory_high_age: 19, local_authority_district: local_authority_districts(:barnsley))
+        alternative_provision_school.assign_attributes(school_type_group: :other, school_type: :secure_unit)
         expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
       end
+    end
+  end
 
-      it "returns false with a alternative provision school that is not secondary equivalent" do
-        alternative_provision_school = School.new(school_type_group: :la_maintained, school_type: :pupil_referral_unit, statutory_high_age: 11, local_authority_district: local_authority_districts(:barnsley))
-        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq false
-      end
+  context "when it is not a secondary school" do
+    it "returns false" do
+      primary_school = School.new(
+        phase: :primary,
+        school_type_group: :la_maintained,
+        local_authority_district: local_authority_districts(:barnsley)
+      )
+      expect(MathsAndPhysics::SchoolEligibility.new(primary_school).eligible_current_school?).to eql false
     end
   end
 end

--- a/spec/models/maths_and_physics/school_eligibility_spec.rb
+++ b/spec/models/maths_and_physics/school_eligibility_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe MathsAndPhysics::SchoolEligibility do
-  describe "#check" do
-    subject { MathsAndPhysics::SchoolEligibility.new(school).check }
+  describe "#eligible_current_school?" do
+    subject { MathsAndPhysics::SchoolEligibility.new(school).eligible_current_school? }
     let(:school) { build(:school, school_attributes.merge({local_authority_district: local_authority_district})) }
 
     context "when it is in an eligible local authority district" do

--- a/spec/models/maths_and_physics/school_eligibility_spec.rb
+++ b/spec/models/maths_and_physics/school_eligibility_spec.rb
@@ -152,5 +152,22 @@ RSpec.describe MathsAndPhysics::SchoolEligibility do
       let(:school) { build(:school, :maths_and_physics_eligible, close_date: Date.yesterday) }
       it { is_expected.to be false }
     end
+
+    context "with alternative provision school" do
+      it "returns true with a state funded secondary equivalent alternative provision school" do
+        alternative_provision_school = School.new(school_type_group: :la_maintained, school_type: :pupil_referral_unit, statutory_high_age: 19, local_authority_district: local_authority_districts(:barnsley))
+        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      end
+
+      it "returns true with a secure unit" do
+        alternative_provision_school = School.new(school_type_group: :other, school_type: :secure_unit, statutory_high_age: 19, local_authority_district: local_authority_districts(:barnsley))
+        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      end
+
+      it "returns false with a alternative provision school that is not secondary equivalent" do
+        alternative_provision_school = School.new(school_type_group: :la_maintained, school_type: :pupil_referral_unit, statutory_high_age: 11, local_authority_district: local_authority_districts(:barnsley))
+        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq false
+      end
+    end
   end
 end

--- a/spec/models/maths_and_physics/school_eligibility_spec.rb
+++ b/spec/models/maths_and_physics/school_eligibility_spec.rb
@@ -79,7 +79,12 @@ RSpec.describe MathsAndPhysics::SchoolEligibility do
 
         context "and it doesn't have an education phase" do
           let(:school_attributes) { special_school_attributes.merge({phase: :not_applicable}) }
-          it { is_expected.to be true }
+          it { is_expected.to be false }
+
+          context "and it has a statutory high age of 16" do
+            let(:school_attributes) { {statutory_high_age: 16} }
+            it { is_expected.to be(true) }
+          end
         end
       end
 
@@ -98,7 +103,12 @@ RSpec.describe MathsAndPhysics::SchoolEligibility do
 
         context "and it doesn't have an education phase" do
           let(:school_attributes) { special_free_school_attributes.merge({phase: :not_applicable}) }
-          it { is_expected.to be true }
+          it { is_expected.to be false }
+
+          context "and it has a statutory high age of 16" do
+            let(:school_attributes) { {statutory_high_age: 16} }
+            it { is_expected.to be(true) }
+          end
         end
       end
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -78,58 +78,54 @@ RSpec.describe School, type: :model do
     end
   end
 
-  describe "#secondary_phase?" do
-    it "returns true for all secondary phases" do
+  describe "#secondary_or_equivalent?" do
+    it "returns true for a secondary school" do
       School::SECONDARY_PHASES.each do |phase|
-        expect(School.new(phase: phase).secondary_phase?).to eq true
+        expect(School.new(phase: phase).secondary_or_equivalent?).to eq true
       end
     end
 
-    it "returns false for all other phases" do
+    it "returns false for schools that are not secondary" do
       non_secondary_phases = School::PHASES.keys.map(&:to_s) - School::SECONDARY_PHASES
 
       non_secondary_phases.each do |phase|
-        expect(School.new(phase: phase).secondary_phase?).to eq false
+        expect(School.new(phase: phase).secondary_or_equivalent?).to eq false
       end
     end
-  end
 
-  describe "#secondary_equivalent_special?" do
     it "returns true for a special school that teaches students over eleven" do
       school = School.new(school_type: :community_special_school, statutory_high_age: 16)
-      expect(school.secondary_equivalent_special?).to eq true
+      expect(school.secondary_or_equivalent?).to eq true
     end
 
     it "returns false for a special school that teaches students eleven or under" do
       school = School.new(school_type: :community_special_school, statutory_high_age: 11)
-      expect(school.secondary_equivalent_special?).to eq false
+      expect(school.secondary_or_equivalent?).to eq false
     end
 
     it "returns false for a non special school that teaches students over eleven" do
       school = School.new(school_type: :community_school, statutory_high_age: 16)
-      expect(school.secondary_equivalent_special?).to eq false
+      expect(school.secondary_or_equivalent?).to eq false
     end
 
     it "returns false for a special school that is a post 16 institution" do
       school = School.new(school_type: :special_post_16_institutions, statutory_high_age: 18)
-      expect(school.secondary_equivalent_special?).to eq false
+      expect(school.secondary_or_equivalent?).to eq false
     end
-  end
 
-  describe "#secondary_equivalent_alternative_provision?" do
     it "returns true for a alternative provision school that teaches students over eleven" do
       school = School.new(school_type: :pupil_referral_unit, statutory_high_age: 16)
-      expect(school.secondary_equivalent_alternative_provision?).to eq true
+      expect(school.secondary_or_equivalent?).to eq true
     end
 
     it "returns false for a alternative provision school that teaches students under eleven" do
       school = School.new(school_type: :pupil_referral_unit, statutory_high_age: 11)
-      expect(school.secondary_equivalent_alternative_provision?).to eq false
+      expect(school.secondary_or_equivalent?).to eq false
     end
 
     it "returns false for a non alternative provision school that teaches students over 11" do
       school = School.new(school_type: :community_school, statutory_high_age: 16)
-      expect(school.secondary_equivalent_alternative_provision?).to eq false
+      expect(school.secondary_or_equivalent?).to eq false
     end
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -115,4 +115,21 @@ RSpec.describe School, type: :model do
       expect(school.secondary_equivalent_special?).to eq false
     end
   end
+
+  describe "#secondary_equivalent_alternative_provision?" do
+    it "returns true for a alternative provision school that teaches students over eleven" do
+      school = School.new(school_type: :pupil_referral_unit, statutory_high_age: 16)
+      expect(school.secondary_equivalent_alternative_provision?).to eq true
+    end
+
+    it "returns false for a alternative provision school that teaches students under eleven" do
+      school = School.new(school_type: :pupil_referral_unit, statutory_high_age: 11)
+      expect(school.secondary_equivalent_alternative_provision?).to eq false
+    end
+
+    it "returns false for a non alternative provision school that teaches students over 11" do
+      school = School.new(school_type: :community_school, statutory_high_age: 16)
+      expect(school.secondary_equivalent_alternative_provision?).to eq false
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -77,4 +77,20 @@ RSpec.describe School, type: :model do
       end
     end
   end
+
+  describe "#secondary_phase?" do
+    it "returns true for all secondary phases" do
+      School::SECONDARY_PHASES.each do |phase|
+        expect(School.new(phase: phase).secondary_phase?).to eq true
+      end
+    end
+
+    it "returns false for all other phases" do
+      non_secondary_phases = School::PHASES.keys.map(&:to_s) - School::SECONDARY_PHASES
+
+      non_secondary_phases.each do |phase|
+        expect(School.new(phase: phase).secondary_phase?).to eq false
+      end
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -93,4 +93,26 @@ RSpec.describe School, type: :model do
       end
     end
   end
+
+  describe "#secondary_equivalent_special?" do
+    it "returns true for a special school that teaches students over eleven" do
+      school = School.new(school_type: :community_special_school, statutory_high_age: 16)
+      expect(school.secondary_equivalent_special?).to eq true
+    end
+
+    it "returns false for a special school that teaches students eleven or under" do
+      school = School.new(school_type: :community_special_school, statutory_high_age: 11)
+      expect(school.secondary_equivalent_special?).to eq false
+    end
+
+    it "returns false for a non special school that teaches students over eleven" do
+      school = School.new(school_type: :community_school, statutory_high_age: 16)
+      expect(school.secondary_equivalent_special?).to eq false
+    end
+
+    it "returns false for a special school that is a post 16 institution" do
+      school = School.new(school_type: :special_post_16_institutions, statutory_high_age: 18)
+      expect(school.secondary_equivalent_special?).to eq false
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -61,4 +61,20 @@ RSpec.describe School, type: :model do
       expect(school.dfe_number).to eq("123/4567")
     end
   end
+
+  describe "#state_funded?" do
+    it "returns true for state funded school type groups" do
+      School::STATE_FUNDED_SCHOOL_TYPE_GROUPS.each do |group|
+        expect(School.new(school_type_group: group).state_funded?).to eq true
+      end
+    end
+
+    it "returns false for school type groups that are not state funded" do
+      non_state_funded = School::SCHOOL_TYPE_GROUPS.keys.map(&:to_s) - School::STATE_FUNDED_SCHOOL_TYPE_GROUPS
+
+      non_state_funded.each do |phase|
+        expect(School.new(school_type_group: phase).state_funded?).to eq false
+      end
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe School, type: :model do
     end
   end
 
-  describe "dfe_number" do
+  describe "#dfe_number" do
     let(:school) do
       build(:school,
         name: "Bash Street School",

--- a/spec/models/student_loans/school_eligibility_spec.rb
+++ b/spec/models/student_loans/school_eligibility_spec.rb
@@ -2,253 +2,219 @@ require "rails_helper"
 
 RSpec.describe StudentLoans::SchoolEligibility do
   describe "#eligible_claim_school?" do
-    subject { StudentLoans::SchoolEligibility.new(school).eligible_claim_school? }
-    let(:school) { build(:school, school_attributes.merge({local_authority: local_authority})) }
+    context "with a secondary school" do
+      let(:secondary_school) {
+        School.new(
+          school_type_group: :la_maintained,
+          phase: :secondary,
+          close_date: nil,
+          local_authority: local_authorities(:barnsley)
+        )
+      }
 
-    context "when it is in an eligible area" do
-      let(:local_authority) { local_authorities(:barnsley) }
-
-      context "and it is an academy" do
-        let(:academy_school_attributes) { {school_type_group: :academies} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { academy_school_attributes.merge({phase: :secondary}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { academy_school_attributes.merge({phase: :primary}) }
-          it { is_expected.to be false }
-        end
+      it "returns true with an open, state funded secondary school in an eligible local authority" do
+        expect(StudentLoans::SchoolEligibility.new(secondary_school).eligible_claim_school?).to eql true
       end
 
-      context "and it is a free school" do
-        let(:free_school_attributes) { {school_type_group: :free_schools} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { free_school_attributes.merge({phase: :secondary}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { free_school_attributes.merge({phase: :middle_deemed_primary}) }
-          it { is_expected.to be false }
-        end
+      it "returns false when closed before the policy start date" do
+        secondary_school.assign_attributes(close_date: StudentLoans::SchoolEligibility::POLICY_START_DATE - 1.month)
+        expect(StudentLoans::SchoolEligibility.new(secondary_school).eligible_claim_school?).to eql false
       end
 
-      context "and it is a college" do
-        let(:college_attributes) { {school_type_group: :colleges} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { college_attributes.merge({phase: :middle_deemed_secondary}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { college_attributes.merge({phase: :sixteen_plus}) }
-          it { is_expected.to be false }
-        end
+      it "returns true when closed after the policy start date" do
+        secondary_school.assign_attributes(close_date: StudentLoans::SchoolEligibility::POLICY_START_DATE + 1.month)
+        expect(StudentLoans::SchoolEligibility.new(secondary_school).eligible_claim_school?).to eql true
       end
 
-      context "and it is a LA maintained school" do
-        let(:la_maintained_attributes) { {school_type_group: :la_maintained} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { la_maintained_attributes.merge({phase: :all_through}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { la_maintained_attributes.merge({phase: :nursery}) }
-          it { is_expected.to be false }
-        end
+      it "returns false when not in an eligible local authority" do
+        secondary_school.assign_attributes(local_authority: local_authorities(:camden))
+        expect(StudentLoans::SchoolEligibility.new(secondary_school).eligible_claim_school?).to eql false
       end
 
-      context "and it is a state funded special school" do
-        let(:special_school_attributes) { {school_type: :community_special_school, school_type_group: :special_schools} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :secondary}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :nursery}) }
-          it { is_expected.to be false }
-        end
-
-        context "and it doesn't have an education phase" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :not_applicable}) }
-          it { is_expected.to be false }
-
-          context "and it has a statutory high age of 16" do
-            let(:school_attributes) { {statutory_high_age: 16} }
-            it { is_expected.to be(true) }
-          end
-        end
-      end
-
-      context "and it is a special free school" do
-        let(:special_free_school_attributes) { {school_type: :free_school_special, school_type_group: :free_schools} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { special_free_school_attributes.merge({phase: :secondary}) }
-          it { is_expected.to be true }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { special_free_school_attributes.merge({phase: :nursery}) }
-          it { is_expected.to be false }
-        end
-
-        context "and it doesn't have an education phase" do
-          let(:school_attributes) { special_free_school_attributes.merge({phase: :not_applicable}) }
-          it { is_expected.to be false }
-        end
-
-        context "and it has a statutory high age of over 11" do
-          let(:school_attributes) { special_free_school_attributes.merge({statutory_high_age: 16}) }
-          it { is_expected.to be true }
-        end
-      end
-
-      context "and it is an independent special school" do
-        let(:special_school_attributes) { {school_type: :other_independent_special_school, school_type_group: :special_schools} }
-
-        context "and it has an education phase of secondary, middle deemed secondary, or all-through" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :secondary}) }
-          it { is_expected.to be false }
-        end
-
-        context "and it has an education phase of nursery, primary, middle deemed primary, or 16+" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :nursery}) }
-          it { is_expected.to be false }
-        end
-
-        context "and it doesn't have an education phase" do
-          let(:school_attributes) { special_school_attributes.merge({phase: :not_applicable}) }
-          it { is_expected.to be false }
-        end
-      end
-
-      context "and it is a special post 16 institution" do
-        let(:school_attributes) { {school_type: :special_post_16_institutions, school_type_group: :special_schools, phase: :not_applicable} }
-        it { is_expected.to be false }
-      end
-
-      context "and it is not a state funded school" do
-        let(:school_attributes) { {school_type_group: :independent_schools} }
-        it { is_expected.to be false }
+      it "returns false when not state funded" do
+        secondary_school.assign_attributes(school_type_group: :independent_schools)
+        expect(StudentLoans::SchoolEligibility.new(secondary_school).eligible_claim_school?).to eql false
       end
     end
 
-    context "when it is not in an eligible area" do
-      let(:local_authority) { local_authorities(:camden) }
-      let(:school_attributes) { {} }
-      it { is_expected.to be false }
-    end
+    context "with a special school" do
+      let(:special_school) {
+        School.new(
+          close_date: nil,
+          school_type: :community_special_school,
+          school_type_group: :special_schools,
+          statutory_high_age: 16,
+          local_authority: local_authorities(:barnsley)
+        )
+      }
 
-    context "when it is otherwise eligible but closed before the start of the policy" do
-      let(:before_start_of_policy) { StudentLoans::SchoolEligibility::POLICY_START_DATE - 1.day }
-      let(:school) { build(:school, :student_loan_eligible, close_date: before_start_of_policy) }
-      it { is_expected.to be false }
-    end
+      it "returns true with an open, state funded secondary equivalent special school in an eligible local authority district" do
+        expect(StudentLoans::SchoolEligibility.new(special_school).eligible_claim_school?).to eql true
+      end
 
-    context "when it is otherwise eligible but closed after the start of the policy" do
-      let(:after_start_of_policy) { StudentLoans::SchoolEligibility::POLICY_START_DATE + 1.day }
-      let(:school) { build(:school, :student_loan_eligible, close_date: after_start_of_policy) }
-      it { is_expected.to be true }
+      it "returns false when closed before the policy start date" do
+        special_school.assign_attributes(close_date: StudentLoans::SchoolEligibility::POLICY_START_DATE - 1.month)
+        expect(StudentLoans::SchoolEligibility.new(special_school).eligible_claim_school?).to eql false
+      end
+      it "returns true when closed after the policy start date" do
+        special_school.assign_attributes(close_date: StudentLoans::SchoolEligibility::POLICY_START_DATE + 1.month)
+        expect(StudentLoans::SchoolEligibility.new(special_school).eligible_claim_school?).to eql true
+      end
+
+      it "returns false when not in an eligble local authority" do
+        special_school.assign_attributes(local_authority: local_authorities(:camden))
+        expect(StudentLoans::SchoolEligibility.new(special_school).eligible_claim_school?).to eql false
+      end
+
+      it "returns false when not state funded" do
+        special_school.assign_attributes(school_type_group: :independent_schools)
+        expect(StudentLoans::SchoolEligibility.new(special_school).eligible_claim_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        special_school.assign_attributes(statutory_high_age: 11)
+        expect(StudentLoans::SchoolEligibility.new(special_school).eligible_claim_school?).to eql false
+      end
     end
 
     context "with alternative provision school" do
-      it "returns true with a state funded secondary equivalent alternative provision school" do
-        alternative_provision_school = School.new(school_type_group: :la_maintained, school_type: :pupil_referral_unit, statutory_high_age: 19, local_authority_district: local_authority_districts(:barnsley))
-        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      let(:alternative_provision_school) {
+        School.new(
+          close_date: nil,
+          school_type_group: :la_maintained,
+          school_type: :pupil_referral_unit,
+          statutory_high_age: 19, local_authority: local_authorities(:barnsley)
+        )
+      }
+
+      it "returns true with an open, state funded secondary equivalent alternative provision school in an eligible local authority" do
+        expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_claim_school?).to eq true
+      end
+
+      it "returns false when closed before the policy start date" do
+        alternative_provision_school.assign_attributes(close_date: StudentLoans::SchoolEligibility::POLICY_START_DATE - 1.month)
+        expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_claim_school?).to eql false
+      end
+
+      it "returns true when closed after the policy start date" do
+        alternative_provision_school.assign_attributes(close_date: StudentLoans::SchoolEligibility::POLICY_START_DATE + 1.month)
+        expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_claim_school?).to eql true
+      end
+
+      it "returns false when not in an eligble local authority" do
+        alternative_provision_school.assign_attributes(local_authority: local_authorities(:camden))
+        expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_claim_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        alternative_provision_school.assign_attributes(statutory_high_age: 11)
+        expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_claim_school?).to eq false
       end
 
       it "returns true with a secure unit" do
-        alternative_provision_school = School.new(school_type_group: :other, school_type: :secure_unit, statutory_high_age: 19, local_authority_district: local_authority_districts(:barnsley))
-        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+        alternative_provision_school.assign_attributes(school_type_group: :other, school_type: :secure_unit)
+        expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_claim_school?).to eq true
       end
+    end
 
-      it "returns false with a alternative provision school that is not secondary equivalent" do
-        alternative_provision_school = School.new(school_type_group: :la_maintained, school_type: :pupil_referral_unit, statutory_high_age: 11, local_authority_district: local_authority_districts(:barnsley))
-        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq false
+    context "when it is not a secondary school" do
+      it "returns false" do
+        primary_school = School.new(phase: :primary, school_type_group: :la_maintained, local_authority: local_authorities(:barnsley))
+        expect(StudentLoans::SchoolEligibility.new(primary_school).eligible_claim_school?).to eql false
       end
     end
   end
 
   describe "#eligible_current_school?" do
-    subject { StudentLoans::SchoolEligibility.new(school).eligible_current_school? }
-    let(:school) { build(:school, school_attributes) }
+    context "with a secondary school" do
+      let(:secondary_school) {
+        School.new(
+          school_type_group: :la_maintained,
+          phase: :secondary,
+          close_date: nil
+        )
+      }
 
-    # e.g. Hampstead School, URN 4567
-    context "with a local authority maintained secondary school" do
-      let(:school_attributes) { {phase: :secondary, school_type_group: :la_maintained} }
-      it { is_expected.to be(true) }
-    end
+      it "returns true with an open, state funded secondary school" do
+        expect(StudentLoans::SchoolEligibility.new(secondary_school).eligible_current_school?).to eql true
+      end
 
-    # e.g. Hursthead Infant School, URN 106052
-    context "with a local authority maintained primary school" do
-      let(:school_attributes) { {phase: :primary, school_type_group: :la_maintained} }
-      it { is_expected.to be(false) }
-    end
+      it "returns false when closed" do
+        secondary_school.assign_attributes(close_date: Date.new)
+        expect(StudentLoans::SchoolEligibility.new(secondary_school).eligible_current_school?).to eql false
+      end
 
-    # e.g. The Samuel Lister Academy, URN 137576
-    context "with a secondary academy" do
-      let(:school_attributes) { {phase: :secondary, school_type_group: :academies} }
-      it { is_expected.to be(true) }
-    end
-
-    # e.g. Willow Bank Primary School, URN 136932
-    context "with a primary academy" do
-      let(:school_attributes) { {phase: :primary, school_type_group: :academies} }
-      it { is_expected.to be(false) }
-    end
-
-    # e.g. West London Free School, URN 136750
-    context "with a secondary free school" do
-      let(:school_attributes) { {phase: :secondary, school_type_group: :free_schools} }
-      it { is_expected.to be(true) }
-    end
-
-    # e.g. Stockport College, URN 130512
-    context "with a sixteen-plus college" do
-      let(:school_attributes) { {phase: :sixteen_plus, school_type_group: :colleges} }
-      it { is_expected.to be(false) }
-    end
-
-    # e.g. Bradford Grammar School, URN 107455
-    context "with an independent school with not_applicable phase" do
-      let(:school_attributes) { {phase: :not_applicable, school_type_group: :independent_schools} }
-      it { is_expected.to be(false) }
-    end
-
-    # e.g. Coney Hill School, URN 101696
-    context "with a non-maintained special school with not_applicable phase" do
-      let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :non_maintained_special_school} }
-      it { is_expected.to be(false) }
-
-      context "and it has a statutory high age of 16" do
-        let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :non_maintained_special_school, statutory_high_age: 16} }
-        it { is_expected.to be(true) }
+      it "returns false when not state funded" do
+        secondary_school.assign_attributes(school_type_group: :independent_schools)
+        expect(StudentLoans::SchoolEligibility.new(secondary_school).eligible_current_school?).to eql false
       end
     end
 
-    # e.g. Frank Barnes School for Deaf Children, URN 100091
-    context "with a community special school with not_applicable phase" do
-      let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :community_special_school} }
-      it { is_expected.to be(false) }
+    context "with a special school" do
+      let(:special_school) {
+        School.new(
+          close_date: nil,
+          school_type: :community_special_school,
+          school_type_group: :special_schools,
+          statutory_high_age: 16
+        )
+      }
 
-      context "and it has a statutory high age of 16" do
-        let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :community_special_school, statutory_high_age: 16} }
-        it { is_expected.to be(true) }
+      it "returns true with an open, state funded secondary equivalent special school" do
+        expect(StudentLoans::SchoolEligibility.new(special_school).eligible_current_school?).to eql true
+      end
+
+      it "returns false when closed" do
+        special_school.assign_attributes(close_date: Date.new)
+        expect(StudentLoans::SchoolEligibility.new(special_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not state funded" do
+        special_school.assign_attributes(school_type_group: :independent_schools)
+        expect(StudentLoans::SchoolEligibility.new(special_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        special_school.assign_attributes(statutory_high_age: 11)
+        expect(StudentLoans::SchoolEligibility.new(special_school).eligible_current_school?).to eql false
       end
     end
 
-    context "with a closed school that would otherwise be eligible" do
-      let(:school_attributes) { {phase: :secondary, school_type_group: :la_maintained, close_date: Date.yesterday} }
-      it { is_expected.to be(false) }
+    context "with alternative provision school" do
+      let(:alternative_provision_school) {
+        School.new(
+          close_date: nil,
+          school_type_group: :la_maintained,
+          school_type: :pupil_referral_unit,
+          statutory_high_age: 19
+        )
+      }
+
+      it "returns true with an open, state funded secondary equivalent alternative provision school" do
+        expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      end
+
+      it "returns false when closed" do
+        alternative_provision_school.assign_attributes(close_date: Date.new)
+        expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        alternative_provision_school.assign_attributes(statutory_high_age: 11)
+        expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq false
+      end
+
+      it "returns true with a secure unit" do
+        alternative_provision_school.assign_attributes(school_type_group: :other, school_type: :secure_unit)
+        expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      end
+    end
+
+    context "when it is not a secondary school" do
+      it "returns false" do
+        primary_school = School.new(phase: :primary, school_type_group: :la_maintained)
+        expect(StudentLoans::SchoolEligibility.new(primary_school).eligible_current_school?).to eql false
+      end
     end
   end
 end

--- a/spec/models/student_loans/school_eligibility_spec.rb
+++ b/spec/models/student_loans/school_eligibility_spec.rb
@@ -79,7 +79,12 @@ RSpec.describe StudentLoans::SchoolEligibility do
 
         context "and it doesn't have an education phase" do
           let(:school_attributes) { special_school_attributes.merge({phase: :not_applicable}) }
-          it { is_expected.to be true }
+          it { is_expected.to be false }
+
+          context "and it has a statutory high age of 16" do
+            let(:school_attributes) { {statutory_high_age: 16} }
+            it { is_expected.to be(true) }
+          end
         end
       end
 
@@ -98,6 +103,11 @@ RSpec.describe StudentLoans::SchoolEligibility do
 
         context "and it doesn't have an education phase" do
           let(:school_attributes) { special_free_school_attributes.merge({phase: :not_applicable}) }
+          it { is_expected.to be false }
+        end
+
+        context "and it has a statutory high age of over 11" do
+          let(:school_attributes) { special_free_school_attributes.merge({statutory_high_age: 16}) }
           it { is_expected.to be true }
         end
       end
@@ -200,13 +210,23 @@ RSpec.describe StudentLoans::SchoolEligibility do
     # e.g. Coney Hill School, URN 101696
     context "with a non-maintained special school with not_applicable phase" do
       let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :non_maintained_special_school} }
-      it { is_expected.to be(true) }
+      it { is_expected.to be(false) }
+
+      context "and it has a statutory high age of 16" do
+        let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :non_maintained_special_school, statutory_high_age: 16} }
+        it { is_expected.to be(true) }
+      end
     end
 
     # e.g. Frank Barnes School for Deaf Children, URN 100091
     context "with a community special school with not_applicable phase" do
       let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :community_special_school} }
-      it { is_expected.to be(true) }
+      it { is_expected.to be(false) }
+
+      context "and it has a statutory high age of 16" do
+        let(:school_attributes) { {phase: :not_applicable, school_type_group: :special_schools, school_type: :community_special_school, statutory_high_age: 16} }
+        it { is_expected.to be(true) }
+      end
     end
 
     context "with a closed school that would otherwise be eligible" do

--- a/spec/models/student_loans/school_eligibility_spec.rb
+++ b/spec/models/student_loans/school_eligibility_spec.rb
@@ -159,6 +159,23 @@ RSpec.describe StudentLoans::SchoolEligibility do
       let(:school) { build(:school, :student_loan_eligible, close_date: after_start_of_policy) }
       it { is_expected.to be true }
     end
+
+    context "with alternative provision school" do
+      it "returns true with a state funded secondary equivalent alternative provision school" do
+        alternative_provision_school = School.new(school_type_group: :la_maintained, school_type: :pupil_referral_unit, statutory_high_age: 19, local_authority_district: local_authority_districts(:barnsley))
+        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      end
+
+      it "returns true with a secure unit" do
+        alternative_provision_school = School.new(school_type_group: :other, school_type: :secure_unit, statutory_high_age: 19, local_authority_district: local_authority_districts(:barnsley))
+        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      end
+
+      it "returns false with a alternative provision school that is not secondary equivalent" do
+        alternative_provision_school = School.new(school_type_group: :la_maintained, school_type: :pupil_referral_unit, statutory_high_age: 11, local_authority_district: local_authority_districts(:barnsley))
+        expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq false
+      end
+    end
   end
 
   describe "#eligible_current_school?" do

--- a/spec/services/school_data_importer_spec.rb
+++ b/spec/services/school_data_importer_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe SchoolDataImporter do
         expect(imported_school.local_authority_district.name).to eql("Barnsley")
         expect(imported_school.close_date).to be_nil
         expect(imported_school.establishment_number).to eq(4027)
+        expect(imported_school.statutory_high_age).to eq(18)
       end
 
       it "imports a closed school with the date it closed" do


### PR DESCRIPTION
Special schools with a `phase` of `not_applicable` are still eligble when they teach students over the age of 11. We use the `statututoryHighAge` column in the Get information about schools data to test the elgiblity of this type of school.

Alternative provision schools that teach students over the age of 11 are also eligible. Alternative provision schools are those of the `school_type`:

- pupil_referral_unit
- secure_unit
- free_school_alternative_provider
- academy_alternative_provision_converter
- academy_alternative_provision_sponsor_led

The same `statututoryHighAge` can be used along with the school type to determine eligibility.

Secue units do not have a recognised state funded `school_type_group` so I had to add an exception for it in the `state_funded?` method as the group they are in contains non-state funded school types - I still need to confirm this with policy before merging this change.

## Significant spec refactoring ahead
The school eligibility specs have undergone significant refactoring as part of this work. The goal was to make it clearer what attributes make a school eligible and provide appropriate test coverage.

## When merging
Please check the trello card where there are two zendesk tickets that need to be updated once this work is in production.