### PR TITLE
Record the mean time to reach a decision on a claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,24 @@ the user IP address as part of the payload data sent to Application Insights in
 [`config/initializers/application_insights.rb`](config/initializers/application_insights.rb)
 for how to mixin this code to your Rails application.
 
+### Geckoboard
+
+The application has a Geckoboard dashboard that is updated every time a Claim is
+submitted or approved, or a payment is recorded. The class that does most of the
+work can be found in app/models/claim/geckoboard_dataset.rb.
+
+If any changes are made to the `DATASET_FIELDS` constant, then it's important
+that the underlying Geckoboard dataset is reset, as the Geckoboard API doesn't
+support adding new fields to an already existing dataset. The easiest way to do
+this is to run the following Rake command:
+
+```bash
+bundle exec rake geckoboard:reset
+```
+
+This deletes the existing dataset, and then recreates the dataset with the
+exisiting claim data.
+
 ### Azure ARM templates
 
 There are some templates that we've abstracted out of our resource group

--- a/app/jobs/geckoboard/update_unchecked_claims_job.rb
+++ b/app/jobs/geckoboard/update_unchecked_claims_job.rb
@@ -3,7 +3,7 @@ module Geckoboard
     self.cron_expression = "0 3 * * *"
 
     def perform
-      Claim::GeckoboardDataset.new(Claim.awaiting_checking).save
+      Claim::GeckoboardDataset.new(claims: Claim.awaiting_checking).save
     end
   end
 end

--- a/app/jobs/record_or_update_geckoboard_dataset_job.rb
+++ b/app/jobs/record_or_update_geckoboard_dataset_job.rb
@@ -1,6 +1,6 @@
 class RecordOrUpdateGeckoboardDatasetJob < ApplicationJob
   def perform(claim_ids)
     claims = Claim.where(id: claim_ids)
-    Claim::GeckoboardDataset.new(claims).save
+    Claim::GeckoboardDataset.new(claims: claims).save
   end
 end

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -14,6 +14,10 @@ class Check < ApplicationRecord
     persisted?
   end
 
+  def number_of_days_since_claim_submitted
+    (claim.check.created_at.to_date - claim.submitted_at.to_date).to_i
+  end
+
   private
 
   def claim_must_be_approvable

--- a/app/models/claim/geckoboard_dataset.rb
+++ b/app/models/claim/geckoboard_dataset.rb
@@ -18,14 +18,18 @@ class Claim
     ]
     BATCH_SIZE = 500
 
-    def initialize(claim_or_claims)
-      @claims = Array(claim_or_claims)
+    def initialize(claims: [])
+      @claims = claims
     end
 
     def save
       batched_claims.each do |batch|
         dataset.post(data_for_claims(batch))
       end
+    end
+
+    def delete
+      client.datasets.delete(dataset_name)
     end
 
     private

--- a/app/models/claim/geckoboard_dataset.rb
+++ b/app/models/claim/geckoboard_dataset.rb
@@ -12,6 +12,7 @@ class Claim
       Geckoboard::StringField.new(:checked, name: "Checked"),
       Geckoboard::DateTimeField.new(:checked_at, name: "Checked at"),
       Geckoboard::StringField.new(:check_result, name: "Check result"),
+      Geckoboard::NumberField.new(:number_of_days_to_check, name: "Number of days to check", optional: true),
       Geckoboard::StringField.new(:paid, name: "Paid"),
       Geckoboard::DateTimeField.new(:paid_at, name: "Paid at"),
     ]
@@ -39,6 +40,7 @@ class Claim
           checked: claim.check.present?.to_s,
           checked_at: claim.check.present? ? claim.check.created_at : placeholder_date_for_nil_value,
           check_result: claim.check.present? ? claim.check.result : "",
+          number_of_days_to_check: claim.check&.number_of_days_since_claim_submitted,
           paid: claim.scheduled_payment_date.present?.to_s,
           paid_at: claim.scheduled_payment_date.presence || placeholder_date_for_nil_value,
         }

--- a/app/models/claim/geckoboard_dataset.rb
+++ b/app/models/claim/geckoboard_dataset.rb
@@ -4,6 +4,10 @@ class Claim
   class GeckoboardDataset
     attr_reader :claims
 
+    # If any change is made to the `DATASET_FIELDS` constant below, it's important
+    # to run the `rake geckoboard:reset` task.
+    # See https://github.com/DFE-Digital/dfe-teachers-payment-service#geckoboard for more
+    # detail
     DATASET_FIELDS = [
       Geckoboard::StringField.new(:reference, name: "Reference"),
       Geckoboard::StringField.new(:policy, name: "Policy"),

--- a/lib/tasks/geckoboard.rake
+++ b/lib/tasks/geckoboard.rake
@@ -1,0 +1,7 @@
+namespace :geckoboard do
+  desc "Reset and recreate Geckoboard claims dataset"
+  task reset: :environment do
+    Claim::GeckoboardDataset.new.delete
+    Claim::GeckoboardDataset.new(claims: Claim.submitted).save
+  end
+end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -23,4 +23,11 @@ RSpec.describe Check, type: :model do
     expect(check).not_to be_valid
     expect(check.errors.messages[:base]).to eq(["This claim cannot be approved"])
   end
+
+  it "returns the number of days between the claim being submitted and the claim being checked" do
+    claim = create(:claim, :submitted, submitted_at: 12.days.ago)
+    check = build(:check, claim: claim, created_at: DateTime.now)
+
+    expect(check.number_of_days_since_claim_submitted).to eq(12)
+  end
 end

--- a/spec/models/claim/geckoboard_dataset_spec.rb
+++ b/spec/models/claim/geckoboard_dataset_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Claim::GeckoboardDataset, type: :model do
 
   it "sends a claim's details to the Geckoboard dataset" do
     ClimateControl.modify ENVIRONMENT_NAME: "test" do
-      event = Claim::GeckoboardDataset.new([claim])
+      event = Claim::GeckoboardDataset.new(claims: [claim])
 
       dataset_post_stub = stub_geckoboard_dataset_update("claims.test")
 
@@ -21,7 +21,7 @@ RSpec.describe Claim::GeckoboardDataset, type: :model do
     let(:claims) { build_list(:claim, 520, :submitted, created_at: DateTime.now) }
 
     it "batches the claims into groups" do
-      event = Claim::GeckoboardDataset.new(claims)
+      event = Claim::GeckoboardDataset.new(claims: claims)
 
       dataset_post_stub = stub_geckoboard_dataset_update("claims.test")
 
@@ -34,6 +34,17 @@ RSpec.describe Claim::GeckoboardDataset, type: :model do
       expect(dataset_post_stub.with { |request|
         request_body_matches_geckoboard_data_for_claims?(request, claims.last(20))
       }).to have_been_requested
+    end
+  end
+
+  describe "#delete" do
+    it "deletes the dataset" do
+      dataset_delete_stub = stub_geckoboard_dataset_delete("claims.test")
+
+      dataset = Claim::GeckoboardDataset.new
+      dataset.delete
+
+      expect(dataset_delete_stub).to have_been_requested
     end
   end
 end

--- a/spec/support/geckoboard_helpers.rb
+++ b/spec/support/geckoboard_helpers.rb
@@ -37,6 +37,11 @@ module GeckoboardHelpers
         name: "Check result",
         type: "string",
       },
+      number_of_days_to_check: {
+        name: "Number of days to check",
+        optional: true,
+        type: "number",
+      },
       paid: {
         name: "Paid",
         type: "string",
@@ -75,6 +80,7 @@ module GeckoboardHelpers
         "checked" => claim.check.present?.to_s,
         "checked_at" => (claim.check.present? ? claim.check.created_at : DateTime.parse("1970-01-01")).strftime("%Y-%m-%dT%H:%M:%S%:z"),
         "check_result" => claim.check.present? ? claim.check.result : "",
+        "number_of_days_to_check" => claim.check&.number_of_days_since_claim_submitted,
         "paid" => claim.payment.present?.to_s,
         "paid_at" => (claim.payment.present? ? claim.scheduled_payment_date : DateTime.parse("1970-01-01")).strftime("%Y-%m-%dT%H:%M:%S%:z"),
       }

--- a/spec/support/geckoboard_helpers.rb
+++ b/spec/support/geckoboard_helpers.rb
@@ -70,6 +70,10 @@ module GeckoboardHelpers
     stub_request(:post, "https://api.geckoboard.com/datasets/#{dataset_id}/data")
   end
 
+  def stub_geckoboard_dataset_delete(dataset_id)
+    stub_request(:delete, "https://api.geckoboard.com/datasets/#{dataset_id}")
+  end
+
   def request_body_matches_geckoboard_data_for_claims?(request, claims)
     expected_claims_data = claims.map { |claim|
       {


### PR DESCRIPTION
This updates the Geckoboard dataset to add a `number_of_days_to_check` value, which gets updated when a claim is approved. This will then allow us to show the average number of days it takes a claim to be approved / rejected on our dashboard(s)
