### PR TITLE
Fix Docker test runs in CI

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -26,6 +26,7 @@ services:
       - db
     environment:
       DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_USERNAME: postgres
+      DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_PASSWORD: password
       DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_HOST: db
     env_file:
       - .env.test
@@ -36,6 +37,8 @@ services:
     image: postgres
     volumes:
       - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
 
 volumes:
   db-data:


### PR DESCRIPTION
The `postgres` Docker image now requires a password to be set, so this sets a `POSTGRES_PASSWORD` env variable in the `db` container, and a corresponding `DFE_TEACHERS_PAYMENT_SERVICE_DATABASE_PASSWORD` var in the `test` container.

More info here https://github.com/docker-library/postgres/issues/681
