### PR TITLE
A Service Operator can remove problematic payments from a payroll run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog]
 - Emails are sent for unchecked claims three weeks after they are submitted,
   advising users that their claim is still in progress
 - Developers can export data needed for school check mail merge
+- A Service Operator can remove problematic payments from a payroll run
 
 ## [Release 048] - 2020-01-28
 

--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -1,0 +1,16 @@
+module Admin
+  class PaymentsController < BaseAdminController
+    before_action :ensure_service_operator
+
+    def destroy
+      payroll_run = PayrollRun.find(params[:payroll_run_id])
+      if payroll_run.confirmation_report_uploaded_by.nil?
+        payment = payroll_run.payments.find(params[:id])
+        payment.destroy
+        redirect_to admin_payroll_run_path(payroll_run), notice: "Payment has been removed from payroll run"
+      else
+        redirect_to admin_payroll_run_path(payroll_run), alert: "A payment cannot be removed from an already confirmed payroll run"
+      end
+    end
+  end
+end

--- a/app/helpers/admin/payment_helper.rb
+++ b/app/helpers/admin/payment_helper.rb
@@ -1,0 +1,8 @@
+module Admin
+  module PaymentHelper
+    def list_references(payment)
+      references = payment.claims.pluck(:reference)
+      references.join("<br/>").html_safe
+    end
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,5 +1,5 @@
 class Payment < ApplicationRecord
-  has_many :claims
+  has_many :claims, dependent: :nullify
   belongs_to :payroll_run
 
   validates :award_amount, presence: true

--- a/app/models/payment_confirmation.rb
+++ b/app/models/payment_confirmation.rb
@@ -60,7 +60,7 @@ class PaymentConfirmation
   def check_for_missing_payments
     missing_payment_ids = payroll_run.payments.map { |payment| payment.id } - csv.rows.map { |c| c["Payment ID"] }
     missing_payment_ids.each do |id|
-      errors.append("The payment ID #{id} is missing from the CSV")
+      errors.append("Payment ID #{id} is missing from the file. Please check with Cantium to see if there is a problem with this payment. You may need to remove some payments from the Payroll Run then try uploading it again")
     end
   end
 

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -64,4 +64,44 @@
       <%= text_field_tag "payroll_run_download_link", new_admin_payroll_run_download_url(@payroll_run), data: {"copy-to-clipboard": :true}, readonly: true, class: ["govuk-input"] %>
     </div>
   <% end %>
+
+  <div class="govuk-grid-column-full">
+
+    <h2 class="govuk-heading-l">Payments</h2>
+
+    <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Payment ID</th>
+        <th scope="col" class="govuk-table__header">Claim Reference(s)</th>
+        <th scope="col" class="govuk-table__header">Applicant Name</th>
+        <% unless @payroll_run.confirmation_report_uploaded_by %>
+          <th scope="col" class="govuk-table__header"></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @payroll_run.payments.each do |payment| %>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header"><%= payment.id %></th>
+          <td class="govuk-table__cell"><%= list_references(payment) %></td>
+          <td class="govuk-table__cell"><%= payment.banking_name %></td>
+          <% unless @payroll_run.confirmation_report_uploaded_by %>
+            <td class="govuk-table__cell">
+              <%= button_to 'Remove',
+                            admin_payroll_run_payment_path(id: payment.id, payroll_run_id: payment.payroll_run.id),
+                            method: :delete,
+                            class: "govuk-button govuk-button--warning",
+                            data: {
+                              confirm: "Are you sure you want to remove this payment from the payroll run?"
+                            }
+              %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+    </table>
+  </div>
+
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
     resources :payroll_runs, only: [:index, :new, :create, :show] do
       resources :payment_confirmation_report_uploads, only: [:new, :create]
       resource :download, only: [:new, :create, :show], controller: "payroll_run_downloads"
+      resources :payments, only: [:destroy]
     end
 
     resources :policy_configurations, only: [:index, :edit, :update]

--- a/spec/models/payment_confirmation_spec.rb
+++ b/spec/models/payment_confirmation_spec.rb
@@ -146,7 +146,9 @@ RSpec.describe PaymentConfirmation do
 
     it "fails and populates its errors, and does not update the payments" do
       expect(payment_confirmation.ingest).to be_falsey
-      expect(payment_confirmation.errors).to eq(["The payment ID #{payroll_run.payments[1].id} is missing from the CSV"])
+      expect(payment_confirmation.errors).to eq([
+        "Payment ID #{payroll_run.payments[1].id} is missing from the file. Please check with Cantium to see if there is a problem with this payment. You may need to remove some payments from the Payroll Run then try uploading it again",
+      ])
 
       expect(payroll_run.payments[0].reload.payroll_reference).to eq(nil)
       expect(payroll_run.payments[1].reload.payroll_reference).to eq(nil)

--- a/spec/requests/admin_payroll_run_payments_spec.rb
+++ b/spec/requests/admin_payroll_run_payments_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "Admin payroll run payments" do
+  let(:admin) { create(:dfe_signin_user) }
+
+  before do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin.dfe_sign_in_id)
+  end
+
+  describe "destroy" do
+    let(:payroll_run) { create(:payroll_run, claims_counts: {MathsAndPhysics => 1, StudentLoans => 1}) }
+    let(:payment) { payroll_run.payments.first }
+
+    it "deletes a payroll run and redirects with a message" do
+      expect {
+        delete admin_payroll_run_payment_path(
+          payroll_run_id: payroll_run.id,
+          id: payment.id
+        )
+      }.to change(payroll_run.reload.payments, :count).by(-1)
+
+      expect(payroll_run.payments).to_not include(payment)
+
+      expect(response).to redirect_to(admin_payroll_run_path(payroll_run))
+      follow_redirect!
+
+      expect(response.body).to include("Payment has been removed from payroll run")
+    end
+
+    it "cannot delete a payment from an already confirmed payroll run" do
+      payroll_run.confirmation_report_uploaded_by = admin.id
+      payroll_run.save
+
+      expect {
+        delete admin_payroll_run_payment_path(
+          payroll_run_id: payroll_run.id,
+          id: payment.id
+        )
+      }.to change(payroll_run.reload.payments, :count).by(0)
+
+      expect(payroll_run.payments).to include(payment)
+
+      expect(response).to redirect_to(admin_payroll_run_path(payroll_run))
+      follow_redirect!
+
+      expect(response.body).to include("A payment cannot be removed from an already confirmed payroll run")
+    end
+  end
+end


### PR DESCRIPTION
This allows service operators to remove payments from a Payroll Run if Cantium have confirmed there is some problem (i.e. incorrect bank details) that has stopped a payment from taking place. I've also updated the guidance that a user sees if a payment has been missed off and the confirmation report cannot be uploaded.

Once a confirmation report has been uploaded, it's no longer possible to remove payments from a run

# Screenshots

## Before a payroll run has been confirmed

![image](https://user-images.githubusercontent.com/109774/73439199-29212b00-4347-11ea-8861-0d67fbe00281.png)

## After a payroll run has been confirmed

![image](https://user-images.githubusercontent.com/109774/73439229-36d6b080-4347-11ea-9837-d5c945b0fa56.png)
