### PR TITLE
Maths & Physics claims use new tasks interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog]
 
 - Allow service operators to mark a check as completed
 - Update school eligibility to include City Technology Colleges
+- Service operators are taken straight to the tasks list when checking a Maths
+  and Physics claim
 
 ## [Release 055] - 2020-02-24
 

--- a/app/controllers/admin/checks_controller.rb
+++ b/app/controllers/admin/checks_controller.rb
@@ -38,7 +38,7 @@ class Admin::ChecksController < Admin::BaseAdminController
     if next_check.present?
       admin_claim_check_path(@claim, check: next_check)
     else
-      admin_claim_path(@claim)
+      admin_claim_path(@claim, anchor: "claim_decision_form")
     end
   end
 end

--- a/app/views/admin/checks/_claim_summary.html.erb
+++ b/app/views/admin/checks/_claim_summary.html.erb
@@ -2,6 +2,9 @@
   <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
   <h1 class="govuk-heading-xl">
     <%= @claim.reference %>
+    <span class="govuk-body-m">
+      <%= link_to "View full claim", admin_claim_path(@claim), class: "govuk-link" %>
+    </span>
   </h1>
 </div>
 

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -47,7 +47,13 @@
                 <td class="govuk-table__cell"><%= decision_deadline_warning(claim) %></td>
               <% end %>
               <td class="govuk-table__cell"><%= l(claim.decision_deadline_date) %></td>
-              <td class="govuk-table__cell"><%= link_to 'View claim', admin_claim_path(claim), class: "govuk-link" %></td>
+              <td class="govuk-table__cell">
+                <% if claim.policy == MathsAndPhysics %>
+                  <%= link_to 'View tasks', admin_claim_checks_path(claim), class: "govuk-link" %>
+                <% else %>
+                  <%= link_to 'View claim', admin_claim_path(claim), class: "govuk-link" %>
+                <% end %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Admin checks a claim" do
     scenario "User can approve a claim" do
       freeze_time do
         stub_geckoboard_dataset_update
-        submitted_claims = create_list(:claim, 5, :submitted)
+        submitted_claims = create_list(:claim, 5, :submitted, policy: StudentLoans)
         claim_to_approve = submitted_claims.first
 
         click_on "View claims"
@@ -69,10 +69,10 @@ RSpec.feature "Admin checks a claim" do
     end
 
     scenario "User can see checks for a claim" do
-      claim = create(:claim, :submitted)
-      visit admin_claim_path(claim)
+      claim = create(:claim, :submitted, policy: MathsAndPhysics)
 
-      click_on "View checks"
+      visit admin_claims_path
+      find("a[href='#{admin_claim_checks_path(claim)}']").click
 
       expect(page).to have_content("1. Qualifications")
       expect(page).to have_content("2. Employment")

--- a/spec/requests/admin_checks_spec.rb
+++ b/spec/requests/admin_checks_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Admin checks", type: :request do
 
               expect(claim.checks.last.name).to eql(last_check)
               expect(claim.checks.last.created_by).to eql(user)
-              expect(response).to redirect_to(admin_claim_path(claim))
+              expect(response).to redirect_to(admin_claim_path(claim, anchor: "claim_decision_form"))
             end
           end
 


### PR DESCRIPTION
This is a temporary step to encourage service operators to check Maths and Physics claims using the new "checks" or "tasks" interface.