### PR TITLE
Enable the firewall on our KeyVaults and storage accounts

### DIFF
--- a/azure/resource_groups/ProjectCore/parameters/development.json
+++ b/azure/resource_groups/ProjectCore/parameters/development.json
@@ -5,6 +5,9 @@
     "vnetAddressSpaceCIDR": {
       "value": "11.0.1.0/24"
     },
+    "defaultSubnetAddressPrefix": {
+      "value": "11.0.1.16/28"
+    },
     "workerSubnetAddressPrefix": {
       "value": "11.0.1.0/28"
     }

--- a/azure/resource_groups/ProjectCore/parameters/production.json
+++ b/azure/resource_groups/ProjectCore/parameters/production.json
@@ -5,6 +5,9 @@
     "vnetAddressSpaceCIDR": {
       "value": "11.0.3.0/24"
     },
+    "defaultSubnetAddressPrefix": {
+      "value": "11.0.3.16/28"
+    },
     "workerSubnetAddressPrefix": {
       "value": "11.0.3.0/28"
     }

--- a/azure/resource_groups/ProjectCore/parameters/test.json
+++ b/azure/resource_groups/ProjectCore/parameters/test.json
@@ -5,6 +5,9 @@
     "vnetAddressSpaceCIDR": {
       "value": "11.0.2.0/24"
     },
+    "defaultSubnetAddressPrefix": {
+      "value": "11.0.2.16/28"
+    },
     "workerSubnetAddressPrefix": {
       "value": "11.0.2.0/28"
     }

--- a/azure/resource_groups/ProjectCore/template.json
+++ b/azure/resource_groups/ProjectCore/template.json
@@ -57,7 +57,7 @@
                       "locations": ["westeurope", "northeurope"]
                     },
                     {
-                      "service": "Microsoft.Sql",
+                      "service": "Microsoft.KeyVault",
                       "locations": ["westeurope"]
                     }
                   ],

--- a/azure/resource_groups/ProjectCore/template.json
+++ b/azure/resource_groups/ProjectCore/template.json
@@ -9,6 +9,9 @@
     "vnetAddressSpaceCIDR": {
       "type": "string"
     },
+    "defaultSubnetAddressPrefix": {
+      "type": "string"
+    },
     "workerSubnetAddressPrefix": {
       "type": "string"
     }
@@ -44,6 +47,25 @@
           },
           "subnetConfiguration": {
             "value": [
+              {
+                "name": "default",
+                "properties": {
+                  "addressPrefix": "[parameters('defaultSubnetAddressPrefix')]",
+                  "serviceEndpoints": [
+                    {
+                      "service": "Microsoft.Storage",
+                      "locations": ["westeurope", "northeurope"]
+                    },
+                    {
+                      "service": "Microsoft.Sql",
+                      "locations": ["westeurope"]
+                    }
+                  ],
+                  "delegations": [],
+                  "privateEndpointNetworkPolicies": "Enabled",
+                  "privateLinkServiceNetworkPolicies": "Enabled"
+                }
+              },
               {
                 "name": "[variables('workerSubnetName')]",
                 "properties": {
@@ -106,6 +128,10 @@
     "workerNetworkProfileId": {
       "type": "string",
       "value": "[resourceId('Microsoft.Network/networkProfiles', variables('workerNetworkProfileName'))]"
+    },
+    "defaultSubnetId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), 'default')]"
     }
   }
 }

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -233,7 +233,6 @@
     "vspDeploymentName": "[concat(parameters('resourceNamePrefix'), '-vsp')]",
     "vspAppServiceWebTestDeploymentName": "[concat(parameters('resourceNamePrefix'), '-vsp-app-service-web-test')]",
 
-    "storageAccountName": "[replace(concat(parameters('resourceNamePrefix'), 'storage'), '-', '')]",
     "databaseServerName": "[concat(parameters('resourceNamePrefix'), '-db')]",
 
     "applicationInsightsName": "[concat(parameters('resourceNamePrefix'), '-ai')]",
@@ -267,9 +266,6 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "storageAccountName": {
-            "value": "[variables('storageAccountName')]"
-          },
           "databaseServerName": {
             "value": "[variables('databaseServerName')]"
           },

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -9,6 +9,9 @@
     "gitCommitHash": {
       "type": "string"
     },
+    "defaultSubnetId": {
+      "type": "string"
+    },
     "secretsResourceGroupName": {
       "type": "string"
     },

--- a/azure/resource_groups/secrets/template.json
+++ b/azure/resource_groups/secrets/template.json
@@ -9,6 +9,9 @@
     "deliveryTeamUserGroupObjectId": {
       "type": "string"
     },
+    "defaultSubnetId": {
+      "type": "string"
+    },
     "logRetentionInDays": {
       "type": "int",
       "defaultValue": 365,
@@ -75,7 +78,19 @@
               "secrets": ["get"]
             }
           }
-        ]
+        ],
+        "networkAcls": {
+          "bypass": "AzureServices",
+          "virtualNetworkRules": [
+              {
+                "id": "[parameters('defaultSubnetId')]",
+                "action": "Allow",
+                "state": "succeeded"
+              }
+            ],
+          "ipRules": [],
+          "defaultAction": "Deny"
+        }
       }
     },
     {

--- a/azure/resource_groups/secrets/template.json
+++ b/azure/resource_groups/secrets/template.json
@@ -32,19 +32,40 @@
   },
   "resources": [
     {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2017-05-10",
-      "name": "[variables('storageAccountDeploymentName')]",
+      "apiVersion": "2018-02-01",
+      "name": "[variables('storageAccountName')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "location": "[resourceGroup().location]",
+      "tags": {},
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "Storage",
       "properties": {
-        "mode": "Incremental",
-        "templateLink": {
-          "uri": "[concat(variables('platformBuildingBlocksDeploymentUrlBase'), 'storage-account.json')]",
-          "contentVersion": "1.0.0.0"
+        "encryption": {
+          "services": {
+            "blob": {
+              "enabled": true
+            },
+            "file": {
+              "enabled": true
+            }
+          },
+          "keySource": "Microsoft.Storage"
         },
-        "parameters": {
-          "storageAccountName": {
-            "value": "[variables('storageAccountName')]"
-          }
+        "accessTier": "[json('null')]",
+        "supportsHttpsTrafficOnly": true,
+        "networkAcls": {
+          "bypass": "AzureServices",
+          "virtualNetworkRules": [
+            {
+              "id": "[parameters('defaultSubnetId')]",
+              "action": "Allow",
+              "state": "succeeded"
+            }
+          ],
+          "ipRules": [],
+          "defaultAction": "Deny"
         }
       }
     },
@@ -82,12 +103,12 @@
         "networkAcls": {
           "bypass": "AzureServices",
           "virtualNetworkRules": [
-              {
-                "id": "[parameters('defaultSubnetId')]",
-                "action": "Allow",
-                "state": "succeeded"
-              }
-            ],
+            {
+              "id": "[parameters('defaultSubnetId')]",
+              "action": "Allow",
+              "state": "succeeded"
+            }
+          ],
           "ipRules": [],
           "defaultAction": "Deny"
         }
@@ -100,7 +121,7 @@
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
-        "[resourceId('Microsoft.Resources/deployments', variables('storageAccountDeploymentName'))]"
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
       ],
       "properties": {
         "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",

--- a/azure/templates/database.json
+++ b/azure/templates/database.json
@@ -2,9 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "storageAccountName": {
-      "type": "string"
-    },
     "databaseServerName": {
       "type": "string"
     },
@@ -19,68 +16,66 @@
     },
     "alertEmailAddress": {
       "type": "string"
+    },
+    "postgresSku": {
+      "type": "object",
+      "defaultValue": {
+        "name": "GP_Gen5_2",
+        "tier": "GeneralPurpose",
+        "size": 5120,
+        "family": "Gen5",
+        "capacity": 2
+      }
     }
   },
   "variables": {
     "platformBuildingBlocksDeploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
 
-    "databaseServerDeploymentName": "[concat(deployment().name, '-database-server')]",
     "databaseDeploymentName": "[concat(deployment().name, '-database')]",
-    "storageAccountDeploymentName": "[concat(deployment().name, '-storage-account')]"
+
+    "securityAlertPolicyName": "[concat(parameters('databaseServerName'), '-DefaultSecurityAlert')]"
   },
   "resources": [
     {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2017-05-10",
-      "name": "[variables('storageAccountDeploymentName')]",
+      "name": "[parameters('databaseServerName')]",
+      "type": "Microsoft.DBforPostgreSQL/servers",
+      "apiVersion": "2017-12-01",
+      "location": "[resourceGroup().location]",
+      "tags": {},
+      "sku": "[parameters('postgresSku')]",
       "properties": {
-        "mode": "Incremental",
-        "templateLink": {
-          "uri": "[concat(variables('platformBuildingBlocksDeploymentUrlBase'), 'storage-account.json')]",
-          "contentVersion": "1.0.0.0"
+        "storageProfile": {
+          "storageMB": "[parameters('postgresSku').size]",
+          "backupRetentionDays": 35,
+          "geoRedundantBackup": "disabled",
+          "storageAutoGrow": "disabled"
         },
-        "parameters": {
-          "storageAccountName": {
-            "value": "[parameters('storageAccountName')]"
-          }
+        "version": "9.6",
+        "sslEnforcement": "Enabled",
+        "administratorLogin": "[parameters('databaseUsername')]",
+        "administratorLoginPassword": "[parameters('databasePassword')]"
+      },
+      "resources": [
+        {
+          "name": "[variables('securityAlertPolicyName')]",
+          "type": "securityAlertPolicies",
+          "apiVersion": "2017-12-01",
+          "properties": {
+            "state": "Enabled",
+            "disabledAlerts": [],
+            "emailAddresses": ["[parameters('alertEmailAddress')]"],
+            "emailAccountAdmins": false,
+            "retentionDays": 90
+          },
+          "dependsOn": ["[parameters('databaseServerName')]"]
         }
-      }
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2017-05-10",
-      "name": "[variables('databaseServerDeploymentName')]",
-      "dependsOn": ["[resourceId('Microsoft.Resources/deployments', variables('storageAccountDeploymentName'))]"],
-      "properties": {
-        "mode": "Incremental",
-        "templateLink": {
-          "uri": "[concat(variables('platformBuildingBlocksDeploymentUrlBase'), 'postgresql-server.json')]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "postgresServerName": {
-            "value": "[parameters('databaseServerName')]"
-          },
-          "postgresAdminLogin": {
-            "value": "[parameters('databaseUsername')]"
-          },
-          "postgresAdminPassword": {
-            "value": "[parameters('databasePassword')]"
-          },
-          "securityAlertEmailAddress": {
-            "value": "[parameters('alertEmailAddress')]"
-          },
-          "storageAccountName": {
-            "value": "[parameters('storageAccountName')]"
-          }
-        }
-      }
+      ]
     },
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2017-05-10",
       "name": "[variables('databaseDeploymentName')]",
-      "dependsOn": ["[resourceId('Microsoft.Resources/deployments', variables('databaseServerDeploymentName'))]"],
+      "dependsOn": ["[resourceId('Microsoft.DBforPostgreSQL/servers', parameters('databaseServerName'))]"],
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -101,7 +96,7 @@
       "type": "Microsoft.DBforPostgreSQL/servers/configurations",
       "apiVersion": "2017-12-01",
       "name": "[concat(parameters('databaseServerName'), '/log_disconnections')]",
-      "dependsOn": ["[resourceId('Microsoft.Resources/deployments', variables('databaseServerDeploymentName'))]"],
+      "dependsOn": ["[resourceId('Microsoft.DBforPostgreSQL/servers', parameters('databaseServerName'))]"],
       "properties": {
         "value": "ON",
         "source": "user-override"
@@ -115,7 +110,7 @@
     },
     "databaseServerFullyQualifiedDomainName": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('databaseServerDeploymentName'))).outputs.fullyQualifiedDomainName.value]"
+      "value": "[reference(resourceId('Microsoft.DBforPostgreSQL/servers', parameters('databaseServerName'))).fullyQualifiedDomainName]"
     }
   }
 }

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -187,6 +187,11 @@ SECRETS_DEPLOYMENT_RESULT=$(
     --resource-group "$SECRETS_RESOURCE_GROUP_NAME" \
     --template-file "$SECRETS_TEMPLATE_FILE_PATH" \
     --parameters "@$SECRETS_PARAMETERS_FILE_PATH" \
+    --parameters "$(
+      filter-azure-outputs \
+        "$PROJECT_CORE_DEPLOYMENT_RESULT" \
+        "['defaultSubnetId']"
+      )" \
     --mode Complete \
     --verbose \
     <&- || true

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -242,7 +242,7 @@ APP_DEPLOYMENT_RESULT=$(
     --parameters "$(
       filter-azure-outputs \
         "$PROJECT_CORE_DEPLOYMENT_RESULT" \
-        "['workerSubnetId', 'workerNetworkProfileId']"
+        "['workerSubnetId', 'workerNetworkProfileId', 'defaultSubnetId']"
     )" \
     "${EXTRA_APP_DEPLOYMENT_OPTIONS[@]}" \
     --mode Complete \

--- a/docs/govuk-verify.md
+++ b/docs/govuk-verify.md
@@ -114,6 +114,10 @@ where:
 
 Run the request script with the next version number in the sequence:
 
+Note: Before running this script you will need to
+[add your IP to the allow list](https://dfedigital.atlassian.net/wiki/spaces/TP/pages/1264418844/Secrets)
+of the KeyVault firewall belonging to the environment you are requesting for.
+
 ```bash
 bin/request-vsp-certs <environment> <version>
 ```
@@ -152,6 +156,10 @@ generated within 5 days and we be sent to the group email address.
 
 When you receive the certificates run the import script for both signing and
 encryption certificates:
+
+Note: Before running this script you will need to
+[add your IP to the allow list](https://dfedigital.atlassian.net/wiki/spaces/TP/pages/1264418844/Secrets)
+of the KeyVault firewall belonging to the environment you are importing for.
 
 ```bash
 bin/import-vsp-certs <environment> <version>


### PR DESCRIPTION
To harden up our infrastructure a firewall has been added to our storage account and KeyVault.

This will affect developers viewing secrets in our KeyVault. It will require an extra step of adding your IP to the allow list on the firewall. For production this will require a PIM request. I've added some documentation to [confluence].(https://dfedigital.atlassian.net/wiki/spaces/TP/pages/1264418844/Secrets)

The storage account used by Postgres' security alerts is no longer needed so I've removed it.