### PR TITLE
Use a separate Logit stack for non-production environments

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -149,7 +149,7 @@
       }
     },
     "LOGSTASH_PORT": {
-      "value": 23890
+      "value": 17002
     },
     "ADMIN_ALLOWED_IPS": {
       "reference": {

--- a/azure/resource_groups/app/parameters/test.template.json
+++ b/azure/resource_groups/app/parameters/test.template.json
@@ -155,7 +155,7 @@
       }
     },
     "LOGSTASH_PORT": {
-      "value": 23890
+      "value": 17002
     },
     "ADMIN_ALLOWED_IPS": {
       "reference": {


### PR DESCRIPTION
Until now we have been putting all Rails logs into a single Logit stack.
We have been using the named_tags.environment field to distinguish
between log entries from production, development, test, and local
development. This means that we have to make sure that our Logstash
logger is always populating this field correctly, and we found out that
it is not. I will soon make a commit which fixes this.

But, for an extra level of safety, to make sure that production logs
don't get mixed up with non-production logs, we have decided to separate
them completely by using a separate Logit stack.

This commit sets the non-secret LOGSTASH_PORT environment variable. To
use the new Logit stack, we also need to change the value of
LOGSTASH_HOST in the development and test key vaults. I will do this
before merging this commit into master.