### PR TITLE
Batch Geckoboard requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog]
   monitoring
 - Allow unverified addresses from GOV.UK Verify responses
 - Unsubmitted claims are purged every 24 hours
+- Batch Geckoboard data when submitting to the API
 
 ## [Release 045] - 2020-01-16
 

--- a/spec/models/claim/geckoboard_event_spec.rb
+++ b/spec/models/claim/geckoboard_event_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Claim::GeckoboardEvent, type: :model do
-  let(:claim) { create(:claim, :submitted, created_at: DateTime.now) }
+  let(:claim) { build(:claim, :submitted, created_at: DateTime.now) }
   let(:event_name) { "some_event" }
 
   it "sends the claim's reference, policy, along with the timestamp to the dataset indicated by the event name" do
@@ -14,6 +14,26 @@ RSpec.describe Claim::GeckoboardEvent, type: :model do
 
       expect(dataset_post_stub.with { |request|
         request_body_matches_geckoboard_data_for_claims?(request, [claim], :created_at)
+      }).to have_been_requested
+    end
+  end
+
+  context "with lots of claims" do
+    let(:claims) { build_list(:claim, 520, :submitted, created_at: DateTime.now) }
+
+    it "batches the claims into groups" do
+      event = Claim::GeckoboardEvent.new(claims, event_name, :created_at)
+
+      dataset_post_stub = stub_geckoboard_dataset_update("claims.#{event_name}.test")
+
+      event.record
+
+      expect(dataset_post_stub.with { |request|
+        request_body_matches_geckoboard_data_for_claims?(request, claims.first(500), :created_at)
+      }).to have_been_requested
+
+      expect(dataset_post_stub.with { |request|
+        request_body_matches_geckoboard_data_for_claims?(request, claims.last(20), :created_at)
       }).to have_been_requested
     end
   end


### PR DESCRIPTION
After deploying #629, we got an error because there are now more than 500 sumbitted claims, causing Geckoboard to hit us with an error, as we can only submit 500 datapoints at a time. This adds batching functionality to the `GeckoboardEvent` class, so claims are batched into groups of 500.
