### PR TITLE
Don't match bank account sort code when identifying potentially similar claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Restore uptime alerting to alert when the App / VSP are down
+- Don't match bank account sort code when identifying potentially similar claims
 
 ## [Release 040] - 2019-12-09
 

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -49,8 +49,8 @@ module Admin
     end
 
     def matching_attributes(first_claim, second_claim)
-      first_attributes = first_claim.attributes.slice(*Claim::MatchingAttributeFinder::ATTRIBUTES_TO_MATCH).to_a
-      second_attributes = second_claim.attributes.slice(*Claim::MatchingAttributeFinder::ATTRIBUTES_TO_MATCH).to_a
+      first_attributes = first_claim.attributes.slice(*Claim::MatchingAttributeFinder::ATTRIBUTE_GROUPS_TO_MATCH.flatten).to_a
+      second_attributes = second_claim.attributes.slice(*Claim::MatchingAttributeFinder::ATTRIBUTE_GROUPS_TO_MATCH.flatten).to_a
 
       matching_attributes = first_attributes & second_attributes
       matching_attributes.to_h.compact.keys.map(&:humanize).sort

--- a/app/models/claim/matching_attribute_finder.rb
+++ b/app/models/claim/matching_attribute_finder.rb
@@ -1,12 +1,10 @@
 class Claim
   class MatchingAttributeFinder
-    ATTRIBUTES_TO_MATCH = %w[
-      teacher_reference_number
-      email_address
-      national_insurance_number
-      bank_account_number
-      bank_sort_code
-      building_society_roll_number
+    ATTRIBUTE_GROUPS_TO_MATCH = [
+      ["teacher_reference_number"],
+      ["email_address"],
+      ["national_insurance_number"],
+      ["bank_account_number", "bank_sort_code", "building_society_roll_number"],
     ].freeze
 
     def initialize(source_claim, claims_to_compare = Claim.submitted)
@@ -15,17 +13,29 @@ class Claim
     end
 
     def matching_claims
-      predicates = []
-      values = []
-      ATTRIBUTES_TO_MATCH.each do |attribute|
-        value = @source_claim.read_attribute(attribute)
-        next if value.blank?
+      claims = @claims_to_compare.where.not(id: @source_claim.id)
+      match_queries = nil
 
-        predicates << "LOWER(#{attribute}) = LOWER(?)"
-        values << value
+      ATTRIBUTE_GROUPS_TO_MATCH.each do |attributes|
+        vals = values_for_attributes(attributes)
+
+        next if vals.blank?
+
+        concatenated_columns = "CONCAT(#{attributes.join(",")})"
+        query = Claim.where("LOWER(#{concatenated_columns}) = LOWER(?)", vals.join)
+
+        match_queries = match_queries.nil? ? query : match_queries.or(query)
       end
 
-      @claims_to_compare.where.not(id: @source_claim.id).where(predicates.join(" OR "), *values)
+      claims.merge(match_queries)
+    end
+
+    private
+
+    def values_for_attributes(attributes)
+      attributes.map { |attribute|
+        @source_claim.read_attribute(attribute)
+      }.reject(&:blank?)
     end
   end
 end

--- a/spec/models/claim/matching_attribute_finder_spec.rb
+++ b/spec/models/claim/matching_attribute_finder_spec.rb
@@ -53,22 +53,40 @@ RSpec.describe Claim::MatchingAttributeFinder do
       expect(matching_claims).to eq([claim_with_matching_attribute])
     end
 
-    it "includes a claim with a matching bank account number" do
-      claim_with_matching_attribute = create(:claim, :submitted, bank_account_number: source_claim.bank_account_number)
+    it "does not include a claim with a matching bank account number" do
+      create(:claim, :submitted, bank_account_number: source_claim.bank_account_number)
 
-      expect(matching_claims).to eq([claim_with_matching_attribute])
+      expect(matching_claims).to eq([])
     end
 
-    it "includes a claim with a matching bank sort code" do
-      claim_with_matching_attribute = create(:claim, :submitted, bank_sort_code: source_claim.bank_sort_code)
+    it "does not include a claim with a matching bank sort code" do
+      create(:claim, :submitted, bank_sort_code: source_claim.bank_sort_code)
 
-      expect(matching_claims).to eq([claim_with_matching_attribute])
+      expect(matching_claims).to eq([])
     end
 
-    it "includes a claim with a matching building society roll number" do
-      claim_with_matching_attribute = create(:claim, :submitted, building_society_roll_number: source_claim.building_society_roll_number)
+    it "does not include a claim with a matching building society roll number" do
+      create(:claim, :submitted, building_society_roll_number: source_claim.building_society_roll_number)
 
-      expect(matching_claims).to eq([claim_with_matching_attribute])
+      expect(matching_claims).to eq([])
+    end
+
+    it "includes a claim with a matching bank account number and sort code" do
+      source_claim.update!(building_society_roll_number: nil)
+      claim_with_matching_attributes = create(:claim, :submitted,
+        bank_account_number: source_claim.bank_account_number,
+        bank_sort_code: source_claim.bank_sort_code)
+
+      expect(matching_claims).to eq([claim_with_matching_attributes])
+    end
+
+    it "includes a claim with a matching bank account number, sort code and roll number" do
+      claim_with_matching_attributes = create(:claim, :submitted,
+        bank_account_number: source_claim.bank_account_number,
+        bank_sort_code: source_claim.bank_sort_code,
+        building_society_roll_number: source_claim.building_society_roll_number)
+
+      expect(matching_claims).to eq([claim_with_matching_attributes])
     end
 
     it "does not match claims with nil building society roll numbers" do


### PR DESCRIPTION
This changes the `ATTRIBUTES_TO_MATCH` array to be an array of groups to match against in the database. If there is more than one attribute in the group, we concatenate the subjects and  predicates together, so we can make sure both things match. At the moment, we only need this for bank details, but we may need this for other things (such as maybe firstname / lastname / DOB etc)
