### PR TITLE
Changes to achieve AAA status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - QLS questions now refer to academic year, instead of "1 September"
+- Styling tweaks to make the service AAA accessible. Accessiblity updated to
+  reflect AAA status
 
 ## [Relase 047] - 2020-01-23
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 $govuk-font-url-function: "image-url";
 $govuk-image-url-function: "font-url";
 
+@import "components/gds_kit_tweaks";
 @import "govuk-frontend/govuk/all";
 @import "accessible-autocomplete/src/autocomplete";
 

--- a/app/assets/stylesheets/components/gds_kit_tweaks.scss
+++ b/app/assets/stylesheets/components/gds_kit_tweaks.scss
@@ -1,3 +1,5 @@
+$govuk-link-colour: #175b96;
+
 .govuk-hint {
   color: #52575b;
 }

--- a/app/assets/stylesheets/components/gds_kit_tweaks.scss
+++ b/app/assets/stylesheets/components/gds_kit_tweaks.scss
@@ -1,5 +1,13 @@
 $govuk-link-colour: #175b96;
 
+:not(.govuk-panel--interruption)input.govuk-button:not(.govuk-button.govuk-button--secondary) {
+  background-color: #006636;
+
+  &:hover {
+    background-color: #00562e;
+  }
+}
+
 .govuk-hint {
   color: #52575b;
 }

--- a/app/assets/stylesheets/components/gds_kit_tweaks.scss
+++ b/app/assets/stylesheets/components/gds_kit_tweaks.scss
@@ -3,3 +3,15 @@ $govuk-link-colour: #175b96;
 .govuk-hint {
   color: #52575b;
 }
+
+.govuk-phase-banner__content a {
+  color: $govuk-link-colour;
+}
+
+.govuk-tag {
+  background-color: $govuk-link-colour;
+}
+
+.govuk-header__container {
+  border-bottom-color: $govuk-link-colour;
+}

--- a/app/assets/stylesheets/components/panel.scss
+++ b/app/assets/stylesheets/components/panel.scss
@@ -1,7 +1,5 @@
-$interrupt-background-colour: #005a9e;
-
 .govuk-panel--informational {
-  background-color: $interrupt-background-colour;
+  background-color: $govuk-link-colour;
   color: govuk-colour("white");
   text-align: left;
   padding: govuk-spacing(3) - $govuk-border-width;
@@ -19,7 +17,7 @@ $interrupt-background-colour: #005a9e;
 }
 
 .govuk-panel--interruption {
-  background-color: govuk-colour("blue");
+  background-color: $govuk-link-colour;
   text-align: left;
 
   * {

--- a/app/assets/stylesheets/components/panel.scss
+++ b/app/assets/stylesheets/components/panel.scss
@@ -24,6 +24,13 @@
     color: govuk-colour("white");
   }
 
+  .govuk-radios__label::before,
+  & ::after {
+    color: govuk-colour("black");
+    border-color: govuk-colour("black");
+    background-color: govuk-colour("white");
+  }
+
   .govuk-list--definition {
     dt,
     dd {

--- a/app/assets/stylesheets/components/panel.scss
+++ b/app/assets/stylesheets/components/panel.scss
@@ -39,4 +39,8 @@ $interrupt-background-colour: #005a9e;
     background-color: govuk-colour("white");
     box-shadow: 0 2px 0 govuk-colour("dark-blue");
   }
+
+  .govuk-button:hover {
+    background-color: govuk-colour("light-grey");
+  }
 }

--- a/app/assets/stylesheets/components/school_search.scss
+++ b/app/assets/stylesheets/components/school_search.scss
@@ -1,3 +1,8 @@
+.autocomplete__option--focused,
+.autocomplete__option:hover {
+  background-color: $govuk-link-colour;
+}
+
 .school-search__suggestion {
   display: flex;
   justify-content: space-between;

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -95,12 +95,12 @@
     <h2 class="govuk-heading-l">How we tested this website</h2>
 
     <p class="govuk-body">
-      This website was last tested on 2 September 2019. The test was carried out by the
+      This website was last tested on 17 January 2020. The test was carried out by the
       <%= link_to "Digital Accessibility Centre", "https://digitalaccessibilitycentre.org/", class: "govuk-link" %>.
     </p>
 
     <p class="govuk-body">
-      This statement was prepared on 31 July 2019. It was last updated on 18 September 2019.
+      This statement was prepared on 31 July 2019. It was last updated on 23 January 2020.
     </p>
 
   </div>

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -89,7 +89,7 @@
     </p>
 
     <p class="govuk-body">
-      We believe this website is compliant with the Web Content Accessibility Guidelines version 2.1 AA standard.
+      We believe this website is compliant with the Web Content Accessibility Guidelines version 2.1 AAA standard.
     </p>
 
     <h2 class="govuk-heading-l">How we tested this website</h2>

--- a/app/views/static_pages/maths_and_physics.html.erb
+++ b/app/views/static_pages/maths_and_physics.html.erb
@@ -8,7 +8,7 @@
 
     <p class="govuk-body">
       Claim £2,000 after tax. (This may be subject to a small student loan deduction. For more information,
-      visit the <%= link_to "eligibility and payment guidance", MathsAndPhysics.eligibility_page_url %>).
+      visit the <%= link_to "eligibility and payment guidance", MathsAndPhysics.eligibility_page_url, class: "govuk-link" %>).
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
The GDS design system targets AA status due to the complexities and practicalities of what some services are. This PR tweaks parts of the design system and some of the custom components that we have added to provide the necessary contrast for us to achieve AAA status. 🤞

The main focus is the contrast on small text (anything under 24px) and mainly involves selecting darker colours for button and links etc to provide that contrast. Whilst the hover state of the govuk-buttons has been changed there is no contrast requirement between normal, hover and disabled states.

![Screenshot 2020-01-27 at 12 41 34](https://user-images.githubusercontent.com/13239597/73175596-79f41200-4102-11ea-8297-2823f36fafe8.png)

![image](https://user-images.githubusercontent.com/13239597/72999218-f337f000-3df6-11ea-86e1-6022b46f3a45.png)

![image](https://user-images.githubusercontent.com/13239597/72999313-18c4f980-3df7-11ea-8f21-a69e09094eb9.png)

![image](https://user-images.githubusercontent.com/13239597/72999408-3e520300-3df7-11ea-84b3-0c0029b84103.png)

