### PR TITLE
Add a claim overview section for service operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog]
 - Update admin menu with new layout
 - Update "Some of this information is wrong" content on the verified page
 - A Service Operator can remove problematic payments from a payroll run
+- Add a claim overview section for service operators
 
 ## [Release 051] - 2020-02-03
 

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -14,6 +14,10 @@ class Admin::ClaimsController < Admin::BaseAdminController
     end
   end
 
+  def overview
+    @claim = Claim.find(params[:id])
+  end
+
   def show
     @claim = Claim.find(params[:id])
     @check = @claim.check || Check.new

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -21,6 +21,22 @@ module Admin
       ]
     end
 
+    def admin_claim_overview(claim)
+      [
+        ["TRN", claim.teacher_reference_number],
+        [t("govuk_verify_fields.full_name").capitalize, claim.full_name],
+        [t("govuk_verify_fields.date_of_birth").capitalize, l(claim.date_of_birth, format: :day_month_year)],
+      ]
+    end
+
+    def admin_submission_overview(claim)
+      [
+        ["SLA", [l(claim.check_deadline_date), check_deadline_warning(claim)].compact.join.html_safe],
+        [t("admin.submitted_at"), l(claim.submitted_at)],
+        [t("admin.email_address"), claim.email_address],
+      ]
+    end
+
     def admin_student_loan_details(claim)
       [].tap do |a|
         a << [t("student_loans.admin.student_loan_repayment_amount"), number_to_currency(claim.eligibility.student_loan_repayment_amount)] if claim.eligibility.respond_to?(:student_loan_repayment_amount)

--- a/app/views/admin/claims/_answer_section.html.erb
+++ b/app/views/admin/claims/_answer_section.html.erb
@@ -1,6 +1,8 @@
-<h2 class="govuk-heading-m">
-  <%= heading %>
-</h2>
+<% if heading.present? %>
+  <h2 class="govuk-heading-m">
+    <%= heading %>
+  </h2>
+<% end %>
 
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%- answers.each do |(label, answer)| %>

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -45,7 +45,7 @@
                 <td class="govuk-table__cell"><%= check_deadline_warning(claim) %></td>
               <% end %>
               <td class="govuk-table__cell"><%= l(claim.check_deadline_date) %></td>
-              <td class="govuk-table__cell"><%= link_to 'View claim', admin_claim_path(claim), class: "govuk-link" %></td>
+              <td class="govuk-table__cell"><%= link_to 'View claim', overview_admin_claim_path(claim), class: "govuk-link" %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/admin/claims/overview.html.erb
+++ b/app/views/admin/claims/overview.html.erb
@@ -1,0 +1,25 @@
+<%= link_to "Back", admin_claims_path, class: "govuk-back-link" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <span class="govuk-caption-xl">
+      <%= @claim.policy.short_name %>
+    </span>
+    <h1 class="govuk-heading-xl">
+      <%= @claim.reference %>
+      <span class="govuk-body-m">
+        <%= link_to "View full claim", admin_claim_path(@claim), class: "govuk-link" %>
+      </span>
+    </h1>
+  </div>
+
+
+  <div class="govuk-grid-column-one-half">
+    <%= render "admin/claims/answer_section", {heading: nil, answers: admin_claim_overview(@claim)} %>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <%= render "admin/claims/answer_section", {heading: nil, answers: admin_submission_overview(@claim)} %>
+  </div>
+</div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to "Back", admin_claims_path, class: "govuk-back-link" %>
+<%= link_to "Back", overview_admin_claim_path(@claim), class: "govuk-back-link" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -16,8 +16,11 @@
       </div>
     <% end %>
 
+    <span class="govuk-caption-xl">
+      <%= @claim.policy.short_name %>
+    </span>
     <h1 class="govuk-heading-xl">
-      Claim <%= @claim.reference %>
+      <%= @claim.reference %>
     </h1>
 
     <%= render("info_panel_identity_unconfirmed", school: @claim.school) unless @claim.identity_confirmed? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
 
     resources :claims, only: [:index, :show] do
       resources :checks, only: [:create], controller: "claim_checks"
+      get "overview", on: :member
       get "search", on: :collection
     end
 

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -35,6 +35,48 @@ describe Admin::ClaimsHelper do
     end
   end
 
+  describe "#admin_claim_overview" do
+    let(:claim) do
+      build(
+        :claim,
+        first_name: "Bruce",
+        surname: "Wayne",
+        teacher_reference_number: "1234567",
+        date_of_birth: Date.new(1901, 1, 1),
+      )
+    end
+
+    it "includes an array of questions and answers" do
+      expected_answers = [
+        ["TRN", "1234567"],
+        [I18n.t("govuk_verify_fields.full_name").capitalize, "Bruce Wayne"],
+        [I18n.t("govuk_verify_fields.date_of_birth").capitalize, "01/01/1901"],
+      ]
+
+      expect(helper.admin_claim_overview(claim)).to eq expected_answers
+    end
+  end
+
+  describe "#admin_submission_overview" do
+    let(:claim) do
+      build(
+        :claim,
+        :submitted,
+        email_address: "test@email.com",
+      )
+    end
+
+    it "includes an array of questions and answers" do
+      expected_answers = [
+        ["SLA", l(claim.check_deadline_date)],
+        [I18n.t("admin.submitted_at"), l(claim.submitted_at)],
+        [I18n.t("admin.email_address"), "test@email.com"],
+      ]
+
+      expect(helper.admin_submission_overview(claim)).to eq expected_answers
+    end
+  end
+
   describe "#admin_student_loan_details" do
     let(:claim) do
       build(

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -72,6 +72,21 @@ RSpec.describe "Admin claims", type: :request do
           end
         end
       end
+
+      describe "claims#overview" do
+        let(:claim) { create(:claim, :submitted, policy: policy) }
+
+        it "displays an overview of the claim and submission details" do
+          get overview_admin_claim_path(claim)
+
+          expect(response.body).to include(claim.reference)
+          expect(response.body).to include(claim.teacher_reference_number)
+          expect(response.body).to include(claim.full_name)
+          expect(response.body).to include(claim.email_address)
+          expect(response.body).to include(I18n.l(claim.submitted_at))
+          expect(response.body).to include(I18n.l(claim.check_deadline_date))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
As part of the work to improve the claim checking process for service
operators we now have an overview of the claim with pertinent
information.

The overview page will eventually have a task list of checks for the
service operator to carry out in order to approve the claim.

After speaking with Mark he'd like to keep the current 'show' claim
page as is for now.

**I'm not entirely sure whether to have the overview as the first page you see, or the show page. The prototype suggests the overview page should be first, but does it make sense in this interim state without the task list?**

## Screenshot

<img width="1170" alt="Screenshot 2020-02-06 at 14 28 47" src="https://user-images.githubusercontent.com/2804149/73945956-0bc30280-48ed-11ea-9124-27e1e8ef224e.png">
