### PR TITLE
Unpin Bundler version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR ${DEPS_HOME}
 COPY Gemfile ${DEPS_HOME}/Gemfile
 COPY Gemfile.lock ${DEPS_HOME}/Gemfile.lock
 
-RUN gem install bundler -v 2.0.2
+RUN gem install bundler
 ENV BUNDLE_BUILD__SASSC=--disable-march-tune-native
 
 RUN if [ ${RAILS_ENV} = "production" ]; then \
@@ -104,7 +104,7 @@ RUN if [ ${RAILS_ENV} = "production" ]; then \
 EXPOSE 3000
 
 ENTRYPOINT [ "bin/docker-entrypoint" ]
-CMD [ "rails", "server" ]
+CMD [ "bundle", "exec", "rails", "server" ]
 
 # ------------------------------------------------------------------------------
 # shellcheck
@@ -141,4 +141,4 @@ COPY *.md ${APP_HOME}/
 COPY azure ${APP_HOME}/azure
 # End
 
-CMD [ "rake" ]
+CMD [ "bundle", "exec", "rake" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,14 +38,18 @@ COPY Gemfile.lock ${DEPS_HOME}/Gemfile.lock
 RUN gem install bundler
 ENV BUNDLE_BUILD__SASSC=--disable-march-tune-native
 
+RUN bundle config set frozen 'true'
 RUN if [ ${RAILS_ENV} = "production" ]; then \
-  bundle install --frozen --retry 3 --without development test; \
+  bundle config set without 'development test'; \
   elif [ ${RAILS_ENV} = "test" ]; then \
-  bundle install --frozen --retry 3 --without development; \
+  bundle config set without 'development'; \
   else \
-  bundle install --frozen --retry 3 --without test; \
+  bundle config set without 'test'; \
   fi
 # End
+RUN bundle config
+
+RUN bundle install --retry 3
 
 # Install JavaScript dependencies
 COPY package.json ${DEPS_HOME}/package.json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,4 +376,4 @@ RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   2.0.2
+   2.1.0

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -3,22 +3,22 @@ set -e
 
 if [ "$RAILS_ENV" != "production" ]; then
   echo "In a non-production environment: initializing database"
-  rake db:create db:schema:load
+  bundle exec rake db:create db:schema:load
 else
   DB_STATUS=$(rake db:migrate:status 2>&1 | tail -n 1)
 
   if [ "$DB_STATUS" == "Schema migrations table does not exist yet."  ]; then
     echo "No tables exist - setting up the database"
-    rails db:setup
+    bundle exec rails db:setup
   else
     echo "Running the schema and data migrations"
-    rails db:migrate:with_data
+    bundle exec rails db:migrate:with_data
   fi
 fi
 
 if [ "$RAILS_ENV" != "test" ]; then
   echo "Scheduling Cron Jobs"
-  rake jobs:schedule
+  bundle exec rake jobs:schedule
 fi
 
 exec "$@"


### PR DESCRIPTION
We locked the version of Bundler to 2.0.2 in the Dockerfile because with
the latest version (2.1.0) the app was failing to start – the calls to
the `rails` command in docker-entrypoint were resulting in "command not
found" errors. We traced the issue to the fact that bundler 2.1.0 when
installed in the Docker container doesn't appear to be creating any
binstubs for commands like `rake` or `rails`. Instead of relying on the
presence of binstubs we call the commands with `bundle exec` instead.

The second commit gets rid of the deprecation warnings introduced by bundler 2.1.0.