### PR TITLE
Claims factory doesn't create potential duplicates

### DIFF
--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -1,4 +1,8 @@
 FactoryBot.define do
+  sequence(:email_address) { |n| "person#{n}@example.com" }
+  sequence(:teacher_reference_number, 1000000) { |n| n }
+  sequence(:national_insurance_number, 100000) { |n| "QQ#{n}C" }
+
   factory :claim do
     transient do
       policy { StudentLoans }
@@ -15,17 +19,17 @@ FactoryBot.define do
       address_line_1 { "1 Test Road" }
       postcode { "AB1 2CD" }
       date_of_birth { 20.years.ago.to_date }
-      teacher_reference_number { "1234567" }
-      national_insurance_number { "QQ123456C" }
+      teacher_reference_number { generate(:teacher_reference_number) }
+      national_insurance_number { generate(:national_insurance_number) }
       has_student_loan { true }
       student_loan_country { :england }
       student_loan_courses { :one_course }
       student_loan_start_date { StudentLoan::BEFORE_1_SEPT_2012 }
       student_loan_plan { StudentLoan::PLAN_1 }
-      email_address { "test@email.com" }
+      email_address { generate(:email_address) }
       banking_name { "Jo Bloggs" }
-      bank_sort_code { 123456 }
-      bank_account_number { 12345678 }
+      bank_sort_code { rand(100000..999999) }
+      bank_account_number { rand(10000000..99999999) }
       payroll_gender { :female }
 
       verified_fields { %w[first_name surname address_line_1 postcode date_of_birth payroll_gender] }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,6 +70,7 @@ RSpec.configure do |config|
   config.include VerifyHelpers
 
   config.before :each do
+    FactoryBot.rewind_sequences
     clear_enqueued_jobs
     ActionMailer::Base.deliveries.clear
     OmniAuth.config.mock_auth[:dfe] = nil

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Admin claims", type: :request do
         end
 
         context "when another claim has matching attributes" do
-          let!(:claim_with_matching_attributes) { create(:claim, :submitted, policy: policy) }
+          let!(:claim_with_matching_attributes) { create(:claim, :submitted, teacher_reference_number: claim.teacher_reference_number, policy: policy) }
 
           it "returns the claim and the duplicate" do
             get admin_claim_path(claim)

--- a/spec/requests/admin_payment_confirmation_report_upload_spec.rb
+++ b/spec/requests/admin_payment_confirmation_report_upload_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe "Admin Payment Confirmation Report upload" do
 
           expect(response).to redirect_to(admin_payroll_runs_path)
 
-          expect(payroll_run.claims[0].reload.payment.payroll_reference).to eq("DFE00001")
-          expect(payroll_run.claims[1].reload.payment.payroll_reference).to eq("DFE00002")
+          expect(payroll_run.payments[0].reload.payroll_reference).to eq("DFE00001")
+          expect(payroll_run.payments[1].reload.payroll_reference).to eq("DFE00002")
 
           expect(payroll_run.reload.confirmation_report_uploaded_by).to eq(admin_session_id)
 


### PR DESCRIPTION
We use the factories to seed our local development databases so we want to make sure they don't create claims that look the same and get flagged by our duplicate claim matching code. Reseting the sequences between each spec ensures they don't get so large that we end up generating
invalid TRNs or NI numbers.