### PR TITLE
Fix reminder email date sent to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog]
 
 - Claim award amount is now sent to the Geckoboard dataset
 - Identify claimants by teacher reference number instead of NI number
+- Fix date sent to user in three week reminder email
 
 ## [Release 049] - 2020-01-29
 

--- a/app/views/claim_mailer/update_after_three_weeks.text.erb
+++ b/app/views/claim_mailer/update_after_three_weeks.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @display_name %>,
 
-We're still reviewing your claim <%= @claim_description %>, which we received on <%= @claim.submitted_at %>. Claim reference: <%= @claim.reference %>.
+We're still reviewing your claim <%= @claim_description %>, which we received on <%= l(@claim.submitted_at.to_date) %>. Claim reference: <%= @claim.reference %>.
 
 We'll notify you as your claim progresses. We do not expect any delays to the processing of your claim.
 

--- a/spec/mailers/previews/claim_mailer_preview.rb
+++ b/spec/mailers/previews/claim_mailer_preview.rb
@@ -12,7 +12,7 @@ class ClaimMailerPreview < ActionMailer::Preview
   end
 
   def update_after_three_weeks
-    ClaimMailer.update_after_three_weeks(claim_for(Claim.update_after_three_weeks))
+    ClaimMailer.update_after_three_weeks(claim_for(Claim.approved))
   end
 
   private


### PR DESCRIPTION
I clocked that we were sending bare datetime strings to users when sending the three week emails:

![image](https://user-images.githubusercontent.com/109774/73435832-4a7f1880-4341-11ea-939f-1c523f3766ee.png)

I've fixed this, using the [I18n `l`](https://guides.rubyonrails.org/i18n.html#the-public-i18n-api) helper. The emails now look like this:

![image](https://user-images.githubusercontent.com/109774/73435889-6a164100-4341-11ea-937c-da8c9af70d4d.png)
