### PR TITLE
Identify claimants by teacher reference instead of NI number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Claim award amount is now sent to the Geckoboard dataset
+- Identify claimants by teacher reference number instead of NI number
 
 ## [Release 049] - 2020-01-29
 

--- a/app/models/claim/claims_preventing_payment_finder.rb
+++ b/app/models/claim/claims_preventing_payment_finder.rb
@@ -10,7 +10,7 @@ class Claim
     # payroll run for the current month.
     #
     # These claims are payrollable, and submitted by the same claimant as
-    # `claim`, as identified by National Insurance number.
+    # `claim`, as identified by teacher reference number (TRN).
     #
     # The returned claims have different payment or tax details to those
     # provided by `claim`, and hence `claim` cannot be paid in the same payment
@@ -22,7 +22,7 @@ class Claim
     private
 
     def find_claims_preventing_payment
-      payrollable_claims_from_same_claimant = Claim.payrollable.where(national_insurance_number: claim.national_insurance_number)
+      payrollable_claims_from_same_claimant = Claim.payrollable.where(teacher_reference_number: claim.teacher_reference_number)
 
       payrollable_claims_from_same_claimant.select do |other_claim|
         Payment::PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES.any? do |attribute|

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -9,8 +9,8 @@ class Payment < ApplicationRecord
 
   validate :personal_details_must_be_consistent
 
-  PERSONAL_DETAILS_ATTRIBUTES_PERMITTING_DISCREPANCIES = %i[first_name middle_name surname payroll_gender email_address address_line_1 address_line_2 address_line_3 address_line_4 postcode has_student_loan banking_name]
-  PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES = %i[national_insurance_number date_of_birth student_loan_plan bank_sort_code bank_account_number building_society_roll_number]
+  PERSONAL_DETAILS_ATTRIBUTES_PERMITTING_DISCREPANCIES = %i[first_name middle_name surname payroll_gender email_address address_line_1 address_line_2 address_line_3 address_line_4 postcode has_student_loan banking_name national_insurance_number]
+  PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES = %i[teacher_reference_number date_of_birth student_loan_plan bank_sort_code bank_account_number building_society_roll_number]
 
   delegate(*(PERSONAL_DETAILS_ATTRIBUTES_PERMITTING_DISCREPANCIES + PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES), to: :claim_for_personal_details)
   delegate :scheduled_payment_date, to: :payroll_run

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -18,9 +18,9 @@ class PayrollRun < ApplicationRecord
   def self.create_with_claims!(claims, attrs = {})
     ActiveRecord::Base.transaction do
       PayrollRun.create!(attrs).tap do |payroll_run|
-        claims.group_by(&:national_insurance_number).each_value do |claims|
-          award_amount = claims.sum(&:award_amount)
-          Payment.create!(payroll_run: payroll_run, claims: claims, award_amount: award_amount)
+        claims.group_by(&:teacher_reference_number).each_value do |grouped_claims|
+          award_amount = grouped_claims.sum(&:award_amount)
+          Payment.create!(payroll_run: payroll_run, claims: grouped_claims, award_amount: award_amount)
         end
       end
     end

--- a/spec/models/claim/claims_preventing_payment_finder_spec.rb
+++ b/spec/models/claim/claims_preventing_payment_finder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Claim::ClaimsPreventingPaymentFinder do
   describe "#claims_preventing_payment" do
     let(:personal_details) do
       {
-        national_insurance_number: generate(:national_insurance_number),
+        teacher_reference_number: generate(:teacher_reference_number),
         bank_account_number: "32828838",
         bank_sort_code: "183828",
         first_name: "Boris",
@@ -15,7 +15,7 @@ RSpec.describe Claim::ClaimsPreventingPaymentFinder do
     let(:claim) { create(:claim, :submitted, personal_details) }
     subject(:claims_preventing_payment) { finder.claims_preventing_payment }
 
-    context "when there is another claim with the same National Insurance number, with inconsistent personal details that would prevent us from running payroll" do
+    context "when there is another claim with the same teacher reference number, with inconsistent personal details that would prevent us from running payroll" do
       let(:inconsistent_personal_details) do
         personal_details.merge(
           bank_account_number: "87282828",
@@ -40,7 +40,7 @@ RSpec.describe Claim::ClaimsPreventingPaymentFinder do
       end
     end
 
-    context "when there is another claim with the same National Insurance number, with inconsistent details that would not prevent us from running payroll" do
+    context "when there is another claim with the same teacher reference number, with inconsistent details that would not prevent us from running payroll" do
       let(:inconsistent_personal_details) do
         personal_details.merge(
           first_name: "Jarvis",

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -454,11 +454,11 @@ RSpec.describe Claim, type: :model do
       expect(create(:claim, :rejected).approvable?).to eq false
     end
 
-    it "returns false when there exists another payrollable claim with the same National Insurance number but with inconsistent attributes that would prevent us from running payroll" do
-      national_insurance_number = generate(:national_insurance_number)
-      create(:claim, :approved, national_insurance_number: national_insurance_number, date_of_birth: 20.years.ago)
+    it "returns false when there exists another payrollable claim with the same teacher reference number but with inconsistent attributes that would prevent us from running payroll" do
+      teacher_reference_number = generate(:teacher_reference_number)
+      create(:claim, :approved, teacher_reference_number: teacher_reference_number, date_of_birth: 20.years.ago)
 
-      expect(create(:claim, :submitted, national_insurance_number: national_insurance_number, date_of_birth: 30.years.ago).approvable?).to eq false
+      expect(create(:claim, :submitted, teacher_reference_number: teacher_reference_number, date_of_birth: 30.years.ago).approvable?).to eq false
     end
   end
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -68,11 +68,11 @@ RSpec.describe Payment do
       expect(subject).to be_valid
     end
 
-    it "is invalid when claims’ National Insurance numbers do not match" do
-      claims[0].national_insurance_number = "JM102019D"
+    it "is invalid when claims’ teacher reference numbers do not match" do
+      claims[0].teacher_reference_number = "9988776"
 
       expect(subject).not_to be_valid
-      expect(subject.errors[:claims]).to eq(["#{claims[0].reference} and #{claims[1].reference} have different values for national insurance number"])
+      expect(subject.errors[:claims]).to eq(["#{claims[0].reference} and #{claims[1].reference} have different values for teacher reference number"])
     end
 
     it "is invalid when claims’ dates of birth do not match" do
@@ -135,6 +135,12 @@ RSpec.describe Payment do
 
     it "remains valid when claims’ addresses do not match" do
       claims[0].address_line_1 = "129 Brookland Drive"
+
+      expect(subject).to be_valid
+    end
+
+    it "is valid when claims’ National Insurance numbers do not match" do
+      claims[0].national_insurance_number = "JM102019D"
 
       expect(subject).to be_valid
     end

--- a/spec/models/payroll_run_spec.rb
+++ b/spec/models/payroll_run_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe PayrollRun, type: :model do
       expect(claims[1].payment.award_amount).to eq(claims[1].award_amount)
     end
 
-    context "with multiple claims from the same National Insurance number" do
+    context "with multiple claims from the same teacher reference number" do
       let(:personal_details) do
         {
           national_insurance_number: generate(:national_insurance_number),

--- a/spec/requests/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin_payroll_runs_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Admin payroll runs" do
       context "when a payroll run contains claims from the same person with different bank details" do
         it "doesn’t create a payroll run and shows an error" do
           personal_details = {
-            national_insurance_number: generate(:national_insurance_number),
+            teacher_reference_number: generate(:teacher_reference_number),
             bank_sort_code: "112233",
           }
           claims = [


### PR DESCRIPTION
Because of the restrictions of payroll, we can only make one payment to
an individual in a given month. Therefor if a user claims for more than
one policy, we need a way to combine their claims into a single payment.
Previously this was done by matching claims with the same
National Insurance number (NiNo), this commit switches that matching to
be based on the claimant's teacher reference number (TRN):

- Historically, users enter their TRN more reliably than NiNo so there
  are few with errors, meaning fewer claims to have to correct
- There is no technically reason for us to be check the NiNo on claims
  during claim checking except because of this matching. If we switch to
  use the TRN instead, claim checkers can ignore the NiNo during claim
  checking, giving them one less thing to worry about (HMRC will deal
  with any errors in NiNo)
- We need to guarantee that the TRN is correct anyway as that will be
  the only identifiable field we will maintain for paid claims once the
  claim window is closed
