### PR TITLE
1108 2.4.4 link purpose in context every links purpose is clear from its context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Check your answers page now has ARIA labels on the change buttons so screen
+  readers will now tell users what they will change by visiting the link
 - Removed unnecessary tags on main and footer elements that were causing
   warnings on validators
 

--- a/app/views/claims/_check_your_answers_section.html.erb
+++ b/app/views/claims/_check_your_answers_section.html.erb
@@ -16,7 +16,7 @@
       </dd>
 
       <dd class="govuk-summary-list__actions">
-        <%= link_to('Change', claim_path(current_policy_routing_name, slug), class: 'govuk-link') unless slug.nil? %>
+        <%= link_to('Change', claim_path(current_policy_routing_name, slug), class: 'govuk-link', 'aria-label': "Change #{label.downcase}") unless slug.nil? %>
       </dd>
     </div>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -98,7 +98,7 @@
                 <%= link_to "Contact us", contact_us_path(current_policy_routing_name), class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <%= link_to "Cookie", cookies_path(current_policy_routing_name), class: "govuk-footer__link" %>
+                <%= link_to "Cookies", cookies_path(current_policy_routing_name), class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">
                 <%= link_to "Terms and conditions", terms_conditions_path(current_policy_routing_name), class: "govuk-footer__link" %>


### PR DESCRIPTION
This PR will amend the change links on the check your answers page so they will have an ARIA label to provide context for the link.

E.g. `Change which subject did you complete your initial teacher training in?`

This is important as the links will now provide context and let accessibility users know what question they are changing the answer to. We did consider adding some words before the question to help explain the possible janky-ness of the sentence being read out, but when testing with voice over, it was just adding extra words that didn't have much value and made it harder to focus on which question we are changing.