### PR TITLE
Implement usability improvements for the student loans questions

### DIFF
--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -7,17 +7,13 @@
     <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
       <%= form.hidden_field :has_student_loan %>
         <%= form_group_tag current_claim do %>
-          <fieldset class="govuk-fieldset" aria-describedby="student_loans-hint" role="group">
+          <fieldset class="govuk-fieldset" role="group">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <span class="govuk-caption-xl">About your student loans</span>
               <h1 class="govuk-fieldset__heading">
                 <%= t("questions.has_student_loan") %>
               </h1>
             </legend>
-
-            <span class="govuk-hint" id="student_loans-hint">
-              We use this information to determine if we need to apply a student loan deduction to your payment.
-            </span>
 
             <%= errors_tag current_claim, :has_student_loan %>
 
@@ -31,10 +27,22 @@
                 <%= form.label :has_student_loan_false, "No", class: "govuk-label govuk-radios__label" %>
               </div>
             </div>
-
           </fieldset>
         <% end %>
         <%= form.submit "Continue", class: "govuk-button" %>
       <% end %>
+
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Why do you need to know about my student loans?
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p class="govuk-body">
+            We work out your student loan plan type using these questions so we make the correct student loan contributions to HMRC.
+          </p>
+        </div>
+      </details>
   </div>
 </div>

--- a/app/views/claims/student_loan.html.erb
+++ b/app/views/claims/student_loan.html.erb
@@ -9,6 +9,7 @@
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset" aria-describedby="student_loans-hint" role="group">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <span class="govuk-caption-xl">About your student loans</span>
               <h1 class="govuk-fieldset__heading">
                 <%= t("questions.has_student_loan") %>
               </h1>

--- a/app/views/claims/student_loan_country.html.erb
+++ b/app/views/claims/student_loan_country.html.erb
@@ -9,6 +9,7 @@
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <span class="govuk-caption-xl">About your student loans</span>
               <h1 class="govuk-fieldset__heading">
                 <%= t("questions.student_loan_country") %>
               </h1>

--- a/app/views/claims/student_loan_how_many_courses.html.erb
+++ b/app/views/claims/student_loan_how_many_courses.html.erb
@@ -9,6 +9,7 @@
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset" role="group", aria-describedby="student_loan_courses-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <span class="govuk-caption-xl">About your student loans</span>
               <h1 class="govuk-fieldset__heading">
                 <%= t("questions.student_loan_how_many_courses") %>
               </h1>

--- a/app/views/claims/student_loan_start_date.html.erb
+++ b/app/views/claims/student_loan_start_date.html.erb
@@ -9,6 +9,7 @@
         <%= form_group_tag current_claim do %>
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <span class="govuk-caption-xl">About your student loans</span>
               <h1 class="govuk-fieldset__heading">
                 <%= t("questions.student_loan_start_date.#{current_claim.student_loan_courses}") %>
               </h1>

--- a/app/views/student_loans/claims/student_loan_amount.html.erb
+++ b/app/views/student_loans/claims/student_loan_amount.html.erb
@@ -7,33 +7,37 @@
     <%= form_for current_claim, url: claim_path(current_policy_routing_name) do |form| %>
       <%= form_group_tag current_claim do %>
         <%= form.fields_for :eligibility, include_id: false do |fields| %>
+          <fieldset class="govuk-fieldset" role="group">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <span class="govuk-caption-xl">About your student loans</span>
+              <h1 class="govuk-fieldset__heading">
+                <%= fields.label :student_loan_repayment_amount, t("student_loans.questions.student_loan_amount"), class: "govuk-label govuk-label--xl" %>
+              </h1>
+            </legend>
 
-          <h1 class="govuk-form-wrapper">
-            <%= fields.label :student_loan_repayment_amount, t("student_loans.questions.student_loan_amount"), class: "govuk-label govuk-label--xl" %>
-          </h1>
+            <p class="govuk-hint" id="student_loan_repayment_amount-hint">
+              Check your annual student loan statement, or your P60 if you had only one employer.
+              <br><br>
+              You can also add up the student loan contributions from your payslips from this period, but bear in mind the
+              amounts on each payslip might be different.
+            </p>
 
-          <p class="govuk-hint" id="student_loan_repayment_amount-hint">
-            Check your annual student loan statement, or your P60 if you had only one employer.
-            <br><br>
-            You can also add up the student loan contributions from your payslips from this period, but bear in mind the
-            amounts on each payslip might be different.
-          </p>
+            <%= errors_tag current_claim.eligibility, :student_loan_repayment_amount %>
 
-          <%= errors_tag current_claim.eligibility, :student_loan_repayment_amount %>
-
-          <div class="govuk-currency-input">
-            <span class="govuk-currency-input__unit">&pound;</span>
-            <%= fields.number_field(
-                  :student_loan_repayment_amount,
-                  class: css_classes_for_input(current_claim, :student_loan_repayment_amount, "govuk-currency-input__input govuk-input--width-5"),
-                  step: 'any',
-                  min: 1,
-                  max: 99999,
-                  value: currency_value_for_number_field(fields.object.student_loan_repayment_amount),
-                  "aria-describedby" => "student_loan_repayment_amount-hint"
-                )
-            %>
-          </div>
+            <div class="govuk-currency-input">
+              <span class="govuk-currency-input__unit">&pound;</span>
+              <%= fields.number_field(
+                    :student_loan_repayment_amount,
+                    class: css_classes_for_input(current_claim, :student_loan_repayment_amount, "govuk-currency-input__input govuk-input--width-5"),
+                    step: 'any',
+                    min: 1,
+                    max: 99999,
+                    value: currency_value_for_number_field(fields.object.student_loan_repayment_amount),
+                    "aria-describedby" => "student_loan_repayment_amount-hint"
+                  )
+              %>
+            </div>
+          </fieldset>
         <% end %>
       <% end %>
       <%= form.submit "Continue", class: "govuk-button" %>


### PR DESCRIPTION
This adds a couple of small improvements to the flow in the student loans questions, moving the explanation to a details component, and adding subheadings to every question in the flow.

# Screenshots

![image](https://user-images.githubusercontent.com/109774/74254029-cab16080-4ce7-11ea-81cd-5f12083d1688.png)

![image](https://user-images.githubusercontent.com/109774/74254050-d13fd800-4ce7-11ea-83d4-19299a3339f6.png)

![image](https://user-images.githubusercontent.com/109774/74254064-d7ce4f80-4ce7-11ea-8070-9e2abb4346aa.png)

![image](https://user-images.githubusercontent.com/109774/74254079-dd2b9a00-4ce7-11ea-91a7-a98b8bfdd3c9.png)

![image](https://user-images.githubusercontent.com/109774/74254107-e583d500-4ce7-11ea-966b-d1c8b18bcd3a.png)

![image](https://user-images.githubusercontent.com/109774/74254122-ecaae300-4ce7-11ea-9c3a-cbf7af394adf.png)

![image](https://user-images.githubusercontent.com/109774/74254140-f3d1f100-4ce7-11ea-9fd8-f8c0b653e4ba.png)

