### PR TITLE
Update next steps when not using Verify

### DIFF
--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -9,7 +9,11 @@ Your unique reference is <%= @claim.reference %>. You will need this if you cont
 <%- if @claim.identity_confirmed? -%>
 We'll check the details you provided in your application and we'll tell you if your claim was successful within <%= claim_checking_deadline_in_weeks %>.
 <%- else -%>
-We'll try to contact you at your school to confirm your identity before progressing your claim. If we're able to verify your identity, we'll check the details you provided in your application and tell you if your claim was successful within <%= claim_checking_deadline_in_weeks %>.
+Before we can progress your claim, we need to confirm your identity by calling you at your school.
+
+We’ll send you an email from <%= support_email_address(@policy.routing_name) %> to arrange a convenient time for us to call.
+
+If we’re able to confirm your identity, we’ll check the details you provided in your claim and tell you if your claim was successful within <%= claim_checking_deadline_in_weeks %>.
 <%- end -%>
 
 It can take up to 18 weeks to process your application and make a payment into your account.


### PR DESCRIPTION
This better reflects the next steps that actually get taken when a user can't Verify using GOV.UK Verify.
