### PR TITLE
Manually set firewall rules for worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add bash
 RUN apk add postgresql-dev
 RUN apk add tzdata
 RUN apk add nodejs
+RUN apk add curl
 
 ENV APP_HOME /app
 ENV DEPS_HOME /deps

--- a/azure/templates/worker.json
+++ b/azure/templates/worker.json
@@ -47,10 +47,7 @@
           }
         ],
         "restartPolicy": "Always",
-        "osType": "Linux",
-        "networkProfile": {
-          "id": "[parameters('networkProfileId')]"
-        }
+        "osType": "Linux"
       }
     }
   ],

--- a/bin/report-ip
+++ b/bin/report-ip
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/curl canhazip.com

--- a/bin/update-db-firewall-rules
+++ b/bin/update-db-firewall-rules
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 ENVIRONMENT_NAME"
+  exit 1
+fi
+
+ENVIRONMENT_NAME=$1
+
+case $ENVIRONMENT_NAME in
+  "development")
+    SUBSCRIPTION_ID="8655985a-2f87-44d7-a541-0be9a8c2779d"
+    RESOURCE_GROUP_PREFIX="s118d01"
+    ;;
+  "test")
+    SUBSCRIPTION_ID="e9299169-9666-4f15-9da9-5332680145af"
+    RESOURCE_GROUP_PREFIX="s118t01"
+    ;;
+  "production")
+    SUBSCRIPTION_ID="88bd392f-df19-458b-a100-22b4429060ed"
+    RESOURCE_GROUP_PREFIX="s118p01"
+    ;;
+  *)
+    echo "Could not find a known environment with the name: $ENVIRONMENT_NAME"
+    exit 1
+    ;;
+esac
+
+az account set --subscription "$SUBSCRIPTION_ID"
+
+CONTAINER_OUTPUT=$(az container exec --resource-group $RESOURCE_GROUP_PREFIX-app --name $RESOURCE_GROUP_PREFIX-app-worker-aci --exec-command "/bin/report-ip")
+CONTAINER_IP=$(echo "$CONTAINER_OUTPUT" | tr -d '\r')
+
+az postgres server firewall-rule create \
+  --name worker-aci-ip \
+  --start-ip-address "$CONTAINER_IP" \
+  --end-ip-address "$CONTAINER_IP" \
+  --resource-group $RESOURCE_GROUP_PREFIX-app \
+  --server-name $RESOURCE_GROUP_PREFIX-app-db


### PR DESCRIPTION
Because we're having trouble with the preview ACI feature which allows us to deploy container groups into VNETs, we're trying another approach where we grab the IP address of the container group post-deploy and use this to manually update the firewall rules in Postgres. Hopefully this will be a better way to work with containers and mean we don't have to use poorly-supported preview features.
