### PR TITLE
Allow service operators to mark a check as completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Allow service operators to mark a check as completed
+
 ## [Release 055] - 2020-02-24
 
 - Fix skipped heading level on manage services screen

--- a/app/controllers/admin/checks_controller.rb
+++ b/app/controllers/admin/checks_controller.rb
@@ -16,6 +16,8 @@ class Admin::ChecksController < Admin::BaseAdminController
   def create
     Check.create!(name: current_check, claim: @claim, created_by: admin_user)
     redirect_to next_check_path
+  rescue ActiveRecord::RecordInvalid
+    redirect_to admin_claim_check_path(@claim, check: current_check), alert: "This check has already been completed"
   end
 
   private

--- a/app/controllers/admin/checks_controller.rb
+++ b/app/controllers/admin/checks_controller.rb
@@ -2,12 +2,19 @@ class Admin::ChecksController < Admin::BaseAdminController
   before_action :ensure_service_operator
   before_action :load_claim
 
+  CHECKS_SEQUENCE = %w[qualifications employment]
+
   def index
   end
 
   def show
     @eligibility_checks = @claim.policy::AdminChecksPresenter.new(@claim.eligibility)
-    render current_check_template
+    render current_check
+  end
+
+  def create
+    Check.create!(name: current_check, claim: @claim, created_by: admin_user)
+    redirect_to next_check_path
   end
 
   private
@@ -16,7 +23,19 @@ class Admin::ChecksController < Admin::BaseAdminController
     @claim = Claim.find(params[:claim_id])
   end
 
-  def current_check_template
+  def current_check
     params[:check].parameterize.underscore
+  end
+
+  def next_check
+    CHECKS_SEQUENCE[CHECKS_SEQUENCE.index(current_check) + 1]
+  end
+
+  def next_check_path
+    if next_check.present?
+      admin_claim_check_path(@claim, check: next_check)
+    else
+      admin_claim_path(@claim)
+    end
   end
 end

--- a/app/controllers/admin/checks_controller.rb
+++ b/app/controllers/admin/checks_controller.rb
@@ -9,6 +9,7 @@ class Admin::ChecksController < Admin::BaseAdminController
 
   def show
     @eligibility_checks = @claim.policy::AdminChecksPresenter.new(@claim.eligibility)
+    @check = @claim.checks.find_by(name: current_check)
     render current_check
   end
 
@@ -20,7 +21,7 @@ class Admin::ChecksController < Admin::BaseAdminController
   private
 
   def load_claim
-    @claim = Claim.find(params[:claim_id])
+    @claim = Claim.includes(:checks).find(params[:claim_id])
   end
 
   def current_check

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Checks are performed against a claim by service operators
+# Only one check of a particular type can be carried out per claim
+# These checks were designed to make the process of checking a
+# claim more granular
+
+# It records who completed the check and the date/time the action
+# was carried out
+
+class Check < ApplicationRecord
+  belongs_to :claim
+  belongs_to :created_by, class_name: "DfeSignIn::User"
+
+  validates :name, uniqueness: {scope: :claim_id}
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -77,6 +77,7 @@ class Claim < ApplicationRecord
   enum student_loan_plan: STUDENT_LOAN_PLAN_OPTIONS
 
   has_one :decision
+  has_many :checks
 
   belongs_to :eligibility, polymorphic: true, dependent: :destroy
   accepts_nested_attributes_for :eligibility, update_only: true

--- a/app/views/admin/checks/_check_outcome.html.erb
+++ b/app/views/admin/checks/_check_outcome.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  Checked by <strong><%= user_details(check.created_by, include_line_break: false) %></strong> on <strong><%= l(check.created_at) %></strong>
+</p>

--- a/app/views/admin/checks/employment.html.erb
+++ b/app/views/admin/checks/employment.html.erb
@@ -11,6 +11,6 @@
           description: I18n.t("#{@claim.policy.to_s.underscore}.admin.employment_check_description"),
           answers: @eligibility_checks.employment %>
 
-    <%= button_to "Complete employment check and continue", admin_claim_path(@claim), class: "govuk-button", method: :get %>
+    <%= button_to "Complete employment check and continue", admin_claim_checks_path(@claim, check: :employment), class: "govuk-button" %>
   </div>
 </div>

--- a/app/views/admin/checks/employment.html.erb
+++ b/app/views/admin/checks/employment.html.erb
@@ -10,7 +10,13 @@
           heading: "Employment",
           description: I18n.t("#{@claim.policy.to_s.underscore}.admin.employment_check_description"),
           answers: @eligibility_checks.employment %>
+  </div>
 
-    <%= button_to "Complete employment check and continue", admin_claim_checks_path(@claim, check: :employment), class: "govuk-button" %>
+  <div class="govuk-grid-column-full">
+    <% if @check.present? %>
+      <%= render "check_outcome", check: @check %>
+    <% else %>
+      <%= button_to "Complete employment check and continue", admin_claim_checks_path(@claim, check: :employment), class: "govuk-button" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/checks/index.html.erb
+++ b/app/views/admin/checks/index.html.erb
@@ -18,6 +18,9 @@
             <span class="app-task-list__task-name">
               <%= link_to "Check qualification information", admin_claim_check_path(claim_id: @claim.id, check: :qualifications), class: "govuk-link" %>
             </span>
+            <% if @claim.checks.exists?(name: "qualifications") %>
+              <strong class="govuk-tag app-task-list__task-completed">Completed</strong>
+            <% end %>
           </li>
         </ul>
       </li>
@@ -30,6 +33,9 @@
             <span class="app-task-list__task-name">
               <%= link_to "Check employment information", admin_claim_check_path(claim_id: @claim.id, check: :employment), class: "govuk-link" %>
             </span>
+            <% if @claim.checks.exists?(name: "employment") %>
+              <strong class="govuk-tag app-task-list__task-completed">Completed</strong>
+            <% end %>
           </li>
         </ul>
       </li>

--- a/app/views/admin/checks/qualifications.html.erb
+++ b/app/views/admin/checks/qualifications.html.erb
@@ -11,7 +11,13 @@
           heading: "Qualifications",
           description: I18n.t("#{@claim.policy.to_s.underscore}.admin.qualification_check_description"),
           answers: @eligibility_checks.qualifications %>
+  </div>
 
-    <%= button_to "Complete qualifications check and continue", admin_claim_checks_path(claim_id: @claim.id, check: :qualifications), class: "govuk-button" %>
+  <div class="govuk-grid-column-full">
+    <% if @check.present? %>
+      <%= render "check_outcome", check: @check %>
+    <% else %>
+      <%= button_to "Complete qualifications check and continue", admin_claim_checks_path(claim_id: @claim.id, check: :qualifications), class: "govuk-button" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/checks/qualifications.html.erb
+++ b/app/views/admin/checks/qualifications.html.erb
@@ -12,6 +12,6 @@
           description: I18n.t("#{@claim.policy.to_s.underscore}.admin.qualification_check_description"),
           answers: @eligibility_checks.qualifications %>
 
-    <%= button_to "Complete qualifications check and continue", admin_claim_check_path(claim_id: @claim.id, check: :employment), class: "govuk-button", method: :get %>
+    <%= button_to "Complete qualifications check and continue", admin_claim_checks_path(claim_id: @claim.id, check: :qualifications), class: "govuk-button" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
     get "/auth/failure", to: "auth#failure"
 
     resources :claims, only: [:index, :show] do
-      resources :checks, only: [:index, :show], param: :check, constraints: {check: %r{qualifications|employment}}
+      resources :checks, only: [:index, :show, :create], param: :check, constraints: {check: %r{qualifications|employment}}
       resources :decisions, only: [:create]
       get "search", on: :collection
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
     get "/auth/failure", to: "auth#failure"
 
     resources :claims, only: [:index, :show] do
-      resources :checks, only: [:index, :show, :create], param: :check, constraints: {check: %r{qualifications|employment}}
+      resources :checks, only: [:index, :show, :create], param: :check, constraints: {check: %r{#{Admin::ChecksController::CHECKS_SEQUENCE.join("|")}}}
       resources :decisions, only: [:create]
       get "search", on: :collection
     end

--- a/db/migrate/20200219154337_create_claim_checks.rb
+++ b/db/migrate/20200219154337_create_claim_checks.rb
@@ -1,0 +1,12 @@
+class CreateClaimChecks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :checks, id: :uuid do |t|
+      t.string :name
+      t.references :claim, foreign_key: true, type: :uuid
+      t.references :created_by, type: :uuid, foreign_key: {to_table: :dfe_sign_in_users}
+      t.timestamps
+
+      t.index [:name, :claim_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_12_154529) do
+ActiveRecord::Schema.define(version: 2020_02_19_154337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "checks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.uuid "claim_id"
+    t.uuid "created_by_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["claim_id"], name: "index_checks_on_claim_id"
+    t.index ["created_by_id"], name: "index_checks_on_created_by_id"
+    t.index ["name", "claim_id"], name: "index_checks_on_name_and_claim_id", unique: true
+  end
 
   create_table "claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -215,6 +226,8 @@ ActiveRecord::Schema.define(version: 2020_02_12_154529) do
     t.index ["current_school_id"], name: "index_student_loans_eligibilities_on_current_school_id"
   end
 
+  add_foreign_key "checks", "claims"
+  add_foreign_key "checks", "dfe_sign_in_users", column: "created_by_id"
   add_foreign_key "claims", "payments"
   add_foreign_key "decisions", "dfe_sign_in_users", column: "created_by_id"
   add_foreign_key "maths_and_physics_eligibilities", "schools", column: "current_school_id"

--- a/spec/factories/checks.rb
+++ b/spec/factories/checks.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :check do
+    name { Admin::ChecksController::CHECKS_SEQUENCE.sample }
+    association :created_by, factory: :dfe_signin_user
+    association :claim
+  end
+end

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -93,6 +93,22 @@ RSpec.feature "Admin checks a claim" do
       expect(page).to have_content("Claim decision")
     end
 
+    scenario "User can see completed checks" do
+      ten_minutes_ago = 10.minutes.ago
+      checking_user = create(:dfe_signin_user, given_name: "Fred", family_name: "Smith")
+      qualification_check = build(:check, name: "qualifications", created_by: checking_user, created_at: ten_minutes_ago)
+      claim_with_checks = create(:claim, :submitted, checks: [qualification_check, build(:check, name: "employment")])
+      visit admin_claim_checks_path(claim_with_checks)
+
+      expect(page).to have_content("Check qualification information Completed")
+      expect(page).to have_content("Check employment information Completed")
+
+      click_on "Check qualification information"
+      expect(page).to have_content("Checked by #{checking_user.full_name}")
+      expect(page).to have_content(I18n.l(ten_minutes_ago))
+      expect(page).not_to have_button("Complete qualifications check and continue")
+    end
+
     scenario "User can see existing decision details" do
       claim_with_decision = create(:claim, :submitted, decision: build(:decision, result: :approved, notes: "Everything matches"))
       visit admin_claim_path(claim_with_decision)

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Check, type: :model do
+  it "validates that there can only be one check of a particular type per claim" do
+    claim = create(:claim)
+    first_employment_check = create(:check, name: "employment", claim: claim)
+    second_employment_check = build(:check, name: "employment", claim: claim)
+
+    expect(first_employment_check).to be_valid
+    expect(second_employment_check).not_to be_valid
+  end
+end

--- a/spec/requests/admin_checks_spec.rb
+++ b/spec/requests/admin_checks_spec.rb
@@ -61,6 +61,19 @@ RSpec.describe "Admin checks", type: :request do
               expect(response).to redirect_to(admin_claim_path(claim))
             end
           end
+
+          context "when a check has already been marked as completed" do
+            it "doesn't create a check and redirects with an error" do
+              create(:check, name: "qualifications", claim: claim)
+
+              expect {
+                post admin_claim_checks_path(claim, check: "qualifications")
+              }.not_to change { Check.count }
+
+              expect(response).to redirect_to(admin_claim_check_path(claim, check: "qualifications"))
+              expect(flash[:alert]).to eql("This check has already been completed")
+            end
+          end
         end
       end
     end

--- a/spec/requests/admin_checks_spec.rb
+++ b/spec/requests/admin_checks_spec.rb
@@ -36,6 +36,32 @@ RSpec.describe "Admin checks", type: :request do
             expect(response.body).to include(claim.eligibility.current_school.name)
           end
         end
+
+        describe "checks#create" do
+          it "creates a new check and redirects to the next check" do
+            expect {
+              post admin_claim_checks_path(claim, check: "qualifications")
+            }.to change { Check.count }.by(1)
+
+            expect(claim.checks.last.name).to eql("qualifications")
+            expect(claim.checks.last.created_by).to eql(user)
+            expect(response).to redirect_to(admin_claim_check_path(claim, check: "employment"))
+          end
+
+          context "when the last check is marked as completed" do
+            let(:last_check) { Admin::ChecksController::CHECKS_SEQUENCE.last }
+
+            it "creates the check and redirects to the claims#show page" do
+              expect {
+                post admin_claim_checks_path(claim, check: last_check)
+              }.to change { Check.count }.by(1)
+
+              expect(claim.checks.last.name).to eql(last_check)
+              expect(claim.checks.last.created_by).to eql(user)
+              expect(response).to redirect_to(admin_claim_path(claim))
+            end
+          end
+        end
       end
     end
   end

--- a/spec/requests/admin_checks_spec.rb
+++ b/spec/requests/admin_checks_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe "Admin checks", type: :request do
     # Compatible with claims from each policy
     Policies.all.each do |policy|
       context "with a #{policy} claim" do
+        let(:claim) { create(:claim, :submitted, policy: policy) }
+
         describe "checks#show" do
           it "renders the requested page" do
             get admin_claim_check_path(claim, "qualifications")


### PR DESCRIPTION
This allows service operators to mark each check of a particular type as completed, their name and the time of the the action will be displayed on the check page.

## Screenshots

<img width="1106" alt="Screenshot 2020-02-24 at 12 57 05" src="https://user-images.githubusercontent.com/2804149/75154448-91281e80-5705-11ea-9f61-344a92c74744.png">
<img width="1081" alt="Screenshot 2020-02-24 at 12 57 19" src="https://user-images.githubusercontent.com/2804149/75154458-94bba580-5705-11ea-8687-f21ea8a17fcd.png">
