### PR TITLE
1211 setup error messages on claim in progress interruption page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix existing session page so if no option is selected a user doesn't continue
+  their claim
 - Update Geckoboard with how many claims are passed their check deadline
 - Log entries are now tagged with their deployed environment
 

--- a/app/assets/stylesheets/components/panel.scss
+++ b/app/assets/stylesheets/components/panel.scss
@@ -1,5 +1,7 @@
+$interrupt-background-colour: #005a9e;
+
 .govuk-panel--informational {
-  background-color: govuk-colour("blue");
+  background-color: $interrupt-background-colour;
   color: govuk-colour("white");
   text-align: left;
   padding: govuk-spacing(3) - $govuk-border-width;
@@ -31,7 +33,8 @@
     }
   }
 
-  .govuk-button {
+  .govuk-button,
+  .govuk-button:disabled:hover {
     color: govuk-colour("black");
     background-color: govuk-colour("white");
     box-shadow: 0 2px 0 govuk-colour("dark-blue");

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -46,6 +46,10 @@ class ClaimsController < BasePublicController
   end
 
   def start_new
+    new_policy_description = I18n.t("#{params[:policy].underscore}.claim_description")
+
+    return redirect_to existing_session_path, alert: "Select yes if you want to start a claim #{new_policy_description}" unless params[:start_new_claim].present?
+
     if ActiveModel::Type::Boolean.new.cast(params[:start_new_claim]) == true
       clear_claim_session
       redirect_to(new_claim_path(params[:policy]))

--- a/app/views/claims/existing_session.html.erb
+++ b/app/views/claims/existing_session.html.erb
@@ -20,12 +20,12 @@
 
           <div class="govuk-radios govuk-!-margin-bottom-9">
             <div class="govuk-radios__item">
-              <%= form.radio_button(:start_new_claim, false, class: "govuk-radios__input") %>
-              <%= form.label :start_new_claim_false, "No, finish the claim I have in progress", class: "govuk-label govuk-radios__label" %>
-            </div>
-            <div class="govuk-radios__item">
               <%= form.radio_button(:start_new_claim, true, class: "govuk-radios__input") %>
               <%= form.label :start_new_claim_true, "Yes, start claim #{policy_description(params[:policy])} and lose my progress on my first claim", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button(:start_new_claim, false, class: "govuk-radios__input") %>
+              <%= form.label :start_new_claim_false, "No, finish the claim I have in progress", class: "govuk-label govuk-radios__label" %>
             </div>
           </div>
 

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -22,4 +22,10 @@ RSpec.feature "Switching policies" do
 
     expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
   end
+
+  scenario "a user does not select an option" do
+    click_on "Submit"
+
+    expect(page).to have_text("Select yes if you want to start a claim for a payment for teaching maths or physics")
+  end
 end


### PR DESCRIPTION
This PR fixes some issues we found with existing session page.  

- If a user selects no option, they are not routed to complete their existing application.
- When no option is selected a user is shown a flash alert with guidance
- Radio options were reordered to be more logical and follow GDS guidance
- Buttons on interrupt cards will no longer turn green when they have been clicked on and are disabled whilst the next page loads
- Interrupt cards have a darker background colour to provide AAA contrast
- After some discussion, the test was kept in the feature spec

![image](https://user-images.githubusercontent.com/13239597/72896285-4a669380-3d17-11ea-8e35-0b7b6aa7ba3d.png)
