### PR TITLE
Eligible schools in the West Somerset opportunity area should be able to apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Schools in the West Somerset opportunity area are now regarded as eligible
+  again, after the West Somerset local authority district ceased to exist.
+
 ## [Release 043] - 2020-01-08
 
 - Update to privacy policy to explain how data can be amended and add bullet

--- a/app/models/maths_and_physics/school_eligibility.rb
+++ b/app/models/maths_and_physics/school_eligibility.rb
@@ -45,13 +45,19 @@ module MathsAndPhysics
       "E06000014", # York
     ].freeze
 
+    SCHOOL_URNS_CONSIDERED_AS_ELIGIBLE_LOCAL_AUTHORITY_DISTRICT = [
+      136774, # Minehead Middle School
+      136791, # West Somerset College
+      140631, # Danesfield Church of England Voluntary Controlled Community Middle School
+    ].freeze
+
     def initialize(school)
       @school = school
     end
 
     def eligible_current_school?
       @school.open? &&
-        eligible_local_authority_district? &&
+        (eligible_local_authority_district? || considered_as_eligible_local_authority_district?) &&
         (@school.state_funded? || @school.secure_unit?) &&
         @school.secondary_or_equivalent?
     end
@@ -60,6 +66,10 @@ module MathsAndPhysics
 
     def eligible_local_authority_district?
       ELIGIBLE_LOCAL_AUTHORITY_DISTRICT_CODES.include?(@school.local_authority_district.code)
+    end
+
+    def considered_as_eligible_local_authority_district?
+      SCHOOL_URNS_CONSIDERED_AS_ELIGIBLE_LOCAL_AUTHORITY_DISTRICT.include?(@school.urn)
     end
   end
 end

--- a/app/models/maths_and_physics/school_eligibility.rb
+++ b/app/models/maths_and_physics/school_eligibility.rb
@@ -42,7 +42,6 @@ module MathsAndPhysics
       "E06000021", # Stoke-on-Trent
       "E08000024", # Sunderland
       "E08000036", # Wakefield
-      "E07000191", # West Somerset
       "E06000014", # York
     ].freeze
 

--- a/spec/models/maths_and_physics/school_eligibility_spec.rb
+++ b/spec/models/maths_and_physics/school_eligibility_spec.rb
@@ -32,6 +32,32 @@ RSpec.describe MathsAndPhysics::SchoolEligibility do
       end
     end
 
+    context "with an explicitly eligible school in an ineligible local authority district" do
+      let(:explicitly_eligible_school) {
+        School.new(
+          school_type_group: :la_maintained,
+          phase: :secondary,
+          close_date: nil,
+          urn: 136791,
+          local_authority_district: local_authority_districts(:camden)
+        )
+      }
+
+      it "returns true if the school is otherwise eligible" do
+        expect(MathsAndPhysics::SchoolEligibility.new(explicitly_eligible_school).eligible_current_school?).to eql true
+      end
+
+      it "returns false when closed" do
+        explicitly_eligible_school.assign_attributes(close_date: Date.new)
+        expect(MathsAndPhysics::SchoolEligibility.new(explicitly_eligible_school).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not state funded" do
+        explicitly_eligible_school.assign_attributes(school_type_group: :independent_schools)
+        expect(MathsAndPhysics::SchoolEligibility.new(explicitly_eligible_school).eligible_current_school?).to eql false
+      end
+    end
+
     context "with a special school" do
       let(:special_school) {
         School.new(


### PR DESCRIPTION
The policy document says that schools in the West Somerset opportunity
area are eligible, but this is defined as contiguous with the (now
defunct) West Somerset local authority district. When the local
authority districts of West Somerset and Taunton were merged this local
authority district ceased to exist, and the new local authority district
which schools were moved to is not eligible.

Schools in the `EXPLICITLY_ELIGIBLE_SCHOOL_URNS` list are now treated as
being in an eligible local authority district. This is a list of schools
which are in the West Somerset opportunity area and which are eligible.