### PR TITLE
Tidy up redundant columns

### DIFF
--- a/db/migrate/20200210162032_remove_checked_by_from_decisions.rb
+++ b/db/migrate/20200210162032_remove_checked_by_from_decisions.rb
@@ -1,0 +1,5 @@
+class RemoveCheckedByFromDecisions < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :decisions, :checked_by
+  end
+end

--- a/db/migrate/20200210162349_remove_created_by_from_payroll_runs.rb
+++ b/db/migrate/20200210162349_remove_created_by_from_payroll_runs.rb
@@ -1,0 +1,5 @@
+class RemoveCreatedByFromPayrollRuns < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :payroll_runs, :created_by
+  end
+end

--- a/db/migrate/20200210163354_remove_downloaded_by_from_payroll_runs.rb
+++ b/db/migrate/20200210163354_remove_downloaded_by_from_payroll_runs.rb
@@ -1,0 +1,5 @@
+class RemoveDownloadedByFromPayrollRuns < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :payroll_runs, :downloaded_by
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_10_121152) do
+ActiveRecord::Schema.define(version: 2020_02_10_162032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -57,7 +57,6 @@ ActiveRecord::Schema.define(version: 2020_02_10_121152) do
 
   create_table "decisions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "result"
-    t.string "checked_by"
     t.uuid "claim_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_10_162032) do
+ActiveRecord::Schema.define(version: 2020_02_10_162349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -143,7 +143,6 @@ ActiveRecord::Schema.define(version: 2020_02_10_162032) do
   end
 
   create_table "payroll_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "created_by"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "confirmation_report_uploaded_by"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_10_162349) do
+ActiveRecord::Schema.define(version: 2020_02_10_163354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -147,7 +147,6 @@ ActiveRecord::Schema.define(version: 2020_02_10_162349) do
     t.datetime "updated_at", null: false
     t.string "confirmation_report_uploaded_by"
     t.datetime "downloaded_at"
-    t.string "downloaded_by"
     t.uuid "created_by_id"
     t.uuid "downloaded_by_id"
     t.date "scheduled_payment_date"


### PR DESCRIPTION
This removes a bunch of redundant columns from before we were modelling the the actions of signed-in admin user as an association with a `DfeSignin::User` record: https://trello.com/c/fr9sNCXk/644-display-the-name-of-the-service-operator-who-took-an-action

One old-style string-based ID column remains: `confirmation_report_uploaded_by`. That hasn't been converted to the new-style of association and will get tackled as a separate piece of work.