### PR TITLE
Fix environment not appearing in logs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,7 @@ module DfeTeachersPaymentService
     # Additional information which is passed in the logs for each request
     # See https://rocketjob.github.io/semantic_logger/rails.html#named-tags
     config.log_tags = {
+      request_id: :request_id,
       environment: ENV.fetch("ENVIRONMENT_NAME", "unspecified"),
     }
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,9 +45,6 @@ Rails.application.configure do
   # when problems arise.
   config.log_level = :info
 
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 


### PR DESCRIPTION
We've added the environment to our logs, but this was getting overridden by a config variable in production.rb which was appending the request ID to all logs. We can fix this by setting all the log tag in application.rb.

<!-- Do you need to update CHANGELOG.md? -->
