### PR TITLE
Hide unknown gender warning for decided claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- The admin page for a claim no longer warns about a missing payroll gender once
+  a decision has been made
+
 ## [Release 053] - 2020-02-12
 
 - Don't share the last seen at session variables

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -6,7 +6,7 @@
 
     <% if @claim.payroll_gender_missing? %>
       <div class="govuk-body-l govuk-flash__notice">
-        This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
+        <%= t("admin.unknown_payroll_gender_preventing_approval_message") %>
       </div>
     <% end %>
 
@@ -35,7 +35,7 @@
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           <span class="govuk-warning-text__assistive">Warning</span>
-          This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
+          <%= t("admin.unknown_payroll_gender_preventing_approval_message") %>
         </strong>
       </div>
     <% end %>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render("shared/error_summary", instance: @decision, errored_field_id_overrides: { "result": "decision_result_approved" }) if @decision.errors.any? %>
 
-    <% if @claim.payroll_gender_missing? %>
+    <% if @claim.payroll_gender_missing? && !@claim.decision_made? %>
       <div class="govuk-body-l govuk-flash__notice">
         <%= t("admin.unknown_payroll_gender_preventing_approval_message") %>
       </div>
@@ -30,7 +30,7 @@
 
     <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
 
-    <% if @claim.payroll_gender_missing? %>
+    <% if @claim.payroll_gender_missing? && !@claim.decision_made? %>
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,7 @@ en:
     payment_deleted_claim_next_steps_message:
       one: Please make a note of this claim and contact the claimant to resolve the problems with their payment before the next pay run.
       other: Please make a note of these claims and contact the claimant to resolve the problems with their payment before the next pay run.
+    unknown_payroll_gender_preventing_approval_message: This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
   answers:
     student_loan_start_date:
       one_course:

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -90,6 +90,16 @@ RSpec.feature "Admin checks a claim" do
         expect(page).to have_field("Approve", disabled: true)
         expect(page).to have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))
       end
+
+      context "When a decision has been made" do
+        let!(:claim_missing_payroll_gender_with_decision) { create(:claim, :rejected, payroll_gender: :dont_know) }
+
+        scenario "User is not informed that the claim cannot be approved" do
+          visit admin_claim_path(claim_missing_payroll_gender_with_decision)
+
+          expect(page).to_not have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))
+        end
+      end
     end
 
     context "When the claimant has another approved claim in the same payroll window, with inconsistent personal details" do

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature "Admin checks a claim" do
         find("a[href='#{admin_claim_path(claim_missing_payroll_gender)}']").click
 
         expect(page).to have_field("Approve", disabled: true)
-        expect(page).to have_content("This claim cannot be approved, the payroll gender is missing")
+        expect(page).to have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))
       end
     end
 


### PR DESCRIPTION
Where a claim has had a decision made, do not show the message about needing a payroll gender to make a decision.