### PR TITLE
Display the name of a user who created a payroll run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog]
 - Application complete page and claim submitted email updated to include content
   for claimants that do not complete GOV.UK Verify
 - Service operators can see who approved a claim
+- Service operators can see who created a payroll run
 
 ## [Release 042] - 2019-12-19
 

--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -14,7 +14,7 @@ module Admin
     def create
       claims = Claim.find(params[:claim_ids])
 
-      payroll_run = PayrollRun.create_with_claims!(claims, created_by: admin_user.dfe_sign_in_id)
+      payroll_run = PayrollRun.create_with_claims!(claims, created_by: admin_user)
 
       redirect_to [:admin, payroll_run], notice: "Payroll run created"
     end

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -37,12 +37,8 @@ module Admin
         a << [t("admin.check.checked_at"), l(check.created_at)]
         a << [t("admin.check.result"), check.result.capitalize]
         a << [t("admin.check.notes"), simple_format(check.notes, class: "govuk-body")] if check.notes.present?
-        a << [t("admin.check.checked_by"), checked_by(check)]
+        a << [t("admin.check.checked_by"), user_details(check.checked_by)]
       end
-    end
-
-    def checked_by(check)
-      check.checked_by.full_name.presence || unknown_user(check.checked_by)
     end
 
     def check_deadline_warning(claim)
@@ -65,21 +61,6 @@ module Admin
 
     def days_between(first_date, second_date)
       (second_date - first_date).to_i
-    end
-
-    def unknown_user(user)
-      [
-        "Unknown user",
-        unknown_user_details(user),
-      ].join("<br/>").html_safe
-    end
-
-    def unknown_user_details(user)
-      content_tag(
-        :span,
-        "(DfE Sign-in ID - #{user.dfe_sign_in_id})",
-        class: "govuk-!-font-size-16"
-      )
     end
   end
 end

--- a/app/helpers/dfe_sign_in/user_helper.rb
+++ b/app/helpers/dfe_sign_in/user_helper.rb
@@ -1,0 +1,24 @@
+module DfeSignIn
+  module UserHelper
+    def user_details(user)
+      user.full_name.presence || unknown_user(user)
+    end
+
+    private
+
+    def unknown_user(user)
+      [
+        "Unknown user",
+        unknown_user_details(user),
+      ].join("<br/>").html_safe
+    end
+
+    def unknown_user_details(user)
+      content_tag(
+        :span,
+        "(DfE Sign-in ID - #{user.dfe_sign_in_id})",
+        class: "govuk-!-font-size-16"
+      )
+    end
+  end
+end

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -4,7 +4,7 @@ class PayrollRun < ApplicationRecord
   has_many :payments
   has_many :claims, through: :payments
 
-  validates :created_by, presence: true
+  belongs_to :created_by, class_name: "DfeSignIn::User"
 
   validate :ensure_no_payroll_run_this_month, on: :create
 

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -25,6 +25,15 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
+          Created by
+        </dt>
+
+        <dd class="govuk-summary-list__value">
+          <%= user_details(@payroll_run.created_by) %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
           Downloaded
         </dt>
 

--- a/db/data/20200102151230_update_payroll_run_created_by_to_created_by_id.rb
+++ b/db/data/20200102151230_update_payroll_run_created_by_to_created_by_id.rb
@@ -1,0 +1,13 @@
+class UpdatePayrollRunCreatedByToCreatedById < ActiveRecord::Migration[6.0]
+  def up
+    PayrollRun.all.each do |payroll_run|
+      user_id = payroll_run.read_attribute(:created_by)
+      user = DfeSignIn::User.find_or_create_by(dfe_sign_in_id: user_id)
+      payroll_run.update_column(:created_by_id, user.id)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20191216151537)
+DataMigrate::Data.define(version: 20200102151230)

--- a/db/migrate/20200102142041_add_created_by_to_payroll_runs.rb
+++ b/db/migrate/20200102142041_add_created_by_to_payroll_runs.rb
@@ -1,0 +1,5 @@
+class AddCreatedByToPayrollRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :payroll_runs, :created_by, type: :uuid, foreign_key: {to_table: :dfe_sign_in_users}
+  end
+end

--- a/db/migrate/20200102144145_remove_null_constraint_from_created_by.rb
+++ b/db/migrate/20200102144145_remove_null_constraint_from_created_by.rb
@@ -1,0 +1,5 @@
+class RemoveNullConstraintFromCreatedBy < ActiveRecord::Migration[6.0]
+  def change
+    change_column :payroll_runs, :created_by, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_19_160435) do
+ActiveRecord::Schema.define(version: 2020_01_02_144145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -149,13 +149,15 @@ ActiveRecord::Schema.define(version: 2019_12_19_160435) do
   end
 
   create_table "payroll_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "created_by", null: false
+    t.string "created_by"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "confirmation_report_uploaded_by"
     t.datetime "downloaded_at"
     t.string "downloaded_by"
+    t.uuid "created_by_id"
     t.index ["created_at"], name: "index_payroll_runs_on_created_at"
+    t.index ["created_by_id"], name: "index_payroll_runs_on_created_by_id"
     t.index ["updated_at"], name: "index_payroll_runs_on_updated_at"
   end
 
@@ -219,6 +221,7 @@ ActiveRecord::Schema.define(version: 2019_12_19_160435) do
   add_foreign_key "maths_and_physics_eligibilities", "schools", column: "current_school_id"
   add_foreign_key "payments", "claims"
   add_foreign_key "payments", "payroll_runs"
+  add_foreign_key "payroll_runs", "dfe_sign_in_users", column: "created_by_id"
   add_foreign_key "schools", "local_authority_districts"
   add_foreign_key "student_loans_eligibilities", "schools", column: "claim_school_id"
   add_foreign_key "student_loans_eligibilities", "schools", column: "current_school_id"

--- a/spec/factories/payroll_runs.rb
+++ b/spec/factories/payroll_runs.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :payroll_run do
-    created_by { "123" }
+    association :created_by, factory: :dfe_signin_user
 
     transient do
       claims_counts { {StudentLoans => 1} }

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.feature "Payroll" do
+  let(:user) { create(:dfe_signin_user) }
   let!(:dataset_post_stub) { stub_geckoboard_dataset_update("claims.paid.test") }
 
   scenario "Service operator creates a payroll run" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
 
     click_on "Payroll"
 
@@ -24,6 +25,7 @@ RSpec.feature "Payroll" do
     payroll_run = PayrollRun.order(:created_at).last
 
     expect(page).to have_content("Approved claims 3")
+    expect(page).to have_content("Created by #{user.full_name}")
     expect(page).to have_content("Total award amount £4,000")
     expect(page).to have_content("Payroll run created")
     expect(page).to have_field("payroll_run_download_link", with: new_admin_payroll_run_download_url(payroll_run))
@@ -85,6 +87,7 @@ RSpec.feature "Payroll" do
     click_on "Payroll"
     click_on "View #{payroll_run.created_at.strftime("%B")} payroll run"
 
+    expect(page).to have_content("Created by #{payroll_run.created_by.full_name}")
     expect(page).to have_content payroll_run.claims.count
     expect(page).to have_content "Downloaded No"
     expect(page).to have_field("payroll_run_download_link", with: new_admin_payroll_run_download_url(payroll_run))

--- a/spec/helpers/dfe_sign_in/user_helper_spec.rb
+++ b/spec/helpers/dfe_sign_in/user_helper_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe DfeSignIn::UserHelper, type: :helper do
+  describe "#user_details" do
+    context "when user has a name assigned" do
+      let(:user) { build(:dfe_signin_user, given_name: "Jo", family_name: "Bloggs") }
+
+      it "returns the user's full name" do
+        expect(helper.user_details(user)).to eq("Jo Bloggs")
+      end
+    end
+
+    context "when user has no name assigned" do
+      let(:user) { build(:dfe_signin_user, given_name: nil, family_name: nil) }
+
+      it "returns an unknown user message with the user's DfE Sign-In ID" do
+        user_details = helper.user_details(user)
+        expect(user_details).to match("Unknown user")
+        expect(user_details).to match("DfE Sign-in ID - #{user.dfe_sign_in_id}")
+      end
+    end
+  end
+end

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe PayrollRun, type: :model do
+  let(:user) { create(:dfe_signin_user) }
+
   it "cannot be created when another PayrollRun has occurred in same month" do
     create(:payroll_run)
     another_payroll_run = build(:payroll_run)
@@ -34,7 +36,7 @@ RSpec.describe PayrollRun, type: :model do
       payment_1 = build(:payment, claim: build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 1500)))
       payment_2 = build(:payment, claim: build(:claim, :approved, eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 2000)))
 
-      payroll_run = PayrollRun.create!(created_by: "foo", payments: [payment_1, payment_2])
+      payroll_run = PayrollRun.create!(created_by: user, payments: [payment_1, payment_2])
 
       expect(payroll_run.total_award_amount).to eq(3500)
     end
@@ -44,9 +46,9 @@ RSpec.describe PayrollRun, type: :model do
     let(:claims) { Policies.all.map { |policy| create(:claim, :approved, policy: policy) } }
 
     it "creates a payroll run with payments and populates the award_amount" do
-      payroll_run = PayrollRun.create_with_claims!(claims, created_by: "creator-id")
+      payroll_run = PayrollRun.create_with_claims!(claims, created_by: user)
 
-      expect(payroll_run.reload.created_by).to eq("creator-id")
+      expect(payroll_run.reload.created_by.id).to eq(user.id)
       expect(payroll_run.claims).to match_array(claims)
       expect(claims[0].payment.award_amount).to eq(claims[0].award_amount)
       expect(claims[1].payment.award_amount).to eq(claims[1].award_amount)

--- a/spec/requests/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin_payroll_runs_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Admin payroll runs" do
   context "when signed in as a service operator" do
-    let(:admin_session_id) { "some_user_id" }
+    let(:user) { create(:dfe_signin_user) }
+
     before do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin_session_id)
+      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
     end
 
     describe "admin_payroll_runs#new" do
@@ -25,7 +26,7 @@ RSpec.describe "Admin payroll runs" do
         expect { post admin_payroll_runs_path(claim_ids: claims.map(&:id)) }.to change { PayrollRun.count }.by(1)
 
         payroll_run = PayrollRun.order(:created_at).last
-        expect(payroll_run.created_by).to eq(admin_session_id)
+        expect(payroll_run.created_by.id).to eq(user.id)
         expect(payroll_run.claims).to match_array(claims)
         expect(payroll_run.payments.count).to eq(2)
 


### PR DESCRIPTION
This updates the PayrollRun model to refer to a user in the database, rather than a simple Dfe Sign-In user ID. This also allows the name of a user to be shown like so:

![image](https://user-images.githubusercontent.com/109774/71676920-4b8c4c80-2d79-11ea-9903-ad53c1341c1f.png)
