### PR TITLE
Use the relative script path for reporting the IP of the container

### DIFF
--- a/bin/update-db-firewall-rules
+++ b/bin/update-db-firewall-rules
@@ -28,7 +28,7 @@ esac
 
 az account set --subscription "$SUBSCRIPTION_ID"
 
-CONTAINER_OUTPUT=$(az container exec --resource-group $RESOURCE_GROUP_PREFIX-app --name $RESOURCE_GROUP_PREFIX-app-worker-aci --exec-command "/bin/report-ip")
+CONTAINER_OUTPUT=$(az container exec --resource-group $RESOURCE_GROUP_PREFIX-app --name $RESOURCE_GROUP_PREFIX-app-worker-aci --exec-command "./bin/report-ip")
 CONTAINER_IP=$(echo "$CONTAINER_OUTPUT" | tr -d '\r')
 
 az postgres server firewall-rule create \


### PR DESCRIPTION
When we were testing this on test we manually created the script in the `/bin` folder, that won't work with our script as it is stored in our project directory.
