### PR TITLE
Display the name of the user who downloaded a payroll report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog]
 - Service operators can see who created a payroll run
 - Fix a bug where users who spent more than 90 minutes in Verify would trigger a
   routing exception and not receive the session timeout message.
+- Service operators can see who downloaded a payroll run
 
 ## [Release 042] - 2019-12-19
 

--- a/app/controllers/admin/payroll_run_downloads_controller.rb
+++ b/app/controllers/admin/payroll_run_downloads_controller.rb
@@ -9,7 +9,7 @@ class Admin::PayrollRunDownloadsController < Admin::BaseAdminController
   end
 
   def create
-    @payroll_run.update!(downloaded_at: Time.zone.now, downloaded_by: admin_user.dfe_sign_in_id)
+    @payroll_run.update!(downloaded_at: Time.zone.now, downloaded_by: admin_user)
 
     redirect_to admin_payroll_run_download_path(@payroll_run)
   end

--- a/app/helpers/dfe_sign_in/user_helper.rb
+++ b/app/helpers/dfe_sign_in/user_helper.rb
@@ -1,16 +1,18 @@
 module DfeSignIn
   module UserHelper
-    def user_details(user)
-      user.full_name.presence || unknown_user(user)
+    def user_details(user, include_line_break: true)
+      user.full_name.presence || unknown_user(user, include_line_break)
     end
 
     private
 
-    def unknown_user(user)
+    def unknown_user(user, include_line_break)
+      join_chr = include_line_break == true ? "<br/>" : " "
+
       [
         "Unknown user",
         unknown_user_details(user),
-      ].join("<br/>").html_safe
+      ].join(join_chr).html_safe
     end
 
     def unknown_user_details(user)

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -5,6 +5,7 @@ class PayrollRun < ApplicationRecord
   has_many :claims, through: :payments
 
   belongs_to :created_by, class_name: "DfeSignIn::User"
+  belongs_to :downloaded_by, class_name: "DfeSignIn::User", optional: true
 
   validate :ensure_no_payroll_run_this_month, on: :create
 

--- a/app/views/admin/payroll_run_downloads/show.html.erb
+++ b/app/views/admin/payroll_run_downloads/show.html.erb
@@ -13,7 +13,7 @@
       <p class="govuk-body">
         This month's payroll file was downloaded on
         <%= l(@payroll_run.downloaded_at) %> by
-        <%= @payroll_run.downloaded_by %>.
+        <%= user_details(@payroll_run.downloaded_by.full_name) %>.
       </p>
       <p class="govuk-body">
         For security and privacy, this payroll file can only be downloaded once.

--- a/app/views/admin/payroll_run_downloads/show.html.erb
+++ b/app/views/admin/payroll_run_downloads/show.html.erb
@@ -13,7 +13,7 @@
       <p class="govuk-body">
         This month's payroll file was downloaded on
         <%= l(@payroll_run.downloaded_at) %> by
-        <%= user_details(@payroll_run.downloaded_by.full_name) %>.
+        <%= user_details(@payroll_run.downloaded_by, include_line_break: false) %>.
       </p>
       <p class="govuk-body">
         For security and privacy, this payroll file can only be downloaded once.

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -41,6 +41,17 @@
           <%= @payroll_run.download_triggered? ? l(@payroll_run.downloaded_at) : "No" %>
         </dd>
       </div>
+      <% if @payroll_run.download_triggered? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Downloaded by
+          </dt>
+
+          <dd class="govuk-summary-list__value">
+            <%= user_details(@payroll_run.downloaded_by) %>
+          </dd>
+        </div>
+      <% end %>
     </dl>
   </div>
   <% unless @payroll_run.download_triggered? %>

--- a/db/data/20200106141251_update_payroll_run_downloaded_by_to_downloaded_by_id.rb
+++ b/db/data/20200106141251_update_payroll_run_downloaded_by_to_downloaded_by_id.rb
@@ -1,0 +1,13 @@
+class UpdatePayrollRunDownloadedByToDownloadedById < ActiveRecord::Migration[6.0]
+  def up
+    PayrollRun.all.each do |payroll_run|
+      user_id = payroll_run.read_attribute(:downloaded_by)
+      user = DfeSignIn::User.find_or_create_by(dfe_sign_in_id: user_id)
+      payroll_run.update_column(:downloaded_by_id, user.id)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200102151230)
+DataMigrate::Data.define(version: 20200106141251)

--- a/db/migrate/20200106120123_add_downloaded_by_to_payroll_runs.rb
+++ b/db/migrate/20200106120123_add_downloaded_by_to_payroll_runs.rb
@@ -1,0 +1,5 @@
+class AddDownloadedByToPayrollRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :payroll_runs, :downloaded_by, type: :uuid, foreign_key: {to_table: :dfe_sign_in_users}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_02_144145) do
+ActiveRecord::Schema.define(version: 2020_01_06_120123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -156,8 +156,10 @@ ActiveRecord::Schema.define(version: 2020_01_02_144145) do
     t.datetime "downloaded_at"
     t.string "downloaded_by"
     t.uuid "created_by_id"
+    t.uuid "downloaded_by_id"
     t.index ["created_at"], name: "index_payroll_runs_on_created_at"
     t.index ["created_by_id"], name: "index_payroll_runs_on_created_by_id"
+    t.index ["downloaded_by_id"], name: "index_payroll_runs_on_downloaded_by_id"
     t.index ["updated_at"], name: "index_payroll_runs_on_updated_at"
   end
 
@@ -222,6 +224,7 @@ ActiveRecord::Schema.define(version: 2020_01_02_144145) do
   add_foreign_key "payments", "claims"
   add_foreign_key "payments", "payroll_runs"
   add_foreign_key "payroll_runs", "dfe_sign_in_users", column: "created_by_id"
+  add_foreign_key "payroll_runs", "dfe_sign_in_users", column: "downloaded_by_id"
   add_foreign_key "schools", "local_authority_districts"
   add_foreign_key "student_loans_eligibilities", "schools", column: "claim_school_id"
   add_foreign_key "student_loans_eligibilities", "schools", column: "current_school_id"

--- a/spec/factories/dfe_sign_in/users.rb
+++ b/spec/factories/dfe_sign_in/users.rb
@@ -5,5 +5,12 @@ FactoryBot.define do
     family_name { "Bloggs" }
     email { "jo.bloggs@education.gov.uk" }
     organisation_name { "Department for Education" }
+
+    trait :without_data do
+      given_name { nil }
+      family_name { nil }
+      email { nil }
+      organisation_name { nil }
+    end
   end
 end

--- a/spec/factories/payroll_runs.rb
+++ b/spec/factories/payroll_runs.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :payroll_run do
     association :created_by, factory: :dfe_signin_user
+    association :downloaded_by, factory: :dfe_signin_user
 
     transient do
       claims_counts { {StudentLoans => 1} }

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -98,7 +98,7 @@ describe Admin::ClaimsHelper do
     end
 
     context "when user does not have a name stored" do
-      let(:user) { create(:dfe_signin_user, given_name: nil, family_name: nil) }
+      let(:user) { create(:dfe_signin_user, :without_data) }
 
       it "displays the user ID" do
         user_id_details = helper.admin_check_details(check).last

--- a/spec/helpers/dfe_sign_in/user_helper_spec.rb
+++ b/spec/helpers/dfe_sign_in/user_helper_spec.rb
@@ -11,12 +11,16 @@ RSpec.describe DfeSignIn::UserHelper, type: :helper do
     end
 
     context "when user has no name assigned" do
-      let(:user) { build(:dfe_signin_user, given_name: nil, family_name: nil) }
+      let(:user) { build(:dfe_signin_user, :without_data) }
 
       it "returns an unknown user message with the user's DfE Sign-In ID" do
         user_details = helper.user_details(user)
-        expect(user_details).to match("Unknown user")
-        expect(user_details).to match("DfE Sign-in ID - #{user.dfe_sign_in_id}")
+        expect(user_details).to eq("Unknown user<br/><span class=\"govuk-!-font-size-16\">(DfE Sign-in ID - #{user.dfe_sign_in_id})</span>")
+      end
+
+      it "does not have a line break when include_line_break is set to false" do
+        user_details = helper.user_details(user, include_line_break: false)
+        expect(user_details).to eq("Unknown user <span class=\"govuk-!-font-size-16\">(DfE Sign-in ID - #{user.dfe_sign_in_id})</span>")
       end
     end
   end

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe PayrollRun, type: :model do
 
   describe "#download_available?" do
     it "returns true when the download was triggered within the time limit" do
-      payroll_run = create(:payroll_run, downloaded_at: Time.zone.now, downloaded_by: "admin_user_id")
+      payroll_run = create(:payroll_run, downloaded_at: Time.zone.now, downloaded_by: user)
       expect(payroll_run.download_available?).to eql true
 
       travel_to 31.seconds.from_now do
@@ -87,7 +87,7 @@ RSpec.describe PayrollRun, type: :model do
 
       expect(payroll_run.download_triggered?).to eql false
 
-      payroll_run.update!(downloaded_at: Time.zone.now, downloaded_by: "admin_user_id")
+      payroll_run.update!(downloaded_at: Time.zone.now, downloaded_by: user)
 
       expect(payroll_run.download_triggered?).to eql true
     end

--- a/spec/requests/admin_payroll_run_downloads_spec.rb
+++ b/spec/requests/admin_payroll_run_downloads_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe "Admin payroll run downloads" do
           expect(response.body).to include payroll_run.downloaded_by.full_name
           expect(response.body).to include I18n.l(payroll_run.downloaded_at)
         end
+
+        it "shows the user ID of the user if the user has not name assigned" do
+          user = create(:dfe_signin_user, :without_data)
+          payroll_run = create(:payroll_run, downloaded_at: 31.seconds.ago, downloaded_by: user)
+
+          get admin_payroll_run_download_path(payroll_run)
+
+          expect(response.body).to include payroll_run.downloaded_by.dfe_sign_in_id
+        end
       end
     end
 

--- a/spec/requests/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin_payroll_runs_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Admin payroll runs" do
       end
 
       it "does not show the link to the payroll run download once the download has been triggered" do
-        payroll_run = create(:payroll_run, downloaded_at: Time.zone.now, downloaded_by: "admin_user_id")
+        payroll_run = create(:payroll_run, downloaded_at: Time.zone.now, downloaded_by: user)
 
         get admin_payroll_run_path(payroll_run)
 

--- a/spec/requests/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin_payroll_runs_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe "Admin payroll runs" do
         expect(response).to have_http_status(:ok)
         expect(response.body).not_to include new_admin_payroll_run_download_url(payroll_run)
       end
+
+      it "shows who downloaded the payroll run once the download has been triggered" do
+        payroll_run = create(:payroll_run, downloaded_at: Time.zone.now, downloaded_by: user)
+
+        get admin_payroll_run_path(payroll_run)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.l(payroll_run.downloaded_at))
+        expect(response.body).to include(user.full_name)
+      end
     end
   end
 


### PR DESCRIPTION
This is the final part of https://trello.com/c/fr9sNCXk/877-display-the-name-of-the-service-operator-who-took-an-action, and this displays the name of a user who has downloaded a Payroll Report. As with #731 and #744, if a user's details have been imported, it shows their full name, but if we haven't yet hit the API to import some user data, it shows the user's DfE Sign-In ID:

![image](https://user-images.githubusercontent.com/109774/71822890-f197c980-308d-11ea-8474-d5969169e34a.png)

![image](https://user-images.githubusercontent.com/109774/71822863-e04ebd00-308d-11ea-8818-64b63ffeffda.png)

There is also a data migration to import any existing user IDs that are set on the `downloaded_by` column and convert them into a proper reference to a user object.