### PR TITLE
Ensure file extension appears in data migration

### DIFF
--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -3,11 +3,11 @@ class DataMigrationGenerator < Rails::Generators::NamedBase
 
   def copy_data_migration_file
     @file_name = filename_with_timestamp
-    template "data_migration.template", "db/data/#{@file_name}.rb"
+    template "data_migration.template", "db/data/#{@file_name}"
   end
 
   def filename_with_timestamp
     timestamp = Time.now.utc.strftime("%Y%m%d%H%M%S")
-    "#{timestamp}_#{file_name.underscore}"
+    "#{timestamp}_#{file_name.underscore}.rb"
   end
 end


### PR DESCRIPTION
Before this change the generated data migration would not include the file extension in the `rails runner` line for running the data migration.