### PR TITLE
Reduce the chance of user submitting Verify SAML form twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog]
 - Bank account numbers must be exactly 8 digits long (6- and 7-digit numbers are
   no longer accepted)
 - Multiple approved claims from the same person are grouped in to one payment
+- Fix "Sorry, something went wrong" message displayed by GOV.UK Verify when
+  claimant clicks "Continue" button on /verify/authentications/new page
 
 ## [Release 043] - 2020-01-08
 

--- a/app/assets/javascripts/components/govuk_verify_auth_request_auto_submit.js
+++ b/app/assets/javascripts/components/govuk_verify_auth_request_auto_submit.js
@@ -7,5 +7,14 @@ document.addEventListener("DOMContentLoaded", function() {
     return;
   }
 
+  var submit_button = form.querySelector("#submit_verify_request");
+  submit_button.style.display = "none";
+
+  var heading = form.querySelector("#verify_heading");
+  heading.innerText = "Continuing to next step…";
+
+  var redirection_message = form.querySelector("#verify_redirection_message");
+  redirection_message.innerText = "If your browser does not redirect in a few seconds, please try refreshing the page.";
+
   form.submit();
 });

--- a/app/views/verify/authentications/new.html.erb
+++ b/app/views/verify/authentications/new.html.erb
@@ -1,11 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag @verify_authentication_request.sso_location, authenticity_token: false, id: "verify_auth_request" do %>
-      <h1 class="govuk-heading-xl">Continue to next step</h1>
+      <h1 class="govuk-heading-xl" id="verify_heading">Continue to next step</h1>
       <%= hidden_field_tag "relayState" %>
       <%= hidden_field_tag "SAMLRequest", @verify_authentication_request.saml_request %>
-      <p class="govuk-body">If your browser does not redirect in a few seconds, please press the "Continue" button.</p>
-      <%= submit_tag "Continue", class: "govuk-button" %>
+      <p class="govuk-body" id="verify_redirection_message">Because JavaScript is not enabled on your browser, you must press the Continue button.</p>
+      <%= submit_tag "Continue", class: "govuk-button", id: "submit_verify_request" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
As we have observed in the past (e.g. commit 0f225f8), submitting the
same SAML request to Verify twice causes Verify to show a "Sorry,
something went wrong" error screen.

It was possible to submit the request twice by clicking the "Continue"
button on the `/verify/authentications/new` page after the JavaScript
auto-submit had been triggered. (I was able to reproduce this in a
browser, in our development environment, although not consistently.)

To prevent this, we take advantage of Rails' built-in prevention of
double-clicks (the `data-disable-with` attribute, which is set by
default), which disables the submit button once it is clicked. We change
the JavaScript so that it clicks the submit button instead of submitting
the form element.

We also change the page message so that once button is auto-clicked, it
no longer tells the user to click the "Continue" button, which is now
disabled.

I'm not sure if there is anything we can do to prevent a double
submission in the non-JS case.

<!-- Do you need to update CHANGELOG.md? -->
