### PR TITLE
Service operators can approve GOV.UK Verify-skipped claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog]
 
 - Schools in the West Somerset opportunity area are now regarded as eligible
   again, after the West Somerset local authority district ceased to exist.
+- Service operators can approve claims that did not complete GOV.UK Verify
 
 ## [Release 043] - 2020-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog]
 - Schools in the West Somerset opportunity area are now regarded as eligible
   again, after the West Somerset local authority district ceased to exist.
 - Service operators can approve claims that did not complete GOV.UK Verify
+- Claims that have skipped GOV.UK Verify are identified in admin
 
 ## [Release 043] - 2020-01-08
 

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -1,0 +1,32 @@
+.banner-temporary-message-without-action {
+  background: govuk-colour("blue");
+  color: govuk-colour("white");
+  padding: govuk-spacing(4);
+  margin-bottom: govuk-spacing(4);
+
+  *[class*="govuk-body"] {
+    color: govuk-colour("white");
+  }
+
+  .govuk-body-l {
+    font-weight: 700;
+  }
+
+  a,
+  a.govuk-link,
+  a:visited {
+    color: govuk-colour("white");
+  }
+
+  a.govuk-link:focus {
+    color: $govuk-focus-text-colour;
+  }
+
+  h2 {
+    margin-bottom: govuk-spacing(3);
+  }
+
+  p:last-of-type {
+    margin-bottom: 0;
+  }
+}

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -53,6 +53,10 @@ module Admin
       content_tag(:strong, pluralize(days_until_check_deadline, "day"), class: "govuk-tag #{check_deadline_warning_class}")
     end
 
+    def id_verification_status(claim)
+      claim.identity_confirmed? ? "GOV.UK Verify" : content_tag(:strong, "Unverified", class: "govuk-tag tag--warning")
+    end
+
     def matching_attributes(first_claim, second_claim)
       first_attributes = first_claim.attributes.slice(*Claim::MatchingAttributeFinder::ATTRIBUTE_GROUPS_TO_MATCH.flatten).to_a
       second_attributes = second_claim.attributes.slice(*Claim::MatchingAttributeFinder::ATTRIBUTE_GROUPS_TO_MATCH.flatten).to_a

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -2,6 +2,10 @@ module Admin
   module ClaimsHelper
     include StudentLoans::PresenterMethods
 
+    def confirming_identity_playbook_url
+      "https://docs.google.com/document/d/1wZh68_RV_FTJLxXIDPr3XFtJHW3vRgiXGaBDUo1Q1ZU"
+    end
+
     def admin_eligibility_answers(claim)
       claim.policy::EligibilityAdminAnswersPresenter.new(claim.eligibility).answers
     end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -172,7 +172,7 @@ class Claim < ApplicationRecord
   end
 
   def approvable?
-    submitted? && !payroll_gender_missing? && identity_confirmed? && !checked?
+    submitted? && !payroll_gender_missing? && !checked?
   end
 
   def checked?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -240,6 +240,10 @@ class Claim < ApplicationRecord
     eligibility&.class&.module_parent
   end
 
+  def school
+    eligibility&.current_school
+  end
+
   private
 
   def normalise_trn

--- a/app/models/school_data_importer.rb
+++ b/app/models/school_data_importer.rb
@@ -44,6 +44,7 @@ class SchoolDataImporter
     school.close_date = row.fetch("CloseDate")
     school.establishment_number = row.fetch("EstablishmentNumber")
     school.statutory_high_age = row.fetch("StatutoryHighAge")
+    school.phone_number = row.fetch("TelephoneNum")
     school
   end
 end

--- a/app/views/admin/claims/_info_panel_identity_unconfirmed.html.erb
+++ b/app/views/admin/claims/_info_panel_identity_unconfirmed.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-error-summary" aria-labelledby="identity-error-title" role="alert" data-module="govuk-error-summary">
+  <h2 class="govuk-error-summary__title" id="identity-error-title">
+    Identity has not been confirmed
+  </h2>
+  <p class="govuk-body">Claims without a confirmed identity cannot be approved at present.</p>
+</div>

--- a/app/views/admin/claims/_info_panel_identity_unconfirmed.html.erb
+++ b/app/views/admin/claims/_info_panel_identity_unconfirmed.html.erb
@@ -1,6 +1,15 @@
-<div class="govuk-error-summary" aria-labelledby="identity-error-title" role="alert" data-module="govuk-error-summary">
-  <h2 class="govuk-error-summary__title" id="identity-error-title">
-    Identity has not been confirmed
+<div class="banner-temporary-message-without-action">
+  <h2 class="govuk-body-l">
+    The claimant did not complete GOV.UK Verify
   </h2>
-  <p class="govuk-body">Claims without a confirmed identity cannot be approved at present.</p>
+
+  <p class="govuk-body">
+    Refer to the <%= link_to "Confirming a claimant's identity playbook", confirming_identity_playbook_url, class: "govuk-link" %>
+    and contact <%= school.name %> on <strong><%= school.phone_number %></strong>.
+  </p>
+
+  <p class="govuk-body">
+    Once you have completed all the steps outlined in the playbook, you can
+    <%= link_to "approve or reject this claim", "#claim_check_form", class: "govuk-link" %>.
+  </p>
 </div>

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -25,6 +25,7 @@
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Reference</th>
             <th scope="col" class="govuk-table__header">Applicant Name</th>
+            <th scope="col" class="govuk-table__header">ID Verification</th>
             <th scope="col" class="govuk-table__header">Service</th>
             <% if claims_with_warning.nonzero? %>
               <th scope="col" class="govuk-table__header">Check warning</th>
@@ -38,6 +39,7 @@
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header"><%= claim.reference %></th>
               <td class="govuk-table__cell"><%= claim.full_name %></td>
+              <td class="govuk-table__cell"><%= id_verification_status(claim) %></td>
               <td class="govuk-table__cell"><%= claim.policy.short_name %></td>
               <% if claims_with_warning.nonzero? %>
                 <td class="govuk-table__cell"><%= check_deadline_warning(claim) %></td>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -79,6 +79,18 @@
               </h2>
             </legend>
 
+            <% unless @claim.identity_confirmed? %>
+              <div class="govuk-warning-text">
+                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <strong class="govuk-warning-text__text">
+                  <span class="govuk-warning-text__assistive">Warning</span>
+                  This claimant did not complete GOV.UK Verify. Approve the
+                  claim only if the claimant's identity has been confirmed by
+                  an alternative method.
+                </strong>
+              </div>
+            <% end %>
+
             <%= errors_tag @check, :result %>
             <div class="govuk-radios">
               <%= form.hidden_field :result %>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -4,9 +4,6 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: @check, errored_field_id_overrides: { "result": "check_result_approved" }) if @check.errors.any? %>
 
-
-    <%= render "info_panel_identity_unconfirmed" unless @claim.identity_confirmed? %>
-
     <% if @claim.payroll_gender_missing? %>
       <div class="govuk-body-l govuk-flash__notice">
         This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
@@ -22,6 +19,8 @@
     <h1 class="govuk-heading-xl">
       Claim <%= @claim.reference %>
     </h1>
+
+    <%= render("info_panel_identity_unconfirmed", school: @claim.school) unless @claim.identity_confirmed? %>
 
     <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
 
@@ -70,7 +69,7 @@
     <% if @check.persisted? %>
       <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_check_details(@check)} %>
     <% else %>
-      <%= form_for @check, url: admin_claim_checks_path(@claim) do |form| %>
+      <%= form_for @check, url: admin_claim_checks_path(@claim), html: { id: "claim_check_form" } do |form| %>
         <%= form_group_tag @check do %>
           <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-6">

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -5,14 +5,7 @@
     <%= render("shared/error_summary", instance: @check, errored_field_id_overrides: { "result": "check_result_approved" }) if @check.errors.any? %>
 
 
-    <% unless @claim.identity_confirmed? %>
-      <div class="govuk-error-summary" aria-labelledby="identity-error-title" role="alert" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="identity-error-title">
-          Identity has not been confirmed
-        </h2>
-        <p class="govuk-body">Claims without a confirmed identity cannot be approved at present.</p>
-      </div>
-    <% end %>
+    <%= render "info_panel_identity_unconfirmed" unless @claim.identity_confirmed? %>
 
     <% if @claim.payroll_gender_missing? %>
       <div class="govuk-body-l govuk-flash__notice">
@@ -85,6 +78,7 @@
                 Claim decision
               </h2>
             </legend>
+
             <%= errors_tag @check, :result %>
             <div class="govuk-radios">
               <%= form.hidden_field :result %>

--- a/db/migrate/20200108133802_add_phone_number_to_schools.rb
+++ b/db/migrate/20200108133802_add_phone_number_to_schools.rb
@@ -1,0 +1,5 @@
+class AddPhoneNumberToSchools < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :phone_number, :string, limit: 20
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -189,6 +189,7 @@ ActiveRecord::Schema.define(version: 2020_01_09_115709) do
     t.date "close_date"
     t.integer "establishment_number"
     t.integer "statutory_high_age"
+    t.string "phone_number", limit: 20
     t.index ["created_at"], name: "index_schools_on_created_at"
     t.index ["local_authority_district_id"], name: "index_schools_on_local_authority_district_id"
     t.index ["local_authority_id"], name: "index_schools_on_local_authority_id"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -14,6 +14,8 @@ FactoryBot.define do
     end
 
     trait :submittable do
+      verified
+
       first_name { "Jo" }
       surname { "Bloggs" }
       address_line_1 { "1 Test Road" }
@@ -32,9 +34,6 @@ FactoryBot.define do
       bank_account_number { rand(10000000..99999999) }
       payroll_gender { :female }
 
-      verified_fields { %w[first_name surname address_line_1 postcode date_of_birth payroll_gender] }
-      verify_response { {"scenario" => "IDENTITY_VERIFIED", "pid" => "123", "levelOfAssurance" => "LEVEL_2", "attributes" => {}} }
-
       eligibility_factory { ["#{policy.to_s.underscore}_eligibility".to_sym, :eligible] }
     end
 
@@ -42,6 +41,11 @@ FactoryBot.define do
       submittable
       submitted_at { Time.zone.now }
       reference { Reference.new.to_s }
+    end
+
+    trait :verified do
+      verified_fields { %w[first_name surname address_line_1 postcode date_of_birth payroll_gender] }
+      verify_response { {"scenario" => "IDENTITY_VERIFIED", "pid" => "123", "levelOfAssurance" => "LEVEL_2", "attributes" => {}} }
     end
 
     trait :unverified do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     school_type { :community_school }
     school_type_group { :la_maintained }
     phase { :secondary }
+    sequence(:phone_number) { |n| "01612733#{n}" }
+
     local_authority
     local_authority_district
 

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -93,12 +93,17 @@ RSpec.feature "Admin checks a claim" do
     context "When the claimant has not completed GOV.UK Verify" do
       let!(:claim_without_identity_confirmation) { create(:claim, :unverified) }
 
-      scenario "the service operator should be told the identity hasn't been confirmed" do
+      scenario "the service operator is told the identity hasn't been confirmed and can approve the claim" do
         click_on "View claims"
         find("a[href='#{admin_claim_path(claim_without_identity_confirmation)}']").click
 
         expect(page).to have_content("Identity has not been confirmed")
-        expect(page).to have_field("Approve", disabled: true)
+        choose "Approve"
+        fill_in "Decision notes", with: "Identity confirmed via phone call"
+        click_on "Submit"
+
+        expect(claim_without_identity_confirmation.check.checked_by).to eq(user)
+        expect(claim_without_identity_confirmation.check.notes).to eq("Identity confirmed via phone call")
       end
     end
 

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -97,7 +97,9 @@ RSpec.feature "Admin checks a claim" do
         click_on "View claims"
         find("a[href='#{admin_claim_path(claim_without_identity_confirmation)}']").click
 
-        expect(page).to have_content("Identity has not been confirmed")
+        expect(page).to have_content("The claimant did not complete GOV.UK Verify")
+        expect(page).to have_content(claim_without_identity_confirmation.school.phone_number)
+
         choose "Approve"
         fill_in "Decision notes", with: "Identity confirmed via phone call"
         click_on "Submit"

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -135,6 +135,21 @@ describe Admin::ClaimsHelper do
     end
   end
 
+  describe "#id_verification_status" do
+    it "reports a claim that as having been GOV.UK Verified" do
+      verified_claim = build(:claim, :verified)
+
+      expect(id_verification_status(verified_claim)).to eq "GOV.UK Verify"
+    end
+
+    it "returns a warning tag for an unverified claim" do
+      verified_claim = build(:claim, :unverified)
+
+      expect(id_verification_status(verified_claim)).to have_content "Unverified"
+      expect(id_verification_status(verified_claim)).to have_selector(".tag--warning")
+    end
+  end
+
   describe "#matching_attributes" do
     let(:first_claim) {
       build(

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Check, type: :model do
   end
 
   it "prevents an unapprovable claim from being approved" do
-    claim = create(:claim, :unverified)
+    claim = create(:claim, :ineligible)
     check = build(:check, claim: claim, result: "approved")
 
     expect(check).not_to be_valid

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -441,10 +441,6 @@ RSpec.describe Claim, type: :model do
       expect(create(:claim, :approved).approvable?).to eq false
       expect(create(:claim, :rejected).approvable?).to eq false
     end
-
-    it "returns false for a claim that doesn't have a confirmed identity" do
-      expect(build(:claim, :unverified).approvable?).to eq false
-    end
   end
 
   describe "#payroll_gender_missing?" do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -331,6 +331,17 @@ RSpec.describe Claim, type: :model do
     end
   end
 
+  describe "#school" do
+    it "returns the current_school of the claim eligiblity" do
+      claim = Claim.new(eligibility: StudentLoans::Eligibility.new(current_school: schools(:penistone_grammar_school)))
+      expect(claim.school).to eq schools(:penistone_grammar_school)
+    end
+
+    it "returns nil if no eligibility is set" do
+      expect(Claim.new.school).to be_nil
+    end
+  end
+
   describe "#submit!" do
     around do |example|
       freeze_time { example.run }

--- a/spec/services/school_data_importer_spec.rb
+++ b/spec/services/school_data_importer_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe SchoolDataImporter do
         expect(imported_school.close_date).to be_nil
         expect(imported_school.establishment_number).to eq(4027)
         expect(imported_school.statutory_high_age).to eq(18)
+        expect(imported_school.phone_number).to eq("01226762114")
       end
 
       it "imports a closed school with the date it closed" do


### PR DESCRIPTION
This re-enables the ability to approve claims that did not complete the GOV.UK Verify process.

This is different to how the story was initially outlined. For now we are keeping this super simple and expecting the identity check process to be carried out and managed as part of the existing spreadsheet-based claim checking. Unverified claims can be approved or rejected as before, but we now provide additional information to service operators for these claims:

**Highlight unverified claims on the claim list**
<img width="1024" alt="Screenshot 2020-01-09 at 10 52 07" src="https://user-images.githubusercontent.com/3687/72061946-bf28df00-32ce-11ea-9d7a-ac701287ede3.png">

**Unverified claims include an info panel relating to the manual identity check**
<img width="728" alt="Screenshot 2020-01-09 at 11 00 36" src="https://user-images.githubusercontent.com/3687/72062227-48d8ac80-32cf-11ea-8fa3-91edae940af6.png">

**An additional warning is shown in the claim approve/reject form for unverified claims**
<img width="782" alt="Screenshot 2020-01-09 at 10 52 24" src="https://user-images.githubusercontent.com/3687/72062031-e5e71580-32ce-11ea-9ed1-c955991ad7be.png">

This also updates the `School` model and the import code to save school phone numbers so that we can show that to service operators on the info panel. Phone numbers will get imported overnight on the next school import.