### PR TITLE
Configure admin IP whitelist using Key vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Load the admin IP whitelist from the Key vault
+
 ## [Release 039] - 2019-12-06
 
 - Service operators can create and view a payroll run and provide a link to

--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -157,7 +157,12 @@
       }
     },
     "ADMIN_ALLOWED_IPS": {
-      "value": "::/0,0.0.0.0/0"
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "AdminAllowedIPs"
+      }
     },
     "GOOGLE_ANALYTICS_ID": {
       "value": ""

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -141,7 +141,12 @@
       }
     },
     "ADMIN_ALLOWED_IPS": {
-      "value": "194.72.231.130/31,194.72.231.132/31,213.123.63.150,217.38.175.48/28,217.38.175.64/28,217.38.165.192/28,217.38.165.176/28,185.125.226.42"
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "AdminAllowedIPs"
+      }
     },
     "GOOGLE_ANALYTICS_ID": {
       "reference": {


### PR DESCRIPTION
Makes it possible to change the whitelist without a full release/deploy cycle, which is way faster.

I've added `AdminAllowedIPs` secrets to both Key vaults.