### PR TITLE
Ensure first migration will run without error

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec rake jobs:work
-release: rake db:migrate
+release: yarn install && rake db:migrate

--- a/db/migrate/20190416090236_create_tslr_claims.rb
+++ b/db/migrate/20190416090236_create_tslr_claims.rb
@@ -1,5 +1,7 @@
 class CreateTslrClaims < ActiveRecord::Migration[5.2]
   def change
+    enable_extension "pgcrypto"
+
     create_table :tslr_claims, id: :uuid do |t|
       t.string :qts_award_year
 

--- a/package.json
+++ b/package.json
@@ -8,5 +8,9 @@
   },
   "devDependencies": {
     "prettier": "^1.19.1"
+  },
+  "engines": {
+    "node": "12.12.0",
+    "yarn": "1.19.1"
   }
 }


### PR DESCRIPTION
Because of the timestamp ordering of the first two migrations, running
`rails db:migrate` on a fresh install will fail. This is because the first
timestamped migration tries to create a table with a UUID primary key
_before_ the PostgreSQL extension (`pgcrypto`) required to support UUID
primary keys has been enabled (happens in the second timestamped
migration).

This wasn't an issue when the app was first set up as the second
migration was merged before the first. But this makes install difficult
to do things like run a Heroku pipeline for review apps where we're
running `rails db:migrate` as part of the release process.

Modifying the existing migration to enable the extension feels like the
least bad option as it won't impact existing deployments (no timestamps
are changed and thus as far as Rails is concerned, all existing
migrations have been run), and `enable_extension` is idempotent so
calling it twice will have no negative impact.