### PR TITLE
Adjust content when GOV.UK Verify hasn't been completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog]
 
 - Users can complete and submit a claim without completing GOV.UK Verify
 - Update autocomplete attributes for the address capture page
+- Application complete page updated to include content for claimants that do not
+  complete GOV.UK Verify
 
 ## [Release 042] - 2019-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog]
 
 - Users can complete and submit a claim without completing GOV.UK Verify
 - Update autocomplete attributes for the address capture page
-- Application complete page updated to include content for claimants that do not
-  complete GOV.UK Verify
+- Application complete page and claim submitted email updated to include content
+  for claimants that do not complete GOV.UK Verify
 
 ## [Release 042] - 2019-12-19
 

--- a/app/controllers/verify/authentications_controller.rb
+++ b/app/controllers/verify/authentications_controller.rb
@@ -38,6 +38,12 @@ module Verify
     def no_auth
     end
 
+    # Users unable to complete the GOV.UK Verify identity assurance will be able
+    # to visit this endpoint to continue their claim.
+    def skip
+      redirect_to claim_url(current_policy_routing_name, "name")
+    end
+
     private
 
     def verify_path_for_response_scenario(scenario)

--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -6,7 +6,11 @@ Your unique reference is <%= @claim.reference %>. You will need this if you cont
 
 # What happens next
 
+<%- if @claim.identity_confirmed? -%>
 We'll check the details you provided in your application and we'll tell you if your claim was successful within <%= claim_checking_deadline_in_weeks %>.
+<%- else -%>
+We'll try to contact you at your school to confirm your identity before progressing your claim. If we're able to verify your identity, we'll check the details you provided in your application and tell you if your claim was successful within <%= claim_checking_deadline_in_weeks %>.
+<%- end -%>
 
 It can take up to 18 weeks to process your application and make a payment into your account.
 

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -22,8 +22,8 @@
     </p>
 
     <p class="govuk-body">
-      They will verify the information that you have provided and then
-      send you the outcome of your application in the next <%= claim_checking_deadline_in_weeks %>.
+      They will check the details you provided in your application and tell
+      you if your claim was successful within the next <%= claim_checking_deadline_in_weeks %>.
     </p>
 
     <p class="govuk-body">

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -21,15 +21,28 @@
       We have sent your application to the Department for Education.
     </p>
 
-    <p class="govuk-body">
-      They will check the details you provided in your application and tell
-      you if your claim was successful within the next <%= claim_checking_deadline_in_weeks %>.
-    </p>
+    <% if current_claim.identity_confirmed? %>
+      <p class="govuk-body">
+        They will check the details you provided in your application and tell
+        you if your claim was successful within the next <%= claim_checking_deadline_in_weeks %>.
+      </p>
 
-    <p class="govuk-body">
-      This service is currently in development, so while we expect to be
-      able to send you the outcome in that time frame, it may change.
-    </p>
+      <p class="govuk-body">
+        This service is currently in development, so while we expect to be
+        able to send you the outcome in that time frame, it may change.
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        They will try to contact you at your school to confirm your identity
+        before progressing your claim.
+      </p>
+
+      <p class="govuk-body">
+        If they're able to confirm your identity, they will check the details
+        you provided in your application and tell you if your claim was
+        successful within <%= claim_checking_deadline_in_weeks %>.
+      </p>
+    <% end %>
 
     <p class="govuk-body">
       You will receive email updates as your application progresses.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
       member do
         get "failed"
         get "no_auth"
+        get "skip"
       end
     end
 

--- a/docs/govuk-verify.md
+++ b/docs/govuk-verify.md
@@ -50,6 +50,17 @@ flow from here:
 These steps are explained in more detail in the
 [Verify documentation](https://www.docs.verify.service.gov.uk/get-started/set-up-successful-verification-journey/#run-the-identity-verified-response-scenario).
 
+### How to simulate skipping the Verify user journey in local development
+
+Users that are unable to complete the GOV.UK Verify process are still able to
+submit a claim. To do so they are linked back to the service on the GOV.UK
+Verify failure screen so they can provide their identity information and
+complete their claim. Such claims are then manually check to confirm the
+claimants identity. To simulate such a claim, visit the following URL after you
+reach the screen just before the GOV.UK Verify stage:
+
+https://localhost:3000/verify/authentications/skip
+
 ## Managing Certificates for the IDAP PKI
 
 Two certificates are used one for signing and one for encryption.

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe ClaimMailer, type: :mailer do
         it "mentions that claim has been received in the subject and body" do
           expect(mail.subject).to include("been received")
           expect(mail.body.encoded).to include("We've received your claim")
+          expect(mail.body.encoded).not_to include("confirm your identity")
+        end
+
+        it "adjusts the content for claims that need manual identity confirmation" do
+          claim.update!(verified_fields: [])
+
+          expect(mail.subject).to include("been received")
+          expect(mail.body.encoded).to include("We've received your claim")
+          expect(mail.body.encoded).to include("confirm your identity")
         end
       end
 

--- a/spec/requests/verify_authentications_spec.rb
+++ b/spec/requests/verify_authentications_spec.rb
@@ -124,6 +124,16 @@ RSpec.describe "GOV.UK Verify::AuthenticationsController requests", type: :reque
     end
   end
 
+  describe "verify/authentications/skip" do
+    before { start_student_loans_claim }
+
+    it "redirects the user to the “name” page for their claim" do
+      get skip_verify_authentications_path
+
+      expect(response).to redirect_to(claim_path(StudentLoans.routing_name, "name"))
+    end
+  end
+
   context "when a claim hasn’t been started yet" do
     before { stub_vsp_generate_request }
 


### PR DESCRIPTION
Users that do not complete GOV.UK Verify see different content explaining how their claim will be handled.

This PR also introduces the endpoint that we will link back to from GOV.UK Verify's failure screen so that users can pick up where they left off.