### PR TITLE
Fix test flicker on payroll run spec

### DIFF
--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -123,14 +123,18 @@ RSpec.feature "Payroll" do
 
     expect(ActionMailer::Base.deliveries.count).to eq(2)
 
-    first_email = ActionMailer::Base.deliveries.first
-    second_email = ActionMailer::Base.deliveries.last
+    subjects = ActionMailer::Base.deliveries.map { |delivery| delivery.subject }
+    addressees = ActionMailer::Base.deliveries.map { |delivery| delivery.to }
 
-    expect(first_email.to).to eq([payroll_run.claims[0].email_address])
-    expect(second_email.to).to eq([payroll_run.claims[1].email_address])
+    expect(addressees).to match_array([
+      [payroll_run.claims[0].email_address],
+      [payroll_run.claims[1].email_address],
+    ])
 
-    expect(first_email.subject).to eq("We’re paying your claim to get back your student loan repayments, reference number: #{payroll_run.claims[0].reference}")
-    expect(second_email.subject).to eq("We’re paying your claim to get back your student loan repayments, reference number: #{payroll_run.claims[1].reference}")
+    expect(subjects).to match_array([
+      "We’re paying your claim to get back your student loan repayments, reference number: #{payroll_run.claims[0].reference}",
+      "We’re paying your claim to get back your student loan repayments, reference number: #{payroll_run.claims[1].reference}",
+    ])
 
     expect(dataset_post_stub).to have_been_requested.twice
   end


### PR DESCRIPTION
This test seems to ocassionally fail because claims aren't always in the order we expect them. I've got around this by mapping the subjects and addressee emails to an array and then matching the array, so we don't worry about the order.
