### PR TITLE
Lock to bundler 2.0.2 in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR ${DEPS_HOME}
 COPY Gemfile ${DEPS_HOME}/Gemfile
 COPY Gemfile.lock ${DEPS_HOME}/Gemfile.lock
 
-RUN gem install bundler
+RUN gem install bundler -v 2.0.2
 ENV BUNDLE_BUILD__SASSC=--disable-march-tune-native
 
 RUN if [ ${RAILS_ENV} = "production" ]; then \


### PR DESCRIPTION
Bundler 2.1.0 has been released and the switch to that version coincided with deployments breaking on development. To narrow down the issue we are locking to the previous version to see if that resolves things before we figure out what the problem is with 2.1.0.
