### PR TITLE
Update Heroku configuration to enable acceptance testing apps

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec rake jobs:work
-release: rake db:migrate
+postdeploy: bundle exec rake db:migrate

--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ Development is automatically built and deployed when commits are pushed to
 The release process for Production is documented in
 [`docs/release-process.md`](docs/release-process.md)
 
+### Heroku Review Apps
+
+Pull requests in the
+[GitHub Repository](https://github.com/DFE-Digital/dfe-teachers-payment-service)
+will automatically have a
+[review app](https://devcenter.heroku.com/articles/github-integration-review-apps)
+created in Heroku once CI has passed.
+
+For more information, see the [app's Heroku docs](docs/heroku.md)
+
 ## Accessing production data with a live Rails console
 
 **Accessing a live console is very risky and should only be done as a last

--- a/app.json
+++ b/app.json
@@ -1,5 +1,18 @@
 {
   "environments": {
+    "review": {
+      "addons": ["heroku-postgresql:in-dyno"],
+      "buildpacks": [
+        { "url": "heroku/nodejs" },
+        { "url": "heroku/ruby" }
+      ],
+      "scripts": {
+        "postdeploy": "bundle exec rake db:schema:load db:fixtures:load"
+      },
+      "env": {
+        "FIXTURES_PATH": "spec/fixtures"
+      }
+    },
     "test": {
       "addons": ["heroku-postgresql:in-dyno"],
       "buildpacks": [

--- a/docs/heroku.md
+++ b/docs/heroku.md
@@ -1,0 +1,32 @@
+# Heroku
+
+Pull requests in the
+[GitHub Repository](https://github.com/DFE-Digital/dfe-teachers-payment-service)
+will automatically have a
+[review app](https://devcenter.heroku.com/articles/github-integration-review-apps)
+created in Heroku once CI has passed. This app can be used to test and share the
+behaviour of the pull request, and is particularly useful for acceptance of a
+new feature or change.
+
+## Configuration
+
+### Deploying review apps for the first time
+
+The review apps are configured in `app.json`, except for secret environment
+variables which are configured in the Heroku admin interface. Broadly, they are
+configured as follows:
+
+- In-dyno Postgres databases are used to overcome permissions errors when
+  loading fixtures.
+- The `nodejs` buildpack is explicitly run first so dependencies for the asset
+  pipeline are ready.
+- The first time a review app is deployed it will have the database initialised
+  and the test fixtures loaded to give example data.
+
+The `test` configuration is not currently used in Heroku.
+
+### Subsequent deploys to the same review app
+
+As part of each app's
+[release phase](https://devcenter.heroku.com/articles/release-phase) database
+migrations are run as defined in the `postdeploy` option in the `Procfile`.


### PR DESCRIPTION
We've had review apps set up for a while now, and they haven't worked properly. This fixes them up to use the correct buildpacks, as well as a script that correctly bootstraps the database, so we can use the app. 