### PR TITLE
Update the copy about deductions to make it clearer

### DIFF
--- a/app/views/claim_mailer/approved.text.erb
+++ b/app/views/claim_mailer/approved.text.erb
@@ -4,9 +4,13 @@ Your claim <%= @claim_description %> has been approved.
 
 We will send you another email when we have processed your payment, which may take up to <%= claim_checking_deadline_in_weeks %>.
 
-When we contact you we will include a breakdown of your payment and confirm the amount you will receive. Your payment is taxable and the breakdown will show the following deductions:
+When we contact you we'll confirm the amount you'll receive and include a breakdown of your payment.
 
-* Income Tax and Employee National Insurance (NIC), which we pay on your behalf
-* student loan contribution, which is deducted from your claim payment if applicable
+The payment breakdown will show the following contributions:
 
-If you have any questions about your claim, please contact <%= support_email_address(@policy.routing_name) %> giving your reference: <%= @claim.reference %>.
+* student loan repayment, which is deducted from your payment if applicable
+* Income Tax and Employee National Insurance, which we pay on your behalf
+
+For more information about these contributions, read the eligibility and payment guidance at <%= @policy.eligibility_page_url %>.
+
+If you have any questions about your claim, please contact <%= support_email_address(@policy.routing_name) %> giving your reference:  <%= @claim.reference %>.

--- a/app/views/claims/information_provided.html.erb
+++ b/app/views/claims/information_provided.html.erb
@@ -5,26 +5,33 @@
 
     <h1 class="govuk-heading-xl">How we will use the information you provide</h1>
 
+    <h2 class="govuk-heading-m">To process your claim</h2>
+
     <p class="govuk-body">
-      To process your claim we will check the information in your application with:
+      We will check the information in your application with:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>the school you are currently employed to teach at</li>
       <li>the Department for Education's database of qualified teachers</li>
-      <li>the Teachers Pension Service</li>
+      <li>the Teacher Pension Service</li>
     </ul>
 
-    <p class="govuk-body">Your claim payment is taxable. We’ll send some of your personal information to HMRC to ensure the following contributions are met:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>Income Tax and Employee National Insurance (NIC), which we pay on your behalf</li>
-      <li>student loan repayment, which is deducted from your <%= t("#{current_policy_routing_name.underscore}.award_description") %> and credited to your Student Loans Account, if applicable</li>
-    </ul>
+    <h2 class="govuk-heading-m">To pay you</h2>
 
     <p class="govuk-body">
-      We’ll send you a breakdown of these payments when we process your claim.
+      We'll send some of your personal information to our payroll partner Cantium, who are responsible
+      for processing your payment.
     </p>
+
+    <p class="govuk-body">
+      We also send some of your information to HMRC so that:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>your student loan repayment can be deducted from your payment, if applicable</li>
+      <li>we can pay Income Tax and National Insurance (NI) on your behalf</li>
+    </ul>
 
     <%= button_to "Continue", new_verify_authentications_path, method: :get, class: "govuk-button"%>
 
@@ -35,8 +42,26 @@
         </span>
       </summary>
       <div class="govuk-details__text">
-        We send HMRC your full name, date of birth, payment amount and gender details to ensure your
-        tax contributions are met.
+        <p class="govuk-body">
+          We send Cantium and HMRC your:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>full name</li>
+          <li>NI number</li>
+          <li>gender</li>
+          <li>date of birth</li>
+          <li>address</li>
+        </ul>
+
+        <p class="govuk-body">
+          We also send Cantium your:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>email address</li>
+          <li>bank details</li>
+        </ul>
       </div>
     </details>
   </div>

--- a/app/views/static_pages/maths_and_physics.html.erb
+++ b/app/views/static_pages/maths_and_physics.html.erb
@@ -7,7 +7,12 @@
     </h1>
 
     <p class="govuk-body">
-      Claim £2,000 after tax if you:
+      Claim £2,000 after tax. (This may be subject to a small student loan deduction. For more information,
+      visit the <%= link_to "eligibility and payment guidance", MathsAndPhysics.eligibility_page_url %>).
+    </p>
+
+    <p class="govuk-body">
+      You can claim if you:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
This adds the copy set out in [this Miro board](https://miro.com/app/board/o9J_kvoqa7E=/?moveToWidget=3074457347131294063) to try and make it clearer about how we make and pay deductions when a teacher receives their money.

The pages now look like this:

# Temporary Maths and Physics Start Page

![image](https://user-images.githubusercontent.com/109774/72792685-5546f880-3c31-11ea-84a7-471580c8a85f.png)

# Pre-Verification page

![image](https://user-images.githubusercontent.com/109774/72792753-6b54b900-3c31-11ea-8c98-831698d2fbda.png)

![image](https://user-images.githubusercontent.com/109774/72792851-9212ef80-3c31-11ea-8a5b-894cd219c718.png)

# Approval email

![image](https://user-images.githubusercontent.com/109774/72792794-7d365c00-3c31-11ea-972c-686b379a7ae9.png)
