### PR TITLE
Add webtests/alerts for the app and VSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Restore uptime alerting to alert when the App / VSP are down
+
 ## [Release 040] - 2019-12-09
 
 - Load the admin IP whitelist from the Key vault

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -215,6 +215,7 @@
     ],
 
     "applicationInsightsDeploymentName": "[concat(parameters('resourceNamePrefix'), '-application-insights')]",
+    "availabilityTestsDeploymentName": "[concat(parameters('resourceNamePrefix'), '-availability-tests')]",
     "appDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app')]",
     "appServiceWebTestDeploymentName": "[concat(parameters('resourceNamePrefix'), '-app-service-web-test')]",
     "databaseServerFirewallRulesDeploymentName": "[concat(parameters('resourceNamePrefix'), '-database-server-firewall-rules')]",
@@ -293,6 +294,48 @@
           },
           "attachedService": {
             "value": "[variables('appServiceName')]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "name": "[variables('availabilityTestsDeploymentName')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', variables('applicationInsightsDeploymentName'))]",
+        "[resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))]",
+        "[resourceId('Microsoft.Resources/deployments', variables('vspDeploymentName'))]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'availability_tests.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appInsightsName": {
+            "value": "[variables('applicationInsightsName')]"
+          },
+          "availabilityTests": {
+            "value": [
+              {
+                "nameSuffix": "[variables('appServiceWebTestName')]",
+                "url": "[concat('https://', reference(resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))).outputs.appServiceCanonicalHostName.value, '/healthcheck')]",
+                "guid": "[guid(variables('appServiceWebTestName'))]"
+              },
+              {
+                "nameSuffix": "[variables('vspAppServiceWebTestName')]",
+                "url": "[concat('https://', reference(resourceId('Microsoft.Resources/deployments', variables('vspDeploymentName'))).outputs.appServiceHostName.value, '/admin/healthcheck')]",
+                "guid": "[guid(variables('vspAppServiceName'))]"
+              }
+            ]
+          },
+          "alertEmailAddress": {
+            "value": "[parameters('alertEmailAddress')]"
+          },
+          "webTestLocations": {
+            "value": "[variables('azureAvailabilityTestLocations')]"
           }
         }
       }

--- a/azure/templates/availability_tests.json
+++ b/azure/templates/availability_tests.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appInsightsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the application insights resource"
+      }
+    },
+    "availabilityTests": {
+      "defaultValue": [],
+      "type": "array",
+      "metadata": {
+        "description": "Array of test objects to configure URLs to perform availability tests for."
+      }
+    },
+    "alertEmailAddress": {
+      "type": "string",
+      "metadata": {
+        "description": "Email to send alerts to"
+      }
+    },
+    "webTestLocations": {
+      "type": "array",
+      "metadata": {
+        "description": "The locations to conduct webtests from"
+      }
+    }
+  },
+  "variables": {
+    "actionGroupName": "[concat(parameters('appInsightsName'), '-ag-down-alert')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/actionGroups",
+      "apiVersion": "2019-06-01",
+      "name": "[variables('actionGroupName')]",
+      "location": "global",
+      "tags": {},
+      "properties": {
+        "groupShortName": "[concat(split(parameters('appInsightsName'), '-')[0], '-ops')]",
+        "enabled": true,
+        "useCommonAlertSchema": true,
+        "emailReceivers": [
+          {
+            "name": "email",
+            "emailAddress": "[parameters('alertEmailAddress')]"
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01",
+      "name": "[if(greater(length(parameters('availabilityTests')), 0), concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix), 'UNUSED_WEBTEST')]",
+      "type": "Microsoft.Insights/webtests",
+      "condition": "[greater(length(parameters('availabilityTests')), 0)]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "webTestsCopy",
+        "count": "[if(greater(length(parameters('availabilityTests')), 0), length(parameters('availabilityTests')), 1)]"
+      },
+      "tags": {
+        "[concat('hidden-link:', resourceId('Microsoft.Insights/components', parameters('appInsightsName')))]": "Resource"
+      },
+      "properties": {
+        "SyntheticMonitorId": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
+        "Name": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
+        "Enabled": true,
+        "Frequency": 300,
+        "Timeout": 120,
+        "RetryEnabled": true,
+        "Locations": "[parameters('webTestLocations')]",
+        "Kind": "ping",
+        "Configuration": {
+          "WebTest": "[concat('<WebTest Name=\"', parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix, '\"',  ' Id=\"', parameters('availabilityTests')[copyIndex('webTestsCopy')].guid,'\"    Enabled=\"True\" CssProjectStructure=\"\" CssIteration=\"\" Timeout=\"0\" WorkItemIds=\"\" xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\" Description=\"\" CredentialUserName=\"\" CredentialPassword=\"\" PreAuthenticate=\"True\" Proxy=\"default\" StopOnError=\"False\" RecordedResultFile=\"\" ResultsLocale=\"\">        <Items>        <Request Method=\"GET\" Guid=\"a5f10126-e4cd-570d-961c-cea43999a200\" Version=\"1.1\" Url=\"', replace(parameters('availabilityTests')[copyIndex('webTestsCopy')].url, '&', '&amp;'),'\" ThinkTime=\"0\" Timeout=\"300\" ParseDependentRequests=\"True\" FollowRedirects=\"True\" RecordResult=\"True\" Cache=\"False\" ResponseTimeGoal=\"0\" Encoding=\"utf-8\" ExpectedHttpStatusCode=\"200\" ExpectedResponseUrl=\"\" ReportingName=\"\" IgnoreHttpStatusCode=\"False\" /></Items></WebTest>')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Insights/metricAlerts",
+      "apiVersion": "2018-03-01",
+      "name": "[if(greater(length(parameters('availabilityTests')), 0), concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('metricAlertsCopy')].nameSuffix, '-alert'), 'UNUSED_ALERT')]",
+      "condition": "[greater(length(parameters('availabilityTests')), 0)]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Insights/actionGroups', variables('actionGroupName'))]",
+        "[resourceId('Microsoft.Insights/webtests', concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('metricAlertsCopy')].nameSuffix))]"
+      ],
+      "tags": {
+        "[concat('hidden-link:', resourceId('microsoft.insights/components', parameters('appInsightsName')))]": "Resource",
+        "[concat('hidden-link:', resourceId('Microsoft.Insights/webtests', concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('metricAlertsCopy')].nameSuffix)))]": "Resource"
+      },
+      "location": "global",
+      "copy": {
+        "name": "metricAlertsCopy",
+        "count": "[if(greater(length(parameters('availabilityTests')), 0), length(parameters('availabilityTests')), 1)]"
+      },
+      "properties": {
+        "name": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('metricAlertsCopy')].nameSuffix, '-alert')]",
+        "description": "[concat('Returns when availability of ', parameters('availabilityTests')[copyIndex('metricAlertsCopy')].nameSuffix ,' is less than 100%')]",
+        "severity": 1,
+        "enabled": true,
+        "scopes": [
+          "[resourceId('Microsoft.Insights/webtests', concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('metricAlertsCopy')].nameSuffix))]",
+          "[resourceId('microsoft.insights/components', parameters('appInsightsName'))]"
+        ],
+        "evaluationFrequency": "PT1M",
+        "windowSize": "PT1M",
+        "criteria": {
+          "odata.type": "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria",
+          "webTestId": "[resourceId('Microsoft.Insights/webtests', concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('metricAlertsCopy')].nameSuffix))]",
+          "componentId": "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]",
+          "failedLocationCount": 1
+        },
+        "actions": [
+          {
+            "actionGroupId": "[resourceId('Microsoft.Insights/actionGroups', variables('actionGroupName'))]",
+            "webHookProperties": {}
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This restores the webtest functionality, which was originally deleted due to the template using 'classic' alerts. The template has now been altered to use Azure Metric Alerts.

The deployment deploys alerts for the VSP and the app at the same time, and the template utlises ARM `copy` functionality to deploy multiple webtests and alerts for each endpoint.
