### PR TITLE
Run two concurrent worker processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Run multiple worker instances so long-running queued jobs don't entirely block
+  the queue.
+
 ## [Release 054] - 2020-02-19
 
 - The admin page for a claim no longer warns about a missing payroll gender once

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ gem "logstash-logger", "~> 0.26"
 # Improved memory usage in downloading large files vs Net/HTTP
 gem "httpclient"
 
+# Allow delayed_job to spawn multiple processes
+gem "daemons"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
+    daemons (1.3.1)
     delayed_cron_job (0.7.2)
       delayed_job (>= 4.1)
     delayed_job (4.1.8)
@@ -346,6 +347,7 @@ DEPENDENCIES
   byebug
   capybara
   climate_control
+  daemons
   delayed_cron_job
   delayed_job_active_record
   dotenv-rails

--- a/azure/resource_groups/app/parameters/development.template.json
+++ b/azure/resource_groups/app/parameters/development.template.json
@@ -181,6 +181,9 @@
     "ENVIRONMENT_NAME": {
       "value": "development"
     },
+    "WORKER_COUNT": {
+      "value": 2
+    },
     "VSP.VERIFY_ENVIRONMENT": {
       "value": "INTEGRATION"
     },

--- a/azure/resource_groups/app/parameters/production.template.json
+++ b/azure/resource_groups/app/parameters/production.template.json
@@ -170,6 +170,9 @@
     "ENVIRONMENT_NAME": {
       "value": "production"
     },
+    "WORKER_COUNT": {
+      "value": 2
+    },
     "VSP.VERIFY_ENVIRONMENT": {
       "value": "PRODUCTION"
     },

--- a/azure/resource_groups/app/parameters/test.template.json
+++ b/azure/resource_groups/app/parameters/test.template.json
@@ -182,6 +182,9 @@
     "ENVIRONMENT_NAME": {
       "value": "test"
     },
+    "WORKER_COUNT": {
+      "value": 1
+    },
     "VSP.VERIFY_ENVIRONMENT": {
       "value": "INTEGRATION"
     },

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -164,6 +164,9 @@
     "ENVIRONMENT_NAME": {
       "type": "string"
     },
+    "WORKER_COUNT": {
+      "type": "int"
+    },
     "VSP.VERIFY_ENVIRONMENT": {
       "type": "string"
     },
@@ -526,6 +529,10 @@
               {
                 "name": "ENVIRONMENT_NAME",
                 "value": "[parameters('ENVIRONMENT_NAME')]"
+              },
+              {
+                "name": "WORKER_COUNT",
+                "value": "[parameters('WORKER_COUNT')]"
               },
               {
                 "name": "GOVUK_VERIFY_VSP_HOST",

--- a/azure/templates/app.json
+++ b/azure/templates/app.json
@@ -315,7 +315,7 @@
             "value": "[parameters('containerNetworkProfileId')]"
           },
           "command": {
-            "value": ["bundle", "exec", "rake", "jobs:work"]
+            "value": ["bin/start-worker", "production"]
           }
         }
       }

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Starting workers..."
+RAILS_ENV=production bundle exec bin/delayed_job start -n 2

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+ENVIRONMENT_NAME=$1
+
 echo "Starting workers..."
-RAILS_ENV=production bundle exec bin/delayed_job start -n 2
+RAILS_ENV="$ENVIRONMENT_NAME" bundle exec bin/delayed_job start -n 2 \
+  & tail -f "log/$ENVIRONMENT_NAME.log"

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -3,5 +3,5 @@
 ENVIRONMENT_NAME=$1
 
 echo "Starting workers..."
-RAILS_ENV="$ENVIRONMENT_NAME" bundle exec bin/delayed_job start -n 2 \
+RAILS_ENV="$ENVIRONMENT_NAME" bundle exec bin/delayed_job start -n "$WORKER_COUNT" \
   & tail -f "log/$ENVIRONMENT_NAME.log"


### PR DESCRIPTION
This updates the worker container to run a command that spawns two worker processes and then tails the logs, so we can see what's going on. I don't think specifying the delayed_job log file location will interfere with logit, but I'll keep an eye on it.
