### PR TITLE
Make sure Logstash entries are always tagged with environment name

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -55,7 +55,6 @@ module DfeTeachersPaymentService
     # See https://rocketjob.github.io/semantic_logger/rails.html#named-tags
     config.log_tags = {
       request_id: :request_id,
-      environment: ENV.fetch("ENVIRONMENT_NAME", "unspecified"),
     }
   end
 end

--- a/config/initializers/logstash.rb
+++ b/config/initializers/logstash.rb
@@ -1,3 +1,5 @@
+require "environment_log_formatter"
+
 if ENV["LOGSTASH_HOST"].present?
   Rails.application.configure do
     tcp_logger = LogStashLogger.new(type: :tcp,
@@ -5,6 +7,6 @@ if ENV["LOGSTASH_HOST"].present?
                                     port: ENV.fetch("LOGSTASH_PORT"),
                                     ssl_enable: true)
 
-    SemanticLogger.add_appender(logger: tcp_logger, level: :info, formatter: :json)
+    SemanticLogger.add_appender(logger: tcp_logger, level: :info, formatter: EnvironmentLogFormatter.new)
   end
 end

--- a/lib/environment_log_formatter.rb
+++ b/lib/environment_log_formatter.rb
@@ -1,0 +1,10 @@
+class EnvironmentLogFormatter < SemanticLogger::Formatters::Json
+  def call(log, logger)
+    log = log.dup
+    log.named_tags = log.named_tags.dup.tap do |named_tags|
+      named_tags[:environment] = ENV.fetch("ENVIRONMENT_NAME")
+    end
+
+    super(log, logger)
+  end
+end

--- a/spec/lib/environment_log_formatter_spec.rb
+++ b/spec/lib/environment_log_formatter_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe EnvironmentLogFormatter do
+  subject(:formatter) { described_class.new }
+  let(:log) { SemanticLogger::Log.new("ExampleClass", :info) }
+  let(:logger) { double(host: "example.local", application: "ExampleApp", environment: "example-rails-env") }
+
+  describe "#call" do
+    subject(:formatted_entry) { formatter.call(log, logger) }
+    around { |example| ClimateControl.modify(ENVIRONMENT_NAME: "example_env", &example) }
+
+    context "when there are no named tags active" do
+      it "adds ENV[\"ENVIRONMENT_NAME\"] to the named tags of the log entry" do
+        expect(JSON.parse(formatted_entry)["named_tags"]).to eq("environment" => "example_env")
+      end
+    end
+
+    context "when there are named tags active" do
+      around { |example| SemanticLogger.named_tagged(another_tag: "hello", &example) }
+
+      it "adds ENV[\"ENVIRONMENT_NAME\"] to the named tags of the log entry" do
+        expect(JSON.parse(formatted_entry)["named_tags"]).to eq("environment" => "example_env", "another_tag" => "hello")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to make sure that the named_tag.environment field is included in
all log entries sent by our application. It’s the only way for us to
distinguish between log entries from local development (if enabled),
development or test. This is because log entries from those environments
all go into the same Logit stack.

Until now we have relied on config.log_tags, but this only affects
request logging. This means that other messages such as custom log
messages, or Active Job's automatic start / end messages, do not get
tagged properly. So, we set up a custom SemanticLogger formatter which
appends the tag. This means that all calls that use the Rails logger now
send this field.

I’ve removed the fallback to sending a value of “unspecified” - I cannot
think of a legitimate time when the ENVIRONMENT_NAME environment
variable would not be set.
