### PR TITLE
Prevent service operator from approving an inconsistent claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog]
 - Log entries are now tagged with their deployed environment
 - Record the the time in days between submitting and approving a claim
 - Add a Rake task to update a Geckoboard dataset when a new field has been added
+- Prevent service operator from approving a claim if we would not be able to pay
+  it in the current payroll month because we are already paying the same
+  claimant for another claim with different payment details
 
 ## [Relase 046] - 2020-01-21
 

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -18,6 +18,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
     @claim = Claim.find(params[:id])
     @check = @claim.check || Check.new
     @matching_claims = Claim::MatchingAttributeFinder.new(@claim).matching_claims
+    @claims_preventing_payment = Claim::ClaimsPreventingPaymentFinder.new(@claim).claims_preventing_payment
   end
 
   def search

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -174,7 +174,7 @@ class Claim < ApplicationRecord
   end
 
   def approvable?
-    submitted? && !payroll_gender_missing? && !checked?
+    submitted? && !payroll_gender_missing? && !checked? && !payment_prevented_by_other_claims?
   end
 
   def checked?
@@ -183,6 +183,10 @@ class Claim < ApplicationRecord
 
   def payroll_gender_missing?
     %w[male female].exclude?(payroll_gender)
+  end
+
+  def payment_prevented_by_other_claims?
+    ClaimsPreventingPaymentFinder.new(self).claims_preventing_payment.any?
   end
 
   def check_deadline_date

--- a/app/models/claim/claims_preventing_payment_finder.rb
+++ b/app/models/claim/claims_preventing_payment_finder.rb
@@ -1,0 +1,38 @@
+class Claim
+  class ClaimsPreventingPaymentFinder
+    attr_reader :claim
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    # Returns a list of claims which prevent us from adding `claim` to the
+    # payroll run for the current month.
+    #
+    # These claims are payrollable, and submitted by the same claimant as
+    # `claim`, as identified by National Insurance number.
+    #
+    # The returned claims have different payment or tax details to those
+    # provided by `claim`, and hence `claim` cannot be paid in the same payment
+    # as the returned claims.
+    def claims_preventing_payment
+      @claims_preventing_payment ||= find_claims_preventing_payment
+    end
+
+    private
+
+    def find_claims_preventing_payment
+      payrollable_claims_from_same_claimant = Claim.payrollable.where(national_insurance_number: claim.national_insurance_number)
+
+      payrollable_claims_from_same_claimant.select do |other_claim|
+        Payment::PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES.any? do |attribute|
+          attribute_does_not_match?(other_claim, attribute)
+        end
+      end
+    end
+
+    def attribute_does_not_match?(claim_to_compare, attribute)
+      claim_to_compare.read_attribute(attribute) != claim.read_attribute(attribute)
+    end
+  end
+end

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -66,6 +66,16 @@
       </table>
     <% end %>
 
+    <% if @claims_preventing_payment.any? %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          <%= t('admin.claims_preventing_payment_message', count: @claims_preventing_payment.count, claim_references: @claims_preventing_payment.map(&:reference).to_sentence) %>
+        </strong>
+      </div>
+    <% end %>
+
     <% if @check.persisted? %>
       <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_check_details(@check)} %>
     <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,9 @@ en:
       result: "Result"
       notes: "Notes"
       checked_by: "Checked by"
+    claims_preventing_payment_message:
+      one: This claim cannot currently be approved because we’re already paying another claim (%{claim_references}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.
+      other: This claim cannot currently be approved because we’re already paying other claims (%{claim_references}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.
   answers:
     student_loan_start_date:
       one_course:

--- a/spec/models/claim/claims_preventing_payment_finder_spec.rb
+++ b/spec/models/claim/claims_preventing_payment_finder_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Claim::ClaimsPreventingPaymentFinder do
+  subject(:finder) { described_class.new(claim) }
+
+  describe "#claims_preventing_payment" do
+    let(:personal_details) do
+      {
+        national_insurance_number: generate(:national_insurance_number),
+        bank_account_number: "32828838",
+        bank_sort_code: "183828",
+        first_name: "Boris",
+      }
+    end
+    let(:claim) { create(:claim, :submitted, personal_details) }
+    subject(:claims_preventing_payment) { finder.claims_preventing_payment }
+
+    context "when there is another claim with the same National Insurance number, with inconsistent personal details that would prevent us from running payroll" do
+      let(:inconsistent_personal_details) do
+        personal_details.merge(
+          bank_account_number: "87282828",
+          bank_sort_code: "388183",
+        )
+      end
+
+      it "does not include the other claim when the other claim is not yet approved" do
+        create(:claim, :submitted, inconsistent_personal_details)
+        expect(claims_preventing_payment).to be_empty
+      end
+
+      it "includes the other claim when the other claim is approved but not yet payrolled" do
+        other_claim = create(:claim, :approved, inconsistent_personal_details)
+        expect(claims_preventing_payment).to eq([other_claim])
+      end
+
+      it "does not include the other claim when the other claim is already payrolled" do
+        other_claim = create(:claim, :approved, inconsistent_personal_details)
+        create(:payment, claims: [other_claim])
+        expect(claims_preventing_payment).to be_empty
+      end
+    end
+
+    context "when there is another claim with the same National Insurance number, with inconsistent details that would not prevent us from running payroll" do
+      let(:inconsistent_personal_details) do
+        personal_details.merge(
+          first_name: "Jarvis",
+        )
+      end
+
+      it "does not include the other claim even if that claim is approved and not yet payrolled" do
+        create(:claim, :approved, inconsistent_personal_details)
+        expect(claims_preventing_payment).to be_empty
+      end
+    end
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -453,6 +453,13 @@ RSpec.describe Claim, type: :model do
       expect(create(:claim, :approved).approvable?).to eq false
       expect(create(:claim, :rejected).approvable?).to eq false
     end
+
+    it "returns false when there exists another payrollable claim with the same National Insurance number but with inconsistent attributes that would prevent us from running payroll" do
+      national_insurance_number = generate(:national_insurance_number)
+      create(:claim, :approved, national_insurance_number: national_insurance_number, date_of_birth: 20.years.ago)
+
+      expect(create(:claim, :submitted, national_insurance_number: national_insurance_number, date_of_birth: 30.years.ago).approvable?).to eq false
+    end
   end
 
   describe "#payroll_gender_missing?" do

--- a/spec/requests/admin_claim_checks_spec.rb
+++ b/spec/requests/admin_claim_checks_spec.rb
@@ -85,6 +85,42 @@ RSpec.describe "Admin claim checks", type: :request do
           end
         end
       end
+
+      context "when the claimant has another approved claim in the same payroll window, with inconsistent personal details" do
+        let(:personal_details) do
+          {
+            national_insurance_number: generate(:national_insurance_number),
+            teacher_reference_number: generate(:teacher_reference_number),
+            date_of_birth: 30.years.ago.to_date,
+            student_loan_plan: StudentLoan::PLAN_1,
+            email_address: "email@example.com",
+            bank_sort_code: "112233",
+            bank_account_number: "95928482",
+            building_society_roll_number: nil,
+          }
+        end
+        let(:claim) { create(:claim, :submitted, personal_details.merge(bank_sort_code: "582939", bank_account_number: "74727752")) }
+        let!(:approved_claim) { create(:claim, :approved, personal_details.merge(bank_sort_code: "112233", bank_account_number: "29482823")) }
+        before do
+          post admin_claim_checks_path(claim_id: claim.id, check: {result: result})
+          follow_redirect!
+        end
+
+        context "and the user attempts to approve" do
+          let(:result) { "approved" }
+          it "shows an error" do
+            expect(response.body).to include("Claim cannot be approved because there are inconsistent claims")
+          end
+        end
+
+        context "and the user attempts to reject" do
+          let(:result) { "rejected" }
+          it "doesn’t show an error and rejects successfully" do
+            expect(response.body).not_to include("Claim cannot be approved")
+            expect(response.body).to include("Claim has been rejected successfully")
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This implements the work hinted at in 2d7bf9b. If a service operator
views a claim for which there is a claim from the same claimant which
has been approved but not yet payrolled, and which has inconsistent
personal details which would prevent the two claims from being combined
into a single payment, then inform the service operator that this has
happened and prevent them from approving the claim.

This means that it is now unlikely that we will ever violate the
validations introduced on Payment in 2d7bf9b, but we keep them as an
additional safety net.

We still need to decide how a service operator can resolve this situation
of an inconsistent claim. For example, one option would be to contact
the claimant and ask them whether they are happy to be paid in two
different months or to ask them to re-submit their claim. If we wanted
to enable this sort of conversation, we may need to think about exposing
a subset of the claimant's bank details to the service operator (in a
privacy-preserving manner).

The implementation and user interface follow the same patterns that we
use for the "payroll gender missing" situation.

* Screenshot

<img width="762" alt="Screenshot 2020-01-22 at 14 40 23" src="https://user-images.githubusercontent.com/53756884/72903469-2d38c180-3d25-11ea-8af2-e6d884a45337.png">
