### PR TITLE
Add a .gitkeep to the bin/vsp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ localhost.key
 
 # Ignore Verify Service Provider
 bin/vsp/*
+!bin/vsp/.gitkeep
 
 # Ignore RSpec example status persistence file
 spec/examples.txt


### PR DESCRIPTION
Adds a `.gitkeep` file to the `bin/vsp` directory so that download/unzip/copy of VSP doesn't fail.