### PR TITLE
Add Rake task to export data needed for school subject check email

### DIFF
--- a/app/models/claim/school_check_email_data_export.rb
+++ b/app/models/claim/school_check_email_data_export.rb
@@ -1,0 +1,49 @@
+require "csv"
+
+class Claim
+  # Generates CSV data giving the information needed by a service operator to
+  # perform the mail merge which they use to send the "school check" emails.
+  # These are emails which a service operator sends to schools to verify the
+  # eligibility information provided by the claimant.
+  #
+  # The service operator must give us a list of claim references for which the
+  # school check email has already been sent. These claims will be excluded
+  # from the output of this class.
+  class SchoolCheckEmailDataExport
+    attr_reader :comma_separated_claim_references_to_exclude
+
+    def initialize(comma_separated_claim_references_to_exclude)
+      @comma_separated_claim_references_to_exclude = comma_separated_claim_references_to_exclude
+    end
+
+    def csv_string
+      CSV.generate { |csv|
+        csv << ["Claim reference", "Policy", "Current school URN", "Current school name", "Claimant name", "Subject"]
+
+        claims.each do |claim|
+          csv << [claim.reference, claim.policy.name, claim.school.urn, claim.school.name, claimant_name(claim), subject(claim)]
+        end
+      }
+    end
+
+    private
+
+    def claims
+      Claim.submitted
+        .where.not(reference: claim_references_to_exclude)
+        .includes(eligibility: [:current_school])
+    end
+
+    def claim_references_to_exclude
+      comma_separated_claim_references_to_exclude.split(",")
+    end
+
+    def claimant_name(claim)
+      [claim.first_name, claim.surname].compact.join(" ")
+    end
+
+    def subject(claim)
+      claim.policy::SchoolCheckEmailDataExportPresenter.new(claim).subject
+    end
+  end
+end

--- a/app/models/maths_and_physics/school_check_email_data_export_presenter.rb
+++ b/app/models/maths_and_physics/school_check_email_data_export_presenter.rb
@@ -1,0 +1,13 @@
+module MathsAndPhysics
+  class SchoolCheckEmailDataExportPresenter
+    attr_reader :claim
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def subject
+      ""
+    end
+  end
+end

--- a/app/models/student_loans/school_check_email_data_export_presenter.rb
+++ b/app/models/student_loans/school_check_email_data_export_presenter.rb
@@ -1,0 +1,15 @@
+module StudentLoans
+  class SchoolCheckEmailDataExportPresenter
+    include StudentLoans::PresenterMethods
+
+    attr_reader :claim
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def subject
+      subject_list(claim.eligibility.subjects_taught).downcase
+    end
+  end
+end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,0 +1,9 @@
+namespace :export do
+  desc "Export claims data for school check emails. Specify the claims to exclude by passing a comma-separated list of claim references in the CLAIM_REFERENCES_TO_EXCLUDE environment variable."
+  task school_check: :environment do
+    comma_separated_claim_references_to_exclude = ENV["CLAIM_REFERENCES_TO_EXCLUDE"]
+    raise "You must specify the CLAIM_REFERENCES_TO_EXCLUDE environment variable" if comma_separated_claim_references_to_exclude.blank?
+
+    puts Claim::SchoolCheckEmailDataExport.new(comma_separated_claim_references_to_exclude).csv_string
+  end
+end

--- a/spec/models/claim/school_check_email_data_export_spec.rb
+++ b/spec/models/claim/school_check_email_data_export_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe Claim::SchoolCheckEmailDataExport do
+  let(:submitted_student_loans_claim) do
+    eligibility = create(:student_loans_eligibility, :eligible, biology_taught: true, chemistry_taught: true, computing_taught: false, languages_taught: false, physics_taught: true)
+    create(:claim, :submitted, eligibility: eligibility, first_name: "John", middle_name: "Herbert", surname: "Adams")
+  end
+  let(:submitted_maths_and_physics_claim) { create(:claim, :submitted, policy: MathsAndPhysics) }
+  let!(:submitted_claims) { [submitted_student_loans_claim, submitted_maths_and_physics_claim] }
+  let!(:submittable_claims) { create_list(:claim, 4, :submittable) }
+  let!(:excluded_claims) { create_list(:claim, 3, :submitted) }
+
+  subject { described_class.new(excluded_claims.map(&:reference).join(",")) }
+
+  describe "#csv_string" do
+    let(:csv) { CSV.parse(subject.csv_string, headers: true) }
+
+    it "returns a parseable CSV string with the expected headers" do
+      expect(csv.headers).to eq(["Claim reference", "Policy", "Current school URN", "Current school name", "Claimant name", "Subject"])
+    end
+
+    it "contains a row for each submitted, non-excluded claim" do
+      expect(csv.map { |row| row["Claim reference"] }).to match_array(submitted_claims.map(&:reference))
+    end
+
+    it "includes claims’ reference, policy, current school URN, current school name, and claimant name excluding middle name" do
+      row = csv.find { |row| row["Claim reference"] == submitted_student_loans_claim.reference }
+
+      expect(row["Policy"]).to eq("StudentLoans")
+      expect(row["Current school URN"]).to eq(submitted_student_loans_claim.eligibility.current_school.urn.to_s)
+      expect(row["Current school name"]).to eq(submitted_student_loans_claim.eligibility.current_school.name)
+      expect(row["Claimant name"]).to eq("John Adams")
+    end
+
+    it "includes the subjects taught for a Student Loans claim" do
+      row = csv.find { |row| row["Claim reference"] == submitted_student_loans_claim.reference }
+
+      expect(row["Subject"]).to eq("biology, chemistry and physics")
+    end
+
+    it "includes a blank subject for a Maths and Physics claim" do
+      row = csv.find { |row| row["Claim reference"] == submitted_maths_and_physics_claim.reference }
+
+      expect(row["Subject"]).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
Each month, a service operator sends a verification email to claimants'
schools, asking them to confirm some details of the claim.

In order to do the mail merge for this email, the service operator needs
a developer to provide them with an export of some of the data from the
submitted claims for which the email has not yet been sent. Until now,
we have been doing this as an ad-hoc process where Tekin would run
something in the Rails console.

Since our future plans are to either continue running this monthly
export, or to automate the subject check email, it makes sense to move
some of this ad-hoc process into the codebase.

This commit adds a Rake task that we can run to do the export. It takes
a list of claim references for which the email has already been sent
(this will be provided by the service operator each time a developer
needs to run this task), and prints a CSV to the standard output.

Since AFAIK we cannot upload / download files to / from the place where
the Azure console is run, here's my anticipated workflow:

1. Take list of claim references from the service operator, and do some
local munging to create a comma separated list. Copy it to clipboard.

2. Connect to Azure console and run this task as
`rails export:subject_check_email CLAIM_REFERENCES_TO_EXCLUDE='<paste the comma separated list>'`.

3. Copy the output of this task using terminal UI and save it to a
CSV file on local machine.

4. Create a Google Sheets spreadsheet with access controls that only
allow the service operator to view it. Import the CSV output into this
spreadsheet and share spreadsheet with service operator.

5. Delete the CSV file from local machine.

<!-- Do you need to update CHANGELOG.md? -->
