### PR TITLE
Vary the QTS question based on the academic year configured in the policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- QTS question will vary based on the year the service is accepting claims for
+
 ## [Release 056] - 2020-02-25
 
 - Allow service operators to mark a check as completed

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -13,7 +13,7 @@ class ClaimMailer < ApplicationMailer
 
   def rejected(claim)
     @claim_description = claim_description(claim)
-    @possible_rejection_reasons = I18n.t("#{claim.policy.routing_name.underscore}.possible_rejection_reasons")
+    @possible_rejection_reasons = I18n.t("#{claim.policy.routing_name.underscore}.possible_rejection_reasons", qts_year: ineligible_qts_year(claim))
     view_mail_with_claim_and_subject(claim, "Your claim #{@claim_description} has been rejected, reference number: #{claim.reference}")
   end
 
@@ -26,6 +26,10 @@ class ClaimMailer < ApplicationMailer
 
   def claim_description(claim)
     I18n.t("#{claim.policy.routing_name.underscore}.claim_description")
+  end
+
+  def ineligible_qts_year(claim)
+    (claim.policy.first_eligible_qts_award_year - 1).to_s(:long)
   end
 
   def view_mail_with_claim_and_subject(claim, subject)

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -1,3 +1,10 @@
+# Module namespace specific to the policy for claiming a payment for teaching
+# maths or physics.
+#
+# This payment is available to Maths or Physics teachers in the first five their
+# career employed in state-funded secondary schools in eligible local
+# authorities. Full details of the eligibility criteria can be found at the URL
+# defined by `MathsAndPhysics.eligibility_page_url`.
 module MathsAndPhysics
   extend self
 

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require "academic_year"
+
 # Module namespace specific to the policy for claiming a payment for teaching
 # maths or physics.
 #
@@ -34,5 +38,20 @@ module MathsAndPhysics
 
   def short_name
     I18n.t("maths_and_physics.policy_short_name")
+  end
+
+  # Returns the AcademicYear during or after which teachers must have completed
+  # their Initial Teacher Training and been awarded QTS to be eligible to make
+  # a claim. Anyone qualifying before this academic year should not be able to
+  # make a claim.
+  #
+  # Maths & Physics teachers are eligible to claim if they are in the first five
+  # years of their career.
+  def first_eligible_qts_award_year
+    AcademicYear.new(configuration.current_academic_year) - 5
+  end
+
+  def configuration
+    PolicyConfiguration.for(self)
   end
 end

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -41,8 +41,8 @@ module MathsAndPhysics
     }
 
     enum qts_award_year: {
-      "before_september_2014": 0,
-      "on_or_after_september_2014": 1,
+      before_cut_off_date: 0,
+      on_or_after_cut_off_date: 1,
     }, _prefix: :awarded_qualified_status
 
     belongs_to :current_school, optional: true, class_name: "School"
@@ -122,7 +122,7 @@ module MathsAndPhysics
     end
 
     def ineligible_qts_award_year?
-      awarded_qualified_status_before_september_2014?
+      awarded_qualified_status_before_cut_off_date?
     end
 
     def no_entire_term_contract?

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -52,7 +52,7 @@ module MathsAndPhysics
     validates :initial_teacher_training_subject, on: [:"initial-teacher-training-subject", :submit], presence: {message: "Select if you completed your initial teacher training in Maths, Physics, Science, or None of these subjects"}
     validates :initial_teacher_training_subject_specialism, on: [:"initial-teacher-training-subject-specialism", :submit], presence: {message: "Select the subject your initial teacher training specialised in or select I'm not sure"}, if: :itt_subject_science?
     validates :has_uk_maths_or_physics_degree, on: [:"has-uk-maths-or-physics-degree", :submit], presence: {message: "Select yes if you have a UK degree specialising in maths or physics"}, unless: :initial_teacher_training_specialised_in_maths_or_physics?
-    validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select whether you completed your initial teacher training before or after the start of the academic year 2014 to 2015"}
+    validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select when you completed your initial teacher training"}
     validates :employed_as_supply_teacher, on: [:"supply-teacher", :submit], inclusion: {in: [true, false], message: "Select yes if you are currently employed as a supply teacher"}
     validates :has_entire_term_contract, on: [:"entire-term-contract", :submit], inclusion: {in: [true, false], message: "Select yes if you have a contract to teach at the same school for one term or longer"}, if: :employed_as_supply_teacher?
     validates :employed_directly, on: [:"employed-directly", :submit], inclusion: {in: [true, false], message: "Select yes if you are employed directly by your school"}, if: :employed_as_supply_teacher?

--- a/app/models/maths_and_physics/eligibility_answers_presenter.rb
+++ b/app/models/maths_and_physics/eligibility_answers_presenter.rb
@@ -76,7 +76,7 @@ module MathsAndPhysics
     def qts_award_year
       [
         I18n.t("questions.qts_award_year"),
-        I18n.t("maths_and_physics.questions.qts_award_years.#{eligibility.qts_award_year}"),
+        I18n.t("answers.qts_award_years.#{eligibility.qts_award_year}", year: qts_answer_academic_year.to_s(:long)),
         "qts-year",
       ]
     end
@@ -126,6 +126,14 @@ module MathsAndPhysics
       when "yes" then "Yes"
       when "no" then "No"
       else I18n.t("maths_and_physics.answers.has_uk_maths_or_physics_degree.#{eligibility.has_uk_maths_or_physics_degree}")
+      end
+    end
+
+    def qts_answer_academic_year
+      if eligibility.awarded_qualified_status_on_or_after_cut_off_date?
+        MathsAndPhysics.first_eligible_qts_award_year
+      else
+        MathsAndPhysics.first_eligible_qts_award_year - 1
       end
     end
   end

--- a/app/models/maths_and_physics/eligibility_answers_presenter.rb
+++ b/app/models/maths_and_physics/eligibility_answers_presenter.rb
@@ -17,21 +17,109 @@ module MathsAndPhysics
     # [2]: slug for changing the answer.
     def answers
       [].tap do |a|
-        a << [I18n.t("maths_and_physics.questions.teaching_maths_or_physics"), (eligibility.teaching_maths_or_physics? ? "Yes" : "No"), "teaching-maths-or-physics"]
-        a << [I18n.t("questions.current_school"), eligibility.current_school_name, "current-school"]
-        a << [I18n.t("maths_and_physics.questions.initial_teacher_training_subject"), I18n.t("maths_and_physics.answers.initial_teacher_training_subject.#{eligibility.initial_teacher_training_subject}"), "initial-teacher-training-subject"]
-        a << [I18n.t("maths_and_physics.questions.initial_teacher_training_subject_specialism"), I18n.t("maths_and_physics.answers.initial_teacher_training_subject_specialism.#{eligibility.initial_teacher_training_subject_specialism}"), "initial-teacher-training-subject-specialism"] if eligibility.initial_teacher_training_subject_specialism.present?
-        a << [I18n.t("maths_and_physics.questions.has_uk_maths_or_physics_degree"), degree_answer, "has-uk-maths-or-physics-degree"] if eligibility.has_uk_maths_or_physics_degree.present?
-        a << [I18n.t("questions.qts_award_year"), I18n.t("maths_and_physics.questions.qts_award_years.#{eligibility.qts_award_year}"), "qts-year"]
-        a << [I18n.t("maths_and_physics.questions.employed_as_supply_teacher"), (eligibility.employed_as_supply_teacher? ? "Yes" : "No"), "supply-teacher"]
-        a << [I18n.t("maths_and_physics.questions.has_entire_term_contract"), (eligibility.has_entire_term_contract? ? "Yes" : "No"), "entire-term-contract"] if eligibility.employed_as_supply_teacher?
-        a << [I18n.t("maths_and_physics.questions.employed_directly"), I18n.t("maths_and_physics.answers.employed_directly.#{eligibility.employed_directly? ? "yes" : "no"}"), "employed-directly"] if eligibility.employed_as_supply_teacher?
-        a << [I18n.t("maths_and_physics.questions.disciplinary_action"), (eligibility.subject_to_disciplinary_action? ? "Yes" : "No"), "disciplinary-action"]
-        a << [I18n.t("maths_and_physics.questions.formal_performance_action"), (eligibility.subject_to_formal_performance_action? ? "Yes" : "No"), "formal-performance-action"]
+        a << teaching_maths_or_physics
+        a << current_school
+        a << initial_teacher_training_subject
+        a << initial_teacher_training_subject_specialism if eligibility.initial_teacher_training_subject_specialism.present?
+        a << has_uk_maths_or_physics_degree if eligibility.has_uk_maths_or_physics_degree.present?
+        a << qts_award_year
+        a << employed_as_supply_teacher
+        a << has_entire_term_contract if eligibility.employed_as_supply_teacher?
+        a << employed_directly if eligibility.employed_as_supply_teacher?
+        a << disciplinary_action
+        a << formal_performance_action
       end
     end
 
     private
+
+    def teaching_maths_or_physics
+      [
+        I18n.t("maths_and_physics.questions.teaching_maths_or_physics"),
+        (eligibility.teaching_maths_or_physics? ? "Yes" : "No"),
+        "teaching-maths-or-physics",
+      ]
+    end
+
+    def current_school
+      [
+        I18n.t("questions.current_school"),
+        eligibility.current_school_name,
+        "current-school",
+      ]
+    end
+
+    def initial_teacher_training_subject
+      [
+        I18n.t("maths_and_physics.questions.initial_teacher_training_subject"),
+        I18n.t("maths_and_physics.answers.initial_teacher_training_subject.#{eligibility.initial_teacher_training_subject}"),
+        "initial-teacher-training-subject",
+      ]
+    end
+
+    def initial_teacher_training_subject_specialism
+      [
+        I18n.t("maths_and_physics.questions.initial_teacher_training_subject_specialism"),
+        I18n.t("maths_and_physics.answers.initial_teacher_training_subject_specialism.#{eligibility.initial_teacher_training_subject_specialism}"),
+        "initial-teacher-training-subject-specialism",
+      ]
+    end
+
+    def has_uk_maths_or_physics_degree
+      [
+        I18n.t("maths_and_physics.questions.has_uk_maths_or_physics_degree"),
+        degree_answer,
+        "has-uk-maths-or-physics-degree",
+      ]
+    end
+
+    def qts_award_year
+      [
+        I18n.t("questions.qts_award_year"),
+        I18n.t("maths_and_physics.questions.qts_award_years.#{eligibility.qts_award_year}"),
+        "qts-year",
+      ]
+    end
+
+    def employed_as_supply_teacher
+      [
+        I18n.t("maths_and_physics.questions.employed_as_supply_teacher"),
+        (eligibility.employed_as_supply_teacher? ? "Yes" : "No"),
+        "supply-teacher",
+      ]
+    end
+
+    def has_entire_term_contract
+      [
+        I18n.t("maths_and_physics.questions.has_entire_term_contract"),
+        (eligibility.has_entire_term_contract? ? "Yes" : "No"),
+        "entire-term-contract",
+      ]
+    end
+
+    def employed_directly
+      [
+        I18n.t("maths_and_physics.questions.employed_directly"),
+        I18n.t("maths_and_physics.answers.employed_directly.#{eligibility.employed_directly? ? "yes" : "no"}"),
+        "employed-directly",
+      ]
+    end
+
+    def disciplinary_action
+      [
+        I18n.t("maths_and_physics.questions.disciplinary_action"),
+        (eligibility.subject_to_disciplinary_action? ? "Yes" : "No"),
+        "disciplinary-action",
+      ]
+    end
+
+    def formal_performance_action
+      [
+        I18n.t("maths_and_physics.questions.formal_performance_action"),
+        (eligibility.subject_to_formal_performance_action? ? "Yes" : "No"),
+        "formal-performance-action",
+      ]
+    end
 
     def degree_answer
       case eligibility.has_uk_maths_or_physics_degree

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -1,5 +1,10 @@
-# frozen_string_literal: true
-
+# Module namespace specific to the policy for claiming back your student loan
+# payments.
+#
+# This payment is available to teachers that qualified after 2013 teaching
+# specific subjects in state-funded secondary schools in eligible local
+# authorities. Full details of the eligibility criteria can be found at the URL
+# defined by `StudentLoans.eligibility_page_url`.
 module StudentLoans
   extend self
 

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require "academic_year"
+
 # Module namespace specific to the policy for claiming back your student loan
 # payments.
 #
@@ -34,5 +38,30 @@ module StudentLoans
 
   def short_name
     I18n.t("student_loans.policy_short_name")
+  end
+
+  # Returns the AcademicYear during or after which teachers must have completed
+  # their Initial Teacher Training and been awarded QTS to be eligible to make
+  # a claim. Anyone qualifying before this academic year should not be able to
+  # make a claim.
+  #
+  # Teachers that qualified after 2013 are eligible to claim back student loans
+  # repayments for 10 years. Their first claim will be made in the subsequent
+  # year because they are retrospectively claiming *back* repayments made during
+  # the *financial year*. So for example if you qualify in 2021/2022, you are
+  # eligible to claim back student loan repayments you make in the 2021/2022
+  # "financial year", which ends April 2022, and the claim for that period can
+  # be made from the start of the 2022/2023 "academic year".
+  #
+  # So to give concrete examples, teachers qualifying in 2013/2014 can make
+  # claims up to 2024/2025, and a teacher qualifying in 2014/2015 can make
+  # claims up to 2025/2026 and so on.
+  def first_eligible_qts_award_year
+    eleven_years_prior = AcademicYear.new(configuration.current_academic_year) - 11
+    [AcademicYear.new(2013), eleven_years_prior].max
+  end
+
+  def configuration
+    PolicyConfiguration.for(self)
   end
 end

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -41,7 +41,7 @@ module StudentLoans
     belongs_to :claim_school, optional: true, class_name: "School"
     belongs_to :current_school, optional: true, class_name: "School"
 
-    validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select whether you completed your initial teacher training before or after the start of the academic year 2013 to 2014"}
+    validates :qts_award_year, on: [:"qts-year", :submit], presence: {message: "Select when you completed your initial teacher training"}
     validates :claim_school, on: [:"claim-school", :submit], presence: {message: "Select a school from the list or search again for a different school"}
     validates :employment_status, on: [:"still-teaching", :submit], presence: {message: ->(object, _data) { "Select if you still work at #{object.claim_school_name}, another school or no longer teach in England" }}
     validates :current_school, on: [:"current-school", :submit], presence: {message: "Select a school from the list"}

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -28,8 +28,8 @@ module StudentLoans
     self.table_name = "student_loans_eligibilities"
 
     enum qts_award_year: {
-      "before_september_2013": 0,
-      "on_or_after_september_2013": 1,
+      before_cut_off_date: 0,
+      on_or_after_cut_off_date: 1,
     }, _prefix: :awarded_qualified_status
 
     enum employment_status: {
@@ -98,7 +98,7 @@ module StudentLoans
     private
 
     def ineligible_qts_award_year?
-      awarded_qualified_status_before_september_2013?
+      awarded_qualified_status_before_cut_off_date?
     end
 
     def ineligible_claim_school?

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -35,7 +35,7 @@ module StudentLoans
     def qts_award_year
       [
         I18n.t("questions.qts_award_year"),
-        I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}"),
+        I18n.t("answers.qts_award_years.#{eligibility.qts_award_year}", year: qts_answer_academic_year.to_s(:long)),
         "qts-year",
       ]
     end
@@ -86,6 +86,14 @@ module StudentLoans
         number_to_currency(eligibility.student_loan_repayment_amount),
         "student-loan-amount",
       ]
+    end
+
+    def qts_answer_academic_year
+      if eligibility.awarded_qualified_status_on_or_after_cut_off_date?
+        StudentLoans.first_eligible_qts_award_year
+      else
+        StudentLoans.first_eligible_qts_award_year - 1
+      end
     end
   end
 end

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -20,14 +20,72 @@ module StudentLoans
     # [2]: slug for changing the answer.
     def answers
       [].tap do |a|
-        a << [I18n.t("questions.qts_award_year"), I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}"), "qts-year"]
-        a << [I18n.t("student_loans.questions.claim_school"), eligibility.claim_school_name, "claim-school"]
-        a << [I18n.t("questions.current_school"), eligibility.current_school_name, "still-teaching"]
-        a << [I18n.t("student_loans.questions.subjects_taught", school: eligibility.claim_school_name), subject_list(eligibility.subjects_taught), "subjects-taught"]
-        a << [I18n.t("student_loans.questions.leadership_position"), (eligibility.had_leadership_position? ? "Yes" : "No"), "leadership-position"]
-        a << [I18n.t("student_loans.questions.mostly_performed_leadership_duties"), (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No"), "mostly-performed-leadership-duties"] if eligibility.had_leadership_position?
-        a << [I18n.t("student_loans.questions.student_loan_amount"), number_to_currency(eligibility.student_loan_repayment_amount), "student-loan-amount"]
+        a << qts_award_year
+        a << claim_school
+        a << current_school
+        a << subjects_taught
+        a << leadership_position
+        a << mostly_performed_leadership_duties if eligibility.had_leadership_position?
+        a << student_loan_amount
       end
+    end
+
+    private
+
+    def qts_award_year
+      [
+        I18n.t("questions.qts_award_year"),
+        I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}"),
+        "qts-year",
+      ]
+    end
+
+    def claim_school
+      [
+        I18n.t("student_loans.questions.claim_school"),
+        eligibility.claim_school_name,
+        "claim-school",
+      ]
+    end
+
+    def current_school
+      [
+        I18n.t("questions.current_school"),
+        eligibility.current_school_name,
+        "still-teaching",
+      ]
+    end
+
+    def subjects_taught
+      [
+        I18n.t("student_loans.questions.subjects_taught", school: eligibility.claim_school_name),
+        subject_list(eligibility.subjects_taught),
+        "subjects-taught",
+      ]
+    end
+
+    def leadership_position
+      [
+        I18n.t("student_loans.questions.leadership_position"),
+        (eligibility.had_leadership_position? ? "Yes" : "No"),
+        "leadership-position",
+      ]
+    end
+
+    def mostly_performed_leadership_duties
+      [
+        I18n.t("student_loans.questions.mostly_performed_leadership_duties"),
+        (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No"),
+        "mostly-performed-leadership-duties",
+      ]
+    end
+
+    def student_loan_amount
+      [
+        I18n.t("student_loans.questions.student_loan_amount"),
+        number_to_currency(eligibility.student_loan_repayment_amount),
+        "student-loan-amount",
+      ]
     end
   end
 end

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -21,14 +21,14 @@
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:qts_award_year, :before_cut_off_date, class: "govuk-radios__input") %>
                 <%= fields.label "qts_award_year_before_cut_off_date",
-                      t("#{current_claim.policy.name.underscore}.questions.qts_award_years.before_cut_off_date"),
+                      t("answers.qts_award_years.before_cut_off_date", year: (current_policy.first_eligible_qts_award_year - 1).to_s(:long)),
                       class: "govuk-label govuk-radios__label" %>
               </div>
 
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:qts_award_year, :on_or_after_cut_off_date, class: "govuk-radios__input") %>
                 <%= fields.label "qts_award_year_on_or_after_cut_off_date",
-                      t("#{current_claim.policy.name.underscore}.questions.qts_award_years.on_or_after_cut_off_date"),
+                      t("answers.qts_award_years.on_or_after_cut_off_date", year: current_policy.first_eligible_qts_award_year.to_s(:long)),
                       class: "govuk-label govuk-radios__label" %>
               </div>
             </div>

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -18,12 +18,19 @@
 
             <div class="govuk-radios">
               <%= fields.hidden_field :qts_award_year %>
-              <% current_claim.eligibility.class.qts_award_years.each_key do |option| %>
-                <div class="govuk-radios__item">
-                  <%= fields.radio_button(:qts_award_year, option, class: "govuk-radios__input") %>
-                  <%= fields.label "qts_award_year_#{option}", t("#{current_claim.policy.name.underscore}.questions.qts_award_years.#{option}"), class: "govuk-label govuk-radios__label" %>
-                </div>
-              <% end %>
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:qts_award_year, :before_cut_off_date, class: "govuk-radios__input") %>
+                <%= fields.label "qts_award_year_before_cut_off_date",
+                      t("#{current_claim.policy.name.underscore}.questions.qts_award_years.before_cut_off_date"),
+                      class: "govuk-label govuk-radios__label" %>
+              </div>
+
+              <div class="govuk-radios__item">
+                <%= fields.radio_button(:qts_award_year, :on_or_after_cut_off_date, class: "govuk-radios__input") %>
+                <%= fields.label "qts_award_year_on_or_after_cut_off_date",
+                      t("#{current_claim.policy.name.underscore}.questions.qts_award_years.on_or_after_cut_off_date"),
+                      class: "govuk-label govuk-radios__label" %>
+              </div>
             </div>
           <% end %>
 

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -4,7 +4,7 @@
 
 <p class="govuk-body">
   You can only get this payment if you completed your initial teacher training
-  <%= t("#{current_claim.policy.name.underscore}.questions.qts_award_years.on_or_after_cut_off_date").downcase %>.
+  <%= t("answers.qts_award_years.on_or_after_cut_off_date", year: MathsAndPhysics.first_eligible_qts_award_year.to_s(:long)).downcase %>.
 </p>
 
 <p class="govuk-body">

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -4,7 +4,7 @@
 
 <p class="govuk-body">
   You can only get this payment if you completed your initial teacher training
-  in or after the academic year 2014 to 2015.
+  <%= t("#{current_claim.policy.name.underscore}.questions.qts_award_years.on_or_after_september_2014").downcase %>.
 </p>
 
 <p class="govuk-body">

--- a/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/maths_and_physics/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -4,7 +4,7 @@
 
 <p class="govuk-body">
   You can only get this payment if you completed your initial teacher training
-  <%= t("#{current_claim.policy.name.underscore}.questions.qts_award_years.on_or_after_september_2014").downcase %>.
+  <%= t("#{current_claim.policy.name.underscore}.questions.qts_award_years.on_or_after_cut_off_date").downcase %>.
 </p>
 
 <p class="govuk-body">

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -4,12 +4,11 @@
 
 <p class="govuk-body">
   You can only get this payment if you completed your initial teacher training
-  <%= t("#{current_claim.policy.name.underscore}.questions.qts_award_years.on_or_after_cut_off_date").downcase %>.
+  <%= t("answers.qts_award_years.on_or_after_cut_off_date", year: StudentLoans.first_eligible_qts_award_year.to_s(:long)).downcase %>.
 </p>
 
 <p class="govuk-body">
-  For more information, including eligibility criteria for this payment, visit
-  the
+  For more information, including eligibility criteria for this payment, visit the
   <%= link_to "‘Claim back your student loan repayments’", "#{StudentLoans.eligibility_page_url}#eligible-teachers", class: "govuk-link" %>
   guidance.
 </p>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -4,7 +4,7 @@
 
 <p class="govuk-body">
   You can only get this payment if you completed your initial teacher training
-  in or after the academic year 2013 to 2014.
+  <%= t("#{current_claim.policy.name.underscore}.questions.qts_award_years.on_or_after_september_2013").downcase %>.
 </p>
 
 <p class="govuk-body">

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_qts_award_year.html.erb
@@ -4,7 +4,7 @@
 
 <p class="govuk-body">
   You can only get this payment if you completed your initial teacher training
-  <%= t("#{current_claim.policy.name.underscore}.questions.qts_award_years.on_or_after_september_2013").downcase %>.
+  <%= t("#{current_claim.policy.name.underscore}.questions.qts_award_years.on_or_after_cut_off_date").downcase %>.
 </p>
 
 <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,8 +137,8 @@ en:
       initial_teacher_training_subject_specialism: "Which science subject did your initial teacher training specialise in?"
       has_uk_maths_or_physics_degree: "Do you have a UK undergraduate or postgraduate degree in maths or physics?"
       qts_award_years:
-        before_september_2014: "In or before the academic year 2013 to 2014"
-        on_or_after_september_2014: "In or after the academic year 2014 to 2015"
+        before_cut_off_date: "In or before the academic year 2013 to 2014"
+        on_or_after_cut_off_date: "In or after the academic year 2014 to 2015"
       employed_as_supply_teacher: "Are you currently employed as a supply teacher?"
       has_entire_term_contract: "Do you have a contract to teach at the same school for an entire term or longer?"
       employed_directly: "Are you employed directly by your school?"
@@ -187,8 +187,8 @@ en:
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
       qts_award_years:
-        before_september_2013: "In or before the academic year 2012 to 2013"
-        on_or_after_september_2013: "In or after the academic year 2013 to 2014"
+        before_cut_off_date: "In or before the academic year 2012 to 2013"
+        on_or_after_cut_off_date: "In or after the academic year 2013 to 2014"
       claim_school: "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
       additional_school: "Which additional school were you employed to teach at between 6 April 2018 and 5 April 2019?"
       employment_status: "Are you still employed to teach at a school in England?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,9 @@ en:
       other: Please make a note of these claims and contact the claimant to resolve the problems with their payment before the next pay run.
     unknown_payroll_gender_preventing_approval_message: This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
   answers:
+    qts_award_years:
+      before_cut_off_date: "In or before the academic year %{year}"
+      on_or_after_cut_off_date: "In or after the academic year %{year}"
     student_loan_start_date:
       one_course:
         before_first_september_2012: "Before 1 September 2012"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,7 +131,7 @@ en:
     possible_rejection_reasons: |
       * you are not employed to teach maths or physics at an eligible state-funded secondary school
       * you did not complete your initial teacher training in maths or physics and you do not have a degree in maths or physics
-      * you completed your initial teacher training in or before the academic year 2013 to 2014
+      * you completed your initial teacher training in or before the academic year %{qts_year}
       * you’re a supply teacher contracted by a private agency or for less than a full term
       * you are currently subject to formal capability proceedings or disciplinary action
     questions:
@@ -183,7 +183,7 @@ en:
     claim_action: "claim back student loan repayments"
     award_description: "claim payment"
     possible_rejection_reasons: |
-      * you completed your initial teacher training in or before the academic year 2012 to 2013
+      * you completed your initial teacher training in or before the academic year %{qts_year}
       * you did not teach at an eligible school during the financial year 2018 to 2019
       * you are not currently employed to teach at a state-funded secondary school
       * you did not teach an eligible subject for at least half of your contracted hours

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,7 +131,7 @@ en:
     possible_rejection_reasons: |
       * you are not employed to teach maths or physics at an eligible state-funded secondary school
       * you did not complete your initial teacher training in maths or physics and you do not have a degree in maths or physics
-      * you completed your initial teacher training in or after the academic year 2014 to 2015
+      * you completed your initial teacher training in or before the academic year 2013 to 2014
       * you’re a supply teacher contracted by a private agency or for less than a full term
       * you are currently subject to formal capability proceedings or disciplinary action
     questions:

--- a/lib/academic_year.rb
+++ b/lib/academic_year.rb
@@ -1,0 +1,42 @@
+# Used to model an academic year, which is normally dispayed in the format
+# "YYYY/YYYY". Supports comparison and basic arithmetic operations.
+#
+# Can be initialised both with a single start year, or the academic year as a
+# string. For example:
+#
+#   AcademicYear.new(2014).to_s        #=> "2014/2015"
+#   AcademicYear.new("2014/2015").to_s #=> "2014/2015"
+#
+# It also supports being displayed in a user-friendly format:
+#
+#   AcademicYear.new("2014/2015").to_s(:long) #=> "2014 to 2015"
+class AcademicYear
+  include Comparable
+
+  attr_reader :start_year, :end_year
+
+  def initialize(start_year)
+    @start_year = start_year.to_s.split("/").first.to_i
+    @end_year = @start_year + 1
+  end
+
+  def to_s(format = :default)
+    if format == :long
+      "#{start_year} to #{end_year}"
+    else
+      "#{start_year}/#{end_year}"
+    end
+  end
+
+  def <=>(other)
+    start_year <=> other.start_year
+  end
+
+  def -(other)
+    AcademicYear.new(start_year - other)
+  end
+
+  def +(other)
+    AcademicYear.new(start_year + other)
+  end
+end

--- a/spec/factories/maths_and_physics/eligibilities.rb
+++ b/spec/factories/maths_and_physics/eligibilities.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
       teaching_maths_or_physics { true }
       current_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
       initial_teacher_training_subject { :maths }
-      qts_award_year { "on_or_after_september_2014" }
+      qts_award_year { :on_or_after_cut_off_date }
       employed_as_supply_teacher { false }
       subject_to_disciplinary_action { false }
       subject_to_formal_performance_action { false }

--- a/spec/factories/student_loans/eligibilities.rb
+++ b/spec/factories/student_loans/eligibilities.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :student_loans_eligibility, class: "StudentLoans::Eligibility" do
     trait :eligible do
-      qts_award_year { "on_or_after_september_2013" }
+      qts_award_year { :on_or_after_cut_off_date }
       claim_school { School.find(ActiveRecord::FixtureSet.identify(:penistone_grammar_school, :uuid)) }
       employment_status { :claim_school }
       current_school { claim_school }

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -27,12 +27,12 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     find("a[href='#{claim_path(StudentLoans.routing_name, "qts-year")}']").click
 
-    expect(find("#claim_eligibility_attributes_qts_award_year_on_or_after_september_2013").checked?).to eq(true)
+    expect(find("#claim_eligibility_attributes_qts_award_year_on_or_after_cut_off_date").checked?).to eq(true)
 
-    choose I18n.t("student_loans.questions.qts_award_years.before_september_2013")
+    choose I18n.t("student_loans.questions.qts_award_years.before_cut_off_date")
     click_on "Continue"
 
-    expect(claim.eligibility.reload.qts_award_year).to eq("before_september_2013")
+    expect(claim.eligibility.reload.qts_award_year).to eq("before_cut_off_date")
 
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year 2013 to 2014.")

--- a/spec/features/ineligible_maths_and_physics_claims_spec.rb
+++ b/spec/features/ineligible_maths_and_physics_claims_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Ineligible Maths and Physics claims" do
     choose_initial_teacher_training_subject
     choose_qts_year("In or before the academic year 2013 to 2014")
 
-    expect(claim.eligibility.reload.qts_award_year).to eql("before_september_2014")
+    expect(claim.eligibility.reload.qts_award_year).to eql("before_cut_off_date")
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year 2014 to 2015.")
   end

--- a/spec/features/ineligible_maths_and_physics_claims_spec.rb
+++ b/spec/features/ineligible_maths_and_physics_claims_spec.rb
@@ -35,16 +35,17 @@ RSpec.feature "Ineligible Maths and Physics claims" do
     expect(page).to have_text("You can only get this payment if you completed a degree specialising in maths or physics")
   end
 
-  scenario "qualified before the first eligible year" do
+  scenario "qualified before the first eligible QTS year" do
+    policy_configurations(:maths_and_physics).update!(current_academic_year: "2020/2021")
     claim = start_maths_and_physics_claim
 
     choose_school schools(:penistone_grammar_school)
     choose_initial_teacher_training_subject
-    choose_qts_year("In or before the academic year 2013 to 2014")
+    choose_qts_year("In or before the academic year 2014 to 2015")
 
     expect(claim.eligibility.reload.qts_award_year).to eql("before_cut_off_date")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year 2014 to 2015.")
+    expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year 2015 to 2016.")
   end
 
   scenario "supply teacher doesn't have a contract for a whole term" do

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -1,14 +1,16 @@
 require "rails_helper"
 
 RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
-  scenario "qualified before the first eligible year" do
+  scenario "qualified before the first eligible QTS year" do
+    policy_configurations(:student_loans).update!(current_academic_year: "2025/2026")
+
     visit new_claim_path(StudentLoans.routing_name)
-    choose_qts_year("In or before the academic year 2012 to 2013")
+    choose_qts_year("In or before the academic year 2013 to 2014")
     claim = Claim.order(:created_at).last
 
     expect(claim.eligibility.reload.qts_award_year).to eql("before_cut_off_date")
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year 2013 to 2014.")
+    expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year 2014 to 2015.")
   end
 
   scenario "chooses an ineligible claim school" do

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     choose_qts_year("In or before the academic year 2012 to 2013")
     claim = Claim.order(:created_at).last
 
-    expect(claim.eligibility.reload.qts_award_year).to eql("before_september_2013")
+    expect(claim.eligibility.reload.qts_award_year).to eql("before_cut_off_date")
     expect(page).to have_text("You’re not eligible")
     expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year 2013 to 2014.")
   end

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Maths & Physics claims" do
 
       expect(page).to have_text(I18n.t("questions.qts_award_year"))
       choose_qts_year "In or after the academic year 2014 to 2015"
-      expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_september_2014")
+      expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
 
       expect(page).to have_text(I18n.t("maths_and_physics.questions.employed_as_supply_teacher"))
       choose "No"
@@ -237,7 +237,7 @@ RSpec.feature "Maths & Physics claims" do
 
     expect(page).to have_text(I18n.t("questions.qts_award_year"))
     choose_qts_year "In or after the academic year 2014 to 2015"
-    expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_september_2014")
+    expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
 
     expect(page).to have_text(I18n.t("maths_and_physics.questions.employed_as_supply_teacher"))
     choose "Yes"

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       choose_qts_year
       claim = Claim.order(:created_at).last
 
-      expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_september_2013")
+      expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
 
       expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
 

--- a/spec/fixtures/policy_configurations.yml
+++ b/spec/fixtures/policy_configurations.yml
@@ -4,4 +4,4 @@ student_loans:
 
 maths_and_physics:
   policy_type: MathsAndPhysics
-  current_academic_year: "2020/2021"
+  current_academic_year: "2019/2020"

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -7,7 +7,7 @@ describe ClaimsHelper do
       build(
         :student_loans_eligibility,
         :eligible,
-        qts_award_year: "on_or_after_september_2013",
+        qts_award_year: "on_or_after_cut_off_date",
       )
     end
     let(:claim) do

--- a/spec/lib/academic_year_spec.rb
+++ b/spec/lib/academic_year_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+require "academic_year"
+
+RSpec.describe AcademicYear do
+  it "can be initialised with the full academic year as a String" do
+    expect(AcademicYear.new("2014/2015").start_year).to eq 2014
+  end
+
+  it "can be initialised with a single Integer year" do
+    expect(AcademicYear.new(2020).start_year).to eq 2020
+  end
+
+  it "can be initialised with a single String year" do
+    expect(AcademicYear.new("2019").start_year).to eq 2019
+  end
+
+  it "is comparable" do
+    expect(AcademicYear.new(2012)).to eq AcademicYear.new(2012)
+    expect(AcademicYear.new(2012)).not_to eq AcademicYear.new(2011)
+  end
+
+  it "supports arithmetic 'minus' with integers" do
+    expect(AcademicYear.new(2012) - 1).to eq(AcademicYear.new(2011))
+    expect(AcademicYear.new(2012) - 3).to eq(AcademicYear.new(2009))
+  end
+
+  it "supports arithmetic 'plus' with integers" do
+    expect(AcademicYear.new(2022) + 1).to eq(AcademicYear.new(2023))
+    expect(AcademicYear.new(2008) + 3).to eq(AcademicYear.new(2011))
+  end
+
+  describe "#to_s" do
+    it "returns the accepted short format for displaying academic years" do
+      expect(AcademicYear.new(2014).to_s).to eq "2014/2015"
+      expect(AcademicYear.new("2020").to_s).to eq "2020/2021"
+      expect(AcademicYear.new("2020/2021").to_s).to eq "2020/2021"
+    end
+
+    it "can return the long-form, more human-friendly version of the academic year" do
+      expect(AcademicYear.new(2014).to_s(:long)).to eq "2014 to 2015"
+      expect(AcademicYear.new("2020").to_s(:long)).to eq "2020 to 2021"
+      expect(AcademicYear.new("2020/2021").to_s(:long)).to eq "2020 to 2021"
+    end
+  end
+end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe ClaimMailer, type: :mailer do
         it "mentions that claim has been rejected in the subject and body" do
           expect(mail.subject).to include("rejected")
           expect(mail.body.encoded).to include("not been able to approve")
+
+          ineligible_year = (policy.first_eligible_qts_award_year - 1).to_s(:long)
+          expect(mail.body.encoded)
+            .to include("completed your initial teacher training in or before the academic year #{ineligible_year}")
         end
       end
 

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -77,6 +77,14 @@ RSpec.describe ClaimMailer, type: :mailer do
           expect(mail.body.encoded)
             .to include("completed your initial teacher training in or before the academic year #{ineligible_year}")
         end
+
+        it "changes the ITT reason based on the policy's configured current_academic_year" do
+          PolicyConfiguration.for(policy).update!(current_academic_year: "2025/2026")
+
+          ineligible_year = (policy.first_eligible_qts_award_year - 1).to_s(:long)
+          expect(mail.body.encoded)
+            .to include("completed your initial teacher training in or before the academic year #{ineligible_year}")
+        end
       end
 
       describe "#update_after_three_weeks" do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Claim, type: :model do
     claim = build(:claim)
 
     expect(claim).not_to be_valid(:"qts-year")
-    expect(claim.errors.values).to include(["Select whether you completed your initial teacher training before or after the start of the academic year 2013 to 2014"])
+    expect(claim.errors.values).to include(["Select when you completed your initial teacher training"])
   end
 
   context "when saving in the “gender” validation context" do

--- a/spec/models/maths_and_physics/admin_checks_presenter_spec.rb
+++ b/spec/models/maths_and_physics/admin_checks_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MathsAndPhysics::AdminChecksPresenter, type: :model do
       current_school: school,
       initial_teacher_training_subject: :maths,
       initial_teacher_training_subject_specialism: nil,
-      qts_award_year: "on_or_after_september_2014")
+      qts_award_year: "on_or_after_cut_off_date")
   end
   subject(:presenter) { described_class.new(eligibility) }
 

--- a/spec/models/maths_and_physics/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_admin_answers_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MathsAndPhysics::EligibilityAdminAnswersPresenter, type: :model d
       current_school: school,
       initial_teacher_training_subject: :maths,
       initial_teacher_training_subject_specialism: :not_sure,
-      qts_award_year: "on_or_after_september_2014",
+      qts_award_year: "on_or_after_cut_off_date",
       has_uk_maths_or_physics_degree: "has_non_uk",
       employed_as_supply_teacher: true,
       has_entire_term_contract: true,

--- a/spec/models/maths_and_physics/eligibility_answers_presenter_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_answers_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
       teaching_maths_or_physics: true,
       current_school: schools(:penistone_grammar_school),
       initial_teacher_training_subject: :maths,
-      qts_award_year: "on_or_after_september_2014",
+      qts_award_year: "on_or_after_cut_off_date",
       employed_as_supply_teacher: false,
       subject_to_disciplinary_action: false,
       subject_to_formal_performance_action: false)
@@ -34,7 +34,7 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
         current_school: schools(:penistone_grammar_school),
         initial_teacher_training_subject: :none_of_the_subjects,
         has_uk_maths_or_physics_degree: "has_non_uk",
-        qts_award_year: "on_or_after_september_2014",
+        qts_award_year: "on_or_after_cut_off_date",
         employed_as_supply_teacher: false,
         subject_to_disciplinary_action: false,
         subject_to_formal_performance_action: false)
@@ -64,7 +64,7 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
         initial_teacher_training_subject: :science,
         initial_teacher_training_subject_specialism: :not_sure,
         has_uk_maths_or_physics_degree: "has_non_uk",
-        qts_award_year: "on_or_after_september_2014",
+        qts_award_year: "on_or_after_cut_off_date",
         employed_as_supply_teacher: false,
         subject_to_disciplinary_action: false,
         subject_to_formal_performance_action: false)
@@ -94,7 +94,7 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
         current_school: schools(:penistone_grammar_school),
         initial_teacher_training_subject: :physics,
         initial_teacher_training_subject_specialism: :physics,
-        qts_award_year: "on_or_after_september_2014",
+        qts_award_year: "on_or_after_cut_off_date",
         employed_as_supply_teacher: true,
         has_entire_term_contract: true,
         employed_directly: true,

--- a/spec/models/maths_and_physics/eligibility_answers_presenter_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_answers_presenter_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
     expect(presenter.answers).to eq(expected_answers)
   end
 
+  it "changes the answer for the QTS question based on the answer and the configured academic year" do
+    policy_configurations(:maths_and_physics).update!(current_academic_year: "2021/2022")
+    qts_answer = presenter.answers[3][1]
+    expect(qts_answer).to eq("In or after the academic year 2016 to 2017")
+
+    presenter.eligibility.qts_award_year = :before_cut_off_date
+    qts_answer = presenter.answers[3][1]
+    expect(qts_answer).to eq("In or before the academic year 2015 to 2016")
+  end
+
   context "initial teacher training subject not in a science" do
     let(:eligibility) do
       build(:maths_and_physics_eligibility,

--- a/spec/models/maths_and_physics/eligibility_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
       expect(MathsAndPhysics::Eligibility.new(initial_teacher_training_subject: :science, initial_teacher_training_subject_specialism: :not_sure, has_uk_maths_or_physics_degree: "no").ineligible?).to eql false
     end
 
-    it "returns true when the qts_award_year is before 2014" do
-      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_september_2014").ineligible?).to eql true
-      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "on_or_after_september_2014").ineligible?).to eql false
+    it "returns true when the qts_award_year is before the qualifiying cut-off" do
+      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_cut_off_date").ineligible?).to eql true
+      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "on_or_after_cut_off_date").ineligible?).to eql false
     end
 
     it "returns true when claimant is a supply teacher without a contract of at least one term" do
@@ -67,7 +67,7 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
       expect(MathsAndPhysics::Eligibility.new(teaching_maths_or_physics: false).ineligibility_reason).to eq :not_teaching_maths_or_physics
       expect(MathsAndPhysics::Eligibility.new(current_school: schools(:hampstead_school)).ineligibility_reason).to eq :ineligible_current_school
       expect(MathsAndPhysics::Eligibility.new(initial_teacher_training_subject: :none_of_the_subjects, has_uk_maths_or_physics_degree: "no").ineligibility_reason).to eq :no_maths_or_physics_qualification
-      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_september_2014").ineligibility_reason).to eq :ineligible_qts_award_year
+      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_cut_off_date").ineligibility_reason).to eq :ineligible_qts_award_year
       expect(MathsAndPhysics::Eligibility.new(employed_as_supply_teacher: true, has_entire_term_contract: false).ineligibility_reason).to eql :no_entire_term_contract
       expect(MathsAndPhysics::Eligibility.new(subject_to_disciplinary_action: true).ineligibility_reason).to eql :subject_to_disciplinary_action
       expect(MathsAndPhysics::Eligibility.new(subject_to_formal_performance_action: true).ineligibility_reason).to eql :subject_to_formal_performance_action
@@ -218,7 +218,7 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
   context "when saving in the “qts-year” context" do
     it "validates the presence of qts_award_year" do
       expect(MathsAndPhysics::Eligibility.new).not_to be_valid(:"qts-year")
-      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_september_2014")).to be_valid(:"qts-year")
+      expect(MathsAndPhysics::Eligibility.new(qts_award_year: "before_cut_off_date")).to be_valid(:"qts-year")
     end
   end
 
@@ -294,7 +294,7 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
 
     it "is not valid without a value for qts_award_year" do
       expect(build(:maths_and_physics_eligibility, :eligible, qts_award_year: nil)).not_to be_valid(:submit)
-      expect(build(:maths_and_physics_eligibility, :eligible, qts_award_year: "before_september_2014")).to be_valid(:submit)
+      expect(build(:maths_and_physics_eligibility, :eligible, qts_award_year: "before_cut_off_date")).to be_valid(:submit)
     end
 
     it "is not valid without a value for employed_as_supply_teacher" do

--- a/spec/models/maths_and_physics_spec.rb
+++ b/spec/models/maths_and_physics_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe MathsAndPhysics, type: :model do
+  describe ".first_eligible_qts_award_year" do
+    let(:policy_configuration) { policy_configurations(:maths_and_physics) }
+
+    it "returns an AcademicYear five years before the currently configured current_academic_year" do
+      policy_configuration.update!(current_academic_year: "2019/2020")
+      expect(MathsAndPhysics.first_eligible_qts_award_year).to eq AcademicYear.new(2014)
+
+      policy_configuration.update!(current_academic_year: "2025/2026")
+      expect(MathsAndPhysics.first_eligible_qts_award_year).to eq AcademicYear.new(2020)
+    end
+  end
+end

--- a/spec/models/student_loans/admin_checks_presenter_spec.rb
+++ b/spec/models/student_loans/admin_checks_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StudentLoans::AdminChecksPresenter, type: :model do
   let(:eligibility) do
     build(
       :student_loans_eligibility,
-      qts_award_year: "on_or_after_september_2013",
+      qts_award_year: "on_or_after_cut_off_date",
       claim_school: school,
       current_school: school,
     )

--- a/spec/models/student_loans/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_admin_answers_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StudentLoans::EligibilityAdminAnswersPresenter, type: :model do
   let(:eligibility) do
     build(
       :student_loans_eligibility,
-      qts_award_year: "on_or_after_september_2013",
+      qts_award_year: "on_or_after_cut_off_date",
       claim_school: school,
       current_school: school,
       chemistry_taught: true,

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
   let(:school) { schools(:penistone_grammar_school) }
   let(:eligibility_attributes) do
     {
-      qts_award_year: "on_or_after_september_2013",
+      qts_award_year: "on_or_after_cut_off_date",
       claim_school: school,
       current_school: school,
       had_leadership_position: true,

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
     expect(presenter.answers).to eq expected_answers
   end
 
+  it "changes the answer for the QTS question, based on the configured academic year" do
+    policy_configurations(:student_loans).update!(current_academic_year: "2027/2028")
+
+    qts_answer = presenter.answers[0][1]
+    expect(qts_answer).to eq("In or after the academic year 2016 to 2017")
+
+    presenter.eligibility.qts_award_year = :before_cut_off_date
+    qts_answer = presenter.answers[0][1]
+    expect(qts_answer).to eq("In or before the academic year 2015 to 2016")
+  end
+
   it "excludes questions skipped from the flow" do
     eligibility.had_leadership_position = false
     expect(presenter.answers).to_not include([I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "Yes", "mostly-performed-leadership-duties"])

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     end
 
     it "has handily named boolean methods for the possible values" do
-      eligibility = StudentLoans::Eligibility.new(qts_award_year: "on_or_after_september_2013")
+      eligibility = StudentLoans::Eligibility.new(qts_award_year: "on_or_after_cut_off_date")
 
-      expect(eligibility.awarded_qualified_status_on_or_after_september_2013?).to eq true
-      expect(eligibility.awarded_qualified_status_before_september_2013?).to eq false
+      expect(eligibility.awarded_qualified_status_on_or_after_cut_off_date?).to eq true
+      expect(eligibility.awarded_qualified_status_before_cut_off_date?).to eq false
     end
   end
 
@@ -92,9 +92,9 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
       expect(StudentLoans::Eligibility.new.ineligible?).to eql false
     end
 
-    it "returns true when the qts_award_year is before 2013" do
-      expect(StudentLoans::Eligibility.new(qts_award_year: "before_september_2013").ineligible?).to eql true
-      expect(StudentLoans::Eligibility.new(qts_award_year: "on_or_after_september_2013").ineligible?).to eql false
+    it "returns true when the qts_award_year is before the qualifying cut-off" do
+      expect(StudentLoans::Eligibility.new(qts_award_year: "before_cut_off_date").ineligible?).to eql true
+      expect(StudentLoans::Eligibility.new(qts_award_year: "on_or_after_cut_off_date").ineligible?).to eql false
     end
 
     it "returns true when the claim_school is not eligible" do
@@ -129,7 +129,7 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     end
 
     it "returns a symbol indicating the reason for ineligibility" do
-      expect(StudentLoans::Eligibility.new(qts_award_year: "before_september_2013").ineligibility_reason).to eq :ineligible_qts_award_year
+      expect(StudentLoans::Eligibility.new(qts_award_year: "before_cut_off_date").ineligibility_reason).to eq :ineligible_qts_award_year
       expect(StudentLoans::Eligibility.new(claim_school: schools(:hampstead_school)).ineligibility_reason).to eq :ineligible_claim_school
       expect(StudentLoans::Eligibility.new(employment_status: :no_school).ineligibility_reason).to eq :employed_at_no_school
       expect(StudentLoans::Eligibility.new(current_school: schools(:the_samuel_lister_academy)).ineligibility_reason).to eq :ineligible_current_school

--- a/spec/models/student_loans/slug_sequence_spec.rb
+++ b/spec/models/student_loans/slug_sequence_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe StudentLoans::SlugSequence do
       expect(claim.eligibility).not_to be_ineligible
       expect(slug_sequence.slugs).not_to include("ineligible")
 
-      claim.eligibility.qts_award_year = "before_september_2013"
+      claim.eligibility.qts_award_year = "before_cut_off_date"
       expect(claim.eligibility).to be_ineligible
       expect(slug_sequence.slugs).to include("ineligible")
     end

--- a/spec/models/student_loans_spec.rb
+++ b/spec/models/student_loans_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe StudentLoans, type: :model do
+  describe ".first_eligible_qts_award_year" do
+    let(:policy_configuration) { policy_configurations(:student_loans) }
+
+    it "returns 11 years prior to the currently configured academic year, with a floor of the 2013/2014 academic year" do
+      policy_configuration.update!(current_academic_year: "2031/2032")
+      expect(StudentLoans.first_eligible_qts_award_year).to eq AcademicYear.new(2020)
+
+      policy_configuration.update!(current_academic_year: "2027/2028")
+      expect(StudentLoans.first_eligible_qts_award_year).to eq AcademicYear.new(2016)
+
+      policy_configuration.update!(current_academic_year: "2024/2025")
+      expect(StudentLoans.first_eligible_qts_award_year).to eq AcademicYear.new(2013)
+
+      policy_configuration.update!(current_academic_year: "2023/2024")
+      expect(StudentLoans.first_eligible_qts_award_year).to eq AcademicYear.new(2013)
+    end
+  end
+end

--- a/spec/requests/claims_qts_year_spec.rb
+++ b/spec/requests/claims_qts_year_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "The QTS year question", type: :request do
+  let(:maths_and_physics_configuration) { policy_configurations(:maths_and_physics) }
+
+  it "changes the QTS year option labels based on the current academic year the policy is accepting claims for" do
+    maths_and_physics_configuration.update!(current_academic_year: "2019/2020")
+    start_claim(MathsAndPhysics)
+
+    get claim_path(MathsAndPhysics.routing_name, "qts-year")
+
+    expect(response.body).to include("When did you complete your initial teacher training?")
+    expect(response.body).to include("In or before the academic year 2013 to 2014")
+    expect(response.body).to include("In or after the academic year 2014 to 2015")
+
+    maths_and_physics_configuration.update!(current_academic_year: "2020/2021")
+
+    get claim_path(MathsAndPhysics.routing_name, "qts-year")
+    expect(response.body).to include("In or before the academic year 2014 to 2015")
+    expect(response.body).to include("In or after the academic year 2015 to 2016")
+  end
+end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Claims", type: :request do
       it "makes sure validations appropriate to the context are run" do
         put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: nil}}}
 
-        expect(response.body).to include("Select whether you completed your initial teacher training before or after the start of the academic year 2013 to 2014")
+        expect(response.body).to include("Select when you completed your initial teacher training")
       end
 
       it "resets dependent claim attributes when appropriate" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -126,9 +126,9 @@ RSpec.describe "Claims", type: :request do
       before { start_student_loans_claim }
 
       it "updates the claim with the submitted form data" do
-        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_september_2013"}}}
+        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_cut_off_date"}}}
 
-        expect(in_progress_claim.eligibility.qts_award_year).to eq "on_or_after_september_2013"
+        expect(in_progress_claim.eligibility.qts_award_year).to eq "on_or_after_cut_off_date"
       end
 
       it "makes sure validations appropriate to the context are run" do
@@ -189,7 +189,7 @@ RSpec.describe "Claims", type: :request do
 
     context "when a claim hasn’t been started yet" do
       it "redirects to the start page indicated by the routing" do
-        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_september_2013"}}}
+        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_cut_off_date"}}}
         expect(response).to redirect_to(StudentLoans.start_page_url)
       end
     end

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Claim session timing out", type: :request do
       expect(session[:verify_request_id]).not_to be_nil
 
       travel after_expiry do
-        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {qts_award_year: "on_or_after_september_2013"}}
+        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {qts_award_year: "on_or_after_cut_off_date"}}
 
         expect(response).to redirect_to(timeout_claim_path)
         expect(session[:claim_id]).to be_nil
@@ -37,7 +37,7 @@ RSpec.describe "Claim session timing out", type: :request do
 
     it "does not timeout the session" do
       travel before_expiry do
-        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_september_2013"}}}
+        put claim_path(StudentLoans.routing_name, "qts-year"), params: {claim: {eligibility_attributes: {qts_award_year: "on_or_after_cut_off_date"}}}
 
         expect(response).to redirect_to(claim_path(StudentLoans.routing_name, "claim-school"))
         expect(session[:verify_request_id]).not_to be_nil

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -11,7 +11,7 @@ module RequestHelpers
     {
       StudentLoans => {
         eligibility_attributes: {
-          qts_award_year: "on_or_after_september_2013",
+          qts_award_year: "on_or_after_cut_off_date",
         },
       },
       MathsAndPhysics => {


### PR DESCRIPTION
This updates the claim journey such that the QTS question will vary the options based on the academic year that the policy is currently configured to accept answers for. Further work is [in-progress](https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/1223-vary-qts-eligibility-based-on-academic-year?expand=1) to update the admin area so that it reflects the actual answer the user gave, but right now it is still hard-coded to display the current years. That work will be delivered admin area will be updated in a separate PR.