### PR TITLE
Iterate content on the Verify without Verify journey

### DIFF
--- a/app/views/claim_mailer/submitted.text.erb
+++ b/app/views/claim_mailer/submitted.text.erb
@@ -9,11 +9,11 @@ Your unique reference is <%= @claim.reference %>. You will need this if you cont
 <%- if @claim.identity_confirmed? -%>
 We'll check the details you provided in your application and we'll tell you if your claim was successful within <%= claim_decision_deadline_in_weeks %>.
 <%- else -%>
-Before we can progress your claim, we need to confirm your identity by calling you at your school.
+We’ll check the details you provided in your claim and then contact you to confirm your identity over the phone.
 
-We’ll send you an email from <%= support_email_address(@policy.routing_name) %> to arrange a convenient time for us to call.
+We’ll send you an email from <%= support_email_address(@policy.routing_name) %> to arrange a convenient time for us to call you on your school's landline. Please add <%= support_email_address(@policy.routing_name) %> to your address book to make sure you receive this email.
 
-If we’re able to confirm your identity, we’ll check the details you provided in your claim and tell you if your claim was successful within <%= claim_decision_deadline_in_weeks %>.
+You'll find out if your claim was successful within <%= claim_decision_deadline_in_weeks %> and you'll receive email updates as your application progresses.
 <%- end -%>
 
 It can take up to 18 weeks to process your application and make a payment into your account.

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -17,13 +17,9 @@
 
     <h2 class="govuk-heading-m">What happens next</h2>
 
-    <p class="govuk-body">
-      We have sent your application to the Department for Education.
-    </p>
-
     <% if current_claim.identity_confirmed? %>
       <p class="govuk-body">
-        They will check the details you provided in your application and tell
+        We will check the details you provided in your application and tell
         you if your claim was successful within the next <%= claim_decision_deadline_in_weeks %>.
       </p>
 
@@ -31,22 +27,32 @@
         This service is currently in development, so while we expect to be
         able to send you the outcome in that time frame, it may change.
       </p>
+
+      <p class="govuk-body">
+        You will receive email updates as your application progresses.
+      </p>
     <% else %>
       <p class="govuk-body">
-        They will try to contact you at your school to confirm your identity
-        before progressing your claim.
+        We’ll check the details you provided in your claim and then contact
+        you to confirm your identity over the phone.
       </p>
 
       <p class="govuk-body">
-        If they're able to confirm your identity, they will check the details
-        you provided in your application and tell you if your claim was
-        successful within <%= claim_decision_deadline_in_weeks %>.
+        We'll send you an email from <strong><%= support_email_address(current_claim.policy.routing_name) %></strong>
+        to arrange a convenient time for us to call you on your school's
+        landline.
+      </p>
+
+      <p class="govuk-body">
+        Please add <strong><%= support_email_address(current_claim.policy.routing_name) %></strong>
+        to your address book to make sure you receive this email.
+      </p>
+
+      <p class="govuk-body">
+        You'll find out if your claim was successful within  <%= claim_decision_deadline_in_weeks %>
+        weeks and you'll receive email updates as your application progresses.
       </p>
     <% end %>
-
-    <p class="govuk-body">
-      You will receive email updates as your application progresses.
-    </p>
 
     <div class="govuk-inset-text">
       It can take up to 18 weeks to process your application and

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Submissions", type: :request do
         get claim_confirmation_path(StudentLoans.routing_name)
 
         expect(response.body).to include("Claim submitted")
-        expect(response.body).to include("contact you at your school to confirm your identity")
+        expect(response.body).to include("We’ll check the details you provided in your claim")
         expect(session[:claim_id]).to be_nil
       end
     end


### PR DESCRIPTION
This iterates the content (as outlined on this [Miro Board](https://miro.com/app/board/o9J_kwZcKg4=/?moveToWidget=3074457347168565426)) to make it clearer about next steps when a user cannot be verified using GOV.UK Verify.

![Screenshot_2020-02-12 Claim submitted — Teachers claim back your student loan repayments — GOV UK](https://user-images.githubusercontent.com/109774/74350787-247c5e00-4dae-11ea-818b-c3f38cca50b3.jpg)
\
![Screenshot_2020-02-12 Page title](https://user-images.githubusercontent.com/109774/74350551-c5b6e480-4dad-11ea-8cdd-614e4d3600ce.png)

