### PR TITLE
Fix database setup to load db and data schema files

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -9,7 +9,7 @@ else
 
   if [ "$DB_STATUS" == "Schema migrations table does not exist yet."  ]; then
     echo "No tables exist - setting up the database"
-    bundle exec rails db:setup
+    bundle exec rake db:schema:load:with_data db:seed
   else
     echo "Running the schema and data migrations"
     bundle exec rails db:migrate:with_data


### PR DESCRIPTION
When setting up a new environment we run "db:setup" which loads the db schema and seeds the database. The next time the container starts it attempts to run the data migrations, many of which fail to run.

Instead we should explicitly load the db and data schema files so no needless migrations are ran on subsequent deploys.
