### PR TITLE
Append `bundle exec` to the worker startup script

### DIFF
--- a/azure/templates/worker.json
+++ b/azure/templates/worker.json
@@ -16,7 +16,7 @@
     },
     "command": {
       "type": "array",
-      "defaultValue": ["rake", "jobs:work"]
+      "defaultValue": ["bundle", "exec", "rake", "jobs:work"]
     },
     "networkProfileId": {
       "type": "string"


### PR DESCRIPTION
As we discovered in #717 - Bundler 2.1.0 no longer appears to be generating binstubs for common commands like `rake` or `rails`. We fixed this for the web container, but didn't do this for the worker, so the worker still wasn't coming up cleanly.
