### PR TITLE
Feedback link says it opens in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Feedback link tells users it will open in a new tab
 - Changed existing session page to use radios and tidy up the iterruption card
 - Semantic Logger has been added to make log entries more concise and useful
 - Application logs can now be sent to Logstash for aggregation, analysis and

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -73,7 +73,7 @@
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag ">beta</strong>
           <span class="govuk-phase-banner__text">
-            This is a new service – your <%= link_to "feedback", feedback_url, class: "govuk-link" %> will help us to improve it.
+            This is a new service – your <%= link_to "feedback (opens in a new window or tab)", feedback_url, class: "govuk-link" %> will help us to improve it.
           </span>
         </p>
       </div>


### PR DESCRIPTION
As the link opens in a new window or tab, we should tell the user this
so that they are not sent off somewhere unexpected.

![image](https://user-images.githubusercontent.com/13239597/72793594-925fba80-3c32-11ea-8c22-1e049ddec1b4.png)

