### PR TITLE
Add BUILD_NUMBER env var to containers

### DIFF
--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -100,6 +100,10 @@
     "alertEmailAddress": {
       "type": "string"
     },
+    "azureBuildNumber": {
+      "type": "string",
+      "defaultValue": ""
+    },
     "RAILS_ENV": {
       "type": "string",
       "defaultValue": "production"
@@ -418,6 +422,10 @@
               {
                 "name": "RAILS_SERVE_STATIC_FILES",
                 "value": "[parameters('RAILS_SERVE_STATIC_FILES')]"
+              },
+              {
+                "name": "BUILD_NUMBER",
+                "value": "[parameters('azureBuildNumber')]"
               },
               {
                 "name": "CANONICAL_HOSTNAME",

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -226,6 +226,7 @@ APP_DEPLOYMENT_RESULT=$(
     --template-file "$APP_TEMPLATE_FILE_PATH" \
     --parameters "@$APP_PARAMETERS_FILE_PATH" \
     --parameters "gitCommitHash=$GIT_COMMIT_HASH" \
+    --parameters "azureBuildNumber=$AZURE_BUILD_NUMBER" \
     --parameters "secretsResourceGroupName=$SECRETS_RESOURCE_GROUP_NAME" \
     --parameters "$(
       filter-azure-outputs \


### PR DESCRIPTION
Currently the workers aren't getting the up to date code when we do a production / development deploy. After a lot of chat with other ops people we've realised that this is because we always the the `development` Docker tag, so the container doesn't know that anything has changed, so doesn't pull down the latest image.

This adds a new environment variable to the web and worker containers, set by setting the `AZURE_BUILD_NUMBER` in the build environment when deploying. This means that the worker container knows something has changed and restarts itself, pulling down the latest version of the `development` or `production` image from DockerHub.

Once this is merged, we'll also need to set an `AZURE_BUILD_NUMBER` environment variable in the Azure DevOps config to the value of the build we're deploying.
