### PR TITLE
Release 041

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+
+## [Release 041] - 2019-12-15
+
 - Restore uptime alerting to alert when the App / VSP are down
 - Don't match bank account sort code when identifying potentially similar claims
 - Alternative provisions schools and special schools that teach students who are
@@ -309,7 +312,9 @@ The format is based on [Keep a Changelog]
 - First release for student loan repayments private beta
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-040...HEAD
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-041...HEAD
+[release 041]:
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-040...release-041
 [release 040]:
   https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-039...release-040
 [release 039]:


### PR DESCRIPTION
- Restore uptime alerting to alert when the App / VSP are down
- Don't match bank account sort code when identifying potentially
  similar claims
- Alternative provisions schools and special schools that teach students
  who are over 11 are eligible