### PR TITLE
Allow soft-deleted KeyVaults to be recovered with a flag

### DIFF
--- a/azure/resource_groups/secrets/template.json
+++ b/azure/resource_groups/secrets/template.json
@@ -17,6 +17,9 @@
       "defaultValue": 365,
       "minValue": 0,
       "maxValue": 365
+    },
+    "keyVaultCreateMode": {
+      "type": "string"
     }
   },
   "variables": {
@@ -82,6 +85,7 @@
         },
         "enabledForTemplateDeployment": true,
         "enableSoftDelete": true,
+        "createMode": "[parameters('keyVaultCreateMode')]",
         "accessPolicies": [
           {
             "tenantId": "[subscription().tenantId]",

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -79,6 +79,7 @@ ALERTS_DEPLOYMENT_NAME=$ALERTS_RESOURCE_GROUP_NAME
 LOGIN_TO_AZURE=1
 CONFIRM_BEFORE_DEPLOY=1
 DEPLOY_ALERTS=1
+RECOVER_KEY_VAULT=
 EXTRA_APP_DEPLOYMENT_OPTIONS=()
 
 while [ "$2" ]; do
@@ -103,6 +104,9 @@ while [ "$2" ]; do
     "--tmp-alerts")
       ALERTS_RESOURCE_GROUP_NAME="$ALERTS_RESOURCE_GROUP_NAME-tmp"
       ALERTS_DEPLOYMENT_NAME="$ALERTS_DEPLOYMENT_NAME-tmp"
+      ;;
+    "--recover-keyvault")
+      RECOVER_KEY_VAULT=1
       ;;
     *)
       echo "Unexpected argument: $2"
@@ -179,7 +183,13 @@ if [ $CONFIRM_BEFORE_DEPLOY ]; then
   read -r
 fi
 
-echo "Starting secrets deployment..."
+if [ $RECOVER_KEY_VAULT ]; then
+  KEYVAULT_CREATE_MODE="recover"
+else
+  KEYVAULT_CREATE_MODE="default"
+fi
+
+echo "Starting secrets deployment with KeyVault createMode: $KEYVAULT_CREATE_MODE..."
 
 SECRETS_DEPLOYMENT_RESULT=$(
   az group deployment create \
@@ -192,6 +202,7 @@ SECRETS_DEPLOYMENT_RESULT=$(
         "$PROJECT_CORE_DEPLOYMENT_RESULT" \
         "['defaultSubnetId']"
       )" \
+    --parameters "keyVaultCreateMode=$KEYVAULT_CREATE_MODE" \
     --mode Complete \
     --verbose \
     <&- || true


### PR DESCRIPTION
We considered making this automatic with another step of the script that checks to see if a soft-deleted KeyVault exists and change the `createMode` depending on the result.

However we decided against it. Deleting a KeyVault is quite a purposeful action, the expected result from the next deployment should error loudly to the user to let them know they need to either delete the KeyVault permanently or recover it explicitly.

The KeyVault can be recovered using the `--recover-keyvault` flag when calling the azure-deploy script.