### PR TITLE
Fix call to `CronJobScheduler`

### DIFF
--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -1,6 +1,6 @@
 namespace :jobs do
   desc "Schedule all cron jobs"
   task schedule: :environment do
-    CronJobScheduler.new.run
+    CronJobScheduler.new.schedule
   end
 end


### PR DESCRIPTION
The Rake task was mistakenly calling to the method `#run`, which doesn't exist. The actual method name is `#schedule`
