### PR TITLE
Introduce qualifications and employment checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog]
 - Iterate content on the Verify without Verify journey
 - Service operators can change the academic year a policy is accepting claims
   for
+- Service operators can view qualification and employment checks
 
 ## [Release 053] - 2020-02-12
 

--- a/app/assets/stylesheets/components/task_list.scss
+++ b/app/assets/stylesheets/components/task_list.scss
@@ -1,4 +1,16 @@
-// Task list pattern
+/*
+GOV.UK Task list pattern (experimental)
+
+This is an experimental GOV.UK pattern, the styles and markup
+have been taken from the example given in the GOV.UK prototyping
+kit (https://github.com/alphagov/govuk-prototype-kit/blob/master/app/assets/sass/patterns/_task-list.scss)
+
+For more information on the pattern and when to use it take a
+look at the GOV.UK Design System.
+
+https://design-system.service.gov.uk/patterns/task-list-pages/
+
+*/
 
 .app-task-list {
   list-style-type: none;

--- a/app/assets/stylesheets/components/task_list.scss
+++ b/app/assets/stylesheets/components/task_list.scss
@@ -1,0 +1,65 @@
+// Task list pattern
+
+.app-task-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  @include govuk-media-query($from: tablet) {
+    min-width: 550px;
+  }
+}
+
+.app-task-list__section {
+  display: table;
+  @include govuk-font($size: 24, $weight: bold);
+}
+
+.app-task-list__section-number {
+  display: table-cell;
+
+  @include govuk-media-query($from: tablet) {
+    min-width: govuk-spacing(6);
+    padding-right: 0;
+  }
+}
+
+.app-task-list__items {
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
+  list-style: none;
+  padding-left: 0;
+  @include govuk-media-query($from: tablet) {
+    padding-left: govuk-spacing(6);
+  }
+}
+
+.app-task-list__item {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: 0 !important;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  @include govuk-clearfix;
+}
+
+.app-task-list__item:first-child {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-task-list__task-name {
+  display: block;
+  @include govuk-media-query($from: 450px) {
+    float: left;
+  }
+}
+
+.app-task-list__task-completed {
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -1,0 +1,13 @@
+class Admin::ChecksController < Admin::BaseAdminController
+  before_action :ensure_service_operator
+  before_action :load_claim
+
+  def index
+  end
+
+  private
+
+  def load_claim
+    @claim = Claim.find(params[:claim_id])
+  end
+end

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -6,6 +6,7 @@ class Admin::ChecksController < Admin::BaseAdminController
   end
 
   def show
+    @eligibility_checks = @claim.policy::AdminChecksPresenter.new(@claim.eligibility)
     render current_check_template
   end
 

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -5,9 +5,17 @@ class Admin::ChecksController < Admin::BaseAdminController
   def index
   end
 
+  def show
+    render current_check_template
+  end
+
   private
 
   def load_claim
     @claim = Claim.find(params[:claim_id])
+  end
+
+  def current_check_template
+    params[:check].parameterize.underscore
   end
 end

--- a/app/models/maths_and_physics/admin_checks_presenter.rb
+++ b/app/models/maths_and_physics/admin_checks_presenter.rb
@@ -1,0 +1,35 @@
+module MathsAndPhysics
+  class AdminChecksPresenter
+    include Admin::PresenterMethods
+
+    attr_reader :eligibility
+
+    def initialize(eligibility)
+      @eligibility = eligibility
+    end
+
+    def qualifications
+      [].tap do |a|
+        a << ["Award year", I18n.t("maths_and_physics.questions.qts_award_years.#{eligibility.qts_award_year}")]
+        a << ["ITT subject", (eligibility.initial_teacher_training_subject_specialism || eligibility.initial_teacher_training_subject).humanize]
+        a << ["Maths or Physics degree", maths_or_physics_degree] if eligibility.has_uk_maths_or_physics_degree.present?
+      end
+    end
+
+    def employment
+      [
+        [I18n.t("admin.current_school"), display_school(eligibility.current_school)],
+      ]
+    end
+
+    private
+
+    def maths_or_physics_degree
+      if eligibility.has_uk_maths_or_physics_degree == "yes"
+        "UK Maths or Physics degree"
+      elsif eligibility.has_uk_maths_or_physics_degree == "has_non_uk"
+        "Non-UK Maths or Physics degree"
+      end
+    end
+  end
+end

--- a/app/models/student_loans/admin_checks_presenter.rb
+++ b/app/models/student_loans/admin_checks_presenter.rb
@@ -1,0 +1,24 @@
+module StudentLoans
+  class AdminChecksPresenter
+    include Admin::PresenterMethods
+
+    attr_reader :eligibility
+
+    def initialize(eligibility)
+      @eligibility = eligibility
+    end
+
+    def qualifications
+      [
+        ["Award year", I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}")],
+      ]
+    end
+
+    def employment
+      [
+        ["6 April 2018 to 5 April 2019", display_school(eligibility.claim_school)],
+        [I18n.t("admin.current_school"), display_school(eligibility.current_school)],
+      ]
+    end
+  end
+end

--- a/app/views/admin/checks/_claim_summary.html.erb
+++ b/app/views/admin/checks/_claim_summary.html.erb
@@ -1,0 +1,70 @@
+<div class="govuk-grid-column-full">
+  <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
+  <h1 class="govuk-heading-xl">
+    <%= @claim.reference %>
+  </h1>
+</div>
+
+<div class="govuk-grid-column-one-half">
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <abbr title="Teacher Reference Number">TRN</abbr>
+      </dt>
+
+      <dd class="govuk-summary-list__value">
+        <%= claim.teacher_reference_number %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Full name
+      </dt>
+
+      <dd class="govuk-summary-list__value">
+        <%= claim.full_name %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Date of birth
+      </dt>
+
+      <dd class="govuk-summary-list__value">
+        <%= l(claim.date_of_birth, format: :day_month_year) %>
+      </dd>
+    </div>
+  </dl>
+</div>
+<div class="govuk-grid-column-one-half">
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        SLA
+      </dt>
+
+      <dd class="govuk-summary-list__value">
+        <%= l(claim.decision_deadline_date) %>
+        <%= decision_deadline_warning(claim) %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Submitted
+      </dt>
+
+      <dd class="govuk-summary-list__value">
+        <%= l(claim.submitted_at) %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Email address
+      </dt>
+
+      <dd class="govuk-summary-list__value">
+        <%= claim.email_address %>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/app/views/admin/checks/employment.html.erb
+++ b/app/views/admin/checks/employment.html.erb
@@ -5,22 +5,11 @@
   <%= render "claim_summary", claim: @claim %>
 
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">
-      Employment
-    </h2>
-    <p class="govuk-body-l">Check the claimant's current school matches the below information from their claim.</p>
+    <%= render "admin/claims/answer_section",
+          heading: "Employment",
+          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.employment_check_description"),
+          answers: @eligibility_checks.employment %>
 
-    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= I18n.t("admin.current_school") %>
-        </dt>
-
-        <dd class="govuk-summary-list__value">
-          <%= display_school(@claim.eligibility.current_school) %>
-        </dd>
-      </div>
-    </dl>
     <%= button_to "Complete employment check and continue", admin_claim_path(@claim), class: "govuk-button", method: :get %>
   </div>
 </div>

--- a/app/views/admin/checks/employment.html.erb
+++ b/app/views/admin/checks/employment.html.erb
@@ -1,0 +1,25 @@
+<%= link_to "Back", admin_claim_checks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<div class="govuk-grid-row">
+
+  <%= render "claim_summary", claim: @claim %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">
+      Employment
+    </h2>
+    <p class="govuk-body-l">Check the claimant's current school matches the below information from their claim.</p>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= I18n.t("admin.current_school") %>
+        </dt>
+
+        <dd class="govuk-summary-list__value">
+          <%= display_school(@claim.eligibility.current_school) %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/app/views/admin/checks/employment.html.erb
+++ b/app/views/admin/checks/employment.html.erb
@@ -21,5 +21,6 @@
         </dd>
       </div>
     </dl>
+    <%= button_to "Complete employment check and continue", admin_claim_path(@claim), class: "govuk-button", method: :get %>
   </div>
 </div>

--- a/app/views/admin/checks/index.html.erb
+++ b/app/views/admin/checks/index.html.erb
@@ -1,0 +1,23 @@
+<%= link_to "Back", admin_claim_path(@claim), class: "govuk-back-link" %>
+
+<div class="govuk-grid-row">
+
+  <%= render "claim_summary", claim: @claim %>
+
+  <div class="govuk-grid-column-two-thirds">
+
+    <ol class="app-task-list">
+      <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number">1. </span> Qualifications
+        </h2>
+      </li>
+      <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number">2. </span> Employment
+        </h2>
+      </li>
+    </ol>
+
+  </div>
+</div>

--- a/app/views/admin/checks/index.html.erb
+++ b/app/views/admin/checks/index.html.erb
@@ -11,11 +11,25 @@
         <h2 class="app-task-list__section">
           <span class="app-task-list__section-number">1. </span> Qualifications
         </h2>
+        <ul class="app-task-list__items">
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <%= link_to "Check qualification information", admin_claim_check_path(claim_id: @claim.id, check: :qualifications), class: "govuk-link" %>
+            </span>
+          </li>
+        </ul>
       </li>
       <li>
         <h2 class="app-task-list__section">
           <span class="app-task-list__section-number">2. </span> Employment
         </h2>
+        <ul class="app-task-list__items">
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <%= link_to "Check employment information", admin_claim_check_path(claim_id: @claim.id, check: :employment), class: "govuk-link" %>
+            </span>
+          </li>
+        </ul>
       </li>
     </ol>
 

--- a/app/views/admin/checks/qualifications.html.erb
+++ b/app/views/admin/checks/qualifications.html.erb
@@ -21,5 +21,6 @@
         </dd>
       </div>
     </dl>
+    <%= button_to "Complete qualifications check and continue", admin_claim_check_path(claim_id: @claim.id, check: :employment), class: "govuk-button", method: :get %>
   </div>
 </div>

--- a/app/views/admin/checks/qualifications.html.erb
+++ b/app/views/admin/checks/qualifications.html.erb
@@ -1,0 +1,25 @@
+<%= link_to "Back", admin_claim_checks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<div class="govuk-grid-row">
+
+  <%= render "claim_summary", claim: @claim %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">
+      Qualifications
+    </h2>
+    <p class="govuk-body-l">Check the claimant's initial teacher training (ITT) qualification year matches the below information from their claim.</p>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= I18n.t("admin.qts_award_year") %>
+        </dt>
+
+        <dd class="govuk-summary-list__value">
+          <%= I18n.t("#{@claim.policy.to_s.underscore}.questions.qts_award_years.#{@claim.eligibility.qts_award_year}") %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/app/views/admin/checks/qualifications.html.erb
+++ b/app/views/admin/checks/qualifications.html.erb
@@ -5,22 +5,11 @@
   <%= render "claim_summary", claim: @claim %>
 
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">
-      Qualifications
-    </h2>
-    <p class="govuk-body-l">Check the claimant's initial teacher training (ITT) qualification year matches the below information from their claim.</p>
+    <%= render "admin/claims/answer_section",
+          heading: "Qualifications",
+          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.qualification_check_description"),
+          answers: @eligibility_checks.qualifications %>
 
-    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= I18n.t("admin.qts_award_year") %>
-        </dt>
-
-        <dd class="govuk-summary-list__value">
-          <%= I18n.t("#{@claim.policy.to_s.underscore}.questions.qts_award_years.#{@claim.eligibility.qts_award_year}") %>
-        </dd>
-      </div>
-    </dl>
     <%= button_to "Complete qualifications check and continue", admin_claim_check_path(claim_id: @claim.id, check: :employment), class: "govuk-button", method: :get %>
   </div>
 </div>

--- a/app/views/admin/claims/_answer_section.html.erb
+++ b/app/views/admin/claims/_answer_section.html.erb
@@ -1,6 +1,12 @@
-<h2 class="govuk-heading-m">
+<h2 class="govuk-heading-l">
   <%= heading %>
 </h2>
+
+<% if local_assigns.has_key?(:description) %>
+  <p class="govuk-body-l">
+    <%= description %>
+  </p>
+<% end %>
 
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%- answers.each do |(label, answer)| %>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -16,8 +16,12 @@
       </div>
     <% end %>
 
+    <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
     <h1 class="govuk-heading-xl">
-      Claim <%= @claim.reference %>
+      <%= @claim.reference %>
+      <span class="govuk-body-m">
+        <%= link_to "View checks", admin_claim_checks_path(claim_id: @claim.id), class: "govuk-link" %>
+      </span>
     </h1>
 
     <%= render("info_panel_identity_unconfirmed", school: @claim.school) unless @claim.identity_confirmed? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,6 +170,8 @@ en:
       employed_directly: "Employed directly by school?"
       disciplinary_action: "Subject to disciplinary action?"
       formal_performance_action: "Subject to formal performance action?"
+      qualification_check_description: "Check the claimant's initial teacher training (ITT) qualification year and specialist subject matches the below information from their claim."
+      employment_check_description: "Check the claimant's current school matches the below information from their claim."
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     policy_short_name: "Student Loans"
@@ -210,3 +212,5 @@ en:
       mostly_performed_leadership_duties: "Mostly performed leadership duties?"
       student_loan_repayment_amount: "Student loan repayment amount"
       student_loan_repayment_plan: "Student loan repayment plan"
+      qualification_check_description: "Check the claimant's initial teacher training (ITT) qualification year matches the below information from their claim."
+      employment_check_description: "Check the claimant's previous and current schools match the below information from their claim."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
     get "/auth/failure", to: "auth#failure"
 
     resources :claims, only: [:index, :show] do
+      resources :checks, only: [:index]
       resources :decisions, only: [:create]
       get "search", on: :collection
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
     get "/auth/failure", to: "auth#failure"
 
     resources :claims, only: [:index, :show] do
-      resources :checks, only: [:index]
+      resources :checks, only: [:index, :show], param: :check, constraints: {check: %r{qualifications|employment}}
       resources :decisions, only: [:create]
       get "search", on: :collection
     end

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -82,12 +82,15 @@ RSpec.feature "Admin checks a claim" do
       expect(page).to have_content("Award year")
       expect(page).to have_content(I18n.t("#{claim.policy.to_s.underscore}.questions.qts_award_years.#{claim.eligibility.qts_award_year}"))
 
-      click_on "Back"
+      click_on "Complete qualifications check and continue"
 
-      click_on "Check employment information"
       expect(page).to have_content("Employment")
       expect(page).to have_content("Current school")
       expect(page).to have_link(claim.eligibility.current_school.name)
+
+      click_on "Complete employment check and continue"
+
+      expect(page).to have_content("Claim decision")
     end
 
     scenario "User can see existing decision details" do

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -76,6 +76,18 @@ RSpec.feature "Admin checks a claim" do
 
       expect(page).to have_content("1. Qualifications")
       expect(page).to have_content("2. Employment")
+
+      click_on "Check qualification information"
+      expect(page).to have_content("Qualifications")
+      expect(page).to have_content("Award year")
+      expect(page).to have_content(I18n.t("#{claim.policy.to_s.underscore}.questions.qts_award_years.#{claim.eligibility.qts_award_year}"))
+
+      click_on "Back"
+
+      click_on "Check employment information"
+      expect(page).to have_content("Employment")
+      expect(page).to have_content("Current school")
+      expect(page).to have_link(claim.eligibility.current_school.name)
     end
 
     scenario "User can see existing decision details" do

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -68,6 +68,16 @@ RSpec.feature "Admin checks a claim" do
       expect(mail.body.raw_source).to match("not been able to approve")
     end
 
+    scenario "User can see checks for a claim" do
+      claim = create(:claim, :submitted)
+      visit admin_claim_path(claim)
+
+      click_on "View checks"
+
+      expect(page).to have_content("1. Qualifications")
+      expect(page).to have_content("2. Employment")
+    end
+
     scenario "User can see existing decision details" do
       claim_with_decision = create(:claim, :submitted, decision: build(:decision, result: :approved, notes: "Everything matches"))
       visit admin_claim_path(claim_with_decision)

--- a/spec/models/maths_and_physics/admin_checks_presenter_spec.rb
+++ b/spec/models/maths_and_physics/admin_checks_presenter_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe MathsAndPhysics::AdminChecksPresenter, type: :model do
+  let(:school) { schools(:penistone_grammar_school) }
+  let(:eligibility) do
+    build(:maths_and_physics_eligibility,
+      teaching_maths_or_physics: true,
+      current_school: school,
+      initial_teacher_training_subject: :maths,
+      initial_teacher_training_subject_specialism: nil,
+      qts_award_year: "on_or_after_september_2014")
+  end
+  subject(:presenter) { described_class.new(eligibility) }
+
+  describe "#qualifications" do
+    it "returns an array of label and values for displaying information for qualification checks" do
+      expected_array = [
+        [I18n.t("admin.qts_award_year"), "In or after the academic year 2014 to 2015"],
+        ["ITT subject", "Maths"],
+      ]
+      expect(presenter.qualifications).to eq expected_array
+    end
+
+    it "includes the subject specialism if they chose science" do
+      eligibility.initial_teacher_training_subject = :science
+      eligibility.initial_teacher_training_subject_specialism = :physics
+
+      expected_array = [
+        [I18n.t("admin.qts_award_year"), "In or after the academic year 2014 to 2015"],
+        ["ITT subject", "Physics"],
+      ]
+      expect(presenter.qualifications).to eq expected_array
+    end
+
+    it "includes the their degree if they didn't choose maths or physics for their ITT subject" do
+      eligibility.initial_teacher_training_subject = :science
+      eligibility.initial_teacher_training_subject_specialism = :biology
+      eligibility.has_uk_maths_or_physics_degree = :yes
+
+      expected_array = [
+        [I18n.t("admin.qts_award_year"), "In or after the academic year 2014 to 2015"],
+        ["ITT subject", "Biology"],
+        ["Maths or Physics degree", "UK Maths or Physics degree"],
+      ]
+      expect(presenter.qualifications).to eq expected_array
+    end
+  end
+
+  describe "#employment" do
+    it "returns an array of label and values for displaying information for employment checks" do
+      expect(presenter.employment).to eq [
+        [I18n.t("admin.current_school"), presenter.display_school(eligibility.current_school)],
+      ]
+    end
+  end
+end

--- a/spec/models/student_loans/admin_checks_presenter_spec.rb
+++ b/spec/models/student_loans/admin_checks_presenter_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe StudentLoans::AdminChecksPresenter, type: :model do
+  let(:school) { schools(:penistone_grammar_school) }
+  let(:eligibility) do
+    build(
+      :student_loans_eligibility,
+      qts_award_year: "on_or_after_september_2013",
+      claim_school: school,
+      current_school: school,
+    )
+  end
+  subject(:presenter) { described_class.new(eligibility) }
+
+  describe "#qualifications" do
+    it "returns an array of label and values for displaying information for qualification checks" do
+      expect(presenter.qualifications).to eq [[I18n.t("admin.qts_award_year"), "In or after the academic year 2013 to 2014"]]
+    end
+  end
+
+  describe "#employment" do
+    it "returns an array of label and values for displaying information for employment checks" do
+      expect(presenter.employment).to eq [
+        ["6 April 2018 to 5 April 2019", presenter.display_school(eligibility.claim_school)],
+        [I18n.t("admin.current_school"), presenter.display_school(eligibility.current_school)],
+      ]
+    end
+  end
+end

--- a/spec/requests/admin_checks_spec.rb
+++ b/spec/requests/admin_checks_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe "Admin checks", type: :request do
         expect(response.body).to include("Employment")
       end
     end
+
+    # Compatible with claims from each policy
+    Policies.all.each do |policy|
+      context "with a #{policy} claim" do
+        describe "checks#show" do
+          it "renders the requested page" do
+            get admin_claim_check_path(claim, "qualifications")
+            expect(response.body).to include(I18n.t("admin.qts_award_year"))
+            expect(response.body).to include(I18n.t("#{claim.policy.to_s.underscore}.questions.qts_award_years.#{claim.eligibility.qts_award_year}"))
+
+            get admin_claim_check_path(claim, "employment")
+            expect(response.body).to include(I18n.t("admin.current_school"))
+            expect(response.body).to include(claim.eligibility.current_school.name)
+          end
+        end
+      end
+    end
   end
 
   context "when signed in as a payroll operator or a support agent" do

--- a/spec/requests/admin_checks_spec.rb
+++ b/spec/requests/admin_checks_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Admin checks", type: :request do
+  let(:claim) { create(:claim, :submitted) }
+
+  context "when signed in as a service operator" do
+    let(:user) { create(:dfe_signin_user) }
+
+    before do
+      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+    end
+
+    describe "checks#index" do
+      it "shows a list of checks for a claim" do
+        get admin_claim_checks_path(claim_id: claim.id)
+
+        expect(response.body).to include(claim.reference)
+        expect(response.body).to include("Qualifications")
+        expect(response.body).to include("Employment")
+      end
+    end
+  end
+
+  context "when signed in as a payroll operator or a support agent" do
+    describe "checks#index" do
+      [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
+        it "does not allow the claim checks to be viewed" do
+          sign_in_to_admin_with_role(role)
+          get admin_claim_checks_path(claim_id: claim.id)
+
+          expect(response.code).to eq("401")
+        end
+      end
+    end
+  end
+end

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -38,4 +38,17 @@ describe "Routes", type: :routing do
       expect(claim_path("maths-and-physics", "teaching-maths-or-physics")).to eq "/maths-and-physics/teaching-maths-or-physics"
     end
   end
+
+  describe "Admin claim checks routing" do
+    it "routes GET requests to valid checks on a claim" do
+      claim = create(:claim, :submitted)
+      expect(get: "admin/claims/#{claim.id}/checks/qualifications").to route_to "admin/checks#show", claim_id: claim.id, check: "qualifications"
+      expect(get: "admin/claims/#{claim.id}/checks/employment").to route_to "admin/checks#show", claim_id: claim.id, check: "employment"
+    end
+
+    it "does not route for unrecognised checks" do
+      claim = create(:claim, :submitted)
+      expect(get: "admin/claims/#{claim.id}/checks/foo").not_to be_routable
+    end
+  end
 end


### PR DESCRIPTION
We chose to start with qualification and employment checks as they are common to each policy, with the exception that StudentLoans has some additional information but we can tackle that later.

Eventually we'll get to a point where a service operator can mark these checks as completed or not.

## Screenshots

<img width="1112" alt="Screenshot 2020-02-11 at 18 04 32" src="https://user-images.githubusercontent.com/2804149/74264716-10c2f000-4cf9-11ea-9939-c625594ad4c9.png">
<img width="1167" alt="Screenshot 2020-02-12 at 16 04 57" src="https://user-images.githubusercontent.com/2804149/74353223-7f638480-4db1-11ea-9952-70912503f083.png">
<img width="1128" alt="Screenshot 2020-02-12 at 16 05 12" src="https://user-images.githubusercontent.com/2804149/74353230-825e7500-4db1-11ea-8309-f81833033674.png">

