### PR TITLE
1025 accessibility testing admin area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix skipped heading level on manage services screen
+- Add label to Payroll Cantium link
+- Fix empty th on view claims screen
+- Add page titles to admin area
 - Run multiple worker instances so long-running queued jobs don't entirely block
   the queue.
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  def page_title(title, policy:, show_error: false)
+  def page_title(title, policy: nil, show_error: false)
     [].tap do |a|
       a << "Error" if show_error
       a << title

--- a/app/views/admin/checks/employment.html.erb
+++ b/app/views/admin/checks/employment.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} employment check for #{policy_service_name(@claim.policy.routing_name)}") } %>
 <%= link_to "Back", admin_claim_checks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/checks/index.html.erb
+++ b/app/views/admin/checks/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} checks for #{policy_service_name(@claim.policy.routing_name)}") } %>
+
 <%= link_to "Back", admin_claim_path(@claim), class: "govuk-back-link" %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/checks/qualifications.html.erb
+++ b/app/views/admin/checks/qualifications.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} qualification check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+
 <%= link_to "Back", admin_claim_checks_path(claim_id: @claim.id), class: "govuk-back-link" %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "View claims - #{t("service_name")} – GOV.UK"} %>
+<% content_for(:page_title) { page_title("View claims") } %>
 
 <%= link_to "Back", admin_root_path, class: "govuk-back-link" %>
 <div class="govuk-grid-row">

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -31,7 +31,7 @@
               <th scope="col" class="govuk-table__header">Decision warning</th>
             <% end %>
             <th scope="col" class="govuk-table__header">Decision deadline</th>
-            <th scope="col" class="govuk-table__header"></th>
+            <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { "View claims - #{t("service_name")} – GOV.UK"} %>
+
 <%= link_to "Back", admin_root_path, class: "govuk-back-link" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { "Search claims - #{t("service_name")} – GOV.UK"} %>
+
 <%= link_to "Back", admin_root_path, class: "govuk-back-link" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Search claims - #{t("service_name")} – GOV.UK"} %>
+<% content_for(:page_title) { page_title("Search claims") } %>
 
 <%= link_to "Back", admin_root_path, class: "govuk-back-link" %>
 <div class="govuk-grid-row">

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "View claim #{@claim.reference} for #{policy_service_name(@claim.policy.routing_name)} - #{t("service_name")} – GOV.UK"} %>
+<% content_for(:page_title) { page_title("View claim #{@claim.reference} for #{policy_service_name(@claim.policy.routing_name)}") } %>
 
 <%= link_to "Back", admin_claims_path, class: "govuk-back-link" %>
 

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { "View claim #{@claim.reference} for #{policy_service_name(@claim.policy.routing_name)} - #{t("service_name")} – GOV.UK"} %>
+
 <%= link_to "Back", admin_claims_path, class: "govuk-back-link" %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/page/index.html.erb
+++ b/app/views/admin/page/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { "Admin home - #{t("service_name")} – GOV.UK"} %>
+
 <div class="govuk-grid-row">
 
   <div class="govuk-grid-column-one-half">

--- a/app/views/admin/page/index.html.erb
+++ b/app/views/admin/page/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Admin home - #{t("service_name")} – GOV.UK"} %>
+<% content_for(:page_title) { page_title("Admin home") } %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { "Payroll – #{t("service_name")} – GOV.UK"} %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Payroll – #{t("service_name")} – GOV.UK"} %>
+<% content_for(:page_title) { page_title("Payroll") } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/admin/payroll_runs/new.html.erb
+++ b/app/views/admin/payroll_runs/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Run #{Date.today.strftime("%B")} payroll - #{t("service_name")} – GOV.UK"} %>
+<% content_for(:page_title) { page_title("Run #{Date.today.strftime("%B")} payroll") } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/payroll_runs/new.html.erb
+++ b/app/views/admin/payroll_runs/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { "Run #{Date.today.strftime("%B")} payroll - #{t("service_name")} – GOV.UK"} %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { "#{@payroll_run.created_at.strftime("%B")} payroll run - #{t("service_name")} – GOV.UK"} %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -55,13 +55,13 @@
     </dl>
   </div>
   <% unless @payroll_run.download_triggered? %>
-    <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">
-        You can now send this link to Cantium for processing.
-      </p>
-    </div>
     <div class="govuk-grid-column-full">
-      <%= text_field_tag "payroll_run_download_link", new_admin_payroll_run_download_url(@payroll_run), data: {"copy-to-clipboard": :true}, readonly: true, class: ["govuk-input"] %>
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="payroll_run_download_link">
+          You can now send this link to Cantium for processing.
+        </label>
+        <%= text_field_tag "payroll_run_download_link", new_admin_payroll_run_download_url(@payroll_run), data: {"copy-to-clipboard": :true}, readonly: true, class: ["govuk-input"] %>
+      </div>
     </div>
   <% end %>
 

--- a/app/views/admin/payroll_runs/show.html.erb
+++ b/app/views/admin/payroll_runs/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "#{@payroll_run.created_at.strftime("%B")} payroll run - #{t("service_name")} – GOV.UK"} %>
+<% content_for(:page_title) { page_title("#{@payroll_run.created_at.strftime("%B")} payroll run") } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/policy_configurations/edit.html.erb
+++ b/app/views/admin/policy_configurations/edit.html.erb
@@ -7,13 +7,13 @@
 
     <div class="govuk-panel govuk-panel--informational">
       <% if @policy_configuration.open_for_submissions? %>
-        <h3 class="govuk-panel__title">Service open</h3>
+        <h2 class="govuk-panel__title">Service open</h2>
         <p class="govuk-panel__body">
           This service is currently open and accepting claims for the
           <%= @policy_configuration.current_academic_year%> academic year.
         </p>
       <% else %>
-        <h3 class="govuk-panel__title">Service closed</h3>
+        <h2 class="govuk-panel__title">Service closed</h2>
         <p class="govuk-panel__body">
           This service is currently closed. Users can not submit claims.
         </p>

--- a/app/views/admin/policy_configurations/edit.html.erb
+++ b/app/views/admin/policy_configurations/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { "Manage #{policy_service_name(@policy_configuration.policy.routing_name)} - #{t("service_name")} – GOV.UK"} %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/app/views/admin/policy_configurations/edit.html.erb
+++ b/app/views/admin/policy_configurations/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Manage #{policy_service_name(@policy_configuration.policy.routing_name)} - #{t("service_name")} – GOV.UK"} %>
+<% content_for(:page_title) { page_title("Manage #{policy_service_name(@policy_configuration.policy.routing_name)}") } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/policy_configurations/index.html.erb
+++ b/app/views/admin/policy_configurations/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Manage services - #{t("service_name")} – GOV.UK"} %>
+<% content_for(:page_title) { page_title("Manage services") } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/admin/policy_configurations/index.html.erb
+++ b/app/views/admin/policy_configurations/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:page_title) { "Manage services - #{t("service_name")} – GOV.UK"} %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -2,8 +2,8 @@
 <html lang="en" class="govuk-template app-html-class">
   <head>
     <title>
-      <%= "#{t("service_name")} – GOV.UK" %>
 
+      <%= content_for(:page_title) || "#{t("service_name")} – GOV.UK" %>
     </title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
This is the first of several PRs to fix accessibility issues within the claim admin area. It is looking at the A level of accessibility and includes
- fixing the order of headers
- ensuring inputs have associated headers
- checking that table headers do not have empty <th>
- Adding in meaningful page titles to individual pages

