### PR TITLE
New copy when claim has been removed from payrun

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,8 +85,8 @@ en:
       one: You have removed a claim from the payroll run
       other: You have removed %{count} claims from the payroll run
     payment_deleted_outcome_message:
-      one: Claim %{references} is no longer included in this pay run.
-      other: Claims %{references} are no longer included in this pay run.
+      one: Claim %{references} is no longer included in this pay run. This claim will be automatically added to the next pay run.
+      other: Claims %{references} are no longer included in this pay run. These claims will be automatically added to the next pay run.
     payment_deleted_claim_next_steps_message:
       one: Please make a note of this claim and contact the claimant to resolve the problems with their payment before the next pay run.
       other: Please make a note of these claims and contact the claimant to resolve the problems with their payment before the next pay run.


### PR DESCRIPTION
This makes it clearer that the service operator doesn't need to carry out any other actions other than contacting the claimant in order to get the claim added to the next pay run.

![image](https://user-images.githubusercontent.com/109774/74337930-2be53c80-4d99-11ea-917d-91fb33bc7f1c.png)
