### PR TITLE
Add "approaching SLA" state to Geckoboard dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Allow claimants to search by school postcode
+- Replace "passed SLA deadline" true/false with ok/warning/passed status in
+  Geckoboard dataset
 
 ## [Release 050] - 2020-01-30
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -193,6 +193,10 @@ class Claim < ApplicationRecord
     (submitted_at + CHECK_DEADLINE).to_date
   end
 
+  def deadline_warning_date
+    (submitted_at + CHECK_DEADLINE - CHECK_DEADLINE_WARNING_POINT).to_date
+  end
+
   def address(seperator = ", ")
     Claim::ADDRESS_ATTRIBUTES.map { |attr| send(attr) }.reject(&:blank?).join(seperator)
   end

--- a/app/models/claim/geckoboard_dataset.rb
+++ b/app/models/claim/geckoboard_dataset.rb
@@ -12,7 +12,7 @@ class Claim
       Geckoboard::StringField.new(:reference, name: "Reference"),
       Geckoboard::StringField.new(:policy, name: "Policy"),
       Geckoboard::DateTimeField.new(:submitted_at, name: "Submitted at"),
-      Geckoboard::StringField.new(:passed_checking_deadline, name: "Passed checking deadline"),
+      Geckoboard::StringField.new(:sla_status, name: "SLA status"),
       Geckoboard::StringField.new(:check, name: "Check"),
       Geckoboard::DateTimeField.new(:checked_at, name: "Checked at"),
       Geckoboard::NumberField.new(:number_of_days_to_check, name: "Number of days to check", optional: true),
@@ -42,7 +42,7 @@ class Claim
           reference: claim.reference,
           policy: claim.policy.to_s,
           submitted_at: claim.submitted_at,
-          passed_checking_deadline: claim.check_deadline_date.past?.to_s,
+          sla_status: sla_status_string(claim),
           check: claim.check.present? ? claim.check.result : "unchecked",
           checked_at: claim.check.present? ? claim.check.created_at : placeholder_date_for_nil_value,
           number_of_days_to_check: claim.check&.number_of_days_since_claim_submitted,
@@ -78,6 +78,16 @@ class Claim
 
     def placeholder_date_for_nil_value
       DateTime.parse("1970-01-01")
+    end
+
+    def sla_status_string(claim)
+      if claim.check_deadline_date.past?
+        "passed"
+      elsif claim.deadline_warning_date.past?
+        "warning"
+      else
+        "ok"
+      end
     end
   end
 end

--- a/spec/models/claim/geckoboard_dataset_spec.rb
+++ b/spec/models/claim/geckoboard_dataset_spec.rb
@@ -2,10 +2,12 @@ require "rails_helper"
 
 RSpec.describe Claim::GeckoboardDataset, type: :model do
   let(:claim) { build(:claim, :submitted, created_at: DateTime.now) }
+  let(:dataset) { Claim::GeckoboardDataset.new }
 
   it "returns an award_amount of nil for a claim with no eligibility" do
     ClimateControl.modify ENVIRONMENT_NAME: "test" do
-      expect(Claim::GeckoboardDataset.new(claims: [claim]).data_for_claims([claim]).first["award_amount"]).to be_nil
+      data = dataset.data_for_claims([claim])
+      expect(data.first["award_amount"]).to be_nil
     end
   end
 
@@ -17,7 +19,8 @@ RSpec.describe Claim::GeckoboardDataset, type: :model do
         student_loan_plan: :plan_1,
         eligibility: build(:student_loans_eligibility, student_loan_repayment_amount: 2345.67),
       )
-      expect(Claim::GeckoboardDataset.new(claims: [eligible_claim]).data_for_claims([eligible_claim]).first[:award_amount]).to eq(234567)
+      data = dataset.data_for_claims([eligible_claim])
+      expect(data.first[:award_amount]).to eq(234567)
     end
   end
 

--- a/spec/models/claim/geckoboard_dataset_spec.rb
+++ b/spec/models/claim/geckoboard_dataset_spec.rb
@@ -24,6 +24,30 @@ RSpec.describe Claim::GeckoboardDataset, type: :model do
     end
   end
 
+  it "correctly reports a claim's SLA status when the claim is not approaching the check deadline" do
+    ClimateControl.modify ENVIRONMENT_NAME: "test" do
+      claim_sla_ok = build(:claim, :submitted, submitted_at: (Claim::CHECK_DEADLINE - Claim::CHECK_DEADLINE_WARNING_POINT - 1.week).ago)
+      data = dataset.data_for_claims([claim_sla_ok])
+      expect(data.first[:sla_status]).to eq("ok")
+    end
+  end
+
+  it "correctly reports a claim's SLA status when the check deadline is approaching" do
+    ClimateControl.modify ENVIRONMENT_NAME: "test" do
+      claim_sla_warning = build(:claim, :submitted, submitted_at: (Claim::CHECK_DEADLINE - Claim::CHECK_DEADLINE_WARNING_POINT + 1.week).ago)
+      data = dataset.data_for_claims([claim_sla_warning])
+      expect(data.first[:sla_status]).to eq("warning")
+    end
+  end
+
+  it "correctly reports a claim's SLA status when the check deadline has passed" do
+    ClimateControl.modify ENVIRONMENT_NAME: "test" do
+      claim_sla_passed = build(:claim, :submitted, submitted_at: (Claim::CHECK_DEADLINE + 1.week).ago)
+      data = dataset.data_for_claims([claim_sla_passed])
+      expect(data.first[:sla_status]).to eq("passed")
+    end
+  end
+
   it "sends a claim's details to the Geckoboard dataset" do
     ClimateControl.modify ENVIRONMENT_NAME: "test" do
       event = Claim::GeckoboardDataset.new(claims: [claim])

--- a/spec/support/geckoboard_helpers.rb
+++ b/spec/support/geckoboard_helpers.rb
@@ -21,8 +21,8 @@ module GeckoboardHelpers
         name: "Submitted at",
         type: "datetime",
       },
-      passed_checking_deadline: {
-        name: "Passed checking deadline",
+      sla_status: {
+        name: "SLA status",
         type: "string",
       },
       check: {
@@ -82,7 +82,13 @@ module GeckoboardHelpers
         "reference" => claim.reference,
         "policy" => claim.policy.to_s,
         "submitted_at" => claim.submitted_at&.strftime("%Y-%m-%dT%H:%M:%S%:z"),
-        "passed_checking_deadline" => claim.check_deadline_date.past?.to_s,
+        "sla_status" => if claim.check_deadline_date.past?
+                          "passed"
+                        elsif claim.deadline_warning_date.past?
+                          "warning"
+                        else
+                          "ok"
+                        end,
         "check" => claim.check.present? ? claim.check.result : "unchecked",
         "checked_at" => (claim.check.present? ? claim.check.created_at : DateTime.parse("1970-01-01")).strftime("%Y-%m-%dT%H:%M:%S%:z"),
         "number_of_days_to_check" => claim.check&.number_of_days_since_claim_submitted,


### PR DESCRIPTION
Replaces a boolean "has this claim passed its check deadline" with a string representing the state of the claim relative to the deadline. A claim can either be "ok", "warning" or "passed".
