### PR TITLE
1116 inconsistent error messages

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -53,7 +53,7 @@ class ClaimsController < BasePublicController
   rescue ArgumentError => e
     raise unless e.message == School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR
 
-    current_claim.errors.add(:school_search, "Search for the school name with a minimum of four characters")
+    current_claim.errors.add(:school_search, "Enter the school you currently teach at")
   end
 
   def claim_params

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -53,7 +53,7 @@ class ClaimsController < BasePublicController
   rescue ArgumentError => e
     raise unless e.message == School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR
 
-    current_claim.errors.add(:school_search, "Enter the school you currently teach at")
+    current_claim.errors.add(:school_search, "Enter the name of the school")
   end
 
   def claim_params

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -116,13 +116,13 @@ class Claim < ApplicationRecord
   validate :ni_number_is_correct_format
 
   validates :has_student_loan, on: [:"student-loan", :submit], inclusion: {in: [true, false], message: "Select yes if you have a student loan"}
-  validates :student_loan_country, on: [:"student-loan-country"], presence: {message: "Select the country in which you first applied for your student loan"}
-  validates :student_loan_courses, on: [:"student-loan-how-many-courses"], presence: {message: "Select the number of higher education courses you have studied"}
+  validates :student_loan_country, on: [:"student-loan-country"], presence: {message: "Select the country you lived in when you applied for your student loan"}
+  validates :student_loan_courses, on: [:"student-loan-how-many-courses"], presence: {message: "Select the number of student loans you have taken out"}
   validates :student_loan_start_date, on: [:"student-loan-start-date"], presence: {message: ->(object, data) { I18n.t("validation_errors.student_loan_start_date.#{object.student_loan_courses}") }}
   validates :student_loan_plan, on: [:submit], presence: {message: "We have not been able determined your student loan repayment plan. Answer all questions about your student loan."}
 
   validates :email_address, on: [:"email-address", :submit], presence: {message: "Enter an email address"}
-  validates :email_address, format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email address in the correct format, like name@example.com"},
+  validates :email_address, format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email in the format name@example.com"},
                             length: {maximum: 256, message: "Email address must be 256 characters or less"},
                             allow_blank: true
 

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -47,17 +47,17 @@ module MathsAndPhysics
 
     belongs_to :current_school, optional: true, class_name: "School"
 
-    validates :teaching_maths_or_physics, on: [:"teaching-maths-or-physics", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
-    validates :current_school, on: [:"current-school", :submit], presence: {message: "Select a school from the list"}
-    validates :initial_teacher_training_subject, on: [:"initial-teacher-training-subject", :submit], presence: {message: "Choose a subject, or select None of these subjects"}
-    validates :initial_teacher_training_subject_specialism, on: [:"initial-teacher-training-subject-specialism", :submit], presence: {message: "Choose a subject, or select I'm not sure"}, if: :itt_subject_science?
-    validates :has_uk_maths_or_physics_degree, on: [:"has-uk-maths-or-physics-degree", :submit], presence: {message: "Select whether you have a UK maths or physics degree."}, unless: :initial_teacher_training_specialised_in_maths_or_physics?
-    validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select the academic year you were awarded qualified teacher status"}
-    validates :employed_as_supply_teacher, on: [:"supply-teacher", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
-    validates :has_entire_term_contract, on: [:"entire-term-contract", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}, if: :employed_as_supply_teacher?
-    validates :employed_directly, on: [:"employed-directly", :submit], inclusion: {in: [true, false], message: "Select whether you are employed directly by your school."}, if: :employed_as_supply_teacher?
-    validates :subject_to_disciplinary_action, on: [:"disciplinary-action", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
-    validates :subject_to_formal_performance_action, on: [:"formal-performance-action", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
+    validates :teaching_maths_or_physics, on: [:"teaching-maths-or-physics", :submit], inclusion: {in: [true, false], message: "Select yes if you teach any maths or physics"}
+    validates :current_school, on: [:"current-school", :submit], presence: {message: "Select a school from the list or search again for a different school"}
+    validates :initial_teacher_training_subject, on: [:"initial-teacher-training-subject", :submit], presence: {message: "Select if you completed your initial teacher training in Maths, Physics, Science, or None of these subjects"}
+    validates :initial_teacher_training_subject_specialism, on: [:"initial-teacher-training-subject-specialism", :submit], presence: {message: "Select the subject your initial teacher training specialised in or select I'm not sure"}, if: :itt_subject_science?
+    validates :has_uk_maths_or_physics_degree, on: [:"has-uk-maths-or-physics-degree", :submit], presence: {message: "Select yes if you have a UK degree specialising in maths or physics"}, unless: :initial_teacher_training_specialised_in_maths_or_physics?
+    validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select whether you completed your initial teacher training before or after September 2014"}
+    validates :employed_as_supply_teacher, on: [:"supply-teacher", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently employed as a supply teacher"}
+    validates :has_entire_term_contract, on: [:"entire-term-contract", :submit], inclusion: {in: [true, false], message: "Select yes if you have a contract to teach at the same school for one term or longer"}, if: :employed_as_supply_teacher?
+    validates :employed_directly, on: [:"employed-directly", :submit], inclusion: {in: [true, false], message: "Select yes if you are employed directly by your school"}, if: :employed_as_supply_teacher?
+    validates :subject_to_disciplinary_action, on: [:"disciplinary-action", :submit], inclusion: {in: [true, false], message: "Select yes if you are subject to disciplinary action"}
+    validates :subject_to_formal_performance_action, on: [:"formal-performance-action", :submit], inclusion: {in: [true, false], message: "Select yes if you are subject to formal action for poor performance at work"}
 
     delegate :name, to: :current_school, prefix: true, allow_nil: true
 

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -41,13 +41,13 @@ module StudentLoans
     belongs_to :claim_school, optional: true, class_name: "School"
     belongs_to :current_school, optional: true, class_name: "School"
 
-    validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select the academic year you were awarded qualified teacher status"}
-    validates :claim_school, on: [:"claim-school", :submit], presence: {message: "Select a school from the list"}
+    validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select whether you completed your initial teacher training before or after September 2013"}
+    validates :claim_school, on: [:"claim-school", :submit], presence: {message: "Select a school from the list or search again for a different school"}
     validates :employment_status, on: [:"still-teaching", :submit], presence: {message: "Choose the option that describes your current employment status"}
     validates :current_school, on: [:"current-school", :submit], presence: {message: "Select a school from the list"}
     validate :one_subject_must_be_selected, on: [:"subjects-taught", :submit], unless: :not_taught_eligible_subjects?
-    validates :had_leadership_position, on: [:"leadership-position", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}
-    validates :mostly_performed_leadership_duties, on: [:"mostly-performed-leadership-duties", :submit], inclusion: {in: [true, false], message: "Select either Yes or No"}, if: :had_leadership_position?
+    validates :had_leadership_position, on: [:"leadership-position", :submit], inclusion: {in: [true, false], message: "Select yes if you were employed in a leadership position"}
+    validates :mostly_performed_leadership_duties, on: [:"mostly-performed-leadership-duties", :submit], inclusion: {in: [true, false], message: "Select yes if you spent more than half your working hours on leadership duties"}, if: :had_leadership_position?
     validates :student_loan_repayment_amount, on: [:"student-loan-amount", :submit], presence: {message: "Enter your student loan repayment amount"}
     validates_numericality_of :student_loan_repayment_amount, message: "Enter a valid monetary amount", allow_nil: true, greater_than: 0, less_than_or_equal_to: 99999
 
@@ -114,7 +114,7 @@ module StudentLoans
     end
 
     def one_subject_must_be_selected
-      errors.add(:subjects_taught, "Choose a subject, or select No") if subjects_taught.empty?
+      errors.add(:subjects_taught, "Select if you taught Biology, Chemistry, Physics, Computing, Languages or you didn’t teach any of these subjects") if subjects_taught.empty?
     end
 
     def ineligible_current_school?

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -43,7 +43,7 @@ module StudentLoans
 
     validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select whether you completed your initial teacher training before or after September 2013"}
     validates :claim_school, on: [:"claim-school", :submit], presence: {message: "Select a school from the list or search again for a different school"}
-    validates :employment_status, on: [:"still-teaching", :submit], presence: {message: "Choose the option that describes your current employment status"}
+    validates :employment_status, on: [:"still-teaching", :submit], presence: {message: ->(object, _data) { "Select if you still work at #{object.claim_school_name}, another school or no longer teach in England" }}
     validates :current_school, on: [:"current-school", :submit], presence: {message: "Select a school from the list"}
     validate :one_subject_must_be_selected, on: [:"subjects-taught", :submit], unless: :not_taught_eligible_subjects?
     validates :had_leadership_position, on: [:"leadership-position", :submit], inclusion: {in: [true, false], message: "Select yes if you were employed in a leadership position"}

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -48,6 +48,7 @@
           <%= form_group_tag current_claim, :building_society_roll_number do %>
             <%= form.label :building_society_roll_number, "Building society roll number (if you have one)", class: "govuk-label" %>
             <span id="roll-number-hint" class="govuk-hint">You can find it on your card, statement or passbook</span>
+            <%= errors_tag current_claim, :building_society_roll_number %>
             <%= form.text_field :building_society_roll_number,
               class: css_classes_for_input(current_claim, :building_society_roll_number, "govuk-input--width-20"),
               autocomplete: "off",

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Claim, type: :model do
     claim = build(:claim)
 
     expect(claim).not_to be_valid(:"qts-year")
-    expect(claim.errors.values).to include(["Select the academic year you were awarded qualified teacher status"])
+    expect(claim.errors.values).to include(["Select whether you completed your initial teacher training before or after September 2013"])
   end
 
   context "when saving in the “gender” validation context" do

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -249,6 +249,13 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       expect(StudentLoans::Eligibility.new).not_to be_valid(:"still-teaching")
       expect(StudentLoans::Eligibility.new(employment_status: :claim_school)).to be_valid(:"still-teaching")
     end
+
+    it "includes the claim school name in the error message" do
+      eligibility = build(:student_loans_eligibility, claim_school: schools(:penistone_grammar_school), employment_status: nil)
+
+      expect(eligibility).not_to be_valid(:"still-teaching")
+      expect(eligibility.errors[:employment_status]).to eq(["Select if you still work at Penistone Grammar School, another school or no longer teach in England"])
+    end
   end
 
   context "when saving in the “current-school” context" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Claims", type: :request do
 
     it "validates against the context for the first page in sequence" do
       expect { post claims_path(StudentLoans.routing_name) }.not_to change { Claim.count }
-      expect(response.body).to include("Select the academic year you were awarded qualified teacher status")
+      expect(response.body).to include("Select whether you completed your initial teacher training before or after September 2013")
     end
   end
 
@@ -58,7 +58,7 @@ RSpec.describe "Claims", type: :request do
           get claim_path(StudentLoans.routing_name, "claim-school"), params: {school_search: "Pen"}
 
           expect(response.body).to include("There is a problem")
-          expect(response.body).to include("Enter the school you currently teach at")
+          expect(response.body).to include("Enter the name of the school")
           expect(response.body).not_to include(schools(:penistone_grammar_school).name)
         end
 
@@ -122,7 +122,7 @@ RSpec.describe "Claims", type: :request do
       it "makes sure validations appropriate to the context are run" do
         put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: nil}}}
 
-        expect(response.body).to include("Select the academic year you were awarded qualified teacher status")
+        expect(response.body).to include("Select whether you completed your initial teacher training before or after September 2013")
       end
 
       it "resets dependent claim attributes when appropriate" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Claims", type: :request do
           get claim_path(StudentLoans.routing_name, "claim-school"), params: {school_search: "Pen"}
 
           expect(response.body).to include("There is a problem")
-          expect(response.body).to include("Search for the school name with a minimum of four characters")
+          expect(response.body).to include("Enter the school you currently teach at")
           expect(response.body).not_to include(schools(:penistone_grammar_school).name)
         end
 


### PR DESCRIPTION
Updated error messages to make them consistent and provide some more guidance to users. To be clear these are the messages shown when you don't select an option/input any text and try to continue. 

Messages have been changed to follow the pattern e.g. `select yes if you teach any maths or physics` rather than telling the user to select an option. Messages should now also be consistent in their use of case and punctuation.

Miro board of new error messages can be found here https://miro.com/app/board/o9J_kvlNgOg=/