### PR TITLE
Group multiple claims from the same person into single payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog]
 - Claims that have skipped GOV.UK Verify are identified in admin
 - Bank account numbers must be exactly 8 digits long (6- and 7-digit numbers are
   no longer accepted)
+- Multiple approved claims from the same person are grouped in to one payment
 
 ## [Release 043] - 2020-01-08
 

--- a/app/controllers/admin/payroll_runs_controller.rb
+++ b/app/controllers/admin/payroll_runs_controller.rb
@@ -17,6 +17,8 @@ module Admin
       payroll_run = PayrollRun.create_with_claims!(claims, created_by: admin_user)
 
       redirect_to [:admin, payroll_run], notice: "Payroll run created"
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to new_admin_payroll_run_path, alert: e.message
     end
 
     def show

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -29,6 +29,6 @@ class Payment < ApplicationRecord
   end
 
   def claim_for_personal_details
-    @claim_for_personal_details ||= claims.first
+    @claim_for_personal_details ||= claims.order(:submitted_at).last
   end
 end

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -18,8 +18,9 @@ class PayrollRun < ApplicationRecord
   def self.create_with_claims!(claims, attrs = {})
     ActiveRecord::Base.transaction do
       PayrollRun.create!(attrs).tap do |payroll_run|
-        claims.each do |claim|
-          Payment.create!(payroll_run: payroll_run, claims: [claim], award_amount: claim.award_amount)
+        claims.group_by(&:national_insurance_number).each_value do |claims|
+          award_amount = claims.sum(&:award_amount)
+          Payment.create!(payroll_run: payroll_run, claims: claims, award_amount: award_amount)
         end
       end
     end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -5,8 +5,15 @@ FactoryBot.define do
     end
 
     claims do
+      personal_details = {
+        national_insurance_number: generate(:national_insurance_number),
+        teacher_reference_number: generate(:teacher_reference_number),
+        email_address: "email@example.com",
+        bank_sort_code: "220011",
+        bank_account_number: "12345678",
+      }
       claim_policies.map do |policy|
-        association(:claim, :approved, policy: policy)
+        association(:claim, :approved, personal_details.merge(policy: policy))
       end
     end
     association(:payroll_run, factory: :payroll_run)

--- a/spec/mailers/payment_mailer_spec.rb
+++ b/spec/mailers/payment_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PaymentMailer, type: :mailer do
   Policies.all.each do |policy|
     context "with a payment with a single #{policy} claim" do
       describe "#confirmation" do
-        let(:payment) { build(:payment, :with_figures, net_pay: 500.00, student_loan_repayment: 60, claims: [claim]) }
+        let(:payment) { create(:payment, :with_figures, net_pay: 500.00, student_loan_repayment: 60, claims: [claim]) }
         let(:claim) { build(:claim, :submitted, policy: policy) }
         let(:payment_date_timestamp) { Time.new(2019, 1, 1).to_i }
         let(:mail) { PaymentMailer.confirmation(payment, payment_date_timestamp) }
@@ -43,7 +43,7 @@ RSpec.describe PaymentMailer, type: :mailer do
         end
 
         context "when user does not currently have a student loan" do
-          let(:payment) { build(:payment, :with_figures, student_loan_repayment: nil, claims: [claim]) }
+          let(:payment) { create(:payment, :with_figures, student_loan_repayment: nil, claims: [claim]) }
 
           it "does not mention the content relating to student loan deductions" do
             expect(mail.body.encoded).to_not include("student loan contribution")
@@ -51,7 +51,7 @@ RSpec.describe PaymentMailer, type: :mailer do
         end
 
         context "when user has a student loan" do
-          let(:payment) { build(:payment, :with_figures, student_loan_repayment: 10, claims: [claim]) }
+          let(:payment) { create(:payment, :with_figures, student_loan_repayment: 10, claims: [claim]) }
 
           it "mentions the student loan deduction content and lists their contribution" do
             expect(mail.body.encoded).to include("This payment is treated as pay and is therefore subject to a student loan contribution, if applicable.")
@@ -64,12 +64,19 @@ RSpec.describe PaymentMailer, type: :mailer do
 
   context "with a payment with multiple claims" do
     describe "#confirmation" do
-      let(:payment) { build(:payment, :with_figures, net_pay: 2500.00, student_loan_repayment: 60, claims: claims) }
+      let(:payment) { create(:payment, :with_figures, net_pay: 2500.00, student_loan_repayment: 60, claims: claims) }
       let(:student_loans_eligibility) { build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 500) }
       let(:claims) do
+        personal_details = {
+          national_insurance_number: "JM603818B",
+          teacher_reference_number: "1234567",
+          bank_sort_code: "112233",
+          bank_account_number: "95928482",
+          building_society_roll_number: nil,
+        }
         [
-          build(:claim, :approved, eligibility: student_loans_eligibility),
-          build(:claim, :approved, policy: MathsAndPhysics),
+          build(:claim, :approved, personal_details.merge(eligibility: student_loans_eligibility)),
+          build(:claim, :approved, personal_details.merge(policy: MathsAndPhysics)),
         ]
       end
       let(:payment_date_timestamp) { Time.new(2019, 1, 1).to_i }
@@ -116,7 +123,7 @@ RSpec.describe PaymentMailer, type: :mailer do
       end
 
       context "when user does not currently have a student loan" do
-        let(:payment) { build(:payment, :with_figures, student_loan_repayment: nil, claims: claims) }
+        let(:payment) { create(:payment, :with_figures, student_loan_repayment: nil, claims: claims) }
 
         it "does not mention the content relating to student loan deductions" do
           expect(mail.body.encoded).to_not include("student loan contribution")
@@ -124,7 +131,7 @@ RSpec.describe PaymentMailer, type: :mailer do
       end
 
       context "when user has a student loan" do
-        let(:payment) { build(:payment, :with_figures, student_loan_repayment: 10, claims: claims) }
+        let(:payment) { create(:payment, :with_figures, student_loan_repayment: 10, claims: claims) }
 
         it "mentions the student loan deduction content and lists their contribution" do
           expect(mail.body.encoded).to include("This payment is treated as pay and is therefore subject to a student loan contribution, if applicable.")

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -44,4 +44,99 @@ RSpec.describe Payment do
       end
     end
   end
+
+  context "when the payment is for more than one claim" do
+    subject { build(:payment, claims: claims) }
+    let(:claims) do
+      build_list(:claim, 2, :approved,
+        national_insurance_number: "JM603818B",
+        teacher_reference_number: "1234567",
+        email_address: "email@example.com",
+        bank_sort_code: "112233",
+        bank_account_number: "95928482",
+        building_society_roll_number: nil,
+        address_line_1: "64 West Lane",
+        student_loan_plan: StudentLoan::PLAN_1,
+        date_of_birth: 30.years.ago.to_date,
+        first_name: "Jennifer",
+        middle_name: "Poppy",
+        surname: "Blake",
+        payroll_gender: :female)
+    end
+
+    it "is valid when all claims have matching personal details" do
+      expect(subject).to be_valid
+    end
+
+    it "is invalid when claims’ National Insurance numbers do not match" do
+      claims[0].national_insurance_number = "JM102019D"
+
+      expect(subject).not_to be_valid
+      expect(subject.errors[:claims]).to eq(["#{claims[0].reference} and #{claims[1].reference} have different values for national insurance number"])
+    end
+
+    it "is invalid when claims’ dates of birth do not match" do
+      claims[0].date_of_birth = 20.years.ago.to_date
+
+      expect(subject).not_to be_valid
+      expect(subject.errors[:claims]).to eq(["#{claims[0].reference} and #{claims[1].reference} have different values for date of birth"])
+    end
+
+    it "is invalid when claims’ bank account numbers do not match" do
+      claims[0].bank_account_number = "34192192"
+
+      expect(subject).not_to be_valid
+      expect(subject.errors[:claims]).to eq(["#{claims[0].reference} and #{claims[1].reference} have different values for bank account number"])
+    end
+
+    it "is invalid when claims’ bank sort codes do not match" do
+      claims[0].bank_sort_code = "024828"
+
+      expect(subject).not_to be_valid
+      expect(subject.errors[:claims]).to eq(["#{claims[0].reference} and #{claims[1].reference} have different values for bank sort code"])
+    end
+
+    it "is invalid when claims’ building society roll numbers do not match" do
+      claims[0].building_society_roll_number = "123456789/ABCD"
+
+      expect(subject).not_to be_valid
+      expect(subject.errors[:claims]).to eq(["#{claims[0].reference} and #{claims[1].reference} have different values for building society roll number"])
+    end
+
+    it "is invalid when claims’ student loan plans do not match" do
+      claims[0].student_loan_plan = StudentLoan::PLAN_2
+
+      expect(subject).not_to be_valid
+      expect(subject.errors[:claims]).to eq(["#{claims[0].reference} and #{claims[1].reference} have different values for student loan plan"])
+    end
+
+    it "is invalid when its claims have multiple forbidden discrepancies in personal details" do
+      claims[0].bank_account_number = "34192192"
+      claims[0].bank_sort_code = "013028"
+
+      expect(subject).not_to be_valid
+      expect(subject.errors[:claims]).to eq(["#{claims[0].reference} and #{claims[1].reference} have different values for bank sort code and bank account number"])
+    end
+
+    it "remains valid when claims’ names do not match" do
+      claims[0].first_name = "David"
+      claims[0].middle_name = "Michael"
+      claims[0].surname = "Rollins"
+      claims[0].banking_name = "MR DM ROLLINS"
+
+      expect(subject).to be_valid
+    end
+
+    it "remains valid when claims’ payroll gender do not match" do
+      claims[0].payroll_gender = :male
+
+      expect(subject).to be_valid
+    end
+
+    it "remains valid when claims’ addresses do not match" do
+      claims[0].address_line_1 = "129 Brookland Drive"
+
+      expect(subject).to be_valid
+    end
+  end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -139,4 +139,27 @@ RSpec.describe Payment do
       expect(subject).to be_valid
     end
   end
+
+  describe "personal details" do
+    subject(:payment) { create(:payment, claims: claims) }
+    let(:claims) do
+      personal_details = {
+        national_insurance_number: "JM603818B",
+        teacher_reference_number: "1234567",
+        bank_sort_code: "112233",
+        bank_account_number: "95928482",
+        building_society_roll_number: nil,
+      }
+      [
+        build(:claim, :approved, personal_details.merge(first_name: "Margaret", address_line_1: "17 Green Road", payroll_gender: :female, submitted_at: 5.days.ago)),
+        build(:claim, :approved, personal_details.merge(first_name: "John", address_line_1: "64 West Lane", payroll_gender: :male, submitted_at: 10.days.ago)),
+      ]
+    end
+
+    it "is taken from the payment’s most recently submitted claim" do
+      expect(payment.first_name).to eq("Margaret")
+      expect(payment.address_line_1).to eq("17 Green Road")
+      expect(payment.payroll_gender).to eq("female")
+    end
+  end
 end

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -53,12 +53,22 @@ RSpec.describe PayrollRun, type: :model do
       expect(claims[1].payment.award_amount).to eq(claims[1].award_amount)
     end
 
-    context "with multiple claims with the same National Insurance number" do
+    context "with multiple claims from the same National Insurance number" do
+      let(:personal_details) do
+        {
+          national_insurance_number: generate(:national_insurance_number),
+          teacher_reference_number: generate(:teacher_reference_number),
+          email_address: generate(:email_address),
+          bank_sort_code: "112233",
+          bank_account_number: "95928482",
+          address_line_1: "64 West Lane",
+          student_loan_plan: StudentLoan::PLAN_1,
+        }
+      end
       let(:matching_claims) do
-        national_insurance_number = generate(:national_insurance_number)
         [
-          create(:claim, :approved, policy: StudentLoans, national_insurance_number: national_insurance_number),
-          create(:claim, :approved, policy: MathsAndPhysics, national_insurance_number: national_insurance_number),
+          create(:claim, :approved, personal_details.merge(policy: StudentLoans)),
+          create(:claim, :approved, personal_details.merge(policy: MathsAndPhysics)),
         ]
       end
       let(:other_claim) { create(:claim, :approved) }

--- a/spec/requests/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin_payroll_runs_spec.rb
@@ -32,6 +32,23 @@ RSpec.describe "Admin payroll runs" do
 
         expect(response).to redirect_to(admin_payroll_run_path(payroll_run))
       end
+
+      context "when a payroll run contains claims from the same person with different bank details" do
+        it "doesn’t create a payroll run and shows an error" do
+          personal_details = {
+            national_insurance_number: generate(:national_insurance_number),
+            bank_sort_code: "112233",
+          }
+          claims = [
+            create(:claim, :approved, personal_details.merge(bank_account_number: "12345678")),
+            create(:claim, :approved, personal_details.merge(bank_account_number: "99999999")),
+          ]
+
+          expect { post admin_payroll_runs_path(claim_ids: claims.map(&:id)) }.to change { PayrollRun.count }.by(0)
+          follow_redirect!
+          expect(response.body).to include("Claims #{claims[0].reference} and #{claims[1].reference} have different values for bank account number")
+        end
+      end
     end
 
     describe "admin_payroll_runs#show" do


### PR DESCRIPTION
This currently uses National Insurance number to identify a claimant.

Claims from the same claimant are grouped in to one payment in the payroll run. If any of the personal details on the claim don't match the payroll run will fail and will need some intervention from a developer. In the future we plan to catch these discrepancies earlier in the process so the user should never see the error when creating payroll run. The error message doesn't give much detail as to what claims don't match, however as it is just a stop-gap solution it should be ok.

**Open for discussion: We need to decide which of the personal details we care about not matching, currently we check them all but there may be some that legitimately differ like address.**

# Screenshot
![Screenshot 2020-01-09 at 11 35 12](https://user-images.githubusercontent.com/2804149/72064635-314ff280-32d4-11ea-9b12-14ce70c7315a.png)
