### PR TITLE
Add a heartbeat job which emits a log message every minute

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ rake jobs:schedule
 ```
 
 Look for jobs that inherit from `CronJob` for a complete list of scheduled jobs.
-Currently there is a single scheduled job for importing the schools data once a
-day at 4am: `SchoolDataImporterJob`.
 
 ## Storing non-essential cookies
 

--- a/app/jobs/heartbeat_job.rb
+++ b/app/jobs/heartbeat_job.rb
@@ -1,0 +1,12 @@
+# Writes "Heartbeat job performed" to the logs every minute. This message is
+# evidence that the worker is working properly. We can use a log alerting tool
+# to alert us if too much time passes without seeing one of these messages.
+class HeartbeatJob < CronJob
+  self.cron_expression = "* * * * *"
+
+  queue_as :heartbeat
+
+  def perform
+    logger.info "Heartbeat job performed"
+  end
+end


### PR DESCRIPTION
We'll use the presence of this log message as evidence that the worker container is working correctly. We'll set up an alert in LogIt.io which sends us an email if too much time passes without observing one of these log messages.
