### PR TITLE
Reduce sensitivity of Azure alerts

### DIFF
--- a/azure/templates/app_alerts.json
+++ b/azure/templates/app_alerts.json
@@ -88,7 +88,7 @@
               "metricNamespace": "Microsoft.Web/sites",
               "metricName": "Http5xx",
               "operator": "GreaterThan",
-              "threshold": 1,
+              "threshold": 2,
               "timeAggregation": "Total"
             }
           ]
@@ -110,8 +110,8 @@
         "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average CPU utilization for ', variables('appServicePlanName'), ' is greater than 80%.')]",
         "severity": 1,
-        "evaluationFrequency": "PT1M",
-        "windowSize": "PT5M",
+        "evaluationFrequency": "PT5M",
+        "windowSize": "PT15M",
         "targetResourceType": "Microsoft.Web/serverfarms",
         "targetResourceRegion": "[resourceGroup().location]",
         "criteria": {
@@ -145,8 +145,8 @@
         "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average memory utilization for ', variables('appServicePlanName'), ' is greater than 80%.')]",
         "severity": 1,
-        "evaluationFrequency": "PT1M",
-        "windowSize": "PT5M",
+        "evaluationFrequency": "PT5M",
+        "windowSize": "PT15M",
         "targetResourceType": "Microsoft.Web/serverfarms",
         "targetResourceRegion": "[resourceGroup().location]",
         "criteria": {

--- a/azure/templates/database_alerts.json
+++ b/azure/templates/database_alerts.json
@@ -33,8 +33,8 @@
         "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average CPU utilization for ', variables('databaseServerName'), ' is greater than 80%.')]",
         "severity": 0,
-        "evaluationFrequency": "PT1M",
-        "windowSize": "PT5M",
+        "evaluationFrequency": "PT5M",
+        "windowSize": "PT15M",
         "targetResourceType": "Microsoft.DBforPostgreSQL/servers",
         "targetResourceRegion": "[resourceGroup().location]",
         "criteria": {
@@ -68,8 +68,8 @@
         "enabled": "[parameters('enableAlerts')]",
         "description": "[concat('Alert when average memory utilization for ', variables('databaseServerName'), ' is greater than 80%.')]",
         "severity": 0,
-        "evaluationFrequency": "PT1M",
-        "windowSize": "PT5M",
+        "evaluationFrequency": "PT5M",
+        "windowSize": "PT15M",
         "targetResourceType": "Microsoft.DBforPostgreSQL/servers",
         "targetResourceRegion": "[resourceGroup().location]",
         "criteria": {


### PR DESCRIPTION
Reduces the sensitivity of Azure alerts.

* CPU and Memory alerts now trigger at 80% average usage sustained over 15 minutes (was previously 5 minutes).
* HTTP 500 errors now trigger at three or more errors within a minute (was previously two or more)