### PR TITLE
A Service Operator can remove problematic payments from a payroll run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog]
 
 - Update admin menu with new layout
 - Update "Some of this information is wrong" content on the verified page
+- A Service Operator can remove problematic payments from a payroll run
 
 ## [Release 051] - 2020-02-03
 

--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -1,0 +1,31 @@
+module Admin
+  class PaymentsController < BaseAdminController
+    before_action :ensure_service_operator
+    before_action :find_payroll_run
+    before_action :find_payment
+
+    def remove
+    end
+
+    def destroy
+      if @payroll_run.confirmation_report_uploaded?
+        redirect_to admin_payroll_run_path(@payroll_run), alert: "A payment cannot be removed from an already confirmed payroll run"
+      else
+        @claim_references = @payment.claims.pluck(:reference)
+        @payment.destroy
+      end
+    end
+
+    private
+
+    def find_payroll_run
+      @payroll_run = PayrollRun.find(params[:payroll_run_id])
+    end
+
+    def find_payment
+      @payment = @payroll_run.payments.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to admin_payroll_run_path(@payroll_run), alert: "This payment cannot be found in the payroll run. Maybe you already deleted it?"
+    end
+  end
+end

--- a/app/helpers/admin/payment_helper.rb
+++ b/app/helpers/admin/payment_helper.rb
@@ -1,0 +1,8 @@
+module Admin
+  module PaymentHelper
+    def claim_references(payment)
+      references = payment.claims.pluck(:reference)
+      references.join("<br/>").html_safe
+    end
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,5 +1,5 @@
 class Payment < ApplicationRecord
-  has_many :claims
+  has_many :claims, dependent: :nullify
   belongs_to :payroll_run
 
   validates :award_amount, presence: true

--- a/app/models/payment_confirmation.rb
+++ b/app/models/payment_confirmation.rb
@@ -60,7 +60,7 @@ class PaymentConfirmation
   def check_for_missing_payments
     missing_payment_ids = payroll_run.payments.map { |payment| payment.id } - csv.rows.map { |c| c["Payment ID"] }
     missing_payment_ids.each do |id|
-      errors.append("The payment ID #{id} is missing from the CSV")
+      errors.append("Payment ID #{id} is missing from the file. Please check with Cantium to see if there is a problem with this payment. You may need to remove some payments from the Payroll Run then try uploading it again")
     end
   end
 

--- a/app/models/payment_confirmation.rb
+++ b/app/models/payment_confirmation.rb
@@ -54,7 +54,7 @@ class PaymentConfirmation
   end
 
   def check_payroll_run
-    errors.append("A Payment Confirmation Report has already been uploaded for this payroll run") if payroll_run.confirmation_report_uploaded_by
+    errors.append("A Payment Confirmation Report has already been uploaded for this payroll run") if payroll_run.confirmation_report_uploaded?
   end
 
   def check_for_missing_payments

--- a/app/models/payroll_run.rb
+++ b/app/models/payroll_run.rb
@@ -34,6 +34,10 @@ class PayrollRun < ApplicationRecord
     download_triggered? && Time.zone.now - downloaded_at < DOWNLOAD_FILE_TIMEOUT.seconds
   end
 
+  def confirmation_report_uploaded?
+    confirmation_report_uploaded_by.present?
+  end
+
   private
 
   def ensure_no_payroll_run_this_month

--- a/app/views/admin/payments/destroy.html.erb
+++ b/app/views/admin/payments/destroy.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t("admin.payment_deleted_title",
+            count: @claim_references.count) %>
+    </h1>
+
+    <p class="govuk-body-l">
+      <%= t("admin.payment_deleted_outcome_message",
+            count: @claim_references.count,
+            references: @claim_references.to_sentence) %>
+    </p>
+
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+          <%= t("admin.payment_deleted_claim_next_steps_message",
+                count: @claim_references.count) %>
+        </span>
+      </strong>
+    </div>
+
+    <p class="govuk-body">
+      <%= link_to "Back to payroll run", admin_payroll_run_path(@payroll_run), class: "govuk-link" %>
+    </p>
+  </div>
+</div>

--- a/app/views/admin/payments/remove.html.erb
+++ b/app/views/admin/payments/remove.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      Are you sure you want to remove payment <%= @payment.id %> from the payroll run?
+    </h1>
+
+    <p class="govuk-body-l">
+      <%= t("admin.payment_deletion_claim_warning",
+            count: @payment.claims.count,
+            references: @payment.claims.pluck(:reference).to_sentence) %>
+    </p>
+
+    <%= form_with url: admin_payroll_run_payment_path(id: @payment.id, payroll_run_id: @payment.payroll_run.id), method: :delete do |f| %>
+      <%= f.submit "Remove payment",
+                   class: "govuk-button govuk-button--warning",
+                   data: {
+                     confirm: "Are you sure you want to remove this payment from the payroll run?"
+                    } %>
+      <%= link_to "Cancel", admin_payroll_run_path(@payroll_run), class: "govuk-button govuk-button--secondary govuk-!-margin-left-1" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -32,7 +32,7 @@
             <th scope="row" class="govuk-table__header"><%= l(payroll_run.created_at.to_date) %></th>
             <td class="govuk-table__cell"><%= number_with_delimiter(payroll_run.claims.size) %></td>
             <td class="govuk-table__cell">
-              <% if payroll_run.confirmation_report_uploaded_by %>
+              <% if payroll_run.confirmation_report_uploaded? %>
                 Uploaded
               <% else %>
                 <%= link_to("Upload", new_admin_payroll_run_payment_confirmation_report_upload_path(payroll_run), class: "govuk-link") %>

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -64,4 +64,40 @@
       <%= text_field_tag "payroll_run_download_link", new_admin_payroll_run_download_url(@payroll_run), data: {"copy-to-clipboard": :true}, readonly: true, class: ["govuk-input"] %>
     </div>
   <% end %>
+
+  <div class="govuk-grid-column-full">
+
+    <h2 class="govuk-heading-l">Payments</h2>
+
+    <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Payment ID</th>
+        <th scope="col" class="govuk-table__header">Claim Reference(s)</th>
+        <th scope="col" class="govuk-table__header">Payee Name</th>
+        <% unless @payroll_run.confirmation_report_uploaded? %>
+          <th scope="col" class="govuk-table__header"></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @payroll_run.payments.each do |payment| %>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header"><%= payment.id %></th>
+          <td class="govuk-table__cell"><%= claim_references(payment) %></td>
+          <td class="govuk-table__cell"><%= payment.banking_name %></td>
+          <% unless @payroll_run.confirmation_report_uploaded? %>
+            <td class="govuk-table__cell">
+              <%= link_to 'Remove',
+                          remove_admin_payroll_run_payment_path(id: payment.id, payroll_run_id: payment.payroll_run.id),
+                          class: "govuk-link"
+              %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+    </table>
+  </div>
+
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,18 @@ en:
     claims_preventing_payment_message:
       one: This claim cannot currently be approved because we’re already paying another claim (%{claim_references}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.
       other: This claim cannot currently be approved because we’re already paying other claims (%{claim_references}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.
+    payment_deletion_claim_warning:
+      one: This means claim %{references} will no longer be included in this pay run.
+      other: This means claims %{references} will no longer be included in this pay run.
+    payment_deleted_title:
+      one: You have removed a claim from the payroll run
+      other: You have removed %{count} claims from the payroll run
+    payment_deleted_outcome_message:
+      one: Claim %{references} is no longer included in this pay run.
+      other: Claims %{references} are no longer included in this pay run.
+    payment_deleted_claim_next_steps_message:
+      one: Please make a note of this claim and contact the claimant to resolve the problems with their payment before the next pay run.
+      other: Please make a note of these claims and contact the claimant to resolve the problems with their payment before the next pay run.
   answers:
     student_loan_start_date:
       one_course:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,9 @@ Rails.application.routes.draw do
     resources :payroll_runs, only: [:index, :new, :create, :show] do
       resources :payment_confirmation_report_uploads, only: [:new, :create]
       resource :download, only: [:new, :create, :show], controller: "payroll_run_downloads"
+      resources :payments, only: [:destroy] do
+        get :remove, on: :member
+      end
     end
 
     resources :policy_configurations, only: [:index, :edit, :update]

--- a/spec/models/payment_confirmation_spec.rb
+++ b/spec/models/payment_confirmation_spec.rb
@@ -146,7 +146,9 @@ RSpec.describe PaymentConfirmation do
 
     it "fails and populates its errors, and does not update the payments" do
       expect(payment_confirmation.ingest).to be_falsey
-      expect(payment_confirmation.errors).to eq(["The payment ID #{payroll_run.payments[1].id} is missing from the CSV"])
+      expect(payment_confirmation.errors).to eq([
+        "Payment ID #{payroll_run.payments[1].id} is missing from the file. Please check with Cantium to see if there is a problem with this payment. You may need to remove some payments from the Payroll Run then try uploading it again",
+      ])
 
       expect(payroll_run.payments[0].reload.payroll_reference).to eq(nil)
       expect(payroll_run.payments[1].reload.payroll_reference).to eq(nil)

--- a/spec/requests/admin_payroll_run_payments_spec.rb
+++ b/spec/requests/admin_payroll_run_payments_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "Admin payroll run payments" do
+  let(:admin) { create(:dfe_signin_user) }
+
+  before do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, admin.dfe_sign_in_id)
+  end
+
+  let(:payroll_run) { create(:payroll_run, claims_counts: {MathsAndPhysics => 1, StudentLoans => 1}) }
+  let(:payment) { payroll_run.payments.first }
+
+  describe "remove" do
+    it "shows a confirmation screen" do
+      get remove_admin_payroll_run_payment_path(
+        payroll_run_id: payroll_run.id,
+        id: payment.id
+      )
+
+      expect(response.body).to include(payment.id)
+      expect(response.body).to include(payment.claims.first.reference)
+    end
+  end
+
+  describe "destroy" do
+    it "deletes a payroll run and shows a message" do
+      reference = payment.claims.first.reference
+
+      expect {
+        delete admin_payroll_run_payment_path(
+          payroll_run_id: payroll_run.id,
+          id: payment.id
+        )
+      }.to change(payroll_run.reload.payments, :count).by(-1)
+
+      expect(payroll_run.payments).to_not include(payment)
+
+      expect(response.body).to include("You have removed a claim from the payroll run")
+      expect(response.body).to include(reference)
+    end
+
+    it "cannot delete a payment from an already confirmed payroll run" do
+      payroll_run.confirmation_report_uploaded_by = admin.id
+      payroll_run.save!
+
+      expect {
+        delete admin_payroll_run_payment_path(
+          payroll_run_id: payroll_run.id,
+          id: payment.id
+        )
+      }.to change(payroll_run.reload.payments, :count).by(0)
+
+      expect(payroll_run.payments).to include(payment)
+
+      expect(response).to redirect_to(admin_payroll_run_path(payroll_run))
+
+      expect(flash[:alert]).to eq("A payment cannot be removed from an already confirmed payroll run")
+    end
+
+    it "shows an error if the payment has already been deleted" do
+      payment.destroy
+
+      expect {
+        delete admin_payroll_run_payment_path(
+          payroll_run_id: payroll_run.id,
+          id: payment.id
+        )
+      }.to change(payroll_run.reload.payments, :count).by(0)
+
+      expect(response).to redirect_to(admin_payroll_run_path(payroll_run))
+
+      expect(flash[:alert]).to eq("This payment cannot be found in the payroll run. Maybe you already deleted it?")
+    end
+  end
+end


### PR DESCRIPTION
This allows service operators to remove payments from a Payroll Run if Cantium have confirmed there is some problem (i.e. incorrect bank details) that has stopped a payment from taking place. I've also updated the guidance that a user sees if a payment has been missed off and the confirmation report cannot be uploaded.

Once a confirmation report has been uploaded, it's no longer possible to remove payments from a run

# Screenshots

## Before a payroll run has been confirmed

![image](https://user-images.githubusercontent.com/109774/73439199-29212b00-4347-11ea-8861-0d67fbe00281.png)

## After a payroll run has been confirmed

![image](https://user-images.githubusercontent.com/109774/73439229-36d6b080-4347-11ea-9837-d5c945b0fa56.png)

## Before deleting a payment

![image](https://user-images.githubusercontent.com/109774/73841993-a5b67c80-4813-11ea-8e65-7a3c9ec48295.png)

## After a payment has been deleted 

![image](https://user-images.githubusercontent.com/109774/73842011-aea74e00-4813-11ea-9985-276654aec9a2.png)


