### PR TITLE
Return worker container to virtual network

### DIFF
--- a/azure/resource_groups/ProjectCore/template.json
+++ b/azure/resource_groups/ProjectCore/template.json
@@ -19,7 +19,7 @@
     "vnetDeploymentName": "[concat(parameters('resourceNamePrefix'), '-virtual-network')]",
     "workerNetworkProfileDeploymentName": "[concat(variables('vnetDeploymentName'), '-worker-network-profile')]",
 
-    "vnetName": "[concat(parameters('resourceNamePrefix'), '-vn')]",
+    "vnetName": "[concat(parameters('resourceNamePrefix'), '-wkrvn')]",
     "workerSubnetName": "worker",
 
     "workerNetworkProfileName": "[concat(parameters('resourceNamePrefix'), '-worker-np')]"

--- a/azure/templates/worker.json
+++ b/azure/templates/worker.json
@@ -47,7 +47,10 @@
           }
         ],
         "restartPolicy": "Always",
-        "osType": "Linux"
+        "osType": "Linux",
+        "networkProfile": {
+          "id": "[parameters('networkProfileId')]"
+        }
       }
     }
   ],


### PR DESCRIPTION
Now the issues with Azure's virtual networks and containers have been solved, we can now put the container back in the VN. We've had to rename the VN too, as the original network had some issues. This new name seems more descriptive now though.