### PR TITLE
Make payments CSV classes use payments, not claims

### DIFF
--- a/app/controllers/admin/payroll_run_downloads_controller.rb
+++ b/app/controllers/admin/payroll_run_downloads_controller.rb
@@ -18,7 +18,7 @@ class Admin::PayrollRunDownloadsController < Admin::BaseAdminController
     respond_to do |format|
       format.html
       format.csv do
-        csv = Payroll::ClaimsCsv.new(@payroll_run)
+        csv = Payroll::PaymentsCsv.new(@payroll_run)
         send_file csv.file, type: "text/csv", filename: csv.filename
       end
     end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -6,4 +6,6 @@ class Payment < ApplicationRecord
 
   validates :payroll_reference, :gross_value, :national_insurance, :employers_national_insurance, :tax, :net_pay, :gross_pay, presence: true, on: :upload
   validates :gross_value, :national_insurance, :employers_national_insurance, :student_loan_repayment, :tax, :net_pay, :gross_pay, numericality: true, allow_nil: true
+
+  delegate :first_name, :middle_name, :surname, :national_insurance_number, :payroll_gender, :date_of_birth, :email_address, :address_line_1, :address_line_2, :address_line_3, :address_line_4, :postcode, :has_student_loan, :student_loan_plan, :banking_name, :bank_sort_code, :bank_account_number, :building_society_roll_number, to: :claim
 end

--- a/app/models/payroll/payment_csv_row.rb
+++ b/app/models/payroll/payment_csv_row.rb
@@ -5,7 +5,7 @@ require "csv"
 require "excel_utils"
 
 module Payroll
-  class ClaimCsvRow < SimpleDelegator
+  class PaymentCsvRow < SimpleDelegator
     DATE_FORMAT = "%Y%m%d"
     UNITED_KINGDOM = "United Kingdom"
     BASIC_RATE_TAX_CODE = "BR"
@@ -23,7 +23,7 @@ module Payroll
     private
 
     def data
-      Payroll::ClaimsCsv::FIELDS_WITH_HEADERS.keys.map do |f|
+      Payroll::PaymentsCsv::FIELDS_WITH_HEADERS.keys.map do |f|
         field = send(f)
         ExcelUtils.escape_formulas(field)
       end
@@ -128,15 +128,19 @@ module Payroll
     end
 
     def scheme_name
-      model.policy.name.titlecase
+      model.claim.policy.name.titlecase
     end
 
     def scheme_amount
-      model.payment.award_amount.to_s
+      model.award_amount.to_s
     end
 
     def roll_number
       model.building_society_roll_number
+    end
+
+    def reference
+      model.claim.reference
     end
 
     def model

--- a/app/models/payroll/payments_csv.rb
+++ b/app/models/payroll/payments_csv.rb
@@ -1,7 +1,7 @@
 require "csv"
 
 module Payroll
-  class ClaimsCsv
+  class PaymentsCsv
     attr_reader :payroll_run
 
     FIELDS_WITH_HEADERS = {
@@ -44,8 +44,8 @@ module Payroll
     def file
       Tempfile.new.tap do |file|
         file.write(header_row)
-        payroll_run.claims.includes(:payment).each do |claim|
-          file.write(Payroll::ClaimCsvRow.new(claim).to_s)
+        payroll_run.payments.includes(:claim).each do |payment|
+          file.write(Payroll::PaymentCsvRow.new(payment).to_s)
         end
         file.rewind
       end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,24 +3,24 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "13cc1ba0eab122ed9ac8800c10cc642df54a9dcef897fc4c0e5c3fadaf1c680e",
+      "fingerprint": "dc2ed132897187b2950a4358e22d70cf3f57a65db3730cc0f81e807de5977758",
       "check_name": "SendFile",
       "message": "Model attribute used in file name",
       "file": "app/controllers/admin/payroll_run_downloads_controller.rb",
       "line": 22,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(Payroll::ClaimsCsv.new(PayrollRun.find(params[:payroll_run_id])).file, :type => \"text/csv\", :filename => Payroll::ClaimsCsv.new(PayrollRun.find(params[:payroll_run_id])).filename)",
+      "code": "send_file(Payroll::PaymentsCsv.new(PayrollRun.find(params[:payroll_run_id])).file, :type => \"text/csv\", :filename => Payroll::PaymentsCsv.new(PayrollRun.find(params[:payroll_run_id])).filename)",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "Admin::PayrollRunDownloadsController",
         "method": "show"
       },
-      "user_input": "Payroll::ClaimsCsv.new(PayrollRun.find(params[:payroll_run_id])).file",
+      "user_input": "Payroll::PaymentsCsv.new(PayrollRun.find(params[:payroll_run_id])).file",
       "confidence": "Medium",
       "note": "We generate the filename based on non-user input so we can ignore this"
     }
   ],
-  "updated": "2019-12-04 13:06:34 +0000",
+  "updated": "2019-12-06 10:43:15 +0000",
   "brakeman_version": "4.7.2"
 }

--- a/spec/models/payroll/payment_csv_row_spec.rb
+++ b/spec/models/payroll/payment_csv_row_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-RSpec.describe Payroll::ClaimCsvRow do
-  subject { described_class.new(claim) }
+RSpec.describe Payroll::PaymentCsvRow do
+  subject { described_class.new(payment) }
   let(:claim) { build(:claim) }
 
   describe "to_s with an approved claim that has a payment" do
     let(:row) { CSV.parse(subject.to_s).first }
     let(:payment_award_amount) { BigDecimal("1234.56") }
-    let!(:payment) { build(:payment, award_amount: payment_award_amount, claim: claim) }
+    let(:payment) { build(:payment, award_amount: payment_award_amount, claim: claim) }
     let(:claim) do
       build(:claim, :approved,
         payroll_gender: :female,
@@ -93,7 +93,7 @@ RSpec.describe Payroll::ClaimCsvRow do
     it "escapes fields with strings that could be dangerous in Microsoft Excel and friends" do
       claim.address_line_1 = "=ActiveCell.Row-1,14"
 
-      expect(row[Payroll::ClaimsCsv::FIELDS_WITH_HEADERS.find_index { |k, _| k == :address_line_1 }]).to eq("\\#{claim.address_line_1}")
+      expect(row[Payroll::PaymentsCsv::FIELDS_WITH_HEADERS.find_index { |k, _| k == :address_line_1 }]).to eq("\\#{claim.address_line_1}")
     end
   end
 end

--- a/spec/models/payroll/payments_csv_spec.rb
+++ b/spec/models/payroll/payments_csv_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Payroll::ClaimsCsv do
+RSpec.describe Payroll::PaymentsCsv do
   subject(:claims_csv) { described_class.new(payroll_run) }
 
   let(:payroll_run) { create(:payroll_run, claims_counts: {StudentLoans => 1}, created_at: "2018-10-15") }
@@ -51,7 +51,7 @@ RSpec.describe Payroll::ClaimsCsv do
     end
 
     it "contains data rows for passed in claims" do
-      expected_claim_data_row = Payroll::ClaimCsvRow.new(payroll_run.claims[0]).to_s.chomp
+      expected_claim_data_row = Payroll::PaymentCsvRow.new(payroll_run.payments[0]).to_s.chomp
 
       expect(file_lines[1]).to eq(expected_claim_data_row)
     end


### PR DESCRIPTION
This is prep work for updating the CSV to work with multiple claims,
where each line of the CSV will correspond to a single _payment_, not
necessarily a single claim. We modify and rename the CSV classes to
reflect this.

When we move to multiple claims, there will be some data fields which
are duplicated across a payment's claims, for example address, payroll
gender, etc. We add these fields as methods on the Payment class. At the
moment, they just delegate to the payment's claim. Once we move to
multiple claims, they will probably delegate to the first claim of the
payment. This allows us to keep the CSV generation code the same, and
abstract away the process of getting e.g. an address for a payment.