### PR TITLE
Auto email teachers 3 weeks after a claim is submitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Emails are sent for unchecked claims three weeks after they are submitted,
+  advising users that their claim is still in progress
+
 ## [Release 048] - 2020-01-28
 
 - QLS questions now refer to academic year, instead of "1 September"

--- a/app/jobs/send_emails_after_three_weeks_job.rb
+++ b/app/jobs/send_emails_after_three_weeks_job.rb
@@ -1,0 +1,20 @@
+# Runs every morning at 8am. Finds claims which are not yet checked and which
+# are three weeks old, and sends an email saying we are still in the process of
+# checking.
+
+class SendEmailsAfterThreeWeeksJob < CronJob
+  self.cron_expression = "0 8 * * *"
+
+  def perform
+    Rails.logger.info "Sending three-week emails to #{three_week_old_unchecked_claims.count} unchecked claims from the database"
+    three_week_old_unchecked_claims.each do |claim|
+      ClaimMailer.update_after_three_weeks(claim).deliver_later
+    end
+  end
+
+  private
+
+  def three_week_old_unchecked_claims
+    Claim.awaiting_checking.where(submitted_at: (21.days.ago.beginning_of_day...21.days.ago.end_of_day))
+  end
+end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -17,6 +17,11 @@ class ClaimMailer < ApplicationMailer
     view_mail_with_claim_and_subject(claim, "Your claim #{@claim_description} has been rejected, reference number: #{claim.reference}")
   end
 
+  def update_after_three_weeks(claim)
+    @claim_description = claim_description(claim)
+    view_mail_with_claim_and_subject(claim, "We are still reviewing your claim #{@claim_description}, reference number: #{claim.reference}")
+  end
+
   private
 
   def claim_description(claim)

--- a/app/views/claim_mailer/update_after_three_weeks.text.erb
+++ b/app/views/claim_mailer/update_after_three_weeks.text.erb
@@ -1,0 +1,11 @@
+Dear <%= @display_name %>,
+
+We're still reviewing your claim <%= @claim_description %>, which we received on <%= @claim.submitted_at %>. Claim reference: <%= @claim.reference %>.
+
+We'll notify you as your claim progresses. We do not expect any delays to the processing of your claim.
+
+You do not need to do anything.
+
+Regards,
+
+The Claim additional payments for teaching team

--- a/spec/jobs/send_emails_after_three_weeks_job_spec.rb
+++ b/spec/jobs/send_emails_after_three_weeks_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe SendEmailsAfterThreeWeeksJob do
+  before do
+    create_list(:claim, 2, :submitted, submitted_at: 21.days.ago)
+    create_list(:claim, 2, :submitted, submitted_at: 40.days.ago)
+    create_list(:claim, 2, :submitted, submitted_at: 3.days.ago)
+    create_list(:claim, 2, :approved, submitted_at: 21.days.ago)
+    create_list(:claim, 2)
+  end
+
+  describe "#perform" do
+    it "sends the expected number of emails" do
+      expect {
+        perform_enqueued_jobs do
+          SendEmailsAfterThreeWeeksJob.new.perform
+        end
+      }.to change { ActionMailer::Base.deliveries.count }.by(2)
+    end
+  end
+end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -74,6 +74,18 @@ RSpec.describe ClaimMailer, type: :mailer do
           expect(mail.body.encoded).to include("not been able to approve")
         end
       end
+
+      describe "#update_after_three_weeks" do
+        let(:claim) { build(:claim, :submitted, policy: policy) }
+        let(:mail) { ClaimMailer.update_after_three_weeks(claim) }
+
+        it_behaves_like "an email related to a claim", policy
+
+        it "mentions that the claim is still being reviewed in the subject and body" do
+          expect(mail.subject).to include("still reviewing your claim")
+          expect(mail.body.encoded).to include("still reviewing your claim")
+        end
+      end
     end
   end
 end

--- a/spec/mailers/previews/claim_mailer_preview.rb
+++ b/spec/mailers/previews/claim_mailer_preview.rb
@@ -11,6 +11,10 @@ class ClaimMailerPreview < ActionMailer::Preview
     ClaimMailer.rejected(claim_for(Claim.rejected))
   end
 
+  def update_after_three_weeks
+    ClaimMailer.update_after_three_weeks(claim_for(Claim.update_after_three_weeks))
+  end
+
   private
 
   def claim_for(scope)


### PR DESCRIPTION
Send emails every morning for claims which have been submitted three weeks ago (to the day).

This does not include any logic for retrying emails should a job fail, on the grounds that the emails themselves are purely advisory and don't form an integral part of the claim flow.