### PR TITLE
Update Heroku configuration to enable acceptance testing apps

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec rake jobs:work
-postdeploy: rake db:schema:load db:seed
+postdeploy: bundle exec rake db:schema:load db:seed

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec rake jobs:work
-release: rake db:schema:load
+postdeploy: rake db:schema:load db:seed

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec rake jobs:work
-release: rake db:migrate
+release: bin/prepare-database

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec rake jobs:work
-release: bin/prepare-database
+release: rake db:schema:load

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec rake jobs:work
-postdeploy: bundle exec rake db:schema:load db:seed
+postdeploy: bundle exec rake db:migrate

--- a/app.json
+++ b/app.json
@@ -1,4 +1,8 @@
 {
+  "buildpacks": [
+    { "url": "heroku/nodejs" },
+    { "url": "heroku/ruby" }
+  ],
   "environments": {
     "test": {
       "addons": ["heroku-postgresql:in-dyno"],

--- a/app.json
+++ b/app.json
@@ -3,6 +3,9 @@
     { "url": "heroku/nodejs" },
     { "url": "heroku/ruby" }
   ],
+  "scripts": {
+    "postdeploy": "bundle exec rake db:schema:load db:seed"
+  },
   "environments": {
     "test": {
       "addons": ["heroku-postgresql:in-dyno"],


### PR DESCRIPTION
We tried to set up Heroku to build PRs, but it's been broken for some time now. I've had a look and I think it's down to the fact that Heroku is detecting the buildpacks to use and is using the Ruby one before the the NodeJS one, so is trying to precompile assets before Yarn has had a chance to install them.
