### PR TITLE
Override db:setup to play nicer with data migrations

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -3,7 +3,7 @@ set -e
 
 if [ "$RAILS_ENV" != "production" ]; then
   echo "In a non-production environment: initializing database"
-  bundle exec rake db:create db:schema:load
+  bundle exec rake db:create db:schema:load:with_data
 else
   DB_STATUS=$(bundle exec rake db:migrate:status 2>&1 | tail -n 1)
 

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -9,7 +9,7 @@ else
 
   if [ "$DB_STATUS" == "Schema migrations table does not exist yet."  ]; then
     echo "No tables exist - setting up the database"
-    bundle exec rake db:schema:load:with_data db:seed
+    bundle exec rake db:setup
   else
     echo "Running the schema and data migrations"
     bundle exec rails db:migrate:with_data

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1,1 +1,8 @@
 task(:default).clear_prerequisites.enhance(%i[shellcheck standard prettier brakeman:run spec]) if Rails.env.test? || Rails.env.development?
+
+# Override the db:setup task to make sure entries for existing data migration
+# are seeded in the data_migrations table when setting up for the first time.
+Rake::Task["db:setup"].clear
+namespace :db do
+  task setup: ["db:create", "db:schema:load:with_data", "db:seed"]
+end


### PR DESCRIPTION
When a new database is set up we want to make sure all existing data migrations are listed in the data_migrations table, otherwise they will be treated as having not been run and will be executed the next time `db:migrate:with_data` is called. This causes issues as some of the older data migrations will no longer execute because the schema has moved on since then.

By overriding the `db:setup` we make sure that a developer that runs that (as well as `db:reset`) will end up with a clean database where all migrations and data migrations are marked as having been executed.

Longer term I think we should look to remove the `data_migration` as a dependency altogether, as it is quite intrusive into Rails and has proved one of the more unreliable dependencies we use. Now we have console access we can easily run data migrations manually without the need for any dependencies by following the pattern we followed on the CCS project where we defined them as plain-old-Ruby-code that we manually execute on the server, e.g. https://github.com/dxw/DataSubmissionServiceAPI/blob/develop/db/data_migrate/20181001100230_import_inactive_customers.rb