### PR TITLE
Purge unsubmitted claims nightly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog]
 - Application logs can now be sent to Logstash for aggregation, analysis and
   monitoring
 - Allow unverified addresses from GOV.UK Verify responses
+- Unsubmitted claims are purged every 24 hours
 
 ## [Release 045] - 2020-01-16
 

--- a/app/jobs/purge_unsubmitted_claims_job.rb
+++ b/app/jobs/purge_unsubmitted_claims_job.rb
@@ -1,0 +1,17 @@
+# Runs nightly at midnight and deletes any unsubmitted claims that are more than
+# 24 hours old, purging our database of data we don't want or need to hang on
+# to.
+class PurgeUnsubmittedClaimsJob < CronJob
+  self.cron_expression = "0 0 * * *"
+
+  def perform
+    Rails.logger.info "Purging #{old_unsubmitted_claims.count} old and unsubmitted claims from the database"
+    old_unsubmitted_claims.destroy_all
+  end
+
+  private
+
+  def old_unsubmitted_claims
+    Claim.unsubmitted.where("updated_at < ?", 24.hours.ago)
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -142,6 +142,7 @@ class Claim < ApplicationRecord
   before_save :normalise_bank_account_number, if: :bank_account_number_changed?
   before_save :normalise_bank_sort_code, if: :bank_sort_code_changed?
 
+  scope :unsubmitted, -> { where(submitted_at: nil) }
   scope :submitted, -> { where.not(submitted_at: nil) }
   scope :awaiting_checking, -> { submitted.left_outer_joins(:check).where(checks: {claim_id: nil}) }
   scope :approved, -> { joins(:check).where("checks.result" => :approved) }

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -77,7 +77,7 @@ class Claim < ApplicationRecord
 
   has_one :check
 
-  belongs_to :eligibility, polymorphic: true
+  belongs_to :eligibility, polymorphic: true, dependent: :destroy
   accepts_nested_attributes_for :eligibility, update_only: true
 
   belongs_to :payment, optional: true

--- a/spec/jobs/purge_unsubmitted_claims_job_spec.rb
+++ b/spec/jobs/purge_unsubmitted_claims_job_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe PurgeUnsubmittedClaimsJob do
+  describe "#perform" do
+    let(:over_24_hours_ago) { 24.hours.ago - 1.second }
+    let(:four_hours_ago) { 4.hours.ago }
+
+    it "destroys any unsubmitted claims that have not been updated in the last 24 hours" do
+      expired_unsubmitted_claim = create(:claim, updated_at: over_24_hours_ago)
+      active_unsubmitted_claim = create(:claim, updated_at: four_hours_ago)
+
+      old_submitted_claim = create(:claim, :submitted, updated_at: over_24_hours_ago)
+
+      PurgeUnsubmittedClaimsJob.new.perform
+
+      expect(Claim.exists?(expired_unsubmitted_claim.id)).to eq false
+
+      expect(Claim.exists?(old_submitted_claim.id)).to eq true
+      expect(Claim.exists?(active_unsubmitted_claim.id)).to eq true
+    end
+  end
+end


### PR DESCRIPTION
This will run every day at midnight and remove any unsubmitted claims
that are more than 24 hours old so we don't hang on to user data that we
don't need and can't use.

Because this inheritts from `CronJob` it will automatically get picked
up and scheduled by `CronJobScheduler` when the `jobs:schedule` rake
task is run.

**Note: this PR delivers one part of the larger story around data purging and anonymising.**