### PR TITLE
Allow service operators to change the current academic year on a policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog]
 - The admin page for a claim no longer warns about a missing payroll gender once
   a decision has been made
 - Iterate content on the Verify without Verify journey
+- Service operators can change the academic year a policy is accepting claims
+  for
 
 ## [Release 053] - 2020-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog]
 - Add subheader to student loans questions
 - Add a component saying why ask about student loans
 - New copy when claim has been removed from payrun
+- Claims now track the academic year they were made in
 
 ## [Release 052] - 2020-02-10
 

--- a/app/controllers/admin/policy_configurations_controller.rb
+++ b/app/controllers/admin/policy_configurations_controller.rb
@@ -20,7 +20,7 @@ module Admin
     private
 
     def policy_configuration_params
-      params.require(:policy_configuration).permit(:availability_message, :open_for_submissions)
+      params.require(:policy_configuration).permit(:availability_message, :open_for_submissions, :current_academic_year)
     end
   end
 end

--- a/app/controllers/concerns/part_of_claim_journey.rb
+++ b/app/controllers/concerns/part_of_claim_journey.rb
@@ -41,7 +41,7 @@ module PartOfClaimJourney
   end
 
   def policy_configuration
-    @policy_configuration ||= PolicyConfiguration.find_by(policy_type: current_policy.name)
+    @policy_configuration ||= PolicyConfiguration.for(current_policy)
   end
 
   def set_cache_headers

--- a/app/helpers/admin/policy_configurations_helper.rb
+++ b/app/helpers/admin/policy_configurations_helper.rb
@@ -1,0 +1,26 @@
+module Admin
+  module PolicyConfigurationsHelper
+    def start_of_autumn_term
+      Date.new(Date.today.year, 9, 1)
+    end
+
+    def options_for_academic_year
+      [current_academic_year, next_academic_year]
+    end
+
+    def current_academic_year
+      if Date.today < start_of_autumn_term
+        [(Date.today.year - 1), Date.today.year].join("/")
+      else
+        [Date.today.year, (Date.today.year + 1)].join("/")
+      end
+    end
+
+    def next_academic_year
+      start_year = current_academic_year.split("/").last.to_i
+      end_year = start_year + 1
+
+      [start_year, end_year].join("/")
+    end
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -88,6 +88,8 @@ class Claim < ApplicationRecord
     male: 2,
   }
 
+  validates :academic_year, format: {with: PolicyConfiguration::ACADEMIC_YEAR_REGEXP}
+
   validates :payroll_gender, on: [:gender, :submit], presence: {message: "Choose the option for the gender your school’s payroll system associates with you"}
 
   validates :first_name, on: [:name, :submit], presence: {message: "Enter your first name"}

--- a/app/models/policy_configuration.rb
+++ b/app/models/policy_configuration.rb
@@ -12,6 +12,10 @@
 class PolicyConfiguration < ApplicationRecord
   validates :policy_type, inclusion: {in: Policies.all.map(&:name)}
 
+  def self.for(policy)
+    find_by policy_type: policy.name
+  end
+
   def policy
     policy_type.constantize
   end

--- a/app/models/policy_configuration.rb
+++ b/app/models/policy_configuration.rb
@@ -10,7 +10,10 @@
 # * current_academic_year: the academic year the service is currently accepting
 #   claims for.
 class PolicyConfiguration < ApplicationRecord
+  ACADEMIC_YEAR_REGEXP = /\A20\d{2}\/20\d{2}\z/.freeze
+
   validates :policy_type, inclusion: {in: Policies.all.map(&:name)}
+  validates :current_academic_year, format: {with: ACADEMIC_YEAR_REGEXP}
 
   def self.for(policy)
     find_by policy_type: policy.name

--- a/app/views/admin/policy_configurations/edit.html.erb
+++ b/app/views/admin/policy_configurations/edit.html.erb
@@ -8,14 +8,24 @@
     <div class="govuk-panel govuk-panel--informational">
       <% if @policy_configuration.open_for_submissions? %>
         <h3 class="govuk-panel__title">Service open</h3>
-        <p class="govuk-panel__body">This service is currently open. Users can submit claims.</p>
+        <p class="govuk-panel__body">
+          This service is currently open and accepting claims for the
+          <%= @policy_configuration.current_academic_year%> academic year.
+        </p>
       <% else %>
         <h3 class="govuk-panel__title">Service closed</h3>
-        <p class="govuk-panel__body">This service is currently closed. Users can not submit claims.</p>
+        <p class="govuk-panel__body">
+          This service is currently closed. Users can not submit claims.
+        </p>
       <% end %>
     </div>
 
     <%= form_with model: [:admin, @policy_configuration] do |f| %>
+
+      <div class="govuk-form-group">
+        <%= f.label :current_academic_year, "Accepting claims for academic year", class: "govuk-label" %>
+        <%= f.select :current_academic_year, ["2019/2020", "2020/2021"], {}, class: "govuk-select" %>
+      </div>
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">

--- a/app/views/admin/policy_configurations/edit.html.erb
+++ b/app/views/admin/policy_configurations/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl">Open or close a service</span>
+      <span class="govuk-caption-xl">Manage services</span>
       <%= policy_service_name(@policy_configuration.policy.routing_name) %>
     </h1>
 

--- a/app/views/admin/policy_configurations/edit.html.erb
+++ b/app/views/admin/policy_configurations/edit.html.erb
@@ -24,7 +24,7 @@
 
       <div class="govuk-form-group">
         <%= f.label :current_academic_year, "Accepting claims for academic year", class: "govuk-label" %>
-        <%= f.select :current_academic_year, ["2019/2020", "2020/2021"], {}, class: "govuk-select" %>
+        <%= f.select :current_academic_year, options_for_academic_year, {}, class: "govuk-select" %>
       </div>
 
       <div class="govuk-form-group">

--- a/app/views/admin/policy_configurations/index.html.erb
+++ b/app/views/admin/policy_configurations/index.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">
-      Open or close a service
+      Manage services
     </h1>
   </div>
 

--- a/app/views/admin/policy_configurations/index.html.erb
+++ b/app/views/admin/policy_configurations/index.html.erb
@@ -6,7 +6,10 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Here you can open or close a service. Closing a service will stop users applying and show them a holding page.</p>
+    <p class="govuk-body">
+      Here you can open or close a service for applications and change the
+      academic year that claims are being accepted for.
+    </p>
   </div>
 
   <div class="govuk-grid-column-full">
@@ -14,6 +17,7 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Service</th>
+          <th scope="col" class="govuk-table__header">Accepting claims for</th>
           <th scope="col" class="govuk-table__header">Status</th>
           <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
         </tr>
@@ -22,6 +26,7 @@
         <% @policy_configurations.each do |policy_configuration| %>
           <tr class="govuk-table__row" data-policy-configuration-id="<%= policy_configuration.id %>">
             <th scope="row" class="govuk-table__header"><%= policy_service_name(policy_configuration.policy.routing_name) %></th>
+            <td class="govuk-table__cell"><%= policy_configuration.current_academic_year %></td>
             <td class="govuk-table__cell"><%= policy_configuration.open_for_submissions? ? "Open" : "Closed" %></td>
             <td class="govuk-table__cell"><%= link_to "Change", edit_admin_policy_configuration_path(policy_configuration), class: "govuk-link" %></td>
           </tr>

--- a/app/views/application/_admin_menu.html.erb
+++ b/app/views/application/_admin_menu.html.erb
@@ -12,7 +12,7 @@
         <%= link_to "Payroll", admin_payroll_runs_path, class: "govuk-header__link" %>
       </li>
       <li class="govuk-header__navigation-item">
-        <%= link_to "Open/close a service", admin_policy_configurations_path, class: "govuk-header__link" %>
+        <%= link_to "Manage services", admin_policy_configurations_path, class: "govuk-header__link" %>
       </li>
     <% end %>
     <li class="govuk-header__navigation-item">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,8 +6,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-PolicyConfiguration.create!(policy_type: StudentLoans)
-PolicyConfiguration.create!(policy_type: MathsAndPhysics)
+PolicyConfiguration.create!(policy_type: StudentLoans, current_academic_year: "2018/2019")
+PolicyConfiguration.create!(policy_type: MathsAndPhysics, current_academic_year: "2018/2019")
 
 if Rails.env.development?
   ENV["FIXTURES_PATH"] = "spec/fixtures"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
 
     after(:build) do |claim, evaluator|
       claim.eligibility = build(*evaluator.eligibility_factory) unless claim.eligibility
+      claim.academic_year = "2019/2020" unless claim.academic_year
     end
 
     trait :submittable do

--- a/spec/features/admin_configure_services_spec.rb
+++ b/spec/features/admin_configure_services_spec.rb
@@ -64,4 +64,23 @@ RSpec.feature "Service configuration" do
 
     expect(policy_configuration.reload.open_for_submissions).to be true
   end
+
+  scenario "Service operator changes the academic year a service is accepting payments for" do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+
+    click_on "Manage services"
+
+    within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
+      click_on "Change"
+    end
+
+    select "2020/2021", from: "Accepting claims for academic year"
+    click_on "Save"
+
+    within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
+      expect(page).to have_content("2020/2021")
+    end
+
+    expect(policy_configuration.reload.current_academic_year).to eq "2020/2021"
+  end
 end

--- a/spec/features/admin_configure_services_spec.rb
+++ b/spec/features/admin_configure_services_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Service configuration" do
     scenario "Service operator closes a service for submissions, with JavaScript #{js_status}", js: javascript_enabled do
       sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
 
-      click_on "Open/close a service"
+      click_on "Manage services"
 
       expect(page).to have_content("Teachers: claim back your student loan repayments")
       within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
@@ -42,7 +42,7 @@ RSpec.feature "Service configuration" do
 
     sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
 
-    click_on "Open/close a service"
+    click_on "Manage services"
 
     expect(page).to have_content("Teachers: claim back your student loan repayments")
     within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do

--- a/spec/features/admin_configure_services_spec.rb
+++ b/spec/features/admin_configure_services_spec.rb
@@ -66,21 +66,23 @@ RSpec.feature "Service configuration" do
   end
 
   scenario "Service operator changes the academic year a service is accepting payments for" do
-    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
+    travel_to Date.new(2023) do
+      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
 
-    click_on "Manage services"
+      click_on "Manage services"
 
-    within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
-      click_on "Change"
+      within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
+        click_on "Change"
+      end
+
+      select "2023/2024", from: "Accepting claims for academic year"
+      click_on "Save"
+
+      within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
+        expect(page).to have_content("2023/2024")
+      end
+
+      expect(policy_configuration.reload.current_academic_year).to eq "2023/2024"
     end
-
-    select "2020/2021", from: "Accepting claims for academic year"
-    click_on "Save"
-
-    within(find("tr[data-policy-configuration-id=\"#{policy_configuration.id}\"]")) do
-      expect(page).to have_content("2020/2021")
-    end
-
-    expect(policy_configuration.reload.current_academic_year).to eq "2020/2021"
   end
 end

--- a/spec/helpers/admin/policy_configurations_helper_spec.rb
+++ b/spec/helpers/admin/policy_configurations_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Admin::PolicyConfigurationsHelper, type: :helper do
+  describe "#options_for_academic_year" do
+    it "returns the current and next academic year (based on September 1st being the start of the year)" do
+      travel_to Date.new(2018, 8, 31) do
+        expect(helper.options_for_academic_year).to eq ["2017/2018", "2018/2019"]
+      end
+      travel_to Date.new(2018, 9, 1) do
+        expect(helper.options_for_academic_year).to eq ["2018/2019", "2019/2020"]
+      end
+      travel_to Date.new(2020, 9, 1) do
+        expect(helper.options_for_academic_year).to eq ["2020/2021", "2021/2022"]
+      end
+    end
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Claim, type: :model do
+  it "validates academic years are formated like '2020/2021'" do
+    expect(build(:claim, academic_year: "2022/2023")).to be_valid
+    expect(build(:claim, academic_year: "2020-2021")).not_to be_valid
+  end
+
   context "that has a teacher_reference_number" do
     it "validates the length of the teacher reference number" do
       expect(build(:claim, teacher_reference_number: "1/2/3/4/5/6/7")).to be_valid

--- a/spec/models/policy_configuration_spec.rb
+++ b/spec/models/policy_configuration_spec.rb
@@ -15,4 +15,10 @@ RSpec.describe PolicyConfiguration do
       expect(PolicyConfiguration.new(policy_type: StudentLoans).policy).to eq(StudentLoans)
     end
   end
+
+  it "validates academic years are formated like '2020/2021'" do
+    expect(PolicyConfiguration.new(policy_type: StudentLoans)).not_to be_valid
+    expect(PolicyConfiguration.new(policy_type: StudentLoans, current_academic_year: "2020-2021")).not_to be_valid
+    expect(PolicyConfiguration.new(policy_type: StudentLoans, current_academic_year: "2020/2021")).to be_valid
+  end
 end

--- a/spec/models/policy_configuration_spec.rb
+++ b/spec/models/policy_configuration_spec.rb
@@ -3,6 +3,13 @@
 require "rails_helper"
 
 RSpec.describe PolicyConfiguration do
+  describe "#for" do
+    it "returns the configuration for a given policy" do
+      expect(PolicyConfiguration.for(StudentLoans)).to eq policy_configurations(:student_loans)
+      expect(PolicyConfiguration.for(MathsAndPhysics)).to eq policy_configurations(:maths_and_physics)
+    end
+  end
+
   describe "#policy" do
     it "returns the policy class" do
       expect(PolicyConfiguration.new(policy_type: StudentLoans).policy).to eq(StudentLoans)


### PR DESCRIPTION
This updates the admin interface so that service operators can change the academic year that each policy is accepting claims for:

<img width="1071" alt="Screenshot 2020-02-13 at 16 22 35" src="https://user-images.githubusercontent.com/3687/74455359-1a756080-4e7d-11ea-849f-613d67421895.png">

<img width="1071" alt="Screenshot 2020-02-13 at 16 22 39" src="https://user-images.githubusercontent.com/3687/74455327-0fbacb80-4e7d-11ea-9c03-d3683ab7b526.png">


This is the second part of the work to support future claim years. The final part is to update the claimant journey and eligibility so that they reflect the academic year for which claims are being accepted for.