### PR TITLE
Stop blank attributes showing as matching

### DIFF
--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -58,14 +58,21 @@ module Admin
     end
 
     def matching_attributes(first_claim, second_claim)
-      first_attributes = first_claim.attributes.slice(*Claim::MatchingAttributeFinder::ATTRIBUTE_GROUPS_TO_MATCH.flatten).to_a
-      second_attributes = second_claim.attributes.slice(*Claim::MatchingAttributeFinder::ATTRIBUTE_GROUPS_TO_MATCH.flatten).to_a
+      first_attributes = matching_attributes_for(first_claim)
+      second_attributes = matching_attributes_for(second_claim)
 
       matching_attributes = first_attributes & second_attributes
       matching_attributes.to_h.compact.keys.map(&:humanize).sort
     end
 
     private
+
+    def matching_attributes_for(claim)
+      claim.attributes
+        .slice(*Claim::MatchingAttributeFinder::ATTRIBUTE_GROUPS_TO_MATCH.flatten)
+        .reject { |_, v| v.blank? }
+        .to_a
+    end
 
     def days_between(first_date, second_date)
       (second_date - first_date).to_i

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -162,16 +162,26 @@ describe Admin::ClaimsHelper do
         building_society_roll_number: "123456789/ABCD",
       )
     }
-    let(:second_claim) { build(:claim, :submitted, teacher_reference_number: first_claim.teacher_reference_number, national_insurance_number: first_claim.national_insurance_number, building_society_roll_number: first_claim.building_society_roll_number) }
+    let(:second_claim) {
+      build(
+        :claim,
+        :submitted,
+        teacher_reference_number: first_claim.teacher_reference_number,
+        national_insurance_number: first_claim.national_insurance_number,
+        bank_account_number: first_claim.bank_account_number,
+        bank_sort_code: first_claim.bank_sort_code,
+        building_society_roll_number: first_claim.building_society_roll_number
+      )
+    }
     subject { helper.matching_attributes(first_claim, second_claim) }
 
     it "returns the humanised names of the matching attributes" do
-      expect(subject).to eq(["Building society roll number", "National insurance number", "Teacher reference number"])
+      expect(subject).to eq(["Bank account number", "Bank sort code", "Building society roll number", "National insurance number", "Teacher reference number"])
     end
 
-    it "does not consider nil building society roll number to be a match" do
-      [first_claim, second_claim].each { |claim| claim.building_society_roll_number = nil }
-      expect(subject).to eq(["National insurance number", "Teacher reference number"])
+    it "does not consider a blank building society roll number to be a match" do
+      [first_claim, second_claim].each { |claim| claim.building_society_roll_number = "" }
+      expect(subject).to eq(["Bank account number", "Bank sort code", "National insurance number", "Teacher reference number"])
     end
   end
 end


### PR DESCRIPTION
Previously, the `matching_attributes` helper was returning any attributes that were a blank string as 'matching'. This strips out any blank attributes before comparing.
