### PR TITLE
Change links that look like buttons to be buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Changed buttons on information-provided and eligibility confirmed pages to be
+  actual buttons
 - Check your answers page now has ARIA labels on the change buttons so screen
   readers will now tell users what they will change by visiting the link
 - Removed unnecessary tags on main and footer elements that were causing

--- a/app/views/claims/information_provided.html.erb
+++ b/app/views/claims/information_provided.html.erb
@@ -26,7 +26,7 @@
       We’ll send you a breakdown of these payments when we process your claim.
     </p>
 
-    <%= link_to "Continue", new_verify_authentications_path, class: "govuk-button", role: "button" %>
+    <%= button_to "Continue", new_verify_authentications_path, method: :get, class: "govuk-button"%>
 
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">

--- a/app/views/maths_and_physics/claims/eligibility_confirmed.html.erb
+++ b/app/views/maths_and_physics/claims/eligibility_confirmed.html.erb
@@ -5,6 +5,7 @@
     <h1 class="govuk-heading-xl">You are eligible to claim a payment for teaching maths or physics</h1>
     <p class="govuk-body">Based on your answers you can claim £2,000 for teaching maths or physics.</p>
 
-    <%= link_to "Continue", claim_path(current_policy_routing_name, next_slug), class: "govuk-button", role: "button", data: { module: "govuk-button" } %>
+    <%= button_to "Continue", claim_path(current_policy_routing_name, next_slug), method: :get, class: "govuk-button" %>
+
   </div>
 </div>

--- a/app/views/student_loans/claims/eligibility_confirmed.html.erb
+++ b/app/views/student_loans/claims/eligibility_confirmed.html.erb
@@ -6,6 +6,6 @@
     <h1 class="govuk-heading-xl">You are eligible to claim back student loan repayments</h1>
     <p class="govuk-body">Based on your answers, you can claim back the student loan repayments you made between 6 April 2018 and 5 April 2019.</p>
 
-    <%= link_to "Continue", claim_path(current_policy_routing_name, next_slug), class: "govuk-button", role: "button" %>
+    <%= button_to "Continue", claim_path(current_policy_routing_name, next_slug), method: :get, class: "govuk-button" %>
   </div>
 </div>


### PR DESCRIPTION
We have a couple of links that are styled to look like buttons and have
the appropriate aria role so that screen readers will put them up
however, they do not function as a keyboard only user wold expect them
to. Users were unable to give the buttons focus and press space to
trigger them.

This PR swaps the links to be actual buttons so they will function as
expected.


