### PR TITLE
Add aria-describedby to elements with hints

### DIFF
--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -99,10 +99,10 @@
             </div>
           </fieldset>
           <%= form.label :notes, "Decision notes", class: "govuk-label govuk-label--m" %>
-          <span class="govuk-hint">
+          <span class="govuk-hint" id="notes-hint">
             Please write a brief note explaining why this claim has been rejected or approved.
           </span>
-          <%= form.text_area :notes, class: "govuk-textarea", rows: 5 %>
+          <%= form.text_area :notes, class: "govuk-textarea", "aria-describedby" => "notes-hint", rows: 5 %>
           <%= form.submit "Submit", class: "govuk-button" %>
         <% end %>
       <% end %>

--- a/app/views/admin/policy_configurations/edit.html.erb
+++ b/app/views/admin/policy_configurations/edit.html.erb
@@ -34,7 +34,7 @@
             <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-availability-message-conditional">
               <div class="govuk-form-group">
                 <%= f.label :availability_message, "Availability message", class: "govuk-label" %>
-                <span class="govuk-hint">
+                <span class="govuk-hint" id="availability_message-hint">
                   <p>
                   This is an optional message that should provide an explanation of why the service is closed and / or when we expect it to open again.
                   </p>
@@ -43,7 +43,7 @@
                   For example, "The service is closed for maintenance and will be available from 2pm today."
                   </p>
                 </span>
-                <%= f.text_area :availability_message, class: "govuk-textarea", rows: 5 %>
+                <%= f.text_area :availability_message, class: "govuk-textarea", "aria-describedby" => "availability_message-hint", rows: 5 %>
               </div>
             </div>
           </div>

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -29,21 +29,24 @@
         <strong>No results match that search term. Try again.</strong>
       </p>
     <% else %>
-      <span class="govuk-hint">
+      <span class="govuk-hint" id: "school_search-hint">
         Enter the school name. Use at least four characters.
-      </span>
-
-      <% if school_id_param == :claim_school_id && !params.has_key?(:additional_school) %>
-        <span class="govuk-hint">
+        <% if school_id_param == :claim_school_id && !params.has_key?(:additional_school) %>
+          <br><br>
           If you taught at multiple schools during this period, enter the first school you think might be eligible.
-        </span>
-      <% end %>
+        <% end %>
+      </span>
     <% end %>
 
     <div id="school-search-container">
 
       <%= errors_tag current_claim, :school_search %>
-      <%= text_field_tag :school_search, params[:school_search], id: :school_search, class: css_classes_for_input(current_claim, :school_search), value: school_search_value %>
+      <%= text_field_tag :school_search,
+                         params[:school_search],
+                         id: :school_search,
+                         class: css_classes_for_input(current_claim, :school_search),
+                         value: school_search_value,
+                         "aria-describedby" => "school_search-hint" %>
 
     </div>
 

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -6,14 +6,14 @@
       <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
 
       <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
-        <fieldset class="govuk-fieldset">
+        <fieldset class="govuk-fieldset" aria-describedby="bank_details-hint" role="group">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">
               <%= t("questions.bank_details") %>
             </h1>
           </legend>
 
-          <span class="govuk-hint">
+          <span class="govuk-hint" id="bank_details-hint">
             The account you want us to send your payment to.
           </span>
 

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -10,13 +10,17 @@
           <%= form.label :email_address, t("questions.email_address"), class: "govuk-label govuk-label--xl"  %>
         </h1>
 
-        <span class="govuk-hint">
+        <span class="govuk-hint" id="email_address-hint">
           We will only use your email address to update you about your claim. We recommend you use a personal email address.
         </span>
 
         <%= errors_tag current_claim, :email_address %>
 
-        <%= form.email_field :email_address, autocomplete: "email", spellcheck: "false", class: css_classes_for_input(current_claim, :email_address) %>
+        <%= form.email_field :email_address,
+                             autocomplete: "email",
+                             spellcheck: "false",
+                             class: css_classes_for_input(current_claim, :email_address),
+                             "aria-describedby" => "email_address-hint" %>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>

--- a/app/views/claims/gender.html.erb
+++ b/app/views/claims/gender.html.erb
@@ -5,7 +5,7 @@
     <%= render("shared/error_summary", instance: current_claim, errored_field_id_overrides: { payroll_gender: "claim_payroll_gender_female" }) if current_claim.errors.any? %>
     <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
       <%= form_group_tag current_claim do %>
-        <fieldset class="govuk-fieldset">
+        <fieldset class="govuk-fieldset" aria-describedby="payroll_gender-hint" role="group">
 
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">
@@ -13,7 +13,7 @@
             </h1>
           </legend>
 
-          <span class="govuk-hint">
+          <span class="govuk-hint" id="payroll_gender-hint">
             Your school will need to send HMRC a "Male" or
             "Female" gender to pay you. We ask so we can
             provide this information to HMRC who use it

--- a/app/views/claims/national_insurance_number.html.erb
+++ b/app/views/claims/national_insurance_number.html.erb
@@ -10,7 +10,7 @@
           <%= form.label :national_insurance_number, t("questions.national_insurance_number"), {class: "govuk-label govuk-label--xl"}  %>
         </h1>
 
-        <span class="govuk-hint">
+        <span class="govuk-hint" id="national_insurance_number-hint">
           It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
         </span>
 
@@ -20,8 +20,8 @@
               spellcheck: "false",
               autocomplete: "off",
               minlength: 9,
-              class: css_classes_for_input(current_claim, :national_insurance_number, 'govuk-input--width-10')
-        %>
+              class: css_classes_for_input(current_claim, :national_insurance_number, 'govuk-input--width-10'),
+              "aria-describedby" => "national_insurance_number-hint" %>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>

--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -7,14 +7,14 @@
     <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
       <%= form.hidden_field :has_student_loan %>
         <%= form_group_tag current_claim do %>
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="student_loans-hint" role="group">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
                 <%= t("questions.has_student_loan") %>
               </h1>
             </legend>
 
-            <span class="govuk-hint">
+            <span class="govuk-hint" id="student_loans-hint">
               We use this information to determine if we need to apply a student loan deduction to your payment.
             </span>
 

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -7,14 +7,14 @@
     <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
       <%= form.hidden_field :student_loan_courses %>
         <%= form_group_tag current_claim do %>
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" role="group", aria-describedby="student_loan_courses-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
                 <%= t("questions.student_loan_how_many_courses") %>
               </h1>
             </legend>
 
-            <span class="govuk-hint">
+            <span class="govuk-hint" id="student_loan_courses-hint">
               This includes university degrees, PGCE and Initial Teacher Training courses.
             </span>
 

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -10,7 +10,7 @@
           <%= form.label :teacher_reference_number, t("questions.teacher_reference_number"), class: "govuk-label govuk-label--xl" %>
         </h1>
 
-        <span class="govuk-hint">
+        <span class="govuk-hint" id="teacher_reference_number-hint">
           You can get this from your school, the certificate you got when you
           qualified as a teacher or from the
           <a href="https://www.gov.uk/guidance/individual-teacher-records-information-for-teachers#contact"  class="govuk-link">
@@ -20,7 +20,11 @@
 
         <div class="govuk-form-group">
           <%= errors_tag current_claim, :teacher_reference_number %>
-          <%= form.text_field :teacher_reference_number, spellcheck: "false", autocomplete: "off", class: css_classes_for_input(current_claim, :teacher_reference_number, 'govuk-input--width-10') %>
+          <%= form.text_field :teacher_reference_number,
+                              spellcheck: "false",
+                              autocomplete: "off",
+                              class: css_classes_for_input(current_claim, :teacher_reference_number, 'govuk-input--width-10'),
+                              "aria-describedby" => "teacher_reference_number-hint" %>
         </div>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>

--- a/app/views/maths_and_physics/claims/disciplinary_action.html.erb
+++ b/app/views/maths_and_physics/claims/disciplinary_action.html.erb
@@ -10,7 +10,7 @@
 
           <%= fields.hidden_field :subject_to_disciplinary_action %>
 
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="subject_to_disciplinary_action-hint" role="group">
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
@@ -18,7 +18,7 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint">
+            <span class="govuk-hint" id="subject_to_disciplinary_action-hint">
               For example, if you are under an investigation or have been given
               a warning that has not expired yet. We only use this information
               to check your eligibility.

--- a/app/views/maths_and_physics/claims/formal_performance_action.html.erb
+++ b/app/views/maths_and_physics/claims/formal_performance_action.html.erb
@@ -10,7 +10,7 @@
 
           <%= fields.hidden_field :subject_to_formal_performance_action %>
 
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="formal_performance_action-hint" role="group">
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
@@ -18,7 +18,7 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint">
+            <span class="govuk-hint" id="formal_performance_action-hint">
               For example, under your school’s capability or performance
               management policy. We only use this information to check your
               eligibility.

--- a/app/views/maths_and_physics/claims/has_uk_maths_or_physics_degree.html.erb
+++ b/app/views/maths_and_physics/claims/has_uk_maths_or_physics_degree.html.erb
@@ -10,7 +10,7 @@
 
           <%= fields.hidden_field :has_uk_maths_or_physics_degree %>
 
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="has_uk_maths_or_physics_degree-hint" role="group">
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
@@ -18,7 +18,7 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint">
+            <span class="govuk-hint" id="has_uk_maths_or_physics_degree-hint">
               <p>You must have specialised in maths or physics to be able to
               claim. If you studied maths or physics for less than 50% of your
               degree, please select No.</p>

--- a/app/views/maths_and_physics/claims/initial_teacher_training_subject_specialism.html.erb
+++ b/app/views/maths_and_physics/claims/initial_teacher_training_subject_specialism.html.erb
@@ -10,7 +10,7 @@
 
           <%= fields.hidden_field :initial_teacher_training_subject_specialism %>
 
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="initial_teacher_training_subject_specialism-hint" role="group">
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
@@ -18,7 +18,7 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint">
+            <span class="govuk-hint" id="initial_teacher_training_subject_specialism-hint">
               Your specialism is normally the science you spent the most time training to teach.
             </span>
 
@@ -41,12 +41,16 @@
               </div>
 
               <div class="govuk-radios__item">
-                <%= fields.radio_button(:initial_teacher_training_subject_specialism, :not_sure, class: "govuk-radios__input", data: { aria_controls: "conditional-availability-message-conditional" }) %>
+                <%= fields.radio_button(:initial_teacher_training_subject_specialism,
+                                        :not_sure,
+                                        class: "govuk-radios__input",
+                                        data: { aria_controls: "conditional-availability-message-conditional" },
+                                        "aria-describedby" => "initial_teacher_training_subject_specialism_not_sure-hint") %>
                 <%= fields.label "initial_teacher_training_subject_specialism_not_sure", t("maths_and_physics.answers.initial_teacher_training_subject_specialism.not_sure"), class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-availability-message-conditional">
                 <div class="govuk-form-group">
-                  <span class="govuk-hint">
+                  <span class="govuk-hint" id="initial_teacher_training_subject_specialism_not_sure-hint">
                     <p>
                       If you’re not sure, we’ll check this for you. Your claim may be rejected
                       if your initial teacher training in science did not specialise in physics.

--- a/app/views/maths_and_physics/claims/teaching_maths_or_physics.html.erb
+++ b/app/views/maths_and_physics/claims/teaching_maths_or_physics.html.erb
@@ -10,7 +10,7 @@
 
           <%= fields.hidden_field :teaching_maths_or_physics %>
 
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="teaching_maths_or_physics-hint" role="group">
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
@@ -18,7 +18,7 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint">
+            <span class="govuk-hint" id="teaching_maths_or_physics-hint">
               You are still eligible to claim if you usually teach another
               subject but sometimes teach maths or physics.
             </span>

--- a/app/views/student_loans/claims/leadership_position.html.erb
+++ b/app/views/student_loans/claims/leadership_position.html.erb
@@ -10,7 +10,7 @@
 
           <%= fields.hidden_field :had_leadership_position %>
 
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="had_leadership_position-hint" role="group">
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
@@ -18,7 +18,7 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint">
+            <span class="govuk-hint" id="had_leadership_position-hint">
               This includes head of subject, head of year, head of department,
               deputy head, head teacher or other middle leader role.
             </span>

--- a/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
+++ b/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
@@ -8,7 +8,7 @@
       <%= form_group_tag current_claim do %>
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
           <%= fields.hidden_field :mostly_performed_leadership_duties %>
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="mostly_performed_leadership_duties-hint" role="group">
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
@@ -16,7 +16,7 @@
               </h1>
             </legend>
 
-            <span class="govuk-hint">
+            <span class="govuk-hint" id="mostly_performed_leadership_duties-hint">
               If you were off on long-term leave or sick, include the time you would have spent.
             </span>
 

--- a/app/views/student_loans/claims/student_loan_amount.html.erb
+++ b/app/views/student_loans/claims/student_loan_amount.html.erb
@@ -12,11 +12,9 @@
             <%= fields.label :student_loan_repayment_amount, t("student_loans.questions.student_loan_amount"), class: "govuk-label govuk-label--xl" %>
           </h1>
 
-          <p class="govuk-hint">
+          <p class="govuk-hint" id="student_loan_repayment_amount-hint">
             Check your annual student loan statement, or your P60 if you had only one employer.
-          </p>
-
-          <p class="govuk-hint">
+            <br><br>
             You can also add up the student loan contributions from your payslips from this period, but bear in mind the
             amounts on each payslip might be different.
           </p>
@@ -32,6 +30,7 @@
                   min: 1,
                   max: 99999,
                   value: currency_value_for_number_field(fields.object.student_loan_repayment_amount),
+                  "aria-describedby" => "student_loan_repayment_amount-hint"
                 )
             %>
           </div>


### PR DESCRIPTION
This adds an `aria-describedby` to elements that have hints. In some cases the hints describe a group of elements (such as, for example a bunch of radio buttons), in this case, the `aria-describedby` element is added to the enclosing `fieldset`, which will also have a `role` of `group` (which is a pattern I've seen elsewhere, but hasn't until now, been consistent)
