### PR TITLE
1109 411 parsing no major code errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Removed unnecessary tags on main and footer elements that were causing
+  warnings on validators
+
 ## [Release 044] - 2020-01-14
 
 - Schools in the West Somerset opportunity area are now regarded as eligible

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -105,7 +105,7 @@
       </main>
     </div>
 
-    <footer class="govuk-footer " role="contentinfo">
+    <footer class="govuk-footer">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -95,7 +95,7 @@
     <% end %>
 
     <div class="govuk-width-container">
-      <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
+      <main class="govuk-main-wrapper app-main-class" id="main-content">
         <% flash.each do |name, msg| %>
           <div class="govuk-body-l govuk-flash__<%= name %>">
             <%= msg %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,7 +78,7 @@
         </p>
       </div>
 
-      <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
+      <main class="govuk-main-wrapper app-main-class" id="main-content">
         <% flash.each do |name, msg| %>
           <div class="govuk-body-l govuk-flash__<%= name %>">
             <%= msg %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -88,7 +88,7 @@
       </main>
     </div>
 
-    <footer class="govuk-footer " role="contentinfo">
+    <footer class="govuk-footer ">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/public/404.html
+++ b/public/404.html
@@ -101,7 +101,7 @@
       </main>
     </div>
 
-    <footer class="govuk-footer " role="contentinfo">
+    <footer class="govuk-footer ">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/public/404.html
+++ b/public/404.html
@@ -79,7 +79,7 @@
         </p>
       </div>
 
-      <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+      <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">Page not found</h1>

--- a/public/422.html
+++ b/public/422.html
@@ -81,7 +81,7 @@
         </p>
       </div>
 
-      <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+      <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>

--- a/public/422.html
+++ b/public/422.html
@@ -103,7 +103,7 @@
       </main>
     </div>
 
-    <footer class="govuk-footer " role="contentinfo">
+    <footer class="govuk-footer ">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/public/500.html
+++ b/public/500.html
@@ -82,7 +82,7 @@
         </p>
       </div>
 
-      <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+      <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>

--- a/public/500.html
+++ b/public/500.html
@@ -104,7 +104,7 @@
       </main>
     </div>
 
-    <footer class="govuk-footer " role="contentinfo">
+    <footer class="govuk-footer ">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">


### PR DESCRIPTION
As part of the internal accessibility audit, the website was run through a html validator and identified some places where we had set aria roles that were implicit due to the html elements we had already used.  

This PR just removes those un-needed roles that ARIA recommend we do not use.