### PR TITLE
Updates to privacy policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Update to privacy policy to explain how data can be amended and add bullet
+  point about collecting bank details
 - Users can complete and submit a claim without completing GOV.UK Verify
 - Update autocomplete attributes for the address capture page
 - Application complete page and claim submitted email updated to include content

--- a/app/views/static_pages/privacy_notice.html.erb
+++ b/app/views/static_pages/privacy_notice.html.erb
@@ -49,6 +49,9 @@
         your name, email and (if applicable) your phone number when you contact us
       </li>
       <li>
+        your bank account details (account number, sort code and roll number if applicable)
+      </li>
+      <li>
         your email address if you include it with feedback to us on the service or agree to be contacted for user research
         purposes
       </li>
@@ -136,7 +139,8 @@
         to ask us for access to information about you that we hold
       </li>
       <li>
-        to have your personal data rectified, if it is inaccurate or incomplete
+        to have your personal data rectified, if it is inaccurate or incomplete. In this instance, you will need to
+        submit a new claim (your previous claim will be rejected)
       </li>
       <li>
         to ask us to delete your personal data unless there is a legal reason to continue to store and process it


### PR DESCRIPTION
DfE's Legal Advisers Office came back with some tweaks to the privacy
policy regarding bank details and how users can get data amended

<img width="795" alt="Screenshot 2020-01-02 at 15 36 59" src="https://user-images.githubusercontent.com/13239597/71675504-cd7a7680-2d75-11ea-8bf6-557c5c8b106a.png">
<img width="794" alt="Screenshot 2020-01-02 at 15 36 45" src="https://user-images.githubusercontent.com/13239597/71675506-cd7a7680-2d75-11ea-9bfb-9e6d91428b4e.png">
