### PR TITLE
Release 54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+## [Release 054] - 2020-02-19
+
 - The admin page for a claim no longer warns about a missing payroll gender once
   a decision has been made
 - Iterate content on the Verify without Verify journey
@@ -445,7 +447,9 @@ The format is based on [Keep a Changelog]
 - First release for student loan repayments private beta
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-053...HEAD
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-054...HEAD
+[release 054]:
+  https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-053...release-054
 [release 053]:
   https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/release-052...release-053
 [release 052]:


### PR DESCRIPTION
- The admin page for a claim no longer warns about a missing payroll gender once a decision has been made
- Iterate content on the Verify without Verify journey
- Service operators can change the academic year a policy is accepting claims for
- Service operators can view qualification and employment checks
- PII is automatically deleted from claims which are either rejected and have had no update in the last two months, or which have been paid more than two months ago
- Update "What information is sent" to include Cantium
- Swap Net/HTTP for HTTPClient when downloading the school data file to resolve a memory issue
