### PR TITLE
Don’t pad formatted hours with whitespace

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
       day_month_year: "%d/%m/%Y"
   time:
     formats:
-      default: "%-d %B %Y %l:%M%P"
+      default: "%-d %B %Y %-l:%M%P"
   number:
     currency:
       format:


### PR DESCRIPTION
This changes the result of I18n.format(Time.current) from e.g.

<pre>"20 February 2020  3:11pm"</pre>

to

<pre>"20 February 2020 3:11pm"</pre>

The repeated whitespace has no effect on the output when rendered in a
web browser. However, it makes it difficult to check for the presence of
a formatted time when writing a feature spec, since the have_content
matcher will not detect a string with repeated whitespace.

The hyphen is explained in the documentation for Time#strftime.
