### PR TITLE
Update school eligibility to include City Technology Colleges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Allow service operators to mark a check as completed
+- Update school eligibility to include City Technology Colleges
 
 ## [Release 055] - 2020-02-24
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -157,7 +157,10 @@ class School < ApplicationRecord
   end
 
   def secondary_or_equivalent?
-    secondary_phase? || secondary_equivalent_special? || secondary_equivalent_alternative_provision?
+    secondary_phase? ||
+      secondary_equivalent_special? ||
+      secondary_equivalent_alternative_provision? ||
+      secondary_equivalent_city_technology_college?
   end
 
   private
@@ -180,6 +183,10 @@ class School < ApplicationRecord
 
   def secondary_equivalent_alternative_provision?
     alternative_provision? && has_statutory_high_age_over_eleven?
+  end
+
+  def secondary_equivalent_city_technology_college?
+    city_technology_college? && has_statutory_high_age_over_eleven?
   end
 
   def special?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -136,7 +136,9 @@ class School < ApplicationRecord
   end
 
   def state_funded?
-    (STATE_FUNDED_SCHOOL_TYPE_GROUPS.include?(school_type_group) && school_type != "other_independent_special_school") || secure_unit?
+    (STATE_FUNDED_SCHOOL_TYPE_GROUPS.include?(school_type_group) && school_type != "other_independent_special_school") ||
+      secure_unit? ||
+      city_technology_college?
   end
 
   def open?

--- a/spec/models/maths_and_physics/school_eligibility_spec.rb
+++ b/spec/models/maths_and_physics/school_eligibility_spec.rb
@@ -129,6 +129,37 @@ RSpec.describe MathsAndPhysics::SchoolEligibility do
         expect(MathsAndPhysics::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
       end
     end
+
+    context "with a City Technology College (CTC)" do
+      let(:city_technology_college) {
+        School.new(
+          close_date: nil,
+          school_type: :city_technology_college,
+          school_type_group: :independent_schools,
+          statutory_high_age: 16,
+          local_authority_district: local_authority_districts(:barnsley)
+        )
+      }
+
+      it "returns true with an open, state funded secondary equivalent CTC in an eligible local authority district" do
+        expect(MathsAndPhysics::SchoolEligibility.new(city_technology_college).eligible_current_school?).to eql true
+      end
+
+      it "returns false when closed" do
+        city_technology_college.assign_attributes(close_date: Date.new)
+        expect(MathsAndPhysics::SchoolEligibility.new(city_technology_college).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not in an eligible local authority district" do
+        city_technology_college.assign_attributes(local_authority_district: local_authority_districts(:camden))
+        expect(MathsAndPhysics::SchoolEligibility.new(city_technology_college).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        city_technology_college.assign_attributes(statutory_high_age: 11)
+        expect(MathsAndPhysics::SchoolEligibility.new(city_technology_college).eligible_current_school?).to eq false
+      end
+    end
   end
 
   context "when it is not a secondary school" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -80,6 +80,10 @@ RSpec.describe School, type: :model do
         expect(School.new(school_type_group: phase).state_funded?).to eq false
       end
     end
+
+    it "returns true for City Technology Colleges" do
+      expect(School.new(school_type: :city_technology_college, school_type_group: :independent_schools).state_funded?).to eq true
+    end
   end
 
   describe "#secondary_or_equivalent?" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -135,5 +135,15 @@ RSpec.describe School, type: :model do
       school = School.new(school_type: :community_school, statutory_high_age: 16)
       expect(school.secondary_or_equivalent?).to eq false
     end
+
+    it "returns true for a City Technology College that teaches students over eleven" do
+      school = School.new(school_type: :city_technology_college, statutory_high_age: 16)
+      expect(school.secondary_or_equivalent?).to eq true
+    end
+
+    it "returns false for a City Technology College that only teaches students under eleven" do
+      school = School.new(school_type: :city_technology_college, statutory_high_age: 10)
+      expect(school.secondary_or_equivalent?).to eq false
+    end
   end
 end

--- a/spec/models/student_loans/school_eligibility_spec.rb
+++ b/spec/models/student_loans/school_eligibility_spec.rb
@@ -117,6 +117,37 @@ RSpec.describe StudentLoans::SchoolEligibility do
       end
     end
 
+    context "with a City Technology College (CTC)" do
+      let(:city_technology_college) {
+        School.new(
+          close_date: nil,
+          school_type: :city_technology_college,
+          school_type_group: :independent_schools,
+          statutory_high_age: 16,
+          local_authority: local_authorities(:barnsley)
+        )
+      }
+
+      it "returns true with an open, state funded secondary equivalent CTC in an eligible local authority district" do
+        expect(StudentLoans::SchoolEligibility.new(city_technology_college).eligible_claim_school?).to eql true
+      end
+
+      it "returns false when closed" do
+        city_technology_college.assign_attributes(close_date: Date.new)
+        expect(StudentLoans::SchoolEligibility.new(city_technology_college).eligible_claim_school?).to eql false
+      end
+
+      it "returns false when not in an eligible local authority" do
+        city_technology_college.assign_attributes(local_authority: local_authorities(:camden))
+        expect(StudentLoans::SchoolEligibility.new(city_technology_college).eligible_claim_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        city_technology_college.assign_attributes(statutory_high_age: 11)
+        expect(StudentLoans::SchoolEligibility.new(city_technology_college).eligible_claim_school?).to eq false
+      end
+    end
+
     context "when it is not a secondary school" do
       it "returns false" do
         primary_school = School.new(phase: :primary, school_type_group: :la_maintained, local_authority: local_authorities(:barnsley))
@@ -207,6 +238,32 @@ RSpec.describe StudentLoans::SchoolEligibility do
       it "returns true with a secure unit" do
         alternative_provision_school.assign_attributes(school_type_group: :other, school_type: :secure_unit)
         expect(StudentLoans::SchoolEligibility.new(alternative_provision_school).eligible_current_school?).to eq true
+      end
+    end
+
+    context "with a City Technology College (CTC)" do
+      let(:city_technology_college) {
+        School.new(
+          close_date: nil,
+          school_type: :city_technology_college,
+          school_type_group: :independent_schools,
+          statutory_high_age: 16,
+          local_authority: local_authorities(:camden)
+        )
+      }
+
+      it "returns true with an open, state funded secondary equivalent CTC" do
+        expect(StudentLoans::SchoolEligibility.new(city_technology_college).eligible_current_school?).to eql true
+      end
+
+      it "returns false when closed" do
+        city_technology_college.assign_attributes(close_date: Date.new)
+        expect(StudentLoans::SchoolEligibility.new(city_technology_college).eligible_current_school?).to eql false
+      end
+
+      it "returns false when not secondary equivalent" do
+        city_technology_college.assign_attributes(statutory_high_age: 11)
+        expect(StudentLoans::SchoolEligibility.new(city_technology_college).eligible_current_school?).to eq false
       end
     end
 


### PR DESCRIPTION
We determine state funded schools by two pieces of information: the school type group and the school type. We explicitly rule out schools that have a type group of independent as not being state funded. However it turns out that City Technology Colleges are state funded and
have a type group of independent. 

We have another card in the backlog to look at any other types of state funded schools that we're missing from our rules.

City Technology Colleges have a phase of "not_applicable", however they do teach secondary age students. We can determine this by looking at the statutory high age for the school.

Example of a City Technology College: "Emmanuel College" (URN 108420)

```
irb(main):002:0> MathsAndPhysics::SchoolEligibility.new(School.find_by(urn: "108420")).eligible_current_school?
=> true
irb(main):003:0> StudentLoans::SchoolEligibility.new(School.find_by(urn: "108420")).eligible_current_school?
=> true
```