### PR TITLE
Change payment <-> claim associations to enable multiple payments per claim

### DIFF
--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -7,7 +7,8 @@ module Admin
     end
 
     def new
-      @payroll_run = PayrollRun.new(claims: Claim.payrollable)
+      @claims = Claim.payrollable
+      @total_award_amount = @claims.sum(&:award_amount)
     end
 
     def create

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,5 +1,5 @@
 class Payment < ApplicationRecord
-  belongs_to :claim
+  has_one :claim
   belongs_to :payroll_run
 
   validates :award_amount, presence: true

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -11,7 +11,7 @@ class PayrollRun < ApplicationRecord
   scope :this_month, -> { where(created_at: DateTime.now.all_month) }
 
   def total_award_amount
-    claims.sum(&:award_amount)
+    payments.sum(:award_amount)
   end
 
   def self.create_with_claims!(claims, attrs = {})

--- a/app/views/admin/payroll_runs/new.html.erb
+++ b/app/views/admin/payroll_runs/new.html.erb
@@ -16,7 +16,7 @@
         </dt>
 
         <dd class="govuk-summary-list__value">
-          <%= @payroll_run.claims.size %>
+          <%= @claims.size %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -25,15 +25,15 @@
         </dt>
 
         <dd class="govuk-summary-list__value">
-          <%= number_to_currency(@payroll_run.total_award_amount) %>
+          <%= number_to_currency(@total_award_amount) %>
         </dd>
       </div>
     </dl>
   </div>
 </div>
 
-<%= form_for [:admin, @payroll_run] do |form| %>
-  <% @payroll_run.claims.each do |claim| %>
+<%= form_with url: admin_payroll_runs_path do |form| %>
+  <% @claims.each do |claim| %>
     <%= hidden_field_tag "claim_ids[]", claim.id %>
   <% end %>
   <%= form.submit "Confirm and submit", class: "govuk-button", data: {module: "govuk-button"} %>

--- a/db/data/20191203100302_populate_payment_id_for_claims.rb
+++ b/db/data/20191203100302_populate_payment_id_for_claims.rb
@@ -1,0 +1,9 @@
+class PopulatePaymentIdForClaims < ActiveRecord::Migration[6.0]
+  def up
+    Claim.connection.execute("UPDATE claims SET payment_id = payments.id FROM payments WHERE payments.claim_id = claims.id")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20191120150858)
+DataMigrate::Data.define(version: 20191203100302)

--- a/db/migrate/20191203095639_add_payment_id_to_claims.rb
+++ b/db/migrate/20191203095639_add_payment_id_to_claims.rb
@@ -1,0 +1,5 @@
+class AddPaymentIdToClaims < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :claims, :payment, type: :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,8 +58,10 @@ ActiveRecord::Schema.define(version: 2019_12_03_103255) do
     t.string "surname", limit: 100
     t.string "banking_name"
     t.string "building_society_roll_number"
+    t.uuid "payment_id"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"
+    t.index ["payment_id"], name: "index_claims_on_payment_id"
     t.index ["reference"], name: "index_claims_on_reference", unique: true
     t.index ["submitted_at"], name: "index_claims_on_submitted_at"
   end
@@ -198,6 +200,7 @@ ActiveRecord::Schema.define(version: 2019_12_03_103255) do
     t.index ["current_school_id"], name: "index_student_loans_eligibilities_on_current_school_id"
   end
 
+  add_foreign_key "claims", "payments"
   add_foreign_key "maths_and_physics_eligibilities", "schools", column: "current_school_id"
   add_foreign_key "payments", "claims"
   add_foreign_key "payments", "payroll_runs"

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     claim { association(:claim, :approved, policy: claim_policy) }
     association(:payroll_run, factory: :payroll_run)
 
-    award_amount { 123.45 }
+    award_amount { claim.award_amount }
 
     trait :with_figures do
       gross_value { 487.48 }

--- a/spec/models/payroll/claim_csv_row_spec.rb
+++ b/spec/models/payroll/claim_csv_row_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Payroll::ClaimCsvRow do
   describe "to_s with an approved claim that has a payment" do
     let(:row) { CSV.parse(subject.to_s).first }
     let(:payment_award_amount) { BigDecimal("1234.56") }
+    let!(:payment) { build(:payment, award_amount: payment_award_amount, claim: claim) }
     let(:claim) do
-      build(:payment, award_amount: payment_award_amount, claim: build(:claim, :approved,
+      build(:claim, :approved,
         payroll_gender: :female,
         date_of_birth: Date.new(1980, 12, 1),
         student_loan_plan: StudentLoan::PLAN_2,
@@ -17,7 +18,7 @@ RSpec.describe Payroll::ClaimCsvRow do
         banking_name: "Jo Bloggs",
         building_society_roll_number: "1234/12345678",
         address_line_1: "1 Test Road",
-        postcode: "AB1 2CD")).claim
+        postcode: "AB1 2CD")
     end
 
     it "generates a csv row" do

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe PayrollRun, type: :model do
 
   describe "#total_award_amount" do
     it "returns the sum of the award amounts of its claims" do
-      claim_1 = build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 1500))
-      claim_2 = build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 2000))
+      payment_1 = build(:payment, claim: build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 1500)))
+      payment_2 = build(:payment, claim: build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 2000)))
 
-      payroll_run = PayrollRun.new(claims: [claim_1, claim_2])
+      payroll_run = PayrollRun.create!(created_by: "foo", payments: [payment_1, payment_2])
 
       expect(payroll_run.total_award_amount).to eq(3500)
     end


### PR DESCRIPTION
This is technical groundwork for some feature work that will come later. The main change also allows us to optimise the `PayrollRun#total_award_amount` method, which comes in its own commit.