### PR TITLE
Only accept 8 digit bank account numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog]
   again, after the West Somerset local authority district ceased to exist.
 - Service operators can approve claims that did not complete GOV.UK Verify
 - Claims that have skipped GOV.UK Verify are identified in admin
+- Bank account numbers must be exactly 8 digits long (6- and 7-digit numbers are
+  no longer accepted)
 
 ## [Release 043] - 2020-01-08
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -130,7 +130,7 @@ class Claim < ApplicationRecord
   validates :bank_sort_code, on: [:"bank-details", :submit], presence: {message: "Enter a sort code"}
   validates :bank_account_number, on: [:"bank-details", :submit], presence: {message: "Enter an account number"}
 
-  validate :bank_account_number_must_be_between_six_and_eight_digits
+  validate :bank_account_number_must_be_eight_digits
   validate :bank_sort_code_must_be_six_digits
   validate :building_society_roll_number_must_be_between_one_and_eighteen_digits
   validate :building_society_roll_number_must_be_in_a_valid_format
@@ -297,9 +297,9 @@ class Claim < ApplicationRecord
       unless /\A[a-z0-9\-\s\.\/]{1,18}\z/i.match?(building_society_roll_number)
   end
 
-  def bank_account_number_must_be_between_six_and_eight_digits
-    errors.add(:bank_account_number, "Bank account number must be between 6 and 8 digits") \
-      if bank_account_number.present? && normalised_bank_detail(bank_account_number) !~ /\A\d{6,8}\z/
+  def bank_account_number_must_be_eight_digits
+    errors.add(:bank_account_number, "Bank account number must be 8 digits  – check you've entered the correct number or check with your bank for an 8 digit version") \
+      if bank_account_number.present? && normalised_bank_detail(bank_account_number) !~ /\A\d{8}\z/
   end
 
   def bank_sort_code_must_be_six_digits

--- a/app/views/claims/bank_details.html.erb
+++ b/app/views/claims/bank_details.html.erb
@@ -37,7 +37,7 @@
 
           <%= form_group_tag current_claim, :bank_account_number do %>
             <%= form.label :bank_account_number, "Account number", class: "govuk-label" %>
-            <span id="account-number-hint" class="govuk-hint">For example: 70 87 24 90</span>
+            <span id="account-number-hint" class="govuk-hint">For example: 70872490</span>
             <%= errors_tag current_claim, :bank_account_number %>
             <%= form.text_field :bank_account_number,
               class: css_classes_for_input(current_claim, :bank_account_number, "govuk-input--width-20"),

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -70,8 +70,9 @@ RSpec.describe Claim, type: :model do
   context "that has bank details" do
     it "validates the format of bank_account_number and bank_sort_code" do
       expect(build(:claim, bank_account_number: "ABC12 34 56 789")).not_to be_valid
+      expect(build(:claim, bank_account_number: "12-34-56-78-90")).not_to be_valid
       expect(build(:claim, bank_account_number: "12-34-56-78")).to be_valid
-      expect(build(:claim, bank_account_number: "12-34-56")).to be_valid
+      expect(build(:claim, bank_account_number: "12-34-56")).not_to be_valid
 
       expect(build(:claim, bank_sort_code: "ABC12 34 567")).not_to be_valid
       expect(build(:claim, bank_sort_code: "12 34 56")).to be_valid


### PR DESCRIPTION
Cantium cannot process 6- and 7-digit bank account numbers (although these are technically valid).

This updates bank account validation to only accept exactly 8 digit numbers, as well as provide a more useful error message to the user.

Also updates the example bank account number to be more in line with the [design pattern](https://design-system.service.gov.uk/patterns/bank-details/).