### PR TITLE
Do not explicitly set worker environment name

### DIFF
--- a/azure/templates/app.json
+++ b/azure/templates/app.json
@@ -315,7 +315,7 @@
             "value": "[parameters('containerNetworkProfileId')]"
           },
           "command": {
-            "value": ["bin/start-worker", "production"]
+            "value": ["bin/start-worker"]
           }
         }
       }

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-ENVIRONMENT_NAME=$1
-
 echo "Starting workers..."
-RAILS_ENV="$ENVIRONMENT_NAME" bundle exec bin/delayed_job start -n "$WORKER_COUNT" \
-  & tail -f "log/$ENVIRONMENT_NAME.log"
+bundle exec bin/delayed_job start -n "$WORKER_COUNT" \
+  & tail -f "log/$RAILS_ENV.log"


### PR DESCRIPTION
The change in #874 explicitly launches the worker with `RAILS_ENV` set to `production`. It does this by overriding the `ENVIRONMENT_NAME` variable in the local scope of the worker boot script, instead of just lifting it from the global environment.

This changes that behaviour, so it relies on the `ENVIRONMENT_NAME` which is defined in the ARM templates.