### PR TITLE
Check-your-answers copes with blank date-of-birth

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -29,7 +29,7 @@ module ClaimsHelper
     [].tap do |a|
       a << [t("questions.name"), claim.full_name, "name"] unless claim.name_verified?
       a << [t("questions.address"), claim.address, "address"] unless claim.address_from_govuk_verify?
-      a << [t("questions.date_of_birth"), l(claim.date_of_birth), "date-of-birth"] unless claim.date_of_birth_verified?
+      a << [t("questions.date_of_birth"), date_of_birth_string(claim), "date-of-birth"] unless claim.date_of_birth_verified?
       a << [t("questions.payroll_gender"), t("answers.payroll_gender.#{claim.payroll_gender}"), "gender"] unless claim.payroll_gender_verified?
       a << [t("questions.teacher_reference_number"), claim.teacher_reference_number, "teacher-reference-number"]
       a << [t("questions.national_insurance_number"), claim.national_insurance_number, "national-insurance-number"]
@@ -57,5 +57,9 @@ module ClaimsHelper
 
   def school_search_question(searching_for_additional_school)
     searching_for_additional_school ? t("student_loans.questions.additional_school") : t("student_loans.questions.claim_school")
+  end
+
+  def date_of_birth_string(claim)
+    claim.date_of_birth && l(claim.date_of_birth)
   end
 end

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -119,6 +119,22 @@ describe ClaimsHelper do
 
       expect(helper.identity_answers(claim)).to eq expected_answers
     end
+
+    it "copes with a blank date of birth" do
+      claim.date_of_birth = nil
+
+      expected_answers = [
+        [I18n.t("questions.name"), "Jo Bloggs", "name"],
+        [I18n.t("questions.address"), "Flat 1, 1 Test Road, Test Town, AB1 2CD", "address"],
+        [I18n.t("questions.date_of_birth"), nil, "date-of-birth"],
+        [I18n.t("questions.payroll_gender"), "Don’t know", "gender"],
+        [I18n.t("questions.teacher_reference_number"), "1234567", "teacher-reference-number"],
+        [I18n.t("questions.national_insurance_number"), "QQ123456C", "national-insurance-number"],
+        [I18n.t("questions.email_address"), "test@email.com", "email-address"],
+      ]
+
+      expect(helper.identity_answers(claim)).to eq expected_answers
+    end
   end
 
   describe "#payment_answers" do


### PR DESCRIPTION
This makes it so that visiting the check-your-answers page without having fully completed a claim will not result in an exception.

It's not something that should happen under normal usage, but we have seen at least one exception raised by a user visiting the check-your-answers page with a claim that doesn't have a value for
date_of_birth. This updates the helper that displays the answer for the question such that it won't raise an exception if the value is nil.