### PR TITLE
Ensure that the default Rake task uses the `test` environment by default

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,10 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+if Rake.application.top_level_tasks.include?("default")
+  ENV["RAILS_ENV"] ||= "test"
+end
+
 require_relative "config/application"
 
 Rails.application.load_tasks


### PR DESCRIPTION
We use the default Rake task as our standard invocation for running the
test suite and other code quality checks. We noticed that running
`bundle exec rake` was causing dotenv to use the ENVIRONMENT_NAME
variable from the .env.development file, and not .env.test as expected.

We found out that other people have also been experiencing this issue
[1]. The linked comment explains in detail what causes this to happen,
but the gist is that dotenv loads the .env.development file first, and
then loads the .env.test file. However, by default dotenv will not
overwrite the variables defined in the first file with those defined in
the second, so we end up with the incorrect ENVIRONMENT_NAME being used.

The same comment suggested adding `Dotenv.overload('.env.test')` to
`spec/rails_helper.rb`. This wasn't sufficient for us, since by the time
this happens, our config/initializers/dfe_sign_in.rb had already grabbed
the (wrong) values from the environment.

Anyway, ideally, we don't want to load the .env.development file _at
all_ when running the tests, so I didn't try to figure out how to make
the previous approach work. Instead, we noticed that dotenv contains a
special hack, which sets RAILS_ENV to `test` when the currently-running
Rake task is `spec` [2]. There is currently an open pull request on
dotenv which does the same thing when running the default Rake task [3],
but it doesn't seem to have attracted any attention.

In the end I decided to emulate the dotenv hack, by setting RAILS_ENV to
`test` if running the default Rake task. I do this in the Rakefile,
before any of the Rails application is loaded, to ensure that setting
this environment variable happens before dotenv has a chance to load
.development.env.

[1] https://github.com/bkeepers/dotenv/issues/219#issuecomment-164664040
[2] https://github.com/bkeepers/dotenv/pull/241
[3] https://github.com/bkeepers/dotenv/pull/405

<!-- Do you need to update CHANGELOG.md? -->
