### PR TITLE
Use most recent address from Verify even if not verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Allow unverified addresses from GOV.UK Verify responses
+
 ## [Release 044] - 2020-01-14
 
 - Schools in the West Somerset opportunity area are now regarded as eligible

--- a/app/models/claim/verify_response_parameters_parser.rb
+++ b/app/models/claim/verify_response_parameters_parser.rb
@@ -94,7 +94,7 @@ class Claim
     end
 
     def most_recent_address
-      @most_recent_address ||= most_recent_value("addresses", required: false)
+      @most_recent_address ||= most_recent_value("addresses", required: false, verified: false)
     end
 
     def address_lines

--- a/spec/models/claim/verify_response_parameters_parser_spec.rb
+++ b/spec/models/claim/verify_response_parameters_parser_spec.rb
@@ -172,8 +172,8 @@ RSpec.describe Claim::VerifyResponseParametersParser do
   end
 
   describe "the address_line_X methods" do
-    it "returns address lines that are present from the most recent 'verified' address" do
-      short_address_parameters = sample_parsed_verify_response({addresses: [{value: {lines: ["Old Street", "Old Town"], postCode: "M21 1GP"}, verified: true}]})
+    it "returns address lines that are present from the most recent address" do
+      short_address_parameters = sample_parsed_verify_response({addresses: [{value: {lines: ["Old Street", "Old Town"], postCode: "M21 1GP"}}]})
       parser = Claim::VerifyResponseParametersParser.new(short_address_parameters)
       expect(parser.address_line_1).to eq "Old Street"
       expect(parser.address_line_2).to eq "Old Town"
@@ -183,17 +183,16 @@ RSpec.describe Claim::VerifyResponseParametersParser do
       full_address_parameters = sample_parsed_verify_response({
         addresses: [
           {
-            value: {lines: ["Some house", "Verified Street", "Verified Town", "Verified County"], postCode: "M1 7GL"},
-            verified: true,
+            value: {lines: ["Some house", "Unverified Street", "Unverified Town", "Unverified County"], postCode: "M1 7GL"},
             from: "2018-08-08",
           },
         ],
       })
       parser = Claim::VerifyResponseParametersParser.new(full_address_parameters)
       expect(parser.address_line_1).to eq "Some house"
-      expect(parser.address_line_2).to eq "Verified Street"
-      expect(parser.address_line_3).to eq "Verified Town"
-      expect(parser.address_line_4).to eq "Verified County"
+      expect(parser.address_line_2).to eq "Unverified Street"
+      expect(parser.address_line_3).to eq "Unverified Town"
+      expect(parser.address_line_4).to eq "Unverified County"
     end
 
     it "returns nil if there are no 'addresses'" do


### PR DESCRIPTION
When we get a users details back from GOV.UK Verify, we store their most recent "verified" address against their claim and play that back to them. However a user may have a more recent address that isn't "verified".