### PR TITLE
Fix Docker entrypoint migration status check

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -5,7 +5,7 @@ if [ "$RAILS_ENV" != "production" ]; then
   echo "In a non-production environment: initializing database"
   bundle exec rake db:create db:schema:load
 else
-  DB_STATUS=$(rake db:migrate:status 2>&1 | tail -n 1)
+  DB_STATUS=$(bundle exec rake db:migrate:status 2>&1 | tail -n 1)
 
   if [ "$DB_STATUS" == "Schema migrations table does not exist yet."  ]; then
     echo "No tables exist - setting up the database"


### PR DESCRIPTION
Because of a recent Bundler update we need to make sure all our rake commands are prefixed with `bundle exec`.
