### PR TITLE
Ensure prettier checks all the files in the project on CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,14 @@
 /log/
 /node_modules/
 /tmp/
+/.git/
+
+localhost.crt
+localhost.key
+
+.env
+.env.local
+
+.rakeTasks
+.byebug_history
+.generators

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,19 +131,11 @@ COPY --from=shellcheck / /opt/shellcheck/
 ENV PATH /opt/shellcheck/bin:${PATH}
 # End
 
-# Copy test code (sorted by vague frequency of change for caching)
-COPY .prettierignore ${APP_HOME}/.prettierignore
-COPY .prettierrc ${APP_HOME}/.prettierrc
-COPY .rspec ${APP_HOME}/.rspec
-COPY .standard.yml ${APP_HOME}/.standard.yml
-
-COPY spec ${APP_HOME}/spec
-# End
-
-# Copy files for linting (sorted by vague frequency of change for caching)
-COPY docs ${APP_HOME}/docs
-COPY *.md ${APP_HOME}/
-COPY azure ${APP_HOME}/azure
+# Copy all files
+# This is only for the test target and ensures that all the files that could be linted locally are also linted on CI.
+# We need to be mindful of files that get added to the project, if they are secrets or superfluous we should add them
+# to the .dockerignore file.
+COPY . ${APP_HOME}/
 # End
 
 CMD [ "bundle", "exec", "rake" ]

--- a/app.json
+++ b/app.json
@@ -2,10 +2,7 @@
   "environments": {
     "review": {
       "addons": ["heroku-postgresql:in-dyno"],
-      "buildpacks": [
-        { "url": "heroku/nodejs" },
-        { "url": "heroku/ruby" }
-      ],
+      "buildpacks": [{ "url": "heroku/nodejs" }, { "url": "heroku/ruby" }],
       "scripts": {
         "postdeploy": "bundle exec rake db:schema:load db:fixtures:load"
       },


### PR DESCRIPTION
This is only for the test target and ensures that all the files that
could be linted locally are also linted on CI. We need to be mindful
of files that get added to the project, if they are secrets or
superfluous we should add them to the .dockerignore file.

This change doesn't increase the size of the Docker image by much but it
will increase build times slightly because of the way that Docker
caches layers of a Dockerfile, whenever a file is changed it will need
to redo that copy step.