### PR TITLE
Change existing session to use radios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Changed existing session page to use radios and tidy up the iterruption card
 - Semantic Logger has been added to make log entries more concise and useful
 - Application logs can now be sent to Logstash for aggregation, analysis and
   monitoring

--- a/app/assets/stylesheets/components/panel.scss
+++ b/app/assets/stylesheets/components/panel.scss
@@ -24,15 +24,6 @@
     color: govuk-colour("white");
   }
 
-  a,
-  a:link,
-  a:visited {
-    color: govuk-colour("white");
-  }
-  a:hover {
-    color: govuk-colour("light-grey");
-  }
-
   .govuk-list--definition {
     dt,
     dd {
@@ -40,18 +31,9 @@
     }
   }
 
-  .govuk-button:not(.govuk-button--link) {
+  .govuk-button {
+    color: govuk-colour("black");
     background-color: govuk-colour("white");
-    box-shadow: 0 2px 0 govuk-colour("black");
-
-    &:link,
-    &:visited {
-      color: govuk-colour("blue");
-    }
-
-    &:hover,
-    &:focus {
-      background-color: govuk-colour("light-grey");
-    }
+    box-shadow: 0 2px 0 govuk-colour("dark-blue");
   }
 }

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -45,6 +45,15 @@ class ClaimsController < BasePublicController
   def existing_session
   end
 
+  def start_new
+    if ActiveModel::Type::Boolean.new.cast(params[:start_new_claim]) == true
+      clear_claim_session
+      redirect_to(new_claim_path(params[:policy]))
+    else
+      redirect_to(claim_path(current_claim.policy.routing_name, slug: session[:current_slug]))
+    end
+  end
+
   private
 
   helper_method :next_slug

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,9 +2,4 @@ class SessionsController < BasePublicController
   def refresh
     head :ok
   end
-
-  def destroy
-    clear_claim_session
-    redirect_to(new_claim_path(params[:policy]))
-  end
 end

--- a/app/views/claims/existing_session.html.erb
+++ b/app/views/claims/existing_session.html.erb
@@ -1,19 +1,39 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-panel govuk-panel--interruption">
-      <h1 class="govuk-heading-xl">
-        You have a claim in progress <%= policy_description(current_claim.policy.routing_name) %>.
-      </h1>
+      <%= form_with url: start_new_path(policy: params[:policy]), method: :post do |form| %>
+        <fieldset class="govuk-fieldset" aria-describedby="start_new_claim">
 
-      <h2 class="govuk-heading-m">
-        You will lose your progress on this claim if you start a different claim before you send it.
-      </h2>
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-heading-xl" id="start_new_claim">
+                Are you sure you want to start a claim <%= policy_description(params[:policy]) %>?
+              </h1>
+            </legend>
+
+          <h2 class="govuk-heading-m">
+            You have a claim in progress <%= policy_description(current_claim.policy.routing_name) %>.
+          </h2>
+
+          <h2 class="govuk-heading-m">
+            You will lose your progress on this claim if you start a different claim before you send it.
+          </h2>
+
+          <div class="govuk-radios govuk-!-margin-bottom-9">
+            <div class="govuk-radios__item">
+              <%= form.radio_button(:start_new_claim, false, class: "govuk-radios__input") %>
+              <%= form.label :start_new_claim_false, "No, finish the claim I have in progress", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button(:start_new_claim, true, class: "govuk-radios__input") %>
+              <%= form.label :start_new_claim_true, "Yes, start claim #{policy_description(params[:policy])} and lose my progress on my first claim", class: "govuk-label govuk-radios__label" %>
+            </div>
+          </div>
+
+        </fieldset>
+
+        <%= form.submit "Submit", class: "govuk-button" %>
+
+      <% end %>
     </div>
-
-    <p class="govuk-body govuk-!-margin-top-7 govuk-!-margin-bottom-0">
-      <%= link_to "Finish claim in progress", claim_path(current_claim.policy.routing_name, slug: session[:current_slug]), class: "govuk-button" %>
-    </p>
-
-    <%= button_to "Start claim #{policy_description(params[:policy])}", session_path(policy: params[:policy]), method: :delete, class: "govuk-button govuk-button--secondary" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
   end
 
   get "refresh-session", to: "sessions#refresh", as: :refresh_session
-  delete "session", to: "sessions#destroy", as: :session
 
   # Used to constrain claim journey routing so only slugs
   # that are part of a policy’s slug sequence are routed.
@@ -44,9 +43,9 @@ Rails.application.routes.draw do
     post "claim", as: :claims, to: "claims#create"
     post "claim/submit", as: :claim_submission, to: "submissions#create"
     get "claims/confirmation", as: :claim_confirmation, to: "submissions#show"
-
     get "timeout", to: "claims#timeout", as: :timeout_claim
     get "existing-session", as: :existing_session, to: "claims#existing_session"
+    post "start-new", to: "claims#start_new", as: :start_new
 
     %w[privacy_notice terms_conditions contact_us cookies accessibility_statement].each do |page_name|
       get page_name.dasherize, to: "static_pages##{page_name}", as: page_name

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -10,13 +10,15 @@ RSpec.feature "Switching policies" do
     expect(page.title).to have_text(I18n.t("maths_and_physics.policy_name"))
     expect(page.find("header")).to have_text(I18n.t("maths_and_physics.policy_name"))
 
-    click_on "Start claim for a payment for teaching maths or physics"
+    choose "Yes, start claim for a payment for teaching maths or physics and lose my progress on my first claim"
+    click_on "Submit"
 
     expect(page).to have_text(I18n.t("maths_and_physics.questions.teaching_maths_or_physics"))
   end
 
   scenario "a user can choose to continue their claim" do
-    click_on "Finish claim in progress"
+    choose "No, finish the claim I have in progress"
+    click_on "Submit"
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
   end


### PR DESCRIPTION
This PR builds upon the existing interruption card that was used with
some usability improvements. We now ask the user if they want to abandon
their current claim and use radio buttons for them to select their
response.

We have also tided up some of the CSS that is no longer needed.

![image](https://user-images.githubusercontent.com/13239597/72739011-bbcd0780-3b9a-11ea-9c54-3d55742bb394.png)


