### PR TITLE
Add environment name tags to Logstash entries

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -8,3 +8,4 @@ DFE_SIGN_IN_API_CLIENT_ID=teacherpayments
 DFE_SIGN_IN_API_ENDPOINT=https://pp-api.signin.education.gov.uk
 
 ADMIN_ALLOWED_IPS=::1,127.0.0.1
+ENVIRONMENT_NAME=local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Update Geckoboard with how many claims are passed their check deadline
+- Log entries are now tagged with their deployed environment
 
 ## [Relase 046] - 2020-01-21
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,7 @@ RUN if [ ${RAILS_ENV} = "production" ]; then \
   DFE_SIGN_IN_API_SECRET= \
   DFE_SIGN_IN_API_ENDPOINT= \
   ADMIN_ALLOWED_IPS= \
+  ENVIRONMENT_NAME= \
   bundle exec rake assets:precompile; \
   fi
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,14 +50,5 @@ module DfeTeachersPaymentService
     config.action_view.form_with_generates_remote_forms = false
 
     config.guidance_url = "https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details"
-
-    if ENV["LOGSTASH_HOST"].present?
-      tcp_logger = LogStashLogger.new(type: :tcp,
-                                      host: ENV.fetch("LOGSTASH_HOST"),
-                                      port: ENV.fetch("LOGSTASH_PORT"),
-                                      ssl_enable: true)
-
-      SemanticLogger.add_appender(logger: tcp_logger, level: :info, formatter: :json)
-    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,11 @@ module DfeTeachersPaymentService
     config.action_view.form_with_generates_remote_forms = false
 
     config.guidance_url = "https://www.gov.uk/government/publications/additional-payments-for-teaching-eligibility-and-payment-details"
+
+    # Additional information which is passed in the logs for each request
+    # See https://rocketjob.github.io/semantic_logger/rails.html#named-tags
+    config.log_tags = {
+      environment: ENV.fetch("ENVIRONMENT_NAME", "unspecified"),
+    }
   end
 end

--- a/config/initializers/logstash.rb
+++ b/config/initializers/logstash.rb
@@ -1,0 +1,10 @@
+if ENV["LOGSTASH_HOST"].present?
+  Rails.application.configure do
+    tcp_logger = LogStashLogger.new(type: :tcp,
+                                    host: ENV.fetch("LOGSTASH_HOST"),
+                                    port: ENV.fetch("LOGSTASH_PORT"),
+                                    ssl_enable: true)
+
+    SemanticLogger.add_appender(logger: tcp_logger, level: :info, formatter: :json)
+  end
+end


### PR DESCRIPTION
This allows for aggregated logs from different deployments to be distinguished in Logstash.