### PR TITLE
Release 043 🚢

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+## [Release 043] - 2020-01-08
+
 - Update to privacy policy to explain how data can be amended and add bullet
   point about collecting bank details
 - Users can complete and submit a claim without completing GOV.UK Verify
@@ -330,7 +332,9 @@ The format is based on [Keep a Changelog]
 - First release for student loan repayments private beta
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-042...HEAD
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-043...HEAD
+[release 043]:
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-042...release-043
 [release 042]:
   https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-041...release-042
 [release 041]:


### PR DESCRIPTION
- Update to privacy policy to explain how data can be amended and add bullet point about collecting bank details
- Users can complete and submit a claim without completing GOV.UK Verify
- Update autocomplete attributes for the address capture page
- Application complete page and claim submitted email updated to include content for claimants that do not complete GOV.UK Verify
- Service operators can see who approved a claim
- Service operators can see who created a payroll run
- Fix a bug where users who spent more than 90 minutes in Verify would trigger a routing exception and not receive the session timeout message.
- Service operators can see who downloaded a payroll run
