### PR TITLE
Add log aggregation to the service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Semantic Logger has been added to make log entries more concise and useful
+- Application logs can now be sent to Logstash for aggregation, analysis and
+  monitoring
 
 ## [Release 045] - 2020-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Semantic Logger has been added to make log entries more concise and useful
+
 ## [Release 045] - 2020-01-16
 
 - Changed buttons on information-provided and eligibility confirmed pages to be

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem "jwt"
 # Send app telemetry to Azure Application Insights
 gem "application_insights", git: "https://github.com/microsoft/ApplicationInsights-Ruby.git", ref: "5db6b4ad65262d23f26b678143a4a1fd7939e5c2"
 
+# Semantic Logger provides more useful application log entries
+gem "rails_semantic_logger"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem "application_insights", git: "https://github.com/microsoft/ApplicationInsigh
 # Semantic Logger provides more useful application log entries
 gem "rails_semantic_logger"
 
+# Use logstash-logger to send to Logit.io
+gem "logstash-logger", "~> 0.26"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_semantic_logger (4.4.3)
+      rack
+      railties (>= 3.2)
+      semantic_logger (~> 4.4)
     railties (6.0.2.1)
       actionpack (= 6.0.2.1)
       activesupport (= 6.0.2.1)
@@ -269,6 +273,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    semantic_logger (4.6.0)
+      concurrent-ruby (~> 1.0)
     shoulda-matchers (4.2.0)
       activesupport (>= 4.2.0)
     spring (2.1.0)
@@ -358,6 +364,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 4.3)
   rails (= 6.0.2.1)
+  rails_semantic_logger
   rollbar
   rspec-rails
   sass-rails (~> 6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,9 @@ GEM
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logstash-event (1.2.02)
+    logstash-logger (0.26.1)
+      logstash-event (~> 1.2)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -356,6 +359,7 @@ DEPENDENCIES
   jwt
   launchy
   listen (>= 3.0.5, < 3.3)
+  logstash-logger (~> 0.26)
   mail-notify
   nanoid
   omniauth

--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -156,6 +156,17 @@
         "secretName": "GeckoboardAPIKey"
       }
     },
+    "LOGSTASH_HOST": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "LogstashHost"
+      }
+    },
+    "LOGSTASH_PORT": {
+      "value": 23890
+    },
     "ADMIN_ALLOWED_IPS": {
       "reference": {
         "keyVault": {

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -140,6 +140,17 @@
         "secretName": "GeckoboardAPIKey"
       }
     },
+    "LOGSTASH_HOST": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "LogstashHost"
+      }
+    },
+    "LOGSTASH_PORT": {
+      "value": 23890
+    },
     "ADMIN_ALLOWED_IPS": {
       "reference": {
         "keyVault": {

--- a/azure/resource_groups/app/parameters/test.template.json
+++ b/azure/resource_groups/app/parameters/test.template.json
@@ -159,6 +159,17 @@
         "secretName": "GeckoboardAPIKey"
       }
     },
+    "LOGSTASH_HOST": {
+      "reference": {
+        "keyVault": {
+          "id": "${keyVaultId}"
+        },
+        "secretName": "LogstashHost"
+      }
+    },
+    "LOGSTASH_PORT": {
+      "value": 23890
+    },
     "ADMIN_ALLOWED_IPS": {
       "reference": {
         "keyVault": {

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -142,6 +142,12 @@
     "GECKOBOARD_API_KEY": {
       "type": "string"
     },
+    "LOGSTASH_HOST": {
+      "type": "string"
+    },
+    "LOGSTASH_PORT": {
+      "type": "int"
+    },
     "ADMIN_ALLOWED_IPS": {
       "type": "string"
     },
@@ -491,6 +497,14 @@
               {
                 "name": "GECKOBOARD_API_KEY",
                 "value": "[parameters('GECKOBOARD_API_KEY')]"
+              },
+              {
+                "name": "LOGSTASH_HOST",
+                "value": "[parameters('LOGSTASH_HOST')]"
+              },
+              {
+                "name": "LOGSTASH_PORT",
+                "value": "[parameters('LOGSTASH_PORT')]"
               },
               {
                 "name": "ADMIN_ALLOWED_IPS",

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,14 @@ module DfeTeachersPaymentService
     config.action_view.form_with_generates_remote_forms = false
 
     config.guidance_url = "https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details"
+
+    if ENV["LOGSTASH_HOST"].present?
+      tcp_logger = LogStashLogger.new(type: :tcp,
+                                      host: ENV.fetch("LOGSTASH_HOST"),
+                                      port: ENV.fetch("LOGSTASH_PORT"),
+                                      ssl_enable: true)
+
+      SemanticLogger.add_appender(logger: tcp_logger, level: :info, formatter: :json)
+    end
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,3 +32,8 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+# Re-open log appenders after forking the process
+on_worker_boot do
+  SemanticLogger.reopen
+end


### PR DESCRIPTION
Send _application_ logs to a Logstash instance hosted on LogIt.io, so that aggregated logs are searchable and more easily monitored.

This uses the [Rails Semantic Logger](http://rocketjob.github.io/semantic_logger/rails) gem to make the information which is pushed up to Logstash more structured and useful, as well as reducing log noise by turning a request from many log entries into one.

![kibana logit io_app_kibana](https://user-images.githubusercontent.com/619082/72521779-032e5d80-3854-11ea-844d-49e460a119ba.png)

## Docker Logs: Here Be Dragons
@lawrence-dxw  and I spent a good couple of hours dredging through Azure documentation and blog posts from across the web. Getting Docker logs into LogIt.io is a massive pain - the best we could come up with involves configuring Azure logging to write to a Storage Account, and then having a new worker with the Storage Account mounted and running FileBeat to pipe them into Logstash.

Find Teacher Training advises that they also do not log Docker output, and that they ran into the exact same problems and thinking. For the time being I recommend that it is not worth tackling Docker logs further unless we can identify a specific need, and sticking purely to the Rails application logs.