### PR TITLE
Introduce academic year modelling on policies and claims

### DIFF
--- a/app/controllers/base_public_controller.rb
+++ b/app/controllers/base_public_controller.rb
@@ -1,11 +1,15 @@
 class BasePublicController < ApplicationController
   include ClaimSessionTimeout
 
-  helper_method :current_policy_routing_name, :claim_timeout_in_minutes
+  helper_method :current_policy, :current_policy_routing_name, :claim_timeout_in_minutes
   before_action :end_expired_claim_sessions
   after_action :update_last_seen_at
 
   private
+
+  def current_policy
+    Policies[current_policy_routing_name]
+  end
 
   def current_policy_routing_name
     params[:policy]

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -15,8 +15,7 @@ module PartOfClaimJourney
   end
 
   def check_whether_closed_for_submissions
-    policy = Policies[current_policy_routing_name]
-    policy_configuration = PolicyConfiguration.find_by(policy_type: policy.name)
+    policy_configuration = PolicyConfiguration.find_by(policy_type: current_policy.name)
 
     unless policy_configuration.open_for_submissions?
       @availability_message = policy_configuration.availability_message

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -22,11 +22,11 @@ module PartOfClaimJourney
   end
 
   def send_unstarted_claiments_to_the_start
-    redirect_to routing_policy.start_page_url unless current_claim.persisted?
+    redirect_to current_policy.start_page_url unless current_claim.persisted?
   end
 
   def current_claim
-    @current_claim ||= claim_from_session || Claim.new(eligibility: routing_eligibility)
+    @current_claim ||= claim_from_session || Claim.new(eligibility: current_policy::Eligibility.new)
   end
 
   def claim_from_session
@@ -35,20 +35,6 @@ module PartOfClaimJourney
 
   def policy_configuration
     @policy_configuration ||= PolicyConfiguration.find_by(policy_type: current_policy.name)
-  end
-
-  # Returns the policy module that matches the current routing. Note this is
-  # subtly different to `current_policy`, which is more robust and will fall-
-  # back to the policy of the `current_claim` when the routing is not scoped to
-  # a `:policy`, for example with the GOV.UK Verify-related routes.
-  #
-  # You will almost certainly want to use `current_policy` most of the time.
-  def routing_policy
-    Policies[params[:policy]]
-  end
-
-  def routing_eligibility
-    routing_policy && routing_policy::Eligibility.new
   end
 
   def set_cache_headers

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -15,8 +15,6 @@ module PartOfClaimJourney
   end
 
   def check_whether_closed_for_submissions
-    policy_configuration = PolicyConfiguration.find_by(policy_type: current_policy.name)
-
     unless policy_configuration.open_for_submissions?
       @availability_message = policy_configuration.availability_message
       render "static_pages/closed_for_submissions", status: :service_unavailable
@@ -33,6 +31,10 @@ module PartOfClaimJourney
 
   def claim_from_session
     Claim.find(session[:claim_id]) if session.key?(:claim_id)
+  end
+
+  def policy_configuration
+    @policy_configuration ||= PolicyConfiguration.find_by(policy_type: current_policy.name)
   end
 
   # Returns the policy module that matches the current routing. Note this is

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -36,8 +36,6 @@ module PartOfClaimJourney
     Claim.find(session[:claim_id]) if session.key?(:claim_id)
   end
 
-  private
-
   def routing_policy
     Policies[params[:policy]]
   end

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -26,11 +26,15 @@ module PartOfClaimJourney
   end
 
   def current_claim
-    @current_claim ||= claim_from_session || Claim.new(eligibility: current_policy::Eligibility.new)
+    @current_claim ||= claim_from_session || build_new_claim
   end
 
   def claim_from_session
     Claim.find(session[:claim_id]) if session.key?(:claim_id)
+  end
+
+  def build_new_claim
+    Claim.new(eligibility: current_policy::Eligibility.new)
   end
 
   def policy_configuration

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -34,7 +34,10 @@ module PartOfClaimJourney
   end
 
   def build_new_claim
-    Claim.new(eligibility: current_policy::Eligibility.new)
+    Claim.new(
+      eligibility: current_policy::Eligibility.new,
+      academic_year: policy_configuration.current_academic_year,
+    )
   end
 
   def policy_configuration

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -36,6 +36,12 @@ module PartOfClaimJourney
     Claim.find(session[:claim_id]) if session.key?(:claim_id)
   end
 
+  # Returns the policy module that matches the current routing. Note this is
+  # subtly different to `current_policy`, which is more robust and will fall-
+  # back to the policy of the `current_claim` when the routing is not scoped to
+  # a `:policy`, for example with the GOV.UK Verify-related routes.
+  #
+  # You will almost certainly want to use `current_policy` most of the time.
   def routing_policy
     Policies[params[:policy]]
   end

--- a/app/controllers/verify/authentications_controller.rb
+++ b/app/controllers/verify/authentications_controller.rb
@@ -59,12 +59,16 @@ module Verify
       Rollbar.debug("Verify::RedactedResponse", parameters: redacted_response.parameters)
     end
 
+    def current_policy_routing_name
+      claim_from_session&.policy&.routing_name
+    end
+
     # This controller is not namespaced to a policy so we can't redirect a user
     # to a policy-specific start page if a claim isn't in progress. Instead
     # redirect to the root URL and let the routing take care of sending the user
     # to the right place.
     def send_unstarted_claiments_to_the_start
-      redirect_to root_url unless current_claim.persisted?
+      redirect_to root_url unless current_policy_routing_name
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,10 +39,6 @@ module ApplicationHelper
     current_policy.start_page_url
   end
 
-  def current_policy
-    Policies[current_policy_routing_name]
-  end
-
   def claim_decision_deadline_in_weeks
     "#{Claim::DECISION_DEADLINE.to_i / ActiveSupport::Duration::SECONDS_PER_WEEK} weeks"
   end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -60,6 +60,7 @@ class Claim < ApplicationRecord
     banking_name: true,
     building_society_roll_number: true,
     payment_id: false,
+    academic_year: false,
   }.freeze
   DECISION_DEADLINE = 12.weeks
   DECISION_DEADLINE_WARNING_POINT = 2.weeks

--- a/app/models/policy_configuration.rb
+++ b/app/models/policy_configuration.rb
@@ -1,3 +1,12 @@
+# Policy-specific configuration, managed through the service operator's admin
+# interface.
+#
+# Things that are currently configurable:
+#
+# * open_for_submissions: defines whether the policy is currently accepting
+#   claims or not
+# * availability_message: an optional message that is shown to users when the
+#   policy is closed for submissions
 class PolicyConfiguration < ApplicationRecord
   validates :policy_type, inclusion: {in: Policies.all.map(&:name)}
 

--- a/app/models/policy_configuration.rb
+++ b/app/models/policy_configuration.rb
@@ -7,6 +7,8 @@
 #   claims or not
 # * availability_message: an optional message that is shown to users when the
 #   policy is closed for submissions
+# * current_academic_year: the academic year the service is currently accepting
+#   claims for.
 class PolicyConfiguration < ApplicationRecord
   validates :policy_type, inclusion: {in: Policies.all.map(&:name)}
 

--- a/db/data/20200212151005_set_current_academic_year_on_policy_configurations.rb
+++ b/db/data/20200212151005_set_current_academic_year_on_policy_configurations.rb
@@ -1,0 +1,3 @@
+# Run me with `rails runner db/data/20200212151005_set_current_academic_year_on_policy_configurations.rb`
+
+PolicyConfiguration.update_all(current_academic_year: "2019/2020")

--- a/db/data/20200212154927_set_academic_year_on_claims.rb
+++ b/db/data/20200212154927_set_academic_year_on_claims.rb
@@ -1,0 +1,3 @@
+# Run me with `rails runner db/data/20200212154927_set_academic_year_on_claims.rb`
+
+Claim.update_all(academic_year: "2019/2020")

--- a/db/migrate/20200212150805_add_current_academic_year_to_policy_configurations.rb
+++ b/db/migrate/20200212150805_add_current_academic_year_to_policy_configurations.rb
@@ -1,0 +1,5 @@
+class AddCurrentAcademicYearToPolicyConfigurations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :policy_configurations, :current_academic_year, :string, limit: 9
+  end
+end

--- a/db/migrate/20200212154529_add_academic_year_to_claims.rb
+++ b/db/migrate/20200212154529_add_academic_year_to_claims.rb
@@ -1,0 +1,6 @@
+class AddAcademicYearToClaims < ActiveRecord::Migration[6.0]
+  def change
+    add_column :claims, :academic_year, :string, limit: 9
+    add_index :claims, :academic_year
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_12_150805) do
+ActiveRecord::Schema.define(version: 2020_02_12_154529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -47,6 +47,8 @@ ActiveRecord::Schema.define(version: 2020_02_12_150805) do
     t.string "banking_name"
     t.string "building_society_roll_number"
     t.uuid "payment_id"
+    t.string "academic_year", limit: 9
+    t.index ["academic_year"], name: "index_claims_on_academic_year"
     t.index ["created_at"], name: "index_claims_on_created_at"
     t.index ["eligibility_type", "eligibility_id"], name: "index_claims_on_eligibility_type_and_eligibility_id"
     t.index ["payment_id"], name: "index_claims_on_payment_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_11_105406) do
+ActiveRecord::Schema.define(version: 2020_02_12_150805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -161,6 +161,7 @@ ActiveRecord::Schema.define(version: 2020_02_11_105406) do
     t.string "availability_message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "current_academic_year", limit: 9
     t.index ["created_at"], name: "index_policy_configurations_on_created_at"
     t.index ["policy_type"], name: "index_policy_configurations_on_policy_type", unique: true
   end

--- a/spec/fixtures/policy_configurations.yml
+++ b/spec/fixtures/policy_configurations.yml
@@ -1,5 +1,7 @@
 student_loans:
   policy_type: StudentLoans
+  current_academic_year: "2019/2020"
 
 maths_and_physics:
   policy_type: MathsAndPhysics
+  current_academic_year: "2020/2021"

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -25,8 +25,11 @@ RSpec.describe "Claims", type: :request do
   end
 
   describe "claims#create request" do
-    it "creates a new Claim and redirects to the QTS question" do
+    it "creates a new Claim for the policy and redirects to the QTS question" do
       expect { start_student_loans_claim }.to change { Claim.count }.by(1)
+
+      claim = Claim.last
+      expect(claim.eligibility).to be_kind_of(StudentLoans::Eligibility)
 
       expect(response).to redirect_to(claim_path(StudentLoans.routing_name, "claim-school"))
     end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -26,11 +26,14 @@ RSpec.describe "Claims", type: :request do
 
   describe "claims#create request" do
     Policies.all.each do |policy|
-      it "creates a new Claim for the policy and redirects to the next question in the sequence" do
+      it "creates a new #{policy.name} claim for the current academic year and redirects to the next question in the sequence" do
         expect { start_claim(policy) }.to change { Claim.count }.by(1)
 
         claim = Claim.last
+        current_academic_year = policy_configurations(policy.routing_name.underscore).current_academic_year
+
         expect(claim.eligibility).to be_kind_of(policy::Eligibility)
+        expect(claim.academic_year).to eq(current_academic_year)
 
         expect(response).to redirect_to(claim_path(policy.routing_name, policy::SlugSequence::SLUGS[1]))
       end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -14,6 +14,11 @@ module RequestHelpers
           qts_award_year: "on_or_after_september_2013",
         },
       },
+      MathsAndPhysics => {
+        eligibility_attributes: {
+          teaching_maths_or_physics: "true",
+        },
+      },
     }.fetch(policy)
   end
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,12 +1,20 @@
 module RequestHelpers
   def start_student_loans_claim
-    post claims_path(StudentLoans.routing_name), params: {
-      claim: {
+    start_claim(StudentLoans)
+  end
+
+  def start_claim(policy)
+    post claims_path(policy.routing_name), params: {claim: claim_create_params_for(policy)}
+  end
+
+  def claim_create_params_for(policy)
+    {
+      StudentLoans => {
         eligibility_attributes: {
           qts_award_year: "on_or_after_september_2013",
         },
       },
-    }
+    }.fetch(policy)
   end
 
   def sign_in_to_admin_with_role(*args)


### PR DESCRIPTION
This lays some of the groundwork for supporting future academic years in the service, specifically it prepares the way for adjusting the QTS question to reflect the qualifying years that are eligible. What this PR covers:

- Introduces a `PolicyConfiguration#current_academic_year` attribute to represent the year each service currently is accepting claims for
- Introduces a `Claim#academic_year` attribute so we know the academic year each claim was made in

There are also two data migrations to run when this ships to backfill the data:

- `rails runner db/data/20200212151005_set_current_academic_year_on_policy_configurations.rb` to set current_academic_year to "2019/2020" for the two policies
- `rails runner db/data/20200212154927_set_academic_year_on_claims.rb` to back-fill all existing claims with the "2019/2020" academic year

Once this PR has shipped and the data migrations run there will be a follow-up PR to add validations to both `PolicyConfiguration` and `Claim` to validate these values are always present. We have to wait until after this ships, otherwise existing in-progress claims will error as invalid. Other things that will follow on from this:

- An update to the admin interface so that the current academic year can be changed on each policy
- An update that will change the QTS questions based on the current academic year and the rules for each policy

## Policy background

This work is required because each policy has their own unique criteria for eligibility based on the year that teachers qualified. Maths and Physics eligibility is based on teachers that are in the first 5 years of their careers. Therefor each academic year, the QTS year threshold needs to go up by one (from 2014/2015 to 2015/2016 when the academic year 2020/2021 starts). TSLR has its own more complicated rules around QTS year (it won't change until 2025...), which will also need to be accounted for.