### PR TITLE
Ensure container instance has restarted before fetching the IP

### DIFF
--- a/bin/report-ip
+++ b/bin/report-ip
@@ -1,2 +1,2 @@
 #!/bin/bash
-/usr/bin/curl canhazip.com
+/usr/bin/curl https://canhazip.com

--- a/bin/update-db-firewall-rules
+++ b/bin/update-db-firewall-rules
@@ -28,9 +28,14 @@ esac
 
 az account set --subscription "$SUBSCRIPTION_ID"
 
+echo "Restarting the container instance..."
+az container restart --resource-group=$RESOURCE_GROUP_PREFIX-app --name=$RESOURCE_GROUP_PREFIX-app-worker-aci
+
+echo "Fetching the IP address of the container instance..."
 CONTAINER_OUTPUT=$(az container exec --resource-group $RESOURCE_GROUP_PREFIX-app --name $RESOURCE_GROUP_PREFIX-app-worker-aci --exec-command "./bin/report-ip")
 CONTAINER_IP=$(echo "$CONTAINER_OUTPUT" | tr -d '\r')
 
+echo "Updating the Postgres firewall to allow the container instance ($CONTAINER_IP) to connect..."
 az postgres server firewall-rule create \
   --name worker-aci-ip \
   --start-ip-address "$CONTAINER_IP" \


### PR DESCRIPTION
It's possible that the container instance could be in a "Waiting" state if it ran in to an error. This would break our script to fetch the IP address as you can only execute commands on a running container instance.

By restarting the container instance we can ensure that it will be "Running" when we execute our command to fetch the IP address.