### PR TITLE
A user should know why their answer has made them ineligible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog]
 - Don't match bank account sort code when identifying potentially similar claims
 - Alternative provisions schools and special schools that teach students who are
   over 11 are eligible
+- Update content for both maths and physics and student loans ineligible screens
 
 ## [Release 040] - 2019-12-09
 

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -5,7 +5,7 @@
     <%= render "ineligibility_reason_#{current_claim.eligibility.ineligibility_reason}" %>
 
     <p class="govuk-body">
-      For more information about the eligibility criteria, or if you need help with your claim, contact
+      If you need help with your claim, contact
       <%= mail_to support_email_address(current_policy_routing_name), support_email_address(current_policy_routing_name), class: "govuk-link" %>.
     </p>
   </div>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_current_school.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_current_school.html.erb
@@ -5,3 +5,10 @@
 <p class="govuk-body">
   You can only get this payment if you are employed to teach at an eligible state-funded secondary school.
 </p>
+
+<p class="govuk-body">
+  For more information, including regional and employment eligibility criteria for this payment,
+  visit the
+  <%= link_to "’Claim a payment for teaching maths or physics’", "#{MathsAndPhysics.eligibility_page_url}#eligible-subjects", class: "govuk-link" %>
+  guidance.
+</p>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -6,3 +6,9 @@
   You can only get this payment if you completed your initial teacher training
   on or after 1 September 2014.
 </p>
+
+<p class="govuk-body">
+  For more information, including eligibility criteria for this payment, visit the
+  <%= link_to "’Claim a payment for teaching maths or physics’", "#{MathsAndPhysics.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  guidance.
+</p>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_no_entire_term_contract.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_no_entire_term_contract.html.erb
@@ -6,3 +6,10 @@
   You can only get this payment if you are employed directly by your school for
   at least one term.
 </p>
+
+<p class="govuk-body">
+  For more information, including supply teacher eligibility criteria for this
+  payment, visit the
+  <%= link_to "‘Claim a payment for teaching maths or physics’", "#{MathsAndPhysics.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  guidance.
+</p>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_no_maths_or_physics_qualification.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_no_maths_or_physics_qualification.html.erb
@@ -3,12 +3,19 @@
 </h1>
 
 <p class="govuk-body">
-  You can only get this payment if you completed a degree specialising
-  in maths or physics or you specialised in maths and physics for your
-  initial teacher training.
+  You can only get this payment if you completed a degree specialising in maths
+  or physics or you specialised in maths or physics for your initial teacher
+  training.
 </p>
 
 <p class="govuk-body">
   If you trained to teach physics as part of science but specialised in a
   subject other than physics, you are not eligible to claim.
+</p>
+
+<p class="govuk-body">
+  For more information, including which qualifications are eligible
+  for this payment, visit the
+  <%= link_to "’Claim a payment for teaching maths or physics’", "#{MathsAndPhysics.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  guidance.
 </p>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_not_employed_directly.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_not_employed_directly.html.erb
@@ -5,3 +5,11 @@
 <p class="govuk-body">
   You can only get this payment if you are employed directly by the school.
 </p>
+
+<p class="govuk-body">
+  For more information, including supply teacher eligibility criteria for this
+  payment, visit the
+  <%= link_to "’Claim a payment for teaching maths or physics’", "#{MathsAndPhysics.eligibility_page_url}#eligible-teachers", class:
+"govuk-body" %>
+  guidance.
+</p>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_not_teaching_maths_or_physics.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_not_teaching_maths_or_physics.html.erb
@@ -5,3 +5,9 @@
 <p class="govuk-body">
   You can only get this payment if you teach maths or physics.
 </p>
+
+<p class="govuk-body">
+  For more information, including eligibility criteria for this payment, visit the
+  <%= link_to "‘Claim a payment for teaching maths or physics’", "#{MathsAndPhysics.eligibility_page_url}#eligible-subjects", class: "govuk-link" %>
+  guidance.
+</p>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_subject_to_disciplinary_action.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_subject_to_disciplinary_action.html.erb
@@ -8,6 +8,13 @@
 </p>
 
 <div class="govuk-inset-text">
-  If you’re cleared, or your warning expires by 28 February 2020 you
-  can apply again.
+  If you’re cleared or your warning expires by 28 February 2020 you can apply
+  again.
 </div>
+
+<p class="govuk-body">
+  For more information, including performance eligibility criteria for this
+  payment, visit the
+  <%= link_to "’Claim a payment for teaching maths or physics’", "#{MathsAndPhysics.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  guidance.
+</p>

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_subject_to_formal_performance_action.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_subject_to_formal_performance_action.html.erb
@@ -11,3 +11,11 @@
   If the action has ended and any warnings have expired by 28 February 2020 you
   can apply again.
 </div>
+
+
+<p class="govuk-body">
+  For more information, including performance eligibility criteria for this
+  payment, visit the
+  <%= link_to "’Claim a payment for teaching maths or physics’", "#{MathsAndPhysics.eligibility_page_url}#eligible-teachers", class: "govuk-body" %>
+  guidance.
+</p>

--- a/app/views/student_loans/claims/_ineligibility_reason_employed_at_no_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_employed_at_no_school.html.erb
@@ -3,5 +3,11 @@
 </h1>
 
 <p class="govuk-body">
-  You can only get this payment if you’re still employed to teach at a school.
+  You can only get this payment if you’re still employed to teach at a state-funded secondary school.
+</p>
+
+<p class="govuk-body">
+  For more information, including employment eligibility criteria for this payment, visit the
+  <%= link_to "‘Claim back your student loan repayments’", "#{StudentLoans.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  guidance.
 </p>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -6,17 +6,17 @@
   </h1>
 
   <p class="govuk-body">
-    <%= current_claim.eligibility.claim_school_name %> is not an eligible school. You can only get this
-    payment if you were employed to teach at an eligible school between 6 April 2018
-    and 5 April 2019.
+    <%= current_claim.eligibility.claim_school_name %> is not an eligible
+    school. You can only get this payment if you were employed to teach at an
+    eligible school between 6 April 2018 and 5 April 2019.
   </p>
 
   <p class="govuk-body">
-    If you taught at more than one school during this period, you can
-    search again with the next school.
-    You only need to have taught at one eligible school to claim.
+    If you taught at more than one school during this period, you can search
+    again with the next school. You only need to have taught at one eligible school
+    to claim.
   </p>
 
-  <%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button" %>
-  <%= link_to "I've tried all of my schools", claim_path(current_policy_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary" %>
+  <%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button", data: {module: "govuk-button"}%>
+  <%= link_to "I've tried all of my schools", claim_path(current_policy_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary", data: {module: "govuk-button"}  %>
 <% end %>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_current_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_current_school.html.erb
@@ -4,6 +4,13 @@
 
 <p class="govuk-body">
   You must be employed to teach at a state-funded secondary school to be eligible for
-  this payment. <%= current_claim.eligibility.current_school_name %>, where you are currently employed to teach,
-  is not a state-funded secondary school.
+  this payment. <%= current_claim.eligibility.current_school_name %>, where you
+  are currently employed to teach, is not a state-funded secondary school.
+</p>
+
+<p class="govuk-body">
+  For more information, including employment eligibility criteria for this
+  payment, visit the
+  <%= link_to "‘Claim back your student loan repayments’", "#{StudentLoans.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  guidance.
 </p>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -6,3 +6,10 @@
   You can only get this payment if you completed your initial teacher training
   on or after 1 September 2013.
 </p>
+
+<p class="govuk-body">
+  For more information, including eligibility criteria for this payment, visit
+  the
+  <%= link_to "‘Claim back your student loan repayments’", "#{StudentLoans.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  guidance.
+</p>

--- a/app/views/student_loans/claims/_ineligibility_reason_no_more_schools.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_no_more_schools.erb
@@ -3,5 +3,13 @@
 </h1>
 
 <p class="govuk-body">
-  You must have been employed to teach an eligible subject at an eligible school for a period of time between 6 April 2018 and 5 April 2019 to claim.
+  You must have been employed to teach an eligible subject at an eligible
+  school for a period of time between 6 April 2018 and 5 April 2019 to claim.
+</p>
+
+<p class="govuk-body">
+  For more information, including regional and employment eligibility criteria
+  for this payment, visit the
+  <%= link_to "‘Claim back your student loan repayments’", "#{StudentLoans.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
+  guidance.
 </p>

--- a/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -6,7 +6,8 @@
   </h1>
 
   <p class="govuk-body">
-    You did not teach an eligible subject at <%= current_claim.eligibility.claim_school_name %>.
+    You did not teach an eligible subject at
+    <%= current_claim.eligibility.claim_school_name %>.
   </p>
 
   <p class="govuk-body">
@@ -28,6 +29,6 @@
     You only need to have worked at one eligible school to claim.
   </p>
 
-  <%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button" %>
-  <%= link_to "I've tried all of my schools", claim_path(current_policy_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary" %>
+  <%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button", data: {module: "govuk-button"} %>
+  <%= link_to "I've tried all of my schools", claim_path(current_policy_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary", data: {module: "govuk-button"} %>
 <% end %>

--- a/app/views/student_loans/claims/_ineligibility_reason_not_taught_enough.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_not_taught_enough.html.erb
@@ -6,3 +6,10 @@
   You can only get this payment if you spent less than half your working hours
   performing leadership duties between 6 April 2018 and 5 April 2019.
 </p>
+
+<p class="govuk-body">
+  For more information, including employment eligibility criteria for this
+  payment, visit the
+  <%= link_to "‘Claim back your student loan repayments’", "#{StudentLoans.eligibility_page_url}#eligible-subject", class: "govuk-link" %>
+  guidance.
+</p>

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.employment_status).to eq("no_school")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you’re still employed to teach at a school.")
+    expect(page).to have_text("You can only get this payment if you’re still employed to teach at a state-funded secondary school.")
   end
 
   scenario "did not teach an eligible subject" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Claims", type: :request do
         get claim_path(StudentLoans.routing_name, "ineligible")
 
         expect(response.body).to include("You’re not eligible")
-        expect(response.body).to include("You can only get this payment if you’re still employed to teach at a school.")
+        expect(response.body).to include("You can only get this payment if you’re still employed to teach at a state-funded secondary school.")
       end
     end
 


### PR DESCRIPTION
We found claimants were contacting support to confirm eligibility criteria which was over burdening support staff. By updating all the ineligibility content we hope to make it simpler for claimants to understand why they may not be eligible.

Two specs needed updated to reflect the new content.

I decided not to extract the new 'for more information' content to a partial as the url varies and I didn't not want to introduce more nested partials.

All the content are in thsese Google Docs, note that some dates in the docs are out-of-date.

https://docs.google.com/document/d/1pxrOk4sCMesk3IhZLTgn6jcT0dVCvheSqbLwqP_4Jg0/edit?folder=1WU_WvNrG7HEEtAHXmE9ZZO_8NbRdgH96#heading=h.w78bjvgufkjb

https://docs.google.com/document/d/1bnVttY_jN_faNyc0JlR3RPBo7yOFWRGfyiHiyAQC6ro/edit?folder=1rGeTXKllSUHmOw8pC3N7X4M9IZaP89xL