### PR TITLE
Release 44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+## [Release 044] - 2020-01-14
+
 - Schools in the West Somerset opportunity area are now regarded as eligible
   again, after the West Somerset local authority district ceased to exist
 - Service operators can approve claims that did not complete GOV.UK Verify
@@ -343,7 +345,9 @@ The format is based on [Keep a Changelog]
 - First release for student loan repayments private beta
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-043...HEAD
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-044...HEAD
+[release 044]:
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-043...release-044
 [release 043]:
   https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-042...release-043
 [release 042]:


### PR DESCRIPTION
- Schools in the West Somerset opportunity area are now regarded as eligible
   again, after the West Somerset local authority district ceased to exist
 - Service operators can approve claims that did not complete GOV.UK Verify
- Claims that have skipped GOV.UK Verify are identified in admin
- Bank account numbers must be exactly 8 digits long (6- and 7-digit numbers are
  no longer accepted)
- Multiple approved claims from the same person are grouped in to one payment
- Fix "Sorry, something went wrong" message displayed by GOV.UK Verify when
  claimant clicks "Continue" button on /verify/authentications/new page
- Include full name in claims report so it can be used to make TPS data requests