### PR TITLE
Adjust schools import timing to 6am

### DIFF
--- a/app/jobs/school_data_importer_job.rb
+++ b/app/jobs/school_data_importer_job.rb
@@ -1,5 +1,5 @@
 class SchoolDataImporterJob < CronJob
-  self.cron_expression = "0 4 * * *"
+  self.cron_expression = "0 6 * * *"
 
   queue_as :school_data
 


### PR DESCRIPTION
We have been getting sporadic 500 responses from GIAS when we've been running this job at 4am. Having asked GIAS about it they have suggested we shift the job to 6am to minimise the chance that our request will clash with them refreshing the file.
