### PR TITLE
Prevent service operator from approving an inconsistent claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog]
 
 - Update Geckoboard with how many claims are passed their check deadline
 - Log entries are now tagged with their deployed environment
+- Prevent service operator from approving a claim when it is inconsistent with
+  another claim awaiting payment to the same claimant, if this would prevent us
+  from running payroll
 
 ## [Relase 046] - 2020-01-21
 

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -18,6 +18,8 @@ class Admin::ClaimsController < Admin::BaseAdminController
     @claim = Claim.find(params[:id])
     @check = @claim.check || Check.new
     @matching_claims = Claim::MatchingAttributeFinder.new(@claim).matching_claims
+    @inconsistent_claims = @claim.inconsistent_claims
+    @inconsistent_attributes = @claim.inconsistent_attributes(@inconsistent_claims)
   end
 
   def search

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -66,6 +66,18 @@
       </table>
     <% end %>
 
+    <% if @inconsistent_claims.any? %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          This claim cannot be approved because <%= @inconsistent_claims.count == 1 ? 'claim' : 'claims' %> <%= @inconsistent_claims.map(&:reference).to_sentence %>
+          from the same claimant <%= @inconsistent_claims.count == 1 ? "has" : "have" %> different
+          values for <%= @inconsistent_attributes.map { |attribute| Claim.human_attribute_name(attribute).downcase }.to_sentence %>
+        </strong>
+      </div>
+    <% end %>
+
     <% if @check.persisted? %>
       <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_check_details(@check)} %>
     <% else %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,6 +3,26 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "858823e2fccbbf0b77c3d2f575633b2c787067ce615a8203ea5f39a30edc785c",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/claim.rb",
+      "line": 258,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Claim.payrollable.joins(\"INNER JOIN claims AS this_claim ON claims.id != this_claim.id              AND claims.national_insurance_number = this_claim.national_insurance_number              AND (#{Payment::PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES.map do\n \"claims.#{attribute} IS DISTINCT FROM this_claim.#{attribute}\"\n end.join(\" OR \")})\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Claim",
+        "method": "inconsistent_claims"
+      },
+      "user_input": "Payment::PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES.map",
+      "confidence": "High",
+      "note": "The `attribute` values inserted into the SQL come from a constant array; they are not user-generated."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "aac74520956533997d73d1c601c2bcde5d3cd501f14401fb9cb8e2bfdc7862fa",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -41,6 +61,6 @@
       "note": "We generate the filename based on non-user input so we can ignore this"
     }
   ],
-  "updated": "2019-12-17 11:26:22 +0000",
+  "updated": "2020-01-21 16:27:32 +0000",
   "brakeman_version": "4.7.2"
 }

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -92,6 +92,31 @@ RSpec.feature "Admin checks a claim" do
       end
     end
 
+    context "When the claimant has another approved claim in the same payroll window, with inconsistent personal details" do
+      let(:personal_details) do
+        {
+          national_insurance_number: generate(:national_insurance_number),
+          teacher_reference_number: generate(:teacher_reference_number),
+          date_of_birth: 30.years.ago.to_date,
+          student_loan_plan: StudentLoan::PLAN_1,
+          email_address: "email@example.com",
+          bank_sort_code: "112233",
+          bank_account_number: "95928482",
+          building_society_roll_number: nil,
+        }
+      end
+      let!(:claim) { create(:claim, :submitted, personal_details.merge(bank_sort_code: "582939", bank_account_number: "74727752")) }
+      let!(:approved_claim) { create(:claim, :approved, personal_details.merge(bank_sort_code: "112233", bank_account_number: "29482823")) }
+
+      scenario "User is informed that the claim cannot be approved" do
+        click_on "View claims"
+        find("a[href='#{admin_claim_path(claim)}']").click
+
+        expect(page).to have_field("Approve", disabled: true)
+        expect(page).to have_content("This claim cannot be approved because claim #{approved_claim.reference} from the same claimant has different values for bank sort code and bank account number")
+      end
+    end
+
     context "When the claimant has not completed GOV.UK Verify" do
       let!(:claim_without_identity_confirmation) { create(:claim, :unverified) }
 

--- a/spec/requests/admin_claim_checks_spec.rb
+++ b/spec/requests/admin_claim_checks_spec.rb
@@ -85,6 +85,42 @@ RSpec.describe "Admin claim checks", type: :request do
           end
         end
       end
+
+      context "when the claimant has another approved claim in the same payroll window, with inconsistent personal details" do
+        let(:personal_details) do
+          {
+            national_insurance_number: generate(:national_insurance_number),
+            teacher_reference_number: generate(:teacher_reference_number),
+            date_of_birth: 30.years.ago.to_date,
+            student_loan_plan: StudentLoan::PLAN_1,
+            email_address: "email@example.com",
+            bank_sort_code: "112233",
+            bank_account_number: "95928482",
+            building_society_roll_number: nil,
+          }
+        end
+        let(:claim) { create(:claim, :submitted, personal_details.merge(bank_sort_code: "582939", bank_account_number: "74727752")) }
+        let!(:approved_claim) { create(:claim, :approved, personal_details.merge(bank_sort_code: "112233", bank_account_number: "29482823")) }
+        before do
+          post admin_claim_checks_path(claim_id: claim.id, check: {result: result})
+          follow_redirect!
+        end
+
+        context "and the user attempts to approve" do
+          let(:result) { "approved" }
+          it "shows an error" do
+            expect(response.body).to include("Claim cannot be approved because there are inconsistent claims")
+          end
+        end
+
+        context "and the user attempts to reject" do
+          let(:result) { "rejected" }
+          it "doesn’t show an error and rejects successfully" do
+            expect(response.body).not_to include("Claim cannot be approved")
+            expect(response.body).to include("Claim has been rejected successfully")
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This implements the work hinted at in 2d7bf9b. If a service operator
views a claim for which there is a claim from the same claimant which
has been approved but not yet payrolled, and which has inconsistent
personal details which would prevent the two claims from being combined
into a single payment, then inform the service operator that this has
happened and prevent them from approving the claim.

This means that it is now unlikely that we will ever violate the
validations introduced on Payment in 2d7bf9b, but we keep them as an
additional safety net.

We still need to decide how a service operator can resolve this situation
of an inconsistent claim. For example, one option would be to contact
the claimant and ask them whether they are happy to be paid in two
different months or to ask them to re-submit their claim. If we wanted
to enable this sort of conversation, we may need to think about exposing
a subset of the claimant's bank details to the service operator (in a
privacy-preserving manner).

The implementation and user interface follow the same patterns that we
use for the "payroll gender missing" situation.

* Screenshot

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/53756884/72901551-e5fd0180-3d21-11ea-80bd-64dc9c710d1b.png">
