### PR TITLE
Don't share the last seen at session variables

### DIFF
--- a/app/assets/javascripts/components/timeout_dialog.js
+++ b/app/assets/javascripts/components/timeout_dialog.js
@@ -8,6 +8,7 @@
   var continueButtonElement = document.getElementById("continue_session");
   var warningTimeInMinutes = dialogElement.getAttribute("data-warning-in-minutes");
   var timeoutInMinutes = dialogElement.getAttribute("data-timeout-in-minutes");
+  var refreshSessionPath = dialogElement.getAttribute("data-refresh-session-path");
   var timeoutInMilliseconds = (timeoutInMinutes - warningTimeInMinutes) * 60 * 1000;
   var timeoutPath = dialogElement.getAttribute("data-timeout-path");
   var dialog = new window.A11yDialog(dialogElement);
@@ -23,7 +24,7 @@
 
   function refreshSession() {
     Rails.ajax({
-      url: "<%= refresh_session_path %>",
+      url: refreshSessionPath,
       type: "get",
       success: function() {
         clearInterval(window.sessionTimeoutTimer);

--- a/app/controllers/admin/base_admin_controller.rb
+++ b/app/controllers/admin/base_admin_controller.rb
@@ -5,6 +5,7 @@ module Admin
     layout "admin"
 
     before_action :end_expired_admin_sessions, :ensure_authenticated_user
+    after_action :update_last_seen_at
     helper_method :admin_signed_in?, :admin_timeout_in_minutes, :service_operator_signed_in?
 
     private
@@ -42,6 +43,10 @@ module Admin
 
     def ensure_payroll_operator
       render "admin/auth/failure", status: :unauthorized unless payroll_operator_signed_in?
+    end
+
+    def update_last_seen_at
+      session[:admin_last_seen_at] = Time.zone.now
     end
   end
 end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  class SessionsController < BaseAdminController
+    def refresh
+      end_expired_admin_sessions
+
+      head :ok
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,17 +1,11 @@
 class ApplicationController < ActionController::Base
   TIMEOUT_WARNING_LENGTH_IN_MINUTES = 2
 
-  after_action :update_last_seen_at
-
   helper_method :timeout_warning_in_minutes
 
   private
 
   def timeout_warning_in_minutes
     TIMEOUT_WARNING_LENGTH_IN_MINUTES
-  end
-
-  def update_last_seen_at
-    session[:last_seen_at] = Time.zone.now
   end
 end

--- a/app/controllers/base_public_controller.rb
+++ b/app/controllers/base_public_controller.rb
@@ -3,6 +3,7 @@ class BasePublicController < ApplicationController
 
   helper_method :current_policy_routing_name, :claim_timeout_in_minutes
   before_action :end_expired_claim_sessions
+  after_action :update_last_seen_at
 
   private
 
@@ -16,5 +17,9 @@ class BasePublicController < ApplicationController
       clear_claim_session
       redirect_to timeout_claim_path(policy_routing_name_for_redirect)
     end
+  end
+
+  def update_last_seen_at
+    session[:last_seen_at] = Time.zone.now
   end
 end

--- a/app/controllers/concerns/admin_session_timeout.rb
+++ b/app/controllers/concerns/admin_session_timeout.rb
@@ -15,7 +15,7 @@ module AdminSessionTimeout
   end
 
   def admin_session_timed_out?
-    admin_signed_in? && session[:last_seen_at] < admin_timeout_in_minutes.minutes.ago
+    admin_signed_in? && session[:admin_last_seen_at] < admin_timeout_in_minutes.minutes.ago
   end
 
   def admin_timeout_in_minutes

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,10 +1,8 @@
-class SessionsController < ApplicationController
-  include ClaimSessionTimeout
-  include AdminSessionTimeout
+class SessionsController < BasePublicController
+  skip_before_action :end_expired_claim_sessions
 
   def refresh
     clear_claim_session if claim_session_timed_out?
-    end_expired_admin_sessions
 
     head :ok
   end

--- a/app/views/application/_timeout_dialog.html.erb
+++ b/app/views/application/_timeout_dialog.html.erb
@@ -6,6 +6,7 @@
       "timeout-in-minutes" => timeout_in_minutes,
       "warning-in-minutes" => timeout_warning_in_minutes,
       "timeout-path" => path_on_timeout,
+      "refresh-session-path" => refresh_session_path,
     },
   ) do %>
   <div class="dialog-overlay" tabindex="-1" data-a11y-dialog-hide=""></div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -31,7 +31,7 @@
   <body class="govuk-template__body">
     <%= javascript_include_tag 'js_check' %>
 
-    <%= render("timeout_dialog", timeout_in_minutes: admin_timeout_in_minutes, path_on_timeout: admin_sign_in_path) if admin_signed_in? %>
+    <%= render("timeout_dialog", timeout_in_minutes: admin_timeout_in_minutes, path_on_timeout: admin_sign_in_path, refresh_session_path: admin_refresh_session_path) if admin_signed_in? %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
   <body class="govuk-template__body">
     <%= javascript_include_tag 'js_check' %>
 
-    <%= render("timeout_dialog", timeout_in_minutes: claim_timeout_in_minutes, path_on_timeout: timeout_claim_path(current_policy_routing_name)) if claim_in_progress? %>
+    <%= render("timeout_dialog", timeout_in_minutes: claim_timeout_in_minutes, path_on_timeout: timeout_claim_path(current_policy_routing_name), refresh_session_path: refresh_session_path) if claim_in_progress? %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,5 +101,6 @@ Rails.application.routes.draw do
     end
 
     resources :policy_configurations, only: [:index, :edit, :update]
+    get "refresh-session", to: "sessions#refresh", as: :refresh_session
   end
 end

--- a/spec/features/admin_timeout_spec.rb
+++ b/spec/features/admin_timeout_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Admin user session timeout", js: true do
 
   scenario "can refresh their session" do
     expect(page).to have_content("Your session will expire in #{one_second_in_minutes} minutes")
-    expect_any_instance_of(SessionsController).to receive(:update_last_seen_at)
+    expect_any_instance_of(Admin::SessionsController).to receive(:update_last_seen_at)
     click_on "Continue session"
   end
 

--- a/spec/requests/admin_sessions_spec.rb
+++ b/spec/requests/admin_sessions_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Admin Sessions", type: :request do
+  describe "#refresh" do
+    it "updates the last_seen_at session timestamp and responds with OK" do
+      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "_user_id", "_org_id")
+
+      travel(1.minute) do
+        get admin_refresh_session_path
+
+        expect(session[:admin_last_seen_at]).to eql(Time.zone.now)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    it "does not extend an expired admin session" do
+      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "_user_id", "_org_id")
+
+      travel(2.hours) do
+        get admin_refresh_session_path
+
+        expect(session[:user_id]).to be_nil
+
+        get admin_root_path
+        expect(response).to redirect_to(admin_sign_in_path)
+      end
+    end
+  end
+end

--- a/spec/requests/admin_timeout_spec.rb
+++ b/spec/requests/admin_timeout_spec.rb
@@ -7,38 +7,46 @@ RSpec.describe "Admin session timing out", type: :request do
 
   let!(:user) { create(:dfe_signin_user, dfe_sign_in_id: dfe_sign_in_id) }
 
+  let(:before_expiry) { timeout_length_in_minutes.minutes - 2.seconds }
+  let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
+
   before do
     sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, dfe_sign_in_id, organisation_id)
   end
 
-  context "no actions performed for more than the timeout period" do
-    let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
+  it "clears the session and redirects to the login page when no actions have been performed during the timeout period" do
+    expect(session[:user_id]).to eq(user.id)
 
-    it "clears the session and redirects to the login page" do
-      expect(session[:user_id]).to eq(user.id)
+    travel after_expiry do
+      get admin_claims_path
 
-      travel after_expiry do
-        get admin_claims_path
+      expect(response).to redirect_to(admin_sign_in_path)
+      expect(session[:user_id]).to be_nil
 
-        expect(response).to redirect_to(admin_sign_in_path)
-        expect(session[:user_id]).to be_nil
-
-        follow_redirect!
-        expect(response.body).to include("Your session has timed out due to inactivity")
-      end
+      follow_redirect!
+      expect(response.body).to include("Your session has timed out due to inactivity")
     end
   end
 
-  context "no action performed just within the timeout period" do
-    let(:before_expiry) { timeout_length_in_minutes.minutes - 2.seconds }
+  it "does not extend the session when the user performs a claim action" do
+    travel after_expiry do
+      start_student_loans_claim
+      get admin_claims_path
 
-    it "does not timeout the session" do
-      travel before_expiry do
-        get admin_claims_path
+      expect(response).to redirect_to(admin_sign_in_path)
+      expect(session[:user_id]).to be_nil
 
-        expect(response.code).to eq("200")
-        expect(session[:user_id]).to_not be_nil
-      end
+      follow_redirect!
+      expect(response.body).to include("Your session has timed out due to inactivity")
+    end
+  end
+
+  it "does not timeout the session when an action is performed within the timeout period" do
+    travel before_expiry do
+      get admin_claims_path
+
+      expect(response.code).to eq("200")
+      expect(session[:user_id]).to_not be_nil
     end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe "Sessions", type: :request do
   describe "#refresh" do
     it "updates the last_seen_at session timestamp and responds with OK" do
+      start_student_loans_claim
+
       travel_to(1.day.from_now) do
         get refresh_session_path
 
@@ -20,19 +22,6 @@ RSpec.describe "Sessions", type: :request do
 
         get claim_path(StudentLoans.routing_name, "qts-year")
         expect(response).to redirect_to(new_claim_path(StudentLoans.routing_name))
-      end
-    end
-
-    it "does not extend an expired admin session" do
-      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, "_user_id", "_org_id")
-
-      travel(2.hours) do
-        get refresh_session_path
-
-        expect(session[:user_id]).to be_nil
-
-        get admin_root_path
-        expect(response).to redirect_to(admin_sign_in_path)
       end
     end
   end


### PR DESCRIPTION
We picked up a bug in development, where we noticed that it was possible to extend an admin session by visiting a page on the public side of the site.

The seperates out the management of `last_seen_at` into two parts - one to handle admins, and one to handle public users. When a user carries out an action on the public side, this updates `session[:last_seen_at]` and when a user carries out an action on the admin side, this updates `session[:admin_last_seen_at]`.

I've also seperated out the `SessionsController`s, which are used when a user using Javascript opts to extend their session. This means that both the admin and application layouts now pass an additional`refresh_session_path` variable, which is sent to the JS via data attributes, and tells the frontend code which URL to send a request to.
