### PR TITLE
Resolve bugs with scrubbed claims

### DIFF
--- a/app/models/claim/pii_scrubber.rb
+++ b/app/models/claim/pii_scrubber.rb
@@ -23,7 +23,7 @@ class Claim
       :building_society_roll_number,
     ]
 
-    MINIMUM_DATE_OF_LAST_ACTION = 2.months.ago
+    TIME_BEFORE_CLAIM_CONSIDERED_OLD = 2.months
 
     def scrub_completed_claims
       old_claims_rejected_or_paid.update_all(attribute_values_to_set)
@@ -43,7 +43,7 @@ class Claim
         .where(pii_removed_at: nil)
         .where(
           "(decisions.result = :rejected AND decisions.created_at < :minimum_time) OR scheduled_payment_date < :minimum_time",
-          minimum_time: MINIMUM_DATE_OF_LAST_ACTION,
+          minimum_time: TIME_BEFORE_CLAIM_CONSIDERED_OLD.ago,
           rejected: Decision.results.fetch(:rejected)
         )
     end

--- a/spec/models/claim/pii_scrubber_spec.rb
+++ b/spec/models/claim/pii_scrubber_spec.rb
@@ -79,4 +79,18 @@ RSpec.describe Claim::PiiScrubber, type: :model do
       expect(cleaned_claim.pii_removed_at).to eq(Time.zone.now)
     end
   end
+
+  it "calculates the date past which claims are considered old at runtime" do
+    # Initialise the scrubber, and create a claim
+    scrubber = Claim::PiiScrubber.new
+    claim = create(:claim, :submitted)
+    create(:decision, :rejected, claim: claim)
+
+    # Travel three months forwards. At this point the claim should be considered
+    # old enough to scrub information from.
+    travel_to(3.months.from_now)
+    scrubber.scrub_completed_claims
+    cleaned_claim = Claim.find(claim.id)
+    expect(cleaned_claim.pii_removed_at).to eq(Time.zone.now)
+  end
 end


### PR DESCRIPTION
Resolves a few issues with scrubbing PII from old claims:

* [x] Moves the generation of the two-month-ago date after which claims are considered 'old' from being a class constant into being set during instance initialisation.
* [x] Duplicate claim spotting behaviour with claims which have been scrubbed is not as expected.