### PR TITLE
Add a payment date to payroll runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog]
 
 - Removed unnecessary tags on main and footer elements that were causing
   warnings on validators
+- A Payment date is set when a payroll run is ingested
 
 ## [Release 044] - 2020-01-14
 

--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -1,9 +1,9 @@
 class PaymentMailer < ApplicationMailer
   helper :application
 
-  def confirmation(payment, payment_date_timestamp)
+  def confirmation(payment)
     @payment = payment
-    @payment_date = Time.at(payment_date_timestamp).to_date
+    @payment_date = payment.scheduled_payment_date
     @display_name = [payment.first_name, payment.surname].join(" ")
 
     if payment.claims.size == 1

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -152,6 +152,7 @@ class Claim < ApplicationRecord
   scope :by_policy, ->(policy) { where(eligibility_type: policy::Eligibility.to_s) }
 
   delegate :award_amount, to: :eligibility
+  delegate :scheduled_payment_date, to: :payment, allow_nil: true
 
   def submit!
     if submittable?

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -13,6 +13,7 @@ class Payment < ApplicationRecord
   PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES = %i[national_insurance_number date_of_birth student_loan_plan bank_sort_code bank_account_number building_society_roll_number]
 
   delegate(*(PERSONAL_DETAILS_ATTRIBUTES_PERMITTING_DISCREPANCIES + PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES), to: :claim_for_personal_details)
+  delegate :scheduled_payment_date, to: :payroll_run
 
   private
 

--- a/app/models/payment_confirmation.rb
+++ b/app/models/payment_confirmation.rb
@@ -21,11 +21,14 @@ class PaymentConfirmation
         update_payment_fields(payment, row) if payment
       end
 
-      payroll_run.update!(confirmation_report_uploaded_by: admin_user_id)
+      payroll_run.update!(
+        confirmation_report_uploaded_by: admin_user_id,
+        scheduled_payment_date: scheduled_payment_date
+      )
 
       if errors.empty?
         payroll_run.payments.each do |payment|
-          PaymentMailer.confirmation(payment, payment_date_timestamp).deliver_later
+          PaymentMailer.confirmation(payment, scheduled_payment_date.to_time.to_i).deliver_later
           RecordPaymentJob.perform_later(payment)
         end
       else
@@ -36,8 +39,8 @@ class PaymentConfirmation
 
   private
 
-  def payment_date_timestamp
-    Date.today.next_occurring(:friday).to_time.to_i
+  def scheduled_payment_date
+    Date.today.next_occurring(:friday)
   end
 
   def validate

--- a/app/models/payment_confirmation.rb
+++ b/app/models/payment_confirmation.rb
@@ -28,7 +28,7 @@ class PaymentConfirmation
 
       if errors.empty?
         payroll_run.payments.each do |payment|
-          PaymentMailer.confirmation(payment, scheduled_payment_date.to_time.to_i).deliver_later
+          PaymentMailer.confirmation(payment).deliver_later
           RecordPaymentJob.perform_later(payment)
         end
       else

--- a/db/data/20200114160644_add_payment_dates_to_payroll_runs.rb
+++ b/db/data/20200114160644_add_payment_dates_to_payroll_runs.rb
@@ -1,0 +1,15 @@
+class AddPaymentDatesToPayrollRuns < ActiveRecord::Migration[6.0]
+  def up
+    PayrollRun.where.not(confirmation_report_uploaded_by: nil).each do |payroll_run|
+      payroll_run.scheduled_payment_date = payroll_run.updated_at.to_date.next_occurring(:friday)
+      payroll_run.save!
+    end
+  end
+
+  def down
+    PayrollRun.all.each do |payroll_run|
+      payroll_run.scheduled_payment_date = nil
+      payroll_run.save
+    end
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200106141251)
+DataMigrate::Data.define(version: 20200114160644)

--- a/db/migrate/20200114151353_add_scheduled_payment_date_to_payroll_runs.rb
+++ b/db/migrate/20200114151353_add_scheduled_payment_date_to_payroll_runs.rb
@@ -1,0 +1,5 @@
+class AddScheduledPaymentDateToPayrollRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_column :payroll_runs, :scheduled_payment_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_09_115709) do
+ActiveRecord::Schema.define(version: 2020_01_14_151353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -155,6 +155,7 @@ ActiveRecord::Schema.define(version: 2020_01_09_115709) do
     t.string "downloaded_by"
     t.uuid "created_by_id"
     t.uuid "downloaded_by_id"
+    t.date "scheduled_payment_date"
     t.index ["created_at"], name: "index_payroll_runs_on_created_at"
     t.index ["created_by_id"], name: "index_payroll_runs_on_created_by_id"
     t.index ["downloaded_by_id"], name: "index_payroll_runs_on_downloaded_by_id"

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :payment do
     transient do
       claim_policies { [StudentLoans] }
+      scheduled_payment_date { Date.today }
     end
 
     claims do
@@ -30,6 +31,10 @@ FactoryBot.define do
       student_loan_repayment { 0 }
       tax { award_amount * 0.2 }
       net_pay { award_amount }
+
+      payroll_run do
+        create(:payroll_run, :confirmation_report_uploaded, scheduled_payment_date: scheduled_payment_date)
+      end
     end
   end
 end

--- a/spec/factories/payroll_runs.rb
+++ b/spec/factories/payroll_runs.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
 
     trait :confirmation_report_uploaded do
       confirmation_report_uploaded_by { "some-user-id" }
+      scheduled_payment_date { Date.today }
       payment_traits { %i[with_figures] }
     end
   end

--- a/spec/mailers/payment_mailer_spec.rb
+++ b/spec/mailers/payment_mailer_spec.rb
@@ -5,10 +5,9 @@ RSpec.describe PaymentMailer, type: :mailer do
   Policies.all.each do |policy|
     context "with a payment with a single #{policy} claim" do
       describe "#confirmation" do
-        let(:payment) { create(:payment, :with_figures, net_pay: 500.00, student_loan_repayment: 60, claims: [claim]) }
+        let(:payment) { create(:payment, :with_figures, net_pay: 500.00, student_loan_repayment: 60, claims: [claim], scheduled_payment_date: Date.parse("2019-01-01")) }
         let(:claim) { build(:claim, :submitted, policy: policy) }
-        let(:payment_date_timestamp) { Time.new(2019, 1, 1).to_i }
-        let(:mail) { PaymentMailer.confirmation(payment, payment_date_timestamp) }
+        let(:mail) { PaymentMailer.confirmation(payment) }
 
         it "sets the to address to the claimant's email address" do
           expect(mail.to).to eq([payment.email_address])
@@ -64,7 +63,7 @@ RSpec.describe PaymentMailer, type: :mailer do
 
   context "with a payment with multiple claims" do
     describe "#confirmation" do
-      let(:payment) { create(:payment, :with_figures, net_pay: 2500.00, student_loan_repayment: 60, claims: claims) }
+      let(:payment) { create(:payment, :with_figures, net_pay: 2500.00, student_loan_repayment: 60, claims: claims, scheduled_payment_date: Date.parse("2019-01-01")) }
       let(:student_loans_eligibility) { build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: 500) }
       let(:claims) do
         personal_details = {
@@ -79,8 +78,7 @@ RSpec.describe PaymentMailer, type: :mailer do
           build(:claim, :approved, personal_details.merge(policy: MathsAndPhysics)),
         ]
       end
-      let(:payment_date_timestamp) { Time.new(2019, 1, 1).to_i }
-      let(:mail) { PaymentMailer.confirmation(payment, payment_date_timestamp) }
+      let(:mail) { PaymentMailer.confirmation(payment) }
 
       it "sets the to address to the claimant's email address" do
         expect(mail.to).to eq([payment.email_address])

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -621,4 +621,23 @@ RSpec.describe Claim, type: :model do
       expect(described_class.payrollable).to match_array([first_unpayrolled_claim, second_unpayrolled_claim])
     end
   end
+
+  describe "#scheduled_payment_date" do
+    let(:scheduled_payment_date) { Date.parse("2019-01-01") }
+    let(:claim) { create(:claim, :submitted) }
+
+    context "when a claim has a payroll run associated with it" do
+      let!(:payment) { create(:payment, :with_figures, claims: [claim], scheduled_payment_date: scheduled_payment_date) }
+
+      it "returns the payment date" do
+        expect(claim.scheduled_payment_date).to eq(scheduled_payment_date)
+      end
+    end
+
+    context "when a claim does not have a payroll run associated with it" do
+      it "returns nil" do
+        expect(claim.scheduled_payment_date).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
As discussed in #629, we thought it best to add a reliable way to see when a claim has / will be paid. Rather than gunk up the other PR, I've opened a new PR to do this, as there's extra work to be done with a data migration and refactoring the mailers.