### PR TITLE
Allow claimants to search by school postcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Allow claimants to search by school postcode
+
 ## [Release 050] - 2020-01-30
 
 - Claim award amount is now sent to the Geckoboard dataset

--- a/app/assets/javascripts/components/school_search.js.erb
+++ b/app/assets/javascripts/components/school_search.js.erb
@@ -77,7 +77,7 @@ document.addEventListener("DOMContentLoaded", function() {
         error: handleResponse
       });
     },
-    minLength: 4,
+    minLength: parseInt("<%= School::SEARCH_MINIMUM_LENGTH %>"),
     showNoOptionsFound: false,
     confirmOnBlur: false,
     templates: {

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -71,7 +71,7 @@ class ClaimsController < BasePublicController
   rescue ArgumentError => e
     raise unless e.message == School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR
 
-    current_claim.errors.add(:school_search, "Enter the name of the school")
+    current_claim.errors.add(:school_search, "Enter the name or postcode of the school")
   end
 
   def claim_params

--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -21,7 +21,7 @@ class SchoolSearchController < BasePublicController
     rescue ArgumentError => e
       raise unless e.message == School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR
 
-      errors.push("'query' parameter must have a minimum of four characters")
+      errors.push(School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR)
     end
   end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,6 +1,7 @@
 class School < ApplicationRecord
   SEARCH_RESULTS_LIMIT = 50
-  SEARCH_NOT_ENOUGH_CHARACTERS_ERROR = "search_term must have a minimum of 4 characters".freeze
+  SEARCH_MINIMUM_LENGTH = 3
+  SEARCH_NOT_ENOUGH_CHARACTERS_ERROR = "search term must have a minimum of #{SEARCH_MINIMUM_LENGTH} characters".freeze
 
   belongs_to :local_authority
   belongs_to :local_authority_district
@@ -111,7 +112,7 @@ class School < ApplicationRecord
   scope :closed, -> { where.not(close_date: nil) }
 
   def self.search(search_term)
-    raise ArgumentError, SEARCH_NOT_ENOUGH_CHARACTERS_ERROR if search_term.length < 4
+    raise ArgumentError, SEARCH_NOT_ENOUGH_CHARACTERS_ERROR if search_term.length < SEARCH_MINIMUM_LENGTH
 
     where("name ILIKE ?", "%#{sanitize_sql_like(search_term)}%")
       .or(where("REPLACE(postcode, ' ', '') ILIKE ?", "%#{sanitize_sql_like(search_term.tr(" ", ""))}%"))

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -113,7 +113,9 @@ class School < ApplicationRecord
   def self.search(search_term)
     raise ArgumentError, SEARCH_NOT_ENOUGH_CHARACTERS_ERROR if search_term.length < 4
 
-    where("name ILIKE ?", "%#{sanitize_sql_like(search_term)}%").order(:name, close_date: :desc).limit(SEARCH_RESULTS_LIMIT)
+    where("name ILIKE ?", "%#{sanitize_sql_like(search_term)}%")
+      .or(where("REPLACE(postcode, ' ', '') ILIKE ?", "%#{sanitize_sql_like(search_term.tr(" ", ""))}%"))
+      .order(:name, close_date: :desc).limit(SEARCH_RESULTS_LIMIT)
   end
 
   def address

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -30,7 +30,7 @@
       </p>
     <% else %>
       <span class="govuk-hint" id="school_search-hint">
-        Enter the school name. Use at least four characters.
+        Enter the school name or school postcode. Use at least four characters.
         <% if school_id_param == :claim_school_id && !params.has_key?(:additional_school) %>
           <br><br>
           If you taught at multiple schools during this period, enter the first school you think might be eligible.

--- a/app/views/claims/_school_search.html.erb
+++ b/app/views/claims/_school_search.html.erb
@@ -30,7 +30,7 @@
       </p>
     <% else %>
       <span class="govuk-hint" id="school_search-hint">
-        Enter the school name or school postcode. Use at least four characters.
+        Enter the school name or postcode. Use at least three characters.
         <% if school_id_param == :claim_school_id && !params.has_key?(:additional_school) %>
           <br><br>
           If you taught at multiple schools during this period, enter the first school you think might be eligible.

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe School, type: :model do
   it { should validate_presence_of(:phase) }
 
   describe ".search" do
-    it "returns schools matching the search term" do
+    it "returns schools with a name matching the search term" do
       expect(School.search("Penistone")).to match_array([schools(:penistone_grammar_school)])
+    end
+
+    it "returns schools with a postcode matching the search term" do
+      expect(School.search("NW2 3RT")).to match_array([schools(:hampstead_school)])
     end
 
     it "raises an ArgumentError when the search term has fewer than 4 characters" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe School, type: :model do
       expect(School.search("NW2 3RT")).to match_array([schools(:hampstead_school)])
     end
 
-    it "raises an ArgumentError when the search term has fewer than 4 characters" do
-      expect(lambda { School.search("Pen") }).to raise_error(ArgumentError, School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR)
+    it "raises an ArgumentError when the search term has fewer than 3 characters" do
+      expect(lambda { School.search("Pe") }).to raise_error(ArgumentError, School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR)
     end
 
     it "limits the results" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe "Claims", type: :request do
           expect(response.body).to include "Continue"
         end
 
-        it "only returns results if the search term is more than three characters" do
-          get claim_path(StudentLoans.routing_name, "claim-school"), params: {school_search: "Pen"}
+        it "only returns results if the search term is more than two characters" do
+          get claim_path(StudentLoans.routing_name, "claim-school"), params: {school_search: "Pe"}
 
           expect(response.body).to include("There is a problem")
           expect(response.body).to include("Enter the name or postcode of the school")

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Claims", type: :request do
           get claim_path(StudentLoans.routing_name, "claim-school"), params: {school_search: "Pen"}
 
           expect(response.body).to include("There is a problem")
-          expect(response.body).to include("Enter the name of the school")
+          expect(response.body).to include("Enter the name or postcode of the school")
           expect(response.body).not_to include(schools(:penistone_grammar_school).name)
         end
 

--- a/spec/requests/school_search_spec.rb
+++ b/spec/requests/school_search_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe "School search", type: :request do
       expect(response.body).not_to include(schools(:hampstead_school).name)
     end
 
-    it "returns an error if the query parameter is less than four characters" do
-      post school_search_index_path, params: {query: "Pen"}
+    it "returns an error if the query parameter is less than three characters" do
+      post school_search_index_path, params: {query: "Pe"}
 
       expect(response.status).to eq(400)
-      expect(response.body).to include({errors: ["'query' parameter must have a minimum of four characters"]}.to_json)
+      expect(response.body).to include({errors: [School::SEARCH_NOT_ENOUGH_CHARACTERS_ERROR]}.to_json)
       expect(response.body).not_to include(schools(:penistone_grammar_school).name)
     end
 

--- a/spec/requests/school_search_spec.rb
+++ b/spec/requests/school_search_spec.rb
@@ -4,12 +4,20 @@ RSpec.describe "School search", type: :request do
   describe "school_search#create request" do
     before { start_student_loans_claim }
 
-    it "searches for schools using the query parameter" do
+    it "searches for schools by name using the query parameter" do
       post school_search_index_path, params: {query: "Penistone"}
 
       expect(response.status).to eq(200)
       expect(response.body).to include(schools(:penistone_grammar_school).name)
       expect(response.body).to include(schools(:penistone_grammar_school).address)
+      expect(response.body).not_to include(schools(:hampstead_school).name)
+    end
+
+    it "searches for schools by postcode using the query parameter" do
+      post school_search_index_path, params: {query: "s367"}
+
+      expect(response.status).to eq(200)
+      expect(response.body).to include(schools(:penistone_grammar_school).name)
       expect(response.body).not_to include(schools(:hampstead_school).name)
     end
 


### PR DESCRIPTION
The current school search only works if the search query you type matches exactly to part of the school's name. We've seen some queries come in to support where the user hasn't been able to find their school because the thing they've typed doesn't match exactly to the information in Get Information About Schools (eg. They omit an apostrophe).

This PR:

- allows users to search by typing the partial or full postcode of their school
- reduces the minimum character length of the search to 3 so the user doesn't have to remember the postcode sector

## Screenshot

<img width="1142" alt="Screenshot 2020-01-30 at 15 21 08" src="https://user-images.githubusercontent.com/2804149/73462769-31dc2600-4374-11ea-9df2-7b324ff31599.png">
