### PR TITLE
Two small changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog]
 - Run multiple worker instances so long-running queued jobs don't entirely block
   the queue.
 - Don't use "1" or "I" characters in claim references to avoid confusion
+- Adjust option for not teaching eligible subjects for student loans
 
 ## [Release 054] - 2020-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog]
 - Add page titles to admin area
 - Run multiple worker instances so long-running queued jobs don't entirely block
   the queue.
+- Don't use "1" or "I" characters in claim references to avoid confusion
 
 ## [Release 054] - 2020-02-19
 

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -6,6 +6,6 @@ class Reference
   private
 
   def characters_to_use
-    "123456789ABCDEFGHIJKLMNPQRSTUVWXYZ"
+    "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,7 @@ en:
         physics_taught: "Physics"
         computing_taught: "Computing"
         languages_taught: "Languages"
-        none_taught: "No, I didn't teach any of these subjects"
+        none_taught: "I did not teach any of these subjects"
       student_loan_amount:
         "Exactly how much student loan did you repay while employed as a teacher between 6 April 2018 and 5 April 2019?"
     admin:

--- a/spec/services/reference_spec.rb
+++ b/spec/services/reference_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe Reference do
       expect(reference.to_s.length).to eq(8)
     end
 
-    it "contains only numbers and capital letters, excluding 0 and O" do
-      expect(reference.to_s).to match(/\A[1-9A-NP-Z]+\Z/)
+    it "contains only numbers and capital letters, excluding 0, O, 1 and I" do
+      50.times do
+        expect(Reference.new.to_s).to match(/\A[2-9A-HJ-NP-Z]+\Z/)
+      end
     end
   end
 end

--- a/spec/services/reference_spec.rb
+++ b/spec/services/reference_spec.rb
@@ -1,17 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Reference do
-  subject { described_class.new }
+  let(:reference) { Reference.new }
 
   describe "to_s" do
-    let(:reference) { subject.to_s }
-
     it "is 8 characters long" do
-      expect(reference.length).to eq(8)
+      expect(reference.to_s.length).to eq(8)
     end
 
     it "contains only numbers and capital letters, excluding 0 and O" do
-      expect(reference).to match(/\A[1-9A-NP-Z]+\Z/)
+      expect(reference.to_s).to match(/\A[1-9A-NP-Z]+\Z/)
     end
   end
 end


### PR DESCRIPTION
- Don't use "1" or "I" characters in claim references to avoid confusion
- Adjust option for not teaching eligible subjects for student loans