### PR TITLE
Make the development app service alwaysOn

### DIFF
--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -17,7 +17,7 @@
       }
     },
     "appServiceAlwaysOn": {
-      "value": false
+      "value": true
     },
     "appServicePlanSkuTier": {
       "value": "PremiumV2"


### PR DESCRIPTION
As part of the work to reduce Azure alerts we should try to gain as much
parity between development and production as possible.

One of our alerts "High response time" commonly happens on development
but not on production. My theory is that the high response is caused
from the app service warming up from cold triggering the alert.

I've checked and there's no cost difference for having the resource
set to always on.
