### PR TITLE
Fix school search button text changing when submitting

### DIFF
--- a/app/assets/javascripts/components/school_search.js.erb
+++ b/app/assets/javascripts/components/school_search.js.erb
@@ -29,11 +29,16 @@ document.addEventListener("DOMContentLoaded", function() {
   var defaultMethodInputValue = methodInput.method || "";
   var defaultFormSubmitValue = formSubmit.value || "";
 
-  function resetForm() {
+  function setSubmitValue(value) {
+    formSubmit.value = value;
+    formSubmit.setAttribute("data-disable-with", value);
+  }
+
+  function resetForm(e) {
     schoolIdInput.value = defaultSchoolIdInputValue;
     form.method = defaultFormMethod;
     methodInput.value = defaultMethodInputValue;
-    formSubmit.value = defaultFormSubmitValue;
+    setSubmitValue(defaultFormSubmitValue);
   }
 
   var schools = [];
@@ -120,7 +125,7 @@ document.addEventListener("DOMContentLoaded", function() {
       schoolIdInput.value = school.id;
       form.method = "post";
       methodInput.value = "patch";
-      formSubmit.value = "Continue";
+      setSubmitValue("Continue");
     }
   });
 


### PR DESCRIPTION
Out of the box, the Rails `submit_tag` helper sets a `data-disable-with` value, which tells the Unobstructive Javascript Scripting Adapter what to set the input's value to when disabling the submit button after it is clicked. In our JS, we don't change this when changing the value, so whe a user clicks on the "Continue" button, it switches back to "Search". This updates the JS so the `data-disable-with` attribute is changed whenever the value of the submit button is changed.

## Before

![](http://g.recordit.co/vp31sJyzkZ.gif)

## After

![](http://g.recordit.co/gJGD0Zz2qJ.gif)
