### PR TITLE
Handling the situation where a user tries to claim for both policies at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog]
 - Fix a bug where users who spent more than 90 minutes in Verify would trigger a
   routing exception and not receive the session timeout message.
 - Service operators can see who downloaded a payroll run
+- Show a warning message when a user tries to switch policies or start a new
+  claim
 
 ## [Release 042] - 2019-12-19
 

--- a/app/assets/stylesheets/components/panel.scss
+++ b/app/assets/stylesheets/components/panel.scss
@@ -15,3 +15,43 @@
     margin: 0;
   }
 }
+
+.govuk-panel--interruption {
+  background-color: govuk-colour("blue");
+  text-align: left;
+
+  * {
+    color: govuk-colour("white");
+  }
+
+  a,
+  a:link,
+  a:visited {
+    color: govuk-colour("white");
+  }
+  a:hover {
+    color: govuk-colour("light-grey");
+  }
+
+  .govuk-list--definition {
+    dt,
+    dd {
+      color: govuk-colour("blue");
+    }
+  }
+
+  .govuk-button:not(.govuk-button--link) {
+    background-color: govuk-colour("white");
+    box-shadow: 0 2px 0 govuk-colour("black");
+
+    &:link,
+    &:visited {
+      color: govuk-colour("blue");
+    }
+
+    &:hover,
+    &:focus {
+      background-color: govuk-colour("light-grey");
+    }
+  }
+}

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -3,6 +3,7 @@ class ClaimsController < BasePublicController
 
   skip_before_action :send_unstarted_claiments_to_the_start, only: [:new, :create, :timeout]
   before_action :check_page_is_in_sequence, only: [:show, :update]
+  before_action :check_claim_not_in_progress, only: [:new]
   before_action :clear_claim_session, only: [:new]
   before_action :prepend_view_path_for_policy
 
@@ -40,6 +41,9 @@ class ClaimsController < BasePublicController
   def timeout
   end
 
+  def existing_session
+  end
+
   private
 
   helper_method :next_slug
@@ -70,6 +74,14 @@ class ClaimsController < BasePublicController
 
   def check_page_is_in_sequence
     raise ActionController::RoutingError.new("Not Found") unless page_sequence.in_sequence?(params[:slug])
+  end
+
+  def check_claim_not_in_progress
+    redirect_to(existing_session_path(policy: params[:policy])) if claim_in_progress?
+  end
+
+  def claim_in_progress?
+    session[:claim_id].present? && !current_claim.eligibility.ineligible?
   end
 
   def page_sequence

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -3,6 +3,7 @@ class ClaimsController < BasePublicController
 
   skip_before_action :send_unstarted_claiments_to_the_start, only: [:new, :create, :timeout]
   before_action :check_page_is_in_sequence, only: [:show, :update]
+  before_action :update_session_with_current_slug, only: [:show]
   before_action :check_claim_not_in_progress, only: [:new]
   before_action :clear_claim_session, only: [:new]
   before_action :prepend_view_path_for_policy
@@ -74,6 +75,10 @@ class ClaimsController < BasePublicController
 
   def check_page_is_in_sequence
     raise ActionController::RoutingError.new("Not Found") unless page_sequence.in_sequence?(params[:slug])
+  end
+
+  def update_session_with_current_slug
+    session[:current_slug] = params[:slug]
   end
 
   def check_claim_not_in_progress

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -11,7 +11,7 @@ module PartOfClaimJourney
   private
 
   def current_policy_routing_name
-    current_claim.policy&.routing_name
+    super || current_claim.policy&.routing_name
   end
 
   def check_whether_closed_for_submissions

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,10 @@
-class SessionsController < ApplicationController
+class SessionsController < BasePublicController
   def refresh
     head :ok
+  end
+
+  def destroy
+    clear_claim_session
+    redirect_to(new_claim_path(params[:policy]))
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -16,10 +16,4 @@ class StaticPagesController < BasePublicController
 
   def terms_conditions
   end
-
-  private
-
-  def current_policy_routing_name
-    super || "student-loans"
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,10 @@ module ApplicationHelper
     policy ? t("#{policy.underscore}.policy_name") : t("service_name")
   end
 
+  def policy_description(policy)
+    I18n.t("#{policy.underscore}.claim_description")
+  end
+
   def feedback_url
     current_policy.feedback_url
   end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -3,18 +3,18 @@ class ClaimMailer < ApplicationMailer
 
   def submitted(claim)
     @claim_description = claim_description(claim)
-    view_mail_with_claim_and_subject(claim, "Your #{@claim_description} has been received, reference number: #{claim.reference}")
+    view_mail_with_claim_and_subject(claim, "Your claim #{@claim_description} has been received, reference number: #{claim.reference}")
   end
 
   def approved(claim)
     @claim_description = claim_description(claim)
-    view_mail_with_claim_and_subject(claim, "Your #{@claim_description} has been approved, reference number: #{claim.reference}")
+    view_mail_with_claim_and_subject(claim, "Your claim #{@claim_description} has been approved, reference number: #{claim.reference}")
   end
 
   def rejected(claim)
     @claim_description = claim_description(claim)
     @possible_rejection_reasons = I18n.t("#{claim.policy.routing_name.underscore}.possible_rejection_reasons")
-    view_mail_with_claim_and_subject(claim, "Your #{@claim_description} has been rejected, reference number: #{claim.reference}")
+    view_mail_with_claim_and_subject(claim, "Your claim #{@claim_description} has been rejected, reference number: #{claim.reference}")
   end
 
   private

--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -24,7 +24,7 @@ class PaymentMailer < ApplicationMailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       to: @payment.email_address,
-      subject: "We’re paying your #{@claim_description}, reference number: #{@reference}",
+      subject: "We’re paying your claim #{@claim_description}, reference number: #{@reference}",
       reply_to_id: @policy.notify_reply_to_id,
       template_name: :confirmation_for_single_claim
     )

--- a/app/views/claim_mailer/approved.text.erb
+++ b/app/views/claim_mailer/approved.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-Your <%= @claim_description %> has been approved.
+Your claim <%= @claim_description %> has been approved.
 
 We will send you another email when we have processed your payment, which may take up to <%= claim_checking_deadline_in_weeks %>.
 

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-We have not been able to approve your <%= @claim_description %>.
+We have not been able to approve your claim <%= @claim_description %>.
 
 Your claim has not been approved because our records show one of the following:
 

--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-We've received your <%= @claim_description %>.
+We've received your claim <%= @claim_description %>.
 
 Your unique reference is <%= @claim.reference %>. You will need this if you contact us about your claim.
 

--- a/app/views/claims/existing_session.html.erb
+++ b/app/views/claims/existing_session.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-panel govuk-panel--interruption">
+      <h1 class="govuk-heading-xl">
+        You have a claim in progress <%= policy_description(current_claim.policy.routing_name) %>.
+      </h1>
+
+      <h2 class="govuk-heading-m">
+        You will lose your progress on this claim if you start a different claim before you send it.
+      </h2>
+    </div>
+
+    <%= button_to "Start claim #{policy_description(params[:policy])}", session_path(policy: params[:policy]), method: :delete, class: "govuk-button govuk-button--secondary" %>
+  </div>
+</div>

--- a/app/views/claims/existing_session.html.erb
+++ b/app/views/claims/existing_session.html.erb
@@ -10,6 +10,10 @@
       </h2>
     </div>
 
+    <p class="govuk-body govuk-!-margin-top-7 govuk-!-margin-bottom-0">
+      <%= link_to "Finish claim in progress", claim_path(current_claim.policy.routing_name, slug: session[:current_slug]), class: "govuk-button" %>
+    </p>
+
     <%= button_to "Start claim #{policy_description(params[:policy])}", session_path(policy: params[:policy]), method: :delete, class: "govuk-button govuk-button--secondary" %>
   </div>
 </div>

--- a/app/views/payment_mailer/confirmation_for_multiple_claims.text.erb
+++ b/app/views/payment_mailer/confirmation_for_multiple_claims.text.erb
@@ -2,7 +2,7 @@ Dear <%= @display_name %>,
 
 We’re paying:
 <% @payment.claims.each do |claim| %>
-* your <%= I18n.t("#{claim.policy.routing_name.underscore}.claim_description") %>, reference: <%= claim.reference %>
+* your claim <%= I18n.t("#{claim.policy.routing_name.underscore}.claim_description") %>, reference: <%= claim.reference %>
 <% end %>
 
 ^ You will receive <%=number_to_currency(@payment.net_pay) %> on or after <%= l(@payment_date) %>.

--- a/app/views/payment_mailer/confirmation_for_single_claim.text.erb
+++ b/app/views/payment_mailer/confirmation_for_single_claim.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-We’re paying your <%= @claim_description %>.
+We’re paying your claim <%= @claim_description %>.
 
 ^ You will receive <%=number_to_currency(@payment.net_pay) %> on or after <%= l(@payment_date) %>.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,7 @@ en:
   maths_and_physics:
     policy_name: "Claim a payment for teaching maths or physics"
     policy_short_name: "Maths and Physics"
-    claim_description: "claim for a payment for teaching maths or physics"
+    claim_description: "for a payment for teaching maths or physics"
     claim_amount_description: "Payment for teaching maths or physics"
     claim_action: "claim £2,000 for teaching maths or physics"
     award_description: "£2,000 payment"
@@ -157,7 +157,7 @@ en:
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     policy_short_name: "Student Loans"
-    claim_description: "claim to get back your student loan repayments"
+    claim_description: "to get back your student loan repayments"
     claim_amount_description: "Student loan repayments you’ve claimed back"
     claim_action: "claim back student loan repayments"
     award_description: "claim payment"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   end
 
   get "refresh-session", to: "sessions#refresh", as: :refresh_session
+  delete "session", to: "sessions#destroy", as: :session
 
   # Used to constrain claim journey routing so only slugs
   # that are part of a policy’s slug sequence are routed.
@@ -45,6 +46,7 @@ Rails.application.routes.draw do
     get "claims/confirmation", as: :claim_confirmation, to: "submissions#show"
 
     get "timeout", to: "claims#timeout", as: :timeout_claim
+    get "existing-session", as: :existing_session, to: "claims#existing_session"
 
     %w[privacy_notice terms_conditions contact_us cookies accessibility_statement].each do |page_name|
       get page_name.dasherize, to: "static_pages##{page_name}", as: page_name

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -88,6 +88,8 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     visit new_claim_path(StudentLoans.routing_name)
 
+    expect(page).to_not have_content("You have a claim in progress")
+
     expect(page).to have_content("When did you complete your initial teacher training?")
     expect(page).not_to have_css("input[checked]")
     choose_qts_year

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -14,4 +14,10 @@ RSpec.feature "Switching policies" do
 
     expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))
   end
+
+  scenario "a user can choose to continue their claim" do
+    click_on "Finish claim in progress"
+
+    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
+  end
 end

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -1,17 +1,17 @@
 require "rails_helper"
 
-RSpec.feature "A user can switch policies" do
-  it "a user can switch to maths and physics after starting a student loan claim" do
+RSpec.feature "Switching policies" do
+  before do
     start_student_loans_claim
     visit new_claim_path(MathsAndPhysics.routing_name)
-
-    expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))
   end
 
-  it "a user can switch to student loans after starting a maths and physics claim" do
-    start_maths_and_physics_claim
-    visit new_claim_path(StudentLoans.routing_name)
+  scenario "a user can switch to a different policy after starting a claim on another" do
+    expect(page.title).to have_text(I18n.t("maths_and_physics.policy_name"))
+    expect(page.find("header")).to have_text(I18n.t("maths_and_physics.policy_name"))
 
-    expect(page).to have_text(I18n.t("questions.qts_award_year"))
+    click_on "Start claim for a payment for teaching maths or physics"
+
+    expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))
   end
 end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -9,14 +9,18 @@ RSpec.describe "Claims", type: :request do
       end
     end
 
-    context "the user has already started a claim" do
-      before { start_student_loans_claim }
+    it "redirects to the existing claim interruption page if a claim for another policy is already in progress" do
+      start_student_loans_claim
+      get new_claim_path(MathsAndPhysics.routing_name)
 
-      it "clears the current claim from the session, and renders the first page in the sequence" do
-        expect { get new_claim_path(StudentLoans.routing_name) }.to change { session[:claim_id] }.from(String).to(nil)
+      expect(response).to redirect_to(existing_session_path(MathsAndPhysics.routing_name))
+    end
 
-        expect(response.body).to include(I18n.t("questions.qts_award_year"))
-      end
+    it "redirects to the existing claim interruption page if another claim for the same policy is already in progress" do
+      start_student_loans_claim
+      get new_claim_path(StudentLoans.routing_name)
+
+      expect(response).to redirect_to(existing_session_path(StudentLoans.routing_name))
     end
   end
 


### PR DESCRIPTION
When a user is in the middle of a claim, and tries to access the initial page of a new claim, they're now confronted with a warning telling them that they are in the middle of an application, and giving them the opportunity to start a new claim, or continue the claim they are currently making:

![image](https://user-images.githubusercontent.com/109774/71963947-99c7a280-31f4-11ea-883d-ef0cf064feb4.png)

We've used the interruption card pattern, as outlined in the [Home Office Design System](https://home-office-digital-patterns.herokuapp.com/patterns/interruption-card), so this may need some looking over by @titlescreen before merge too.
