### PR TITLE
Remove statutory_high_age from schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -172,7 +172,6 @@ ActiveRecord::Schema.define(version: 2019_12_03_103255) do
     t.uuid "local_authority_district_id"
     t.date "close_date"
     t.integer "establishment_number"
-    t.integer "statutory_high_age"
     t.index ["created_at"], name: "index_schools_on_created_at"
     t.index ["local_authority_district_id"], name: "index_schools_on_local_authority_district_id"
     t.index ["local_authority_id"], name: "index_schools_on_local_authority_id"


### PR DESCRIPTION
I introduced this incorrectly to schema.rb:

https://github.com/DFE-Digital/dfe-teachers-payment-service/blob/eeab5b33685ef9360a112dec0e4bb59f11f12d61/db/schema.rb#L172

Removing it here will mean the migration can run when it is introduced along
with the code that uses it.

<!-- Do you need to update CHANGELOG.md? -->
