### PR TITLE
Disable application alerts in the test environment

### DIFF
--- a/azure/resource_groups/alerts/parameters/test.template.json
+++ b/azure/resource_groups/alerts/parameters/test.template.json
@@ -15,6 +15,9 @@
     },
     "secretsResourceGroupId": {
       "value": "${secretsResourceGroupId}"
+    },
+    "enableAlerts": {
+      "value": false
     }
   }
 }

--- a/azure/resource_groups/alerts/template.json
+++ b/azure/resource_groups/alerts/template.json
@@ -39,6 +39,10 @@
     },
     "databaseServerId": {
       "type": "string"
+    },
+    "enableAlerts": {
+      "type": "bool",
+      "defaultValue": true
     }
   },
   "variables": {
@@ -123,6 +127,9 @@
           },
           "appServicePlanId": {
             "value": "[parameters('appServicePlanId')]"
+          },
+          "enableAlerts": {
+            "value": "[parameters('enableAlerts')]"
           }
         }
       }
@@ -147,6 +154,9 @@
           },
           "databaseServerId": {
             "value": "[parameters('databaseServerId')]"
+          },
+          "enableAlerts": {
+            "value": "[parameters('enableAlerts')]"
           }
         }
       }
@@ -174,6 +184,9 @@
           },
           "appServicePlanId": {
             "value": "[parameters('vspAppServicePlanId')]"
+          },
+          "enableAlerts": {
+            "value": "[parameters('enableAlerts')]"
           }
         }
       }

--- a/azure/resource_groups/app/parameters/test.template.json
+++ b/azure/resource_groups/app/parameters/test.template.json
@@ -79,6 +79,9 @@
         "secretName": "AlertEmailAddress"
       }
     },
+    "enableWebTestAlerts": {
+      "value": false
+    },
     "SECRET_KEY_BASE": {
       "reference": {
         "keyVault": {

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -103,6 +103,10 @@
     "alertEmailAddress": {
       "type": "string"
     },
+    "enableWebTestAlerts": {
+      "type": "bool",
+      "defaultValue": true
+    },
     "azureBuildNumber": {
       "type": "string",
       "defaultValue": ""
@@ -342,6 +346,9 @@
           },
           "webTestLocations": {
             "value": "[variables('azureAvailabilityTestLocations')]"
+          },
+          "enableWebTestAlerts": {
+            "value": "[parameters('enableWebTestAlerts')]"
           }
         }
       }

--- a/azure/templates/app_alerts.json
+++ b/azure/templates/app_alerts.json
@@ -13,6 +13,9 @@
     },
     "appServicePlanId": {
       "type": "string"
+    },
+    "enableAlerts": {
+      "type": "bool"
     }
   },
   "variables": {
@@ -34,7 +37,7 @@
       "location": "global",
       "properties": {
         "scopes": ["[parameters('appServiceId')]"],
-        "enabled": true,
+        "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average response times for ', variables('appServiceName'), ' are greater than 2 seconds.')]",
         "severity": 1,
         "evaluationFrequency": "PT1M",
@@ -69,7 +72,7 @@
       "location": "global",
       "properties": {
         "scopes": ["[parameters('appServiceId')]"],
-        "enabled": true,
+        "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when any HTTP server errors occur for ', variables('appServiceName'), '.')]",
         "severity": 1,
         "evaluationFrequency": "PT1M",
@@ -104,7 +107,7 @@
       "location": "global",
       "properties": {
         "scopes": ["[parameters('appServicePlanId')]"],
-        "enabled": true,
+        "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average CPU utilization for ', variables('appServicePlanName'), ' is greater than 80%.')]",
         "severity": 1,
         "evaluationFrequency": "PT1M",
@@ -139,7 +142,7 @@
       "location": "global",
       "properties": {
         "scopes": ["[parameters('appServicePlanId')]"],
-        "enabled": true,
+        "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average memory utilization for ', variables('appServicePlanName'), ' is greater than 80%.')]",
         "severity": 1,
         "evaluationFrequency": "PT1M",

--- a/azure/templates/availability_tests.json
+++ b/azure/templates/availability_tests.json
@@ -26,6 +26,9 @@
       "metadata": {
         "description": "The locations to conduct webtests from"
       }
+    },
+    "enableWebTestAlerts": {
+      "type": "bool"
     }
   },
   "variables": {
@@ -40,7 +43,7 @@
       "tags": {},
       "properties": {
         "groupShortName": "[concat(split(parameters('appInsightsName'), '-')[0], '-ops')]",
-        "enabled": true,
+        "enabled": "[parameters('enableWebTestAlerts')]",
         "useCommonAlertSchema": true,
         "emailReceivers": [
           {
@@ -51,9 +54,9 @@
       }
     },
     {
+      "type": "Microsoft.Insights/webtests",
       "apiVersion": "2015-05-01",
       "name": "[if(greater(length(parameters('availabilityTests')), 0), concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix), 'UNUSED_WEBTEST')]",
-      "type": "Microsoft.Insights/webtests",
       "condition": "[greater(length(parameters('availabilityTests')), 0)]",
       "location": "[resourceGroup().location]",
       "copy": {
@@ -66,7 +69,7 @@
       "properties": {
         "SyntheticMonitorId": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
         "Name": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('webTestsCopy')].nameSuffix)]",
-        "Enabled": true,
+        "Enabled": "[parameters('enableWebTestAlerts')]",
         "Frequency": 300,
         "Timeout": 120,
         "RetryEnabled": true,
@@ -99,7 +102,7 @@
         "name": "[concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('metricAlertsCopy')].nameSuffix, '-alert')]",
         "description": "[concat('Returns when availability of ', parameters('availabilityTests')[copyIndex('metricAlertsCopy')].nameSuffix ,' is less than 100%')]",
         "severity": 1,
-        "enabled": true,
+        "enabled": "[parameters('enableWebTestAlerts')]",
         "scopes": [
           "[resourceId('Microsoft.Insights/webtests', concat(parameters('appInsightsName'), '-at-', parameters('availabilityTests')[copyIndex('metricAlertsCopy')].nameSuffix))]",
           "[resourceId('microsoft.insights/components', parameters('appInsightsName'))]"

--- a/azure/templates/database_alerts.json
+++ b/azure/templates/database_alerts.json
@@ -10,6 +10,9 @@
     },
     "databaseServerId": {
       "type": "string"
+    },
+    "enableAlerts": {
+      "type": "bool"
     }
   },
   "variables": {
@@ -27,7 +30,7 @@
       "location": "global",
       "properties": {
         "scopes": ["[parameters('databaseServerId')]"],
-        "enabled": true,
+        "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average CPU utilization for ', variables('databaseServerName'), ' is greater than 80%.')]",
         "severity": 0,
         "evaluationFrequency": "PT1M",
@@ -62,7 +65,7 @@
       "location": "global",
       "properties": {
         "scopes": ["[parameters('databaseServerId')]"],
-        "enabled": true,
+        "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average memory utilization for ', variables('databaseServerName'), ' is greater than 80%.')]",
         "severity": 0,
         "evaluationFrequency": "PT1M",
@@ -97,7 +100,7 @@
       "location": "global",
       "properties": {
         "scopes": ["[parameters('databaseServerId')]"],
-        "enabled": true,
+        "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average storage utilization for ', variables('databaseServerName'), ' is greater than 80%.')]",
         "severity": 0,
         "evaluationFrequency": "PT1M",


### PR DESCRIPTION
Most of the alerts are intended to let us know that the application isn't working as expected. For the test environment we mainly care about if the infrastructure has deployed or not. eg. Alerts letting us
know that the CPU usage is high during a deployment are just noise.

I've left the service health alerts in there as they only happen when there's a problem with the infrastructure.
