### PR TITLE
Fix sporadically failing payroll runs feature spec

### DIFF
--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -122,7 +122,7 @@ RSpec.feature "Payroll" do
     expect(page.find("table")).to have_content("Uploaded")
 
     expect(payroll_run.reload.confirmation_report_uploaded_by).to eq("uploader-user-id")
-    expect(payroll_run.claims[0].payment.reload.gross_value).to eq("487.48".to_d)
+    expect(payroll_run.payments[0].reload.gross_value).to eq("487.48".to_d)
 
     expect(ActionMailer::Base.deliveries.count).to eq(2)
 


### PR DESCRIPTION
Fix sporadically failing payroll runs feature spec

There is no connection between the ordering of PayrollRun#claims and
PayrollRun#payments, so if we wish to refer to the same payment multiple times
inside a spec then we need to consistently refer to only one of these
relations.

I ran the test suite ten times in a row without any failures, so
hopefully this is fixed.