### PR TITLE
Remove `verify_response` from a Claim

### DIFF
--- a/app/controllers/verify/authentications_controller.rb
+++ b/app/controllers/verify/authentications_controller.rb
@@ -27,7 +27,6 @@ module Verify
         current_claim.update!(parser.attributes)
         redirect_to claim_url(current_policy_routing_name, "verified")
       else
-        current_claim.update!(verify_response: @response.parameters)
         redirect_to verify_path_for_response_scenario(@response.scenario)
       end
     end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -57,7 +57,6 @@ class Claim < ApplicationRecord
     submitted_at: false,
     updated_at: false,
     govuk_verify_fields: false,
-    verify_response: true,
     banking_name: true,
     building_society_roll_number: true,
     payment_id: false,

--- a/app/models/claim/verify_response_parameters_parser.rb
+++ b/app/models/claim/verify_response_parameters_parser.rb
@@ -8,18 +8,10 @@ class Claim
   #   => { first_name: "Margaret", last_name: "Hamilton", date_of_birth: "1936-08-17", ...}
   #
   # As well as keys for the personal information of the user (name, address,
-  # etc) the returned Hash includes two additional keys:
-  #
-  #   govuk_verify_fields – these are the keys for the attributes that have come
-  #                     back in the Verify response. Recording these allows us
-  #                     to determine which attributes came from Verify and
-  #                     therefore should not be editable by the user.
-  #
-  #   verify_response – this is the entire Verify response payload. We record
-  #                     this so that we can examine the original payload to
-  #                     debug issues in the way we parse responses, but also so
-  #                     we can retrospectively re-parse responses in future if
-  #                     necessary.
+  # etc) the returned Hash includes an additional `govuk_verify_fields` key,
+  # which are the keys for the attributes that have come back in the Verify
+  # response. Recording these allows us to determine which attributes came
+  # from Verify and therefore should not be editable by the user.
   #
   class VerifyResponseParametersParser
     class MissingResponseAttribute < StandardError; end
@@ -29,7 +21,7 @@ class Claim
     end
 
     def attributes
-      identity_attributes.merge(govuk_verify_fields: govuk_verify_fields, verify_response: @response_parameters)
+      identity_attributes.merge(govuk_verify_fields: govuk_verify_fields)
     end
 
     def gender

--- a/db/migrate/20200211105406_remove_verify_response_from_claim.rb
+++ b/db/migrate/20200211105406_remove_verify_response_from_claim.rb
@@ -1,0 +1,5 @@
+class RemoveVerifyResponseFromClaim < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :claims, :verify_response, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_10_163354) do
+ActiveRecord::Schema.define(version: 2020_02_11_105406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 2020_02_10_163354) do
     t.text "govuk_verify_fields", default: [], array: true
     t.string "eligibility_type"
     t.uuid "eligibility_id"
-    t.json "verify_response"
     t.string "first_name", limit: 100
     t.string "middle_name", limit: 100
     t.string "surname", limit: 100

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -45,14 +45,12 @@ FactoryBot.define do
 
     trait :verified do
       govuk_verify_fields { %w[first_name surname address_line_1 postcode date_of_birth payroll_gender] }
-      verify_response { {"scenario" => "IDENTITY_VERIFIED", "pid" => "123", "levelOfAssurance" => "LEVEL_2", "attributes" => {}} }
     end
 
     trait :unverified do
       submitted
 
       govuk_verify_fields { [] }
-      verify_response { nil }
     end
 
     trait :approved do

--- a/spec/features/govuk_verify_spec.rb
+++ b/spec/features/govuk_verify_spec.rb
@@ -49,7 +49,6 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
       expect(@claim.postcode).to eq("L12 345")
       expect(@claim.date_of_birth).to eq(Date.new(1806, 4, 9))
       expect(@claim.payroll_gender).to eq("male")
-      expect(@claim.verify_response).to eq(parsed_vsp_translated_response("identity-verified"))
     end
 
     scenario "successful verification with JavaScript disabled" do
@@ -80,7 +79,6 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
     expect(page).to have_text("you did not complete the process")
 
     @claim.reload
-    expect(@claim.verify_response).to eq(parsed_vsp_translated_response("no-authentication"))
   end
 
   scenario "Failing the Verify process shows a failure message to the user", js: true do
@@ -92,7 +90,6 @@ RSpec.feature "Teacher verifies identity using GOV.UK Verify" do
     expect(page).to have_text("the company you chose does not have enough information about you")
 
     @claim.reload
-    expect(@claim.verify_response).to eq(parsed_vsp_translated_response("authentication-failed"))
   end
 
   scenario "Users can take longer than 60 minutes to complete Verify", js: true do

--- a/spec/models/claim/verify_response_parameters_parser_spec.rb
+++ b/spec/models/claim/verify_response_parameters_parser_spec.rb
@@ -216,7 +216,6 @@ RSpec.describe Claim::VerifyResponseParametersParser do
         address_line_2: "Verified Town",
         postcode: "M12 345",
         govuk_verify_fields: %i[first_name surname date_of_birth address_line_1 address_line_2 postcode],
-        verify_response: sample_parsed_verify_response,
       }
 
       expect(parser.attributes).to eq expected_attributes

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -605,7 +605,6 @@ RSpec.describe Claim, type: :model do
         :first_name,
         :middle_name,
         :surname,
-        :verify_response,
         :banking_name,
         :building_society_roll_number,
       ])


### PR DESCRIPTION
This was introduced when we first started integrating with Verify, as we didn't have a huge amount of confidence in the data it would return, so kept the raw response against a claim too. It has come in handy in the past, but, as the Verify integration is more or less stable, it makes less sense (and is a big risk) for us to be storing this much PII, so we should remove it.
