### PR TITLE
Automatically remove PII from claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog]
 - Service operators can change the academic year a policy is accepting claims
   for
 - Service operators can view qualification and employment checks
+- PII is automatically deleted from claims which are either rejected and have
+  had no update in the last two months, or which have been paid more than two
+  months ago
 
 ## [Release 053] - 2020-02-12
 

--- a/app/assets/stylesheets/components/text.scss
+++ b/app/assets/stylesheets/components/text.scss
@@ -1,0 +1,3 @@
+.capt-text-quiet {
+  color: govuk-colour("dark-grey");
+}

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -10,13 +10,17 @@ module Admin
       claim.policy::EligibilityAdminAnswersPresenter.new(claim.eligibility).answers
     end
 
+    def pii_removed_text
+      content_tag(:span, "Removed", class: "capt-text-quiet")
+    end
+
     def admin_personal_details(claim)
       [
         [t("admin.teacher_reference_number"), claim.teacher_reference_number],
-        [t("govuk_verify_fields.full_name").capitalize, claim.full_name],
-        [t("govuk_verify_fields.date_of_birth").capitalize, l(claim.date_of_birth, format: :day_month_year)],
-        [t("admin.national_insurance_number"), claim.national_insurance_number],
-        [t("govuk_verify_fields.address").capitalize, sanitize(claim.address("<br>").html_safe, tags: %w[br])],
+        [t("govuk_verify_fields.full_name").capitalize, claim.pii_removed? ? pii_removed_text : claim.full_name],
+        [t("govuk_verify_fields.date_of_birth").capitalize, claim.pii_removed? ? pii_removed_text : l(claim.date_of_birth, format: :day_month_year)],
+        [t("admin.national_insurance_number"), claim.pii_removed? ? pii_removed_text : claim.national_insurance_number],
+        [t("govuk_verify_fields.address").capitalize, claim.pii_removed? ? pii_removed_text : sanitize(claim.address("<br>").html_safe, tags: %w[br])],
         [t("admin.email_address"), claim.email_address],
       ]
     end

--- a/app/jobs/delete_pii_from_old_claims_job.rb
+++ b/app/jobs/delete_pii_from_old_claims_job.rb
@@ -1,0 +1,10 @@
+# Runs weekly at 00:30 on a Sunday morning, and instructs the PiiScrubber class
+# to remove PII from eligible claims.
+class DeletePiiFromOldClaimsJob < CronJob
+  self.cron_expression = "30 0 * * 0"
+
+  def perform
+    Rails.logger.info "Deleting PII from old claims which have been rejected or paid"
+    Claim::PiiScrubber.new.scrub_completed_claims
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -234,6 +234,10 @@ class Claim < ApplicationRecord
     (ADDRESS_ATTRIBUTES & govuk_verify_fields).any?
   end
 
+  def pii_removed?
+    pii_removed_at.present?
+  end
+
   def full_name
     [first_name, middle_name, surname].compact.join(" ")
   end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -61,6 +61,7 @@ class Claim < ApplicationRecord
     building_society_roll_number: true,
     payment_id: false,
     academic_year: false,
+    pii_removed_at: false,
   }.freeze
   DECISION_DEADLINE = 12.weeks
   DECISION_DEADLINE_WARNING_POINT = 2.weeks

--- a/app/models/claim/pii_scrubber.rb
+++ b/app/models/claim/pii_scrubber.rb
@@ -1,0 +1,51 @@
+# Removes personally identifiable information from a claim where the claim is
+# either rejected and hasn't been updated in over two months, or where the claim
+# was scheduled to be paid more than two months ago.
+#
+# Attributes are set to nil, and pii_removed_at is set to the current timestamp.
+
+class Claim
+  class PiiScrubber
+    PII_ATTRIBUTES_TO_DELETE = [
+      :first_name,
+      :middle_name,
+      :surname,
+      :date_of_birth,
+      :address_line_1,
+      :address_line_2,
+      :address_line_3,
+      :address_line_4,
+      :postcode,
+      :payroll_gender,
+      :national_insurance_number,
+      :bank_sort_code,
+      :bank_account_number,
+      :building_society_roll_number,
+    ]
+
+    MINIMUM_DATE_OF_LAST_ACTION = 2.months.ago
+
+    def scrub_completed_claims
+      old_claims_rejected_or_paid.update_all(attribute_values_to_set)
+    end
+
+    private
+
+    def attribute_values_to_set
+      PII_ATTRIBUTES_TO_DELETE.map { |attr| [attr, nil] }.to_h.merge(
+        pii_removed_at: Time.zone.now
+      )
+    end
+
+    def old_claims_rejected_or_paid
+      Claim.left_outer_joins(payment: [:payroll_run])
+        .joins(:decision)
+        .where(pii_removed_at: nil)
+        .where(
+          "(decisions.result = :rejected AND decisions.created_at < :minimum_time) OR scheduled_payment_date < :minimum_time",
+          minimum_time: MINIMUM_DATE_OF_LAST_ACTION,
+          rejected: Decision.results.fetch(:rejected)
+        )
+    end
+  end
+end

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -10,6 +10,12 @@
       </div>
     <% end %>
 
+    <% if @claim.pii_removed? %>
+      <div class="govuk-body-l govuk-flash__notice">
+        This claim had personally identifiable information removed on <%= l(@claim.pii_removed_at.to_date) %>.
+      </div>
+    <% end %>
+
     <% if @matching_claims.any? %>
       <div class="govuk-body-l govuk-flash__warning">
         <a href="#claims-with-matches">Details in this claim match those in other claims</a>

--- a/db/migrate/20200205144103_add_pii_removed_at_timestamp.rb
+++ b/db/migrate/20200205144103_add_pii_removed_at_timestamp.rb
@@ -1,0 +1,5 @@
+class AddPiiRemovedAtTimestamp < ActiveRecord::Migration[6.0]
+  def change
+    add_column :claims, :pii_removed_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2020_02_12_154529) do
     t.string "banking_name"
     t.string "building_society_roll_number"
     t.uuid "payment_id"
+    t.datetime "pii_removed_at"
     t.string "academic_year", limit: 9
     t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -69,5 +69,24 @@ FactoryBot.define do
 
       eligibility_factory { ["#{policy.to_s.underscore}_eligibility".to_sym, :ineligible] }
     end
+
+    trait :pii_removed do
+      submitted
+      first_name { nil }
+      middle_name { nil }
+      surname { nil }
+      date_of_birth { nil }
+      address_line_1 { nil }
+      address_line_2 { nil }
+      address_line_3 { nil }
+      address_line_4 { nil }
+      postcode { nil }
+      payroll_gender { nil }
+      national_insurance_number { nil }
+      bank_sort_code { nil }
+      bank_account_number { nil }
+      building_society_roll_number { nil }
+      pii_removed_at { Time.zone.now }
+    end
   end
 end

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -105,6 +105,19 @@ RSpec.feature "Admin checks a claim" do
       expect(page).to have_content(user.full_name)
     end
 
+    context "When the claim has had PII removed" do
+      let!(:claim_with_pii_removed) { create(:claim, :rejected, :pii_removed) }
+
+      scenario "User can see where a claim has had PII removed" do
+        visit admin_claim_path(claim_with_pii_removed)
+        expect(page).to have_content("personally identifiable information removed")
+        expect(page).to have_content("Full name Removed")
+        expect(page).to have_content("Date of birth Removed")
+        expect(page).to have_content("National Insurance number Removed")
+        expect(page).to have_content("Address Removed")
+      end
+    end
+
     context "When the payroll gender is missing" do
       let!(:claim_missing_payroll_gender) { create(:claim, :submitted, payroll_gender: :dont_know) }
 

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -33,6 +33,23 @@ describe Admin::ClaimsHelper do
 
       expect(helper.admin_personal_details(claim)).to eq expected_answers
     end
+
+    context "when a claim has had PII deleted" do
+      let(:claim) { build(:claim, :rejected, :pii_removed, teacher_reference_number: "1234567", email_address: "test@email.com") }
+
+      it "returns the expected strings" do
+        expected_answers = [
+          [I18n.t("admin.teacher_reference_number"), "1234567"],
+          [I18n.t("govuk_verify_fields.full_name").capitalize, helper.pii_removed_text],
+          [I18n.t("govuk_verify_fields.date_of_birth").capitalize, helper.pii_removed_text],
+          [I18n.t("admin.national_insurance_number"), helper.pii_removed_text],
+          [I18n.t("govuk_verify_fields.address").capitalize, helper.pii_removed_text],
+          [I18n.t("admin.email_address"), "test@email.com"],
+        ]
+
+        expect(helper.admin_personal_details(claim)).to eq expected_answers
+      end
+    end
   end
 
   describe "#admin_student_loan_details" do

--- a/spec/jobs/delete_pii_from_old_claims_job_spec.rb
+++ b/spec/jobs/delete_pii_from_old_claims_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe DeletePiiFromOldClaimsJob do
+  describe "#perform" do
+    let(:over_two_months_ago) { 2.months.ago - 1.day }
+
+    it "deletes the PII from eligible claims" do
+      submitted_claim = create(:claim, :submitted)
+      rejected_claim = create(:claim, :submitted)
+      create(:decision, :rejected, claim: rejected_claim, created_at: over_two_months_ago)
+      paid_claim = create(:claim, :approved)
+      create(:payment, :with_figures, claims: [paid_claim], scheduled_payment_date: over_two_months_ago)
+
+      DeletePiiFromOldClaimsJob.new.perform
+
+      expect(Claim.find(submitted_claim.id).pii_removed_at).to be_nil
+      expect(Claim.find(rejected_claim.id).pii_removed_at).to_not be_nil
+      expect(Claim.find(paid_claim.id).pii_removed_at).to_not be_nil
+    end
+  end
+end

--- a/spec/models/claim/pii_scrubber_spec.rb
+++ b/spec/models/claim/pii_scrubber_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe Claim::PiiScrubber, type: :model do
+  let(:over_two_months_ago) { 2.months.ago - 1.day }
+
+  it "does not delete details from a submitted claim" do
+    claim = create(:claim, :submitted, updated_at: over_two_months_ago)
+
+    expect { Claim::PiiScrubber.new.scrub_completed_claims }.not_to change { claim.reload.attributes }
+  end
+
+  it "does not delete details from an approved but unpaid claim" do
+    claim = create(:claim, :approved, updated_at: over_two_months_ago)
+
+    expect { Claim::PiiScrubber.new.scrub_completed_claims }.not_to change { claim.reload.attributes }
+  end
+
+  it "does not delete details from a newly rejected claim" do
+    claim = create(:claim, :rejected)
+
+    expect { Claim::PiiScrubber.new.scrub_completed_claims }.not_to change { claim.reload.attributes }
+  end
+
+  it "does not delete details from a newly paid claim" do
+    claim = create(:claim, :approved)
+    create(:payment, :with_figures, claims: [claim])
+
+    expect { Claim::PiiScrubber.new.scrub_completed_claims }.not_to change { claim.reload.attributes }
+  end
+
+  it "deletes expected details from an old rejected claim, setting a pii_removed_at timestamp" do
+    freeze_time do
+      claim = create(:claim, :submitted)
+      create(:decision, :rejected, claim: claim, created_at: over_two_months_ago)
+
+      Claim::PiiScrubber.new.scrub_completed_claims
+      cleaned_claim = Claim.find(claim.id)
+
+      expect(cleaned_claim.first_name).to be_nil
+      expect(cleaned_claim.middle_name).to be_nil
+      expect(cleaned_claim.surname).to be_nil
+      expect(cleaned_claim.date_of_birth).to be_nil
+      expect(cleaned_claim.address_line_1).to be_nil
+      expect(cleaned_claim.address_line_2).to be_nil
+      expect(cleaned_claim.address_line_3).to be_nil
+      expect(cleaned_claim.address_line_4).to be_nil
+      expect(cleaned_claim.postcode).to be_nil
+      expect(cleaned_claim.payroll_gender).to be_nil
+      expect(cleaned_claim.national_insurance_number).to be_nil
+      expect(cleaned_claim.bank_sort_code).to be_nil
+      expect(cleaned_claim.bank_account_number).to be_nil
+      expect(cleaned_claim.building_society_roll_number).to be_nil
+      expect(cleaned_claim.pii_removed_at).to eq(Time.zone.now)
+    end
+  end
+
+  it "deletes expected details from an old paid claim, setting a pii_removed_at timestamp" do
+    freeze_time do
+      claim = create(:claim, :approved)
+      create(:payment, :with_figures, claims: [claim], scheduled_payment_date: over_two_months_ago)
+
+      Claim::PiiScrubber.new.scrub_completed_claims
+      cleaned_claim = Claim.find(claim.id)
+
+      expect(cleaned_claim.first_name).to be_nil
+      expect(cleaned_claim.middle_name).to be_nil
+      expect(cleaned_claim.surname).to be_nil
+      expect(cleaned_claim.date_of_birth).to be_nil
+      expect(cleaned_claim.address_line_1).to be_nil
+      expect(cleaned_claim.address_line_2).to be_nil
+      expect(cleaned_claim.address_line_3).to be_nil
+      expect(cleaned_claim.address_line_4).to be_nil
+      expect(cleaned_claim.postcode).to be_nil
+      expect(cleaned_claim.payroll_gender).to be_nil
+      expect(cleaned_claim.national_insurance_number).to be_nil
+      expect(cleaned_claim.bank_sort_code).to be_nil
+      expect(cleaned_claim.bank_account_number).to be_nil
+      expect(cleaned_claim.building_society_roll_number).to be_nil
+      expect(cleaned_claim.pii_removed_at).to eq(Time.zone.now)
+    end
+  end
+end


### PR DESCRIPTION
Claims will now have PII automatically removed from the database approximately two months after they are either rejected or paid.

Admins who view a claim which has had PII removed will be informed of the change to the claim.