### PR TITLE
A service operator can amend a claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog]
 - QTS question will vary based on the year the service is accepting claims for
 - QTS answer will vary in admin based on the year the claim was made
 - Claim decision page is shown at the end of the checks process
+- A service operator can amend a claim
 
 ## [Release 056] - 2020-02-25
 

--- a/app/assets/stylesheets/components/_timeline.scss
+++ b/app/assets/stylesheets/components/_timeline.scss
@@ -1,0 +1,66 @@
+/* ==========================================================================
+   #TIMELINE
+   ========================================================================== */
+
+.hmcts-timeline {
+  margin-bottom: govuk-spacing(4);
+  overflow: hidden;
+  position: relative;
+
+  &:before {
+    background-color: govuk-colour("blue");
+    content: "";
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: govuk-spacing(2);
+    width: 5px;
+  }
+}
+
+.hmcts-timeline--full {
+  margin-bottom: 0;
+  &:before {
+    height: calc(100% - 75px);
+  }
+}
+
+.hmcts-timeline__item {
+  padding-bottom: govuk-spacing(6);
+  padding-left: govuk-spacing(4);
+  position: relative;
+
+  &:before {
+    background-color: govuk-colour("blue");
+    content: "";
+    height: 5px;
+    left: 0;
+    position: absolute;
+    top: govuk-spacing(2);
+    width: 15px;
+  }
+}
+
+.hmcts-timeline__title {
+  @include govuk-font($size: 19, $weight: bold);
+  display: inline;
+}
+
+.hmcts-timeline__by {
+  @include govuk-font($size: 19);
+  color: $govuk-secondary-text-colour;
+  display: inline;
+  margin: 0;
+}
+
+.hmcts-timeline__date {
+  @include govuk-font($size: 16);
+  margin-top: govuk-spacing(1);
+  margin-bottom: 0;
+}
+
+.hmcts-timeline__description {
+  @include govuk-font($size: 16);
+  margin-top: govuk-spacing(4);
+  // margin-bottom: 0;
+}

--- a/app/assets/stylesheets/components/gds_kit_tweaks.scss
+++ b/app/assets/stylesheets/components/gds_kit_tweaks.scss
@@ -23,3 +23,7 @@ $govuk-link-colour: #175b96;
 .govuk-header__container {
   border-bottom-color: $govuk-link-colour;
 }
+
+.govuk-heading--navigation .govuk-link:not(:last-of-type) {
+  margin-right: govuk-spacing(2);
+}

--- a/app/controllers/admin/amendments_controller.rb
+++ b/app/controllers/admin/amendments_controller.rb
@@ -1,0 +1,32 @@
+class Admin::AmendmentsController < Admin::BaseAdminController
+  before_action :ensure_service_operator
+
+  def new
+    @claim = Claim.find(params[:claim_id])
+    @amendment = @claim.amendments.build
+  end
+
+  def create
+    @claim = Claim.find(params[:claim_id])
+    @amendment = Amendment.amend_claim(@claim, claim_params, amendment_params)
+
+    if @amendment.persisted?
+      redirect_to admin_claim_url(@claim)
+    else
+      render "new"
+    end
+  end
+
+  private
+
+  def claim_params
+    params.require(:amendment).require(:claim).permit(*Claim::AMENDABLE_ATTRIBUTES)
+  end
+
+  def amendment_params
+    {
+      notes: params[:amendment][:notes],
+      created_by: admin_user
+    }
+  end
+end

--- a/app/controllers/admin/amendments_controller.rb
+++ b/app/controllers/admin/amendments_controller.rb
@@ -1,13 +1,13 @@
 class Admin::AmendmentsController < Admin::BaseAdminController
+  before_action :load_claim
   before_action :ensure_service_operator
+  before_action :ensure_claim_is_amendable
 
   def new
-    @claim = Claim.find(params[:claim_id])
     @amendment = @claim.amendments.build
   end
 
   def create
-    @claim = Claim.find(params[:claim_id])
     @amendment = Amendment.amend_claim(@claim, claim_params, amendment_params)
 
     if @amendment.persisted?
@@ -18,6 +18,16 @@ class Admin::AmendmentsController < Admin::BaseAdminController
   end
 
   private
+
+  def load_claim
+    @claim = Claim.find(params[:claim_id])
+  end
+
+  def ensure_claim_is_amendable
+    unless @claim.amendable?
+      render "not_amendable"
+    end
+  end
 
   def claim_params
     params.require(:amendment).require(:claim).permit(*Claim::AMENDABLE_ATTRIBUTES)

--- a/app/helpers/admin/amendments_helper.rb
+++ b/app/helpers/admin/amendments_helper.rb
@@ -1,0 +1,16 @@
+module Admin
+  module AmendmentsHelper
+    def amendment_errored_field_id_overrides(amendment)
+      nested_claim_attributes_to_ids = Claim::AMENDABLE_ATTRIBUTES.to_h { |attribute|
+        [attribute, "amendment_claim_#{attribute}"]
+      }
+
+      # If we have a validation error on claim_changes (because the user didn’t
+      # change anything) there isn’t an obvious element to link to for them to
+      # correct this error, so just use the first element in the form (TRN).
+      claim_changes_attribute_to_id = {claim_changes: "amendment_claim_teacher_reference_number"}
+
+      nested_claim_attributes_to_ids.merge(claim_changes_attribute_to_id)
+    end
+  end
+end

--- a/app/helpers/admin/timeline_helper.rb
+++ b/app/helpers/admin/timeline_helper.rb
@@ -1,0 +1,42 @@
+module Admin
+  module TimelineHelper
+    def admin_amendment_details(amendment)
+      amendment.claim_changes.map { |attribute, changes|
+        admin_change_details(attribute, changes)
+      }.sort_by(&:first)
+    end
+
+    private
+
+    def admin_change_details(attribute, changes)
+      result = [admin_amendment_attribute_name(attribute)]
+
+      if changes
+        result += [
+          admin_amendment_format_attribute(attribute, changes[0]),
+          admin_amendment_format_attribute(attribute, changes[1])
+        ]
+      end
+
+      result
+    end
+
+    def admin_amendment_attribute_name(attribute)
+      override = case attribute.to_s
+                 when "student_loan_plan" then t("student_loans.admin.student_loan_repayment_plan")
+      end
+
+      override || attribute.to_s.humanize
+    end
+
+    def admin_amendment_format_attribute(attribute, value)
+      override = case attribute.to_s
+                 when "payroll_gender" then "don’t know" if value.to_s == "dont_know"
+                 when "date_of_birth" then l(value, format: :day_month_year)
+                 when "student_loan_plan" then value.to_s == "not_applicable" ? "not applicable" : value&.humanize
+      end
+
+      override || value.to_s
+    end
+  end
+end

--- a/app/models/amendment.rb
+++ b/app/models/amendment.rb
@@ -1,0 +1,17 @@
+# A service operator can amend a claim. When they do so, an Amendment record is
+# created. The amendments of a claim provide an audit trail which explains why
+# the claim has its current attribute values. It stores the details of which
+# attributes were changed, and optionally their old and new values.
+#
+# The claim_changes attribute is a hash whose keys (String) are the names of
+# the attributes changed. The values are either
+# - an array [old_value, new_value]
+# - nil, meaning that this personal data has been removed from the amendment
+class Amendment < ApplicationRecord
+  belongs_to :claim
+  belongs_to :created_by, class_name: "DfeSignIn::User"
+  serialize :claim_changes, Hash
+
+  validates :claim_changes, presence: {message: "To amend the claim you must change at least one value"}
+  validates :notes, presence: {message: "Enter a message to explain why you are making this amendment"}
+end

--- a/app/models/amendment.rb
+++ b/app/models/amendment.rb
@@ -14,6 +14,7 @@ class Amendment < ApplicationRecord
 
   validates :claim_changes, presence: {message: "To amend the claim you must change at least one value"}
   validates :notes, presence: {message: "Enter a message to explain why you are making this amendment"}
+  validate :claim_must_be_amendable, on: :create
 
   # Updates the claim using the attributes given in claim_attributes, and uses
   # these changes to create an associated Amendment record with additional
@@ -47,5 +48,11 @@ class Amendment < ApplicationRecord
     end
 
     amendment
+  end
+
+  private
+
+  def claim_must_be_amendable
+    errors.add(:claim, "must be amendable") unless claim.amendable?
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -81,6 +81,7 @@ class Claim < ApplicationRecord
 
   has_one :decision
   has_many :checks
+  has_many :amendments
 
   belongs_to :eligibility, polymorphic: true, inverse_of: :claim, dependent: :destroy
   accepts_nested_attributes_for :eligibility, update_only: true

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -275,6 +275,10 @@ class Claim < ApplicationRecord
     eligibility&.current_school
   end
 
+  def amendable?
+    submitted? && !decision&.rejected? && !payment && !pii_removed?
+  end
+
   private
 
   def normalise_trn

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -28,6 +28,15 @@ class Claim < ApplicationRecord
     :banking_name,
     :building_society_roll_number
   ].freeze
+  AMENDABLE_ATTRIBUTES = %i[
+    teacher_reference_number
+    payroll_gender
+    date_of_birth
+    student_loan_plan
+    bank_sort_code
+    bank_account_number
+    building_society_roll_number
+  ].freeze
   FILTER_PARAMS = {
     address_line_1: true,
     address_line_2: true,

--- a/app/views/admin/amendments/new.html.erb
+++ b/app/views/admin/amendments/new.html.erb
@@ -1,0 +1,168 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
+    <h1 class="govuk-heading-xl">
+      Amend claim <%= @claim.reference %>
+    </h1>
+
+    <%=
+      if @amendment.errors.any?
+        render(
+          "shared/error_summary",
+          instance: @amendment,
+          errored_field_id_overrides: amendment_errored_field_id_overrides(@amendment)
+        )
+      end
+    %>
+  </div>
+</div>
+
+<%= form_with model: @amendment, url: admin_claim_amendments_path(@claim), html: { autocomplete: "off" } do |f| %>
+  <%= f.fields_for :claim, @amendment.claim do |claim_form| %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <%= form_group_tag(@amendment, :teacher_reference_number) do %>
+          <%= claim_form.label :teacher_reference_number, class: "govuk-label" %>
+          <%= errors_tag @amendment, :teacher_reference_number %>
+        <% end %>
+      </div>
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-form-group">
+          <%= claim_form.text_field :teacher_reference_number, class: "govuk-input govuk-input--width-10" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <%= form_group_tag(@amendment, :payroll_gender) do %>
+          <%= claim_form.label :payroll_gender, class: "govuk-label" %>
+          <%= errors_tag @amendment, :payroll_gender %>
+        <% end %>
+      </div>
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-form-group">
+          <%= claim_form.select :payroll_gender, [["Female", :female], ["Male", :male], ["Don’t know", :dont_know]], {}, { class: "govuk-select" } %>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-grid-column-one-third">
+          <%= form_group_tag(@amendment, :date_of_birth) do %>
+            <legend class="govuk-fieldset__legend">
+              Date of birth
+            </legend>
+          <% end %>
+        </div>
+        <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-form-group">
+            <div class="govuk-date-input">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <%= label_tag :"amendment_claim_date_of_birth_3i", "Day", class: "govuk-label govuk-date-input__label" %>
+                  <%= text_field_tag :"amendment[claim][date_of_birth(3i)]", claim_form.object.date_of_birth.day, id: "amendment_claim_date_of_birth_3i", class: "govuk-input govuk-date-input__input govuk-input--width-2", type: "number", pattern: "[0-9]*" %>
+                </div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <%= label_tag :"amendment_claim_date_of_birth_2i", "Month", class: "govuk-label govuk-date-input__label" %>
+                  <%= text_field_tag :"amendment[claim][date_of_birth(2i)]", claim_form.object.date_of_birth.month, id: "amendment_claim_date_of_birth_2i", class: "govuk-input govuk-date-input__input govuk-input--width-2", type: "number", pattern: "[0-9]*" %>
+                </div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <%= label_tag :"amendment_claim_date_of_birth_1i", "Year", class: "govuk-label govuk-date-input__label" %>
+                  <%= text_field_tag :"amendment[claim][date_of_birth(1i)]", claim_form.object.date_of_birth.year, id: "amendment_claim_date_of_birth_1i", class: "govuk-input govuk-date-input__input govuk-input--width-4", type: "number", pattern: "[0-9]*" %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-form-group">
+        <div class="govuk-grid-column-one-third">
+          <%= form_group_tag(@amendment, :student_loan_plan) do %>
+            <%= claim_form.label :student_loan_plan, "Student loan repayment plan", class: "govuk-label" %>
+            <%= errors_tag @amendment, :student_loan_plan %>
+          <% end %>
+        </div>
+        <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-form-group">
+            <%= claim_form.select :student_loan_plan, Claim::STUDENT_LOAN_PLAN_OPTIONS.map { |option| [option.humanize, option] }, {}, { class: "govuk-select" } %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <%= form_group_tag(@amendment, :bank_sort_code) do %>
+          <%= claim_form.label :bank_sort_code, class: "govuk-label" %>
+          <%= errors_tag @amendment, :bank_sort_code %>
+        <% end %>
+      </div>
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-form-group">
+          <%= claim_form.text_field :bank_sort_code, class: "govuk-input govuk-input--width-5" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <%= form_group_tag(@amendment, :bank_account_number) do %>
+          <%= claim_form.label :bank_account_number, class: "govuk-label" %>
+          <%= errors_tag @amendment, :bank_account_number %>
+        <% end %>
+      </div>
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-form-group">
+          <%= claim_form.text_field :bank_account_number, class: "govuk-input govuk-input--width-10" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <%= form_group_tag(@amendment, :building_society_roll_number) do %>
+          <%= claim_form.label :building_society_roll_number, class: "govuk-label" %>
+          <%= errors_tag @amendment, :building_society_roll_number %>
+        <% end %>
+      </div>
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-form-group">
+          <%= claim_form.text_field :building_society_roll_number, class: "govuk-input govuk-input--width-10" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <%= form_group_tag(@amendment, :notes) do %>
+        <%= f.label :notes, "Change notes", class: "govuk-label" %>
+        <%= errors_tag @amendment, :notes %>
+      <% end %>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-form-group">
+        <span class="govuk-hint">
+          Please explain why you are making this amendment. Do not include personal data about the claimant.
+        </span>
+        <%= f.text_area :notes, class: "govuk-textarea" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= f.submit "Amend claim", class: "govuk-button", data: {module: "govuk-button"} %>
+      <%= link_to "Cancel", admin_claim_url(@claim), class: "govuk-button govuk-button--secondary", data: {module: "govuk-button"} %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/amendments/not_amendable.html.erb
+++ b/app/views/admin/amendments/not_amendable.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
+    <h1 class="govuk-heading-xl">
+      Amend claim <%= @claim.reference %>
+    </h1>
+
+    <div class="govuk-body-l govuk-flash__alert">
+      This claim cannot be amended.
+    </div>
+
+    <p><%= link_to "Return to claim page", admin_claim_path(@claim), class: "govuk-link" %></p>
+  </div>
+</div>

--- a/app/views/admin/checks/_claim_summary.html.erb
+++ b/app/views/admin/checks/_claim_summary.html.erb
@@ -1,9 +1,10 @@
 <div class="govuk-grid-column-full">
   <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
-  <h1 class="govuk-heading-xl">
+  <h1 class="govuk-heading-xl govuk-heading--navigation">
     <%= @claim.reference %>
     <span class="govuk-body-m">
       <%= link_to "View full claim", admin_claim_path(@claim), class: "govuk-link" %>
+      <%= link_to "Amend claim", new_admin_claim_amendment_url(@claim), class: "govuk-link" if @claim.amendable? %>
     </span>
   </h1>
 </div>

--- a/app/views/admin/claims/_amendments_timeline.html.erb
+++ b/app/views/admin/claims/_amendments_timeline.html.erb
@@ -1,0 +1,25 @@
+<h2 class="govuk-heading-m">Claim amendments</h2>
+<div class="hmcts-timeline">
+  <% amendments.each do |amendment| %>
+    <div class="hmcts-timeline__item">
+      <section>
+        <% admin_amendment_details(amendment).each do |details| %>
+          <h3 class="hmcts-timeline__title"><%= details[0] %></h3>
+          <% if details.count > 1 %>
+            <p class="hmcts-timeline__by">changed from <%= details[1] %> to <%= details[2] %></p>
+          <% else %>
+            <p class="hmcts-timeline__by">changed</p>
+          <% end %>
+          <br>
+        <% end %>
+
+        <% if amendment.notes.present? %>
+          <h3 class="hmcts-timeline__title">Change notes</h3>
+          <p class="hmcts-timeline__by"><%= amendment.notes %></p>
+        <% end %>
+      </section>
+
+      <p class="hmcts-timeline__description"> by <%= user_details(amendment.created_by, include_line_break: false) %> on <%= l(amendment.created_at) %></p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -36,6 +36,10 @@
 
     <%= render("info_panel_identity_unconfirmed", school: @claim.school) unless @claim.identity_confirmed? %>
 
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render "admin/claims/answer_section", {heading: "Personal details", answers: admin_personal_details(@claim)} %>
 
     <%= render "admin/claims/answer_section", {heading: "Eligibility details", answers: admin_eligibility_answers(@claim)} %>
@@ -52,4 +56,10 @@
       <%= render "admin/decisions/decision_form", claim: @claim, decision: @decision, claims_preventing_payment: @claims_preventing_payment %>
   <% end %>
   </div>
+
+  <% if @claim.amendments.any? %>
+    <div class="govuk-grid-column-one-third">
+      <%= render "amendments_timeline", amendments: @claim.amendments.reverse %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -25,12 +25,14 @@
     <% end %>
 
     <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-xl govuk-heading--navigation">
       <%= @claim.reference %>
       <span class="govuk-body-m">
         <%= link_to "View checks", admin_claim_checks_path(claim_id: @claim.id), class: "govuk-link" %>
+        <%= link_to "Amend claim", new_admin_claim_amendment_url(@claim), class: "govuk-link" %>
       </span>
     </h1>
+
 
     <%= render("info_panel_identity_unconfirmed", school: @claim.school) unless @claim.identity_confirmed? %>
 

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -29,7 +29,7 @@
       <%= @claim.reference %>
       <span class="govuk-body-m">
         <%= link_to "View checks", admin_claim_checks_path(claim_id: @claim.id), class: "govuk-link" %>
-        <%= link_to "Amend claim", new_admin_claim_amendment_url(@claim), class: "govuk-link" %>
+        <%= link_to "Amend claim", new_admin_claim_amendment_url(@claim), class: "govuk-link" if @claim.amendable? %>
       </span>
     </h1>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
     resources :claims, only: [:index, :show] do
       resources :checks, only: [:index, :show, :create], param: :check, constraints: {check: %r{#{Admin::ChecksController::CHECKS_SEQUENCE.join("|")}}}
       resources :decisions, only: [:create, :new]
+      resources :amendments, only: [:new, :create]
       get "search", on: :collection
     end
 

--- a/db/migrate/20200217165600_create_amendments.rb
+++ b/db/migrate/20200217165600_create_amendments.rb
@@ -1,0 +1,13 @@
+class CreateAmendments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :amendments, id: :uuid do |t|
+      t.references :claim, foreign_key: true, type: :uuid
+      t.text :notes
+      t.string :claim_changes
+      t.references :dfe_sign_in_users, :created_by, type: :uuid, foreign_key: {to_table: :dfe_sign_in_users}
+
+      t.timestamps
+      t.timestamp :personal_data_removed_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,20 @@ ActiveRecord::Schema.define(version: 2020_02_27_160303) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
+  create_table "amendments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "claim_id"
+    t.text "notes"
+    t.string "claim_changes"
+    t.uuid "dfe_sign_in_users_id"
+    t.uuid "created_by_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "personal_data_removed_at"
+    t.index ["claim_id"], name: "index_amendments_on_claim_id"
+    t.index ["created_by_id"], name: "index_amendments_on_created_by_id"
+    t.index ["dfe_sign_in_users_id"], name: "index_amendments_on_dfe_sign_in_users_id"
+  end
+
   create_table "checks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.uuid "claim_id"
@@ -228,6 +242,9 @@ ActiveRecord::Schema.define(version: 2020_02_27_160303) do
     t.index ["current_school_id"], name: "index_student_loans_eligibilities_on_current_school_id"
   end
 
+  add_foreign_key "amendments", "claims"
+  add_foreign_key "amendments", "dfe_sign_in_users", column: "created_by_id"
+  add_foreign_key "amendments", "dfe_sign_in_users", column: "dfe_sign_in_users_id"
   add_foreign_key "checks", "claims"
   add_foreign_key "checks", "dfe_sign_in_users", column: "created_by_id"
   add_foreign_key "claims", "payments"

--- a/spec/factories/amendments.rb
+++ b/spec/factories/amendments.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
     association :created_by, factory: :dfe_signin_user
     claim_changes { {"teacher_reference_number" => [generate(:teacher_reference_number).to_s, claim.teacher_reference_number]} }
     notes { "We couldn’t find the teacher in Teacher Pensions Service data. We contacted them in Zendesk and they told us they made a typo and gave their correct TRN" }
+
+    trait :personal_data_removed do
+      personal_data_removed_at { Time.zone.now }
+      claim_changes { {"teacher_reference_number" => [generate(:teacher_reference_number).to_s, claim.teacher_reference_number], "bank_account_number" => nil} }
+    end
   end
 end

--- a/spec/factories/amendments.rb
+++ b/spec/factories/amendments.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :amendment do
+    association :claim, factory: [:claim, :submitted]
+    association :created_by, factory: :dfe_signin_user
+    claim_changes { {"teacher_reference_number" => [generate(:teacher_reference_number).to_s, claim.teacher_reference_number]} }
+    notes { "We couldn’t find the teacher in Teacher Pensions Service data. We contacted them in Zendesk and they told us they made a typo and gave their correct TRN" }
+  end
+end

--- a/spec/features/admin_amend_claim_spec.rb
+++ b/spec/features/admin_amend_claim_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.feature "Admin amends a claim" do
+  let(:claim) do
+    create(:claim, :submitted,
+      teacher_reference_number: "1234567",
+      payroll_gender: :dont_know,
+      date_of_birth: date_of_birth,
+      student_loan_plan: :plan_1,
+      bank_sort_code: "010203",
+      bank_account_number: "47274828",
+      building_society_roll_number: "RN 123456",)
+  end
+  let(:date_of_birth) { 25.years.ago.to_date }
+  let(:service_operator) { create(:dfe_signin_user, given_name: "Jo", family_name: "Bloggs") }
+
+  scenario "Service operator amends a claim" do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
+
+    visit admin_claim_url(claim)
+
+    click_on "Amend claim"
+
+    new_date_of_birth = 30.years.ago.to_date
+
+    fill_in "Teacher reference number", with: "7654321"
+    select "Male", from: "Payroll gender"
+    fill_in "Day", with: new_date_of_birth.day
+    fill_in "Month", with: new_date_of_birth.month
+    fill_in "Year", with: new_date_of_birth.year
+    select "Plan 2", from: "Student loan repayment plan"
+    fill_in "Bank sort code", with: "111213"
+    fill_in "Bank account number", with: "18929492"
+    fill_in "Building society roll number", with: "JF 838281"
+
+    fill_in "Change notes", with: "This claimant got some of their details wrong and then contacted us"
+
+    expect { click_on "Amend claim" }.to change { claim.reload.amendments.size }.by(1)
+
+    amendment = claim.amendments.last
+    expect(amendment.claim_changes).to eq({
+      "teacher_reference_number" => ["1234567", "7654321"],
+      "payroll_gender" => ["dont_know", "male"],
+      "date_of_birth" => [date_of_birth, new_date_of_birth],
+      "student_loan_plan" => ["plan_1", "plan_2"],
+      "bank_sort_code" => ["010203", "111213"],
+      "bank_account_number" => ["47274828", "18929492"],
+      "building_society_roll_number" => ["RN 123456", "JF 838281"]
+    })
+    expect(amendment.notes).to eq("This claimant got some of their details wrong and then contacted us")
+    expect(amendment.created_by).to eq(service_operator)
+
+    expect(claim.reload.teacher_reference_number).to eq("7654321")
+    expect(claim.payroll_gender).to eq("male")
+    expect(claim.date_of_birth).to eq(new_date_of_birth)
+    expect(claim.student_loan_plan).to eq("plan_2")
+    expect(claim.bank_sort_code).to eq("111213")
+    expect(claim.bank_account_number).to eq("18929492")
+    expect(claim.building_society_roll_number).to eq("JF 838281")
+
+    expect(current_url).to eq(admin_claim_url(claim))
+  end
+
+  scenario "Service operator cancels amending a claim" do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
+
+    visit admin_claim_url(claim)
+
+    click_on "Amend claim"
+
+    fill_in "Teacher reference number", with: "7654321"
+
+    expect { click_on "Cancel" }.not_to change { [claim.reload.amendments.size, claim.teacher_reference_number] }
+
+    expect(current_url).to eq(admin_claim_url(claim))
+  end
+
+  # I would have written this as a request spec but there wasn’t an easy way
+  # to do it because the message is split over various HTML tags.
+  scenario "The amendments timeline can display an amendment that’s had its personal data removed" do
+    create(:amendment, :personal_data_removed, claim: claim, claim_changes: {
+      "teacher_reference_number" => ["7654321", "1234567"],
+      "bank_account_number" => nil
+    })
+
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
+
+    visit admin_claim_url(claim)
+
+    expect(page).to have_content("Teacher reference number\nchanged from 7654321 to 1234567")
+    expect(page).to have_content("Bank account number\nchanged")
+    expect(page).not_to have_content("Bank account number\nchanged from")
+  end
+end

--- a/spec/features/admin_amend_claim_spec.rb
+++ b/spec/features/admin_amend_claim_spec.rb
@@ -59,6 +59,17 @@ RSpec.feature "Admin amends a claim" do
     expect(claim.building_society_roll_number).to eq("JF 838281")
 
     expect(current_url).to eq(admin_claim_url(claim))
+
+    expect(page).to have_content("Teacher reference number\nchanged from 1234567 to 7654321")
+    expect(page).to have_content("Payroll gender\nchanged from don’t know to male")
+    expect(page).to have_content("Date of birth\nchanged from #{I18n.l(date_of_birth, format: :day_month_year)} to #{I18n.l(new_date_of_birth, format: :day_month_year)}")
+    expect(page).to have_content("Student loan repayment plan\nchanged from Plan 1 to Plan 2")
+    expect(page).to have_content("Bank sort code\nchanged from 010203 to 111213")
+    expect(page).to have_content("Bank account number\nchanged from 47274828 to 18929492")
+    expect(page).to have_content("Building society roll number\nchanged from RN 123456 to JF 838281")
+
+    expect(page).to have_content("This claimant got some of their details wrong and then contacted us")
+    expect(page).to have_content("by Jo Bloggs on #{I18n.l(Time.current)}")
   end
 
   scenario "Service operator cancels amending a claim" do

--- a/spec/helpers/admin/timeline_helper_spec.rb
+++ b/spec/helpers/admin/timeline_helper_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe Admin::TimelineHelper do
+  describe "#admin_amendment_details" do
+    let(:amendment) {
+      build(:amendment, :personal_data_removed, claim_changes: {
+        "teacher_reference_number" => [generate(:teacher_reference_number).to_s, generate(:teacher_reference_number).to_s],
+        "bank_account_number" => ["12345678", "87654321"],
+        "bank_sort_code" => ["123456", "654321"],
+        "payroll_gender" => ["male", "dont_know"],
+        "date_of_birth" => [Date.new(1995, 2, 25), Date.new(1990, 2, 25)],
+        "student_loan_plan" => ["not_applicable", "plan_1"]
+      })
+    }
+
+    it "returns an array of arrays, each of which contains formatted attribute name and old and new values" do
+      expect(helper.admin_amendment_details(amendment)).to eq([
+        ["Bank account number", "12345678", "87654321"],
+        ["Bank sort code", "123456", "654321"],
+        ["Date of birth", "25/02/1995", "25/02/1990"],
+        ["Payroll gender", "male", "don’t know"],
+        ["Student loan repayment plan", "not applicable", "Plan 1"],
+        ["Teacher reference number", "1000000", "1000001"]
+      ])
+    end
+
+    context "with an amendment with its personal data removed" do
+      let(:amendment) {
+        build(:amendment, :personal_data_removed, claim_changes: {
+          "teacher_reference_number" => [generate(:teacher_reference_number).to_s, generate(:teacher_reference_number).to_s],
+          "bank_account_number" => nil
+        })
+      }
+
+      it "doesn’t return old or new values for the removed attributes" do
+        expect(helper.admin_amendment_details(amendment)).to eq([
+          ["Bank account number"],
+          ["Teacher reference number", amendment.claim_changes["teacher_reference_number"][0], amendment.claim_changes["teacher_reference_number"][1]]
+        ])
+      end
+    end
+  end
+end

--- a/spec/models/amendment_spec.rb
+++ b/spec/models/amendment_spec.rb
@@ -16,4 +16,195 @@ RSpec.describe Amendment, type: :model do
     amendment.notes = "Claimant made a typo"
     expect(amendment).to be_valid
   end
+
+  describe ".amend_claim" do
+    let(:claim) { create(:claim, :submitted, teacher_reference_number: "1234567", payroll_gender: :male, bank_sort_code: "111213", building_society_roll_number: nil) }
+    let(:dfe_signin_user) { create(:dfe_signin_user) }
+
+    context "given valid claim attributes and valid amendment attributes" do
+      let(:claim_attributes) do
+        {
+          teacher_reference_number: "7654321",
+          payroll_gender: :female
+        }
+      end
+      let(:amendment_attributes) do
+        {
+          notes: "This is a change",
+          created_by: dfe_signin_user
+        }
+      end
+
+      it "updates and saves the claim, and returns a persisted amendment describing the changes to the claim" do
+        amendment = described_class.amend_claim(claim, claim_attributes, amendment_attributes)
+
+        expect(amendment).to be_persisted
+        expect(amendment.claim_changes).to be_an_instance_of(Hash)
+        expect(amendment.claim_changes).to eq("teacher_reference_number" => ["1234567", "7654321"], "payroll_gender" => ["male", "female"])
+        expect(amendment.notes).to eq("This is a change")
+        expect(amendment.created_by).to eq(dfe_signin_user)
+
+        expect(claim.reload.amendments).to eq([amendment])
+        expect(claim.teacher_reference_number).to eq("7654321")
+        expect(claim.payroll_gender).to eq("female")
+      end
+    end
+
+    context "given valid claim attributes and missing amendment notes" do
+      let(:claim_attributes) do
+        {
+          teacher_reference_number: "7654321",
+          payroll_gender: :female
+        }
+      end
+      let(:amendment_attributes) do
+        {
+          created_by: dfe_signin_user
+        }
+      end
+
+      it "assigns the new values to the claim but does not persist them, and returns a non-persisted amendment which has errors and which describes the changes to the claim" do
+        amendment = described_class.amend_claim(claim, claim_attributes, amendment_attributes)
+
+        expect(amendment).to_not be_persisted
+        expect(amendment.claim_changes).to be_an_instance_of(Hash)
+        expect(amendment.claim_changes).to eq("teacher_reference_number" => ["1234567", "7654321"], "payroll_gender" => ["male", "female"])
+        expect(amendment.created_by).to eq(dfe_signin_user)
+
+        expect(claim.teacher_reference_number).to eq("7654321")
+        expect(claim.payroll_gender).to eq("female")
+
+        expect(claim.reload.amendments).to be_empty
+        expect(claim.teacher_reference_number).to eq("1234567")
+        expect(claim.payroll_gender).to eq("male")
+
+        expect(amendment.errors.keys).to eq([:notes])
+      end
+    end
+
+    context "given invalid claim attributes and valid amendment attributes" do
+      let(:claim_attributes) do
+        {
+          teacher_reference_number: "765432",
+          payroll_gender: :female
+        }
+      end
+      let(:amendment_attributes) do
+        {
+          notes: "This is a change",
+          created_by: dfe_signin_user
+        }
+      end
+
+      it "assigns the new values to the claim but does not persist them, and returns a non-persisted amendment, with the errors from the claim copied to the amendment’s errors" do
+        amendment = described_class.amend_claim(claim, claim_attributes, amendment_attributes)
+
+        expect(amendment).to_not be_persisted
+        expect(amendment.created_by).to eq(dfe_signin_user)
+
+        expect(claim.teacher_reference_number).to eq("765432")
+        expect(claim.payroll_gender).to eq("female")
+
+        expect(claim.reload.amendments).to be_empty
+        expect(claim.teacher_reference_number).to eq("1234567")
+        expect(claim.payroll_gender).to eq("male")
+
+        expect(amendment.errors.keys).to match_array([:teacher_reference_number])
+      end
+    end
+
+    context "given invalid claim attributes and missing amendment notes" do
+      let(:claim_attributes) do
+        {
+          teacher_reference_number: "765432",
+          payroll_gender: :female
+        }
+      end
+      let(:amendment_attributes) do
+        {
+          created_by: dfe_signin_user
+        }
+      end
+
+      it "assigns the new values to the claim but does not persist them, and returns a non-persisted amendment which has errors, with the errors from the claim copied to the amendment’s errors" do
+        amendment = described_class.amend_claim(claim, claim_attributes, amendment_attributes)
+
+        expect(amendment).to_not be_persisted
+        expect(amendment.created_by).to eq(dfe_signin_user)
+
+        expect(claim.teacher_reference_number).to eq("765432")
+        expect(claim.payroll_gender).to eq("female")
+
+        expect(claim.reload.amendments).to be_empty
+        expect(claim.teacher_reference_number).to eq("1234567")
+        expect(claim.payroll_gender).to eq("male")
+
+        expect(amendment.errors.keys).to match_array([:notes, :teacher_reference_number])
+      end
+    end
+
+    context "given claim attributes which are all the same as the current values" do
+      let(:claim_attributes) do
+        {
+          teacher_reference_number: claim.teacher_reference_number
+        }
+      end
+      let(:amendment_attributes) do
+        {
+          notes: "This is a change",
+          created_by: dfe_signin_user
+        }
+      end
+
+      it "returns a non-persisted amendment which has errors on claim_changes" do
+        amendment = described_class.amend_claim(claim, claim_attributes, amendment_attributes)
+
+        expect(amendment).to_not be_persisted
+        expect(claim.reload.amendments).to be_empty
+
+        expect(amendment.errors.keys).to eq([:claim_changes])
+      end
+    end
+
+    context "when updating an attribute that gets normalised in a before_save hook" do
+      let(:claim_attributes) do
+        {
+          bank_sort_code: "01-02-03"
+        }
+      end
+      let(:amendment_attributes) do
+        {
+          notes: "This is a change",
+          created_by: dfe_signin_user
+        }
+      end
+
+      it "stores the normalised value in the amendment’s claim_changes" do
+        amendment = described_class.amend_claim(claim, claim_attributes, amendment_attributes)
+
+        expect(amendment.claim_changes).to eq("bank_sort_code" => ["111213", "010203"])
+      end
+    end
+
+    context "when updating a value from nil to an empty string" do
+      let(:claim_attributes) do
+        {
+          teacher_reference_number: "7654321",
+          building_society_roll_number: ""
+        }
+      end
+      let(:amendment_attributes) do
+        {
+          notes: "This is a change",
+          created_by: dfe_signin_user
+        }
+      end
+
+      it "does not mark the value as changed in the amendment’s claim_changes" do
+        amendment = described_class.amend_claim(claim, claim_attributes, amendment_attributes)
+
+        expect(amendment.claim_changes).to eq("teacher_reference_number" => ["1234567", "7654321"])
+      end
+    end
+  end
 end

--- a/spec/models/amendment_spec.rb
+++ b/spec/models/amendment_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Amendment, type: :model do
+  it "is invalid if there are no claim changes" do
+    amendment = build(:amendment, claim_changes: {})
+    expect(amendment).not_to be_valid
+
+    amendment.claim_changes = {"teacher_reference_number" => ["7654321", "1234567"]}
+    expect(amendment).to be_valid
+  end
+
+  it "is invalid if the notes are empty" do
+    amendment = build(:amendment, notes: "")
+    expect(amendment).not_to be_valid
+
+    amendment.notes = "Claimant made a typo"
+    expect(amendment).to be_valid
+  end
+end

--- a/spec/models/amendment_spec.rb
+++ b/spec/models/amendment_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Amendment, type: :model do
     expect(amendment).to be_valid
   end
 
+  it "is invalid if its claim is not amendable" do
+    amendment = build(:amendment, claim: build(:claim, :rejected))
+    expect(amendment).not_to be_valid
+
+    amendment.claim = build(:claim, :approved)
+    expect(amendment).to be_valid
+  end
+
   describe ".amend_claim" do
     let(:claim) { create(:claim, :submitted, teacher_reference_number: "1234567", payroll_gender: :male, bank_sort_code: "111213", building_society_roll_number: nil) }
     let(:dfe_signin_user) { create(:dfe_signin_user) }

--- a/spec/models/claim/pii_scrubber_spec.rb
+++ b/spec/models/claim/pii_scrubber_spec.rb
@@ -93,4 +93,40 @@ RSpec.describe Claim::PiiScrubber, type: :model do
     cleaned_claim = Claim.find(claim.id)
     expect(cleaned_claim.pii_removed_at).to eq(Time.zone.now)
   end
+
+  it "also deletes expected details from the scrubbed claims’ amendments, setting a personal_data_removed_at timestamp on the amendments" do
+    claim, amendment = nil
+    travel_to over_two_months_ago - 1.week do
+      claim = create(:claim, :approved)
+      amendment = create(:amendment, claim: claim, claim_changes: {
+        "teacher_reference_number" => [generate(:teacher_reference_number).to_s, claim.teacher_reference_number],
+        "payroll_gender" => ["male", claim.payroll_gender],
+        "date_of_birth" => [25.years.ago.to_date, claim.date_of_birth],
+        "student_loan_plan" => ["plan_1", claim.student_loan_plan],
+        "bank_sort_code" => ["457288", claim.bank_sort_code],
+        "bank_account_number" => ["84818482", claim.bank_account_number],
+        "building_society_roll_number" => ["123456789/ABCD", claim.building_society_roll_number]
+      })
+      create(:payment, :with_figures, claims: [claim], scheduled_payment_date: over_two_months_ago)
+    end
+
+    freeze_time do
+      original_trn_change = amendment.claim_changes["teacher_reference_number"]
+
+      Claim::PiiScrubber.new.scrub_completed_claims
+
+      cleaned_amendment = Amendment.find(amendment.id)
+
+      expect(cleaned_amendment.claim_changes.keys).to match_array(%w[teacher_reference_number payroll_gender date_of_birth student_loan_plan bank_sort_code bank_account_number building_society_roll_number])
+      expect(cleaned_amendment.notes).not_to be_nil
+      expect(cleaned_amendment.claim_changes["teacher_reference_number"]).to eq(original_trn_change)
+      expect(cleaned_amendment.claim_changes["date_of_birth"]).to eq(nil)
+      expect(cleaned_amendment.claim_changes["payroll_gender"]).to eq(nil)
+      expect(cleaned_amendment.claim_changes["bank_sort_code"]).to eq(nil)
+      expect(cleaned_amendment.claim_changes["bank_account_number"]).to eq(nil)
+      expect(cleaned_amendment.claim_changes["building_society_roll_number"]).to eq(nil)
+
+      expect(cleaned_amendment.personal_data_removed_at).to eq(Time.zone.now)
+    end
+  end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -651,4 +651,38 @@ RSpec.describe Claim, type: :model do
       end
     end
   end
+
+  describe "#amendable?" do
+    it "returns false for a claim that hasn’t been submitted" do
+      claim = build(:claim, :submittable)
+      expect(claim.amendable?).to eq(false)
+    end
+
+    it "returns true for a submitted claim" do
+      claim = build(:claim, :submitted)
+      expect(claim.amendable?).to eq(true)
+    end
+
+    it "returns true for an approved claim that isn’t payrolled" do
+      claim = build(:claim, :approved)
+      expect(claim.amendable?).to eq(true)
+    end
+
+    it "returns false for a payrolled claim" do
+      claim = build(:claim, :approved)
+      create(:payment, claims: [claim])
+
+      expect(claim.amendable?).to eq(false)
+    end
+
+    it "returns false for a rejected claim" do
+      claim = build(:claim, :rejected)
+      expect(claim.amendable?).to eq(false)
+    end
+
+    it "returns false for a claim that’s had its personal data removed" do
+      claim = build(:claim, :pii_removed)
+      expect(claim.amendable?).to eq(false)
+    end
+  end
 end

--- a/spec/requests/admin_amendments_spec.rb
+++ b/spec/requests/admin_amendments_spec.rb
@@ -90,6 +90,16 @@ RSpec.describe "Admin claim amendments" do
 
         expect([claim.national_insurance_number, claim.amendments.size]).to eq(original_counts)
       end
+
+      context "when the claim is not amendable" do
+        let(:claim) { create(:claim, :rejected) }
+
+        it "shows an error" do
+          post admin_claim_amendments_url(claim, amendment: {claim: {teacher_reference_number: claim.teacher_reference_number},
+                                                             notes: "Claimant made a typo"})
+          expect(response.body).to include("This claim cannot be amended.")
+        end
+      end
     end
   end
 

--- a/spec/requests/admin_amendments_spec.rb
+++ b/spec/requests/admin_amendments_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+RSpec.describe "Admin claim amendments" do
+  let(:claim) { create(:claim, :submitted, teacher_reference_number: "1234567", bank_sort_code: "010203", date_of_birth: 25.years.ago.to_date) }
+
+  context "when signed in as a service operator" do
+    let(:service_operator) { create(:dfe_signin_user) }
+    before do
+      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, service_operator.dfe_sign_in_id)
+    end
+
+    describe "admin_amendments#create" do
+      it "creates an amendment and updates the claim" do
+        old_date_of_birth = claim.date_of_birth
+        new_date_of_birth = 30.years.ago.to_date
+        expect {
+          post admin_claim_amendments_url(claim, amendment: {claim: {teacher_reference_number: "7654321", "bank_sort_code": "111213", "date_of_birth(3i)": new_date_of_birth.day, "date_of_birth(2i)": new_date_of_birth.month, "date_of_birth(1i)": new_date_of_birth.year},
+                                                             notes: "Claimant made a typo"})
+        }.to change { claim.reload.amendments.size }.by(1)
+
+        expect(response).to redirect_to(admin_claim_url(claim))
+
+        amendment = claim.amendments.last
+        expect(amendment.claim_changes).to eq({
+          "teacher_reference_number" => ["1234567", "7654321"],
+          "bank_sort_code" => ["010203", "111213"],
+          "date_of_birth" => [old_date_of_birth, new_date_of_birth]
+        })
+        expect(amendment.claim_changes).to be_a(Hash)
+        expect(amendment.notes).to eq("Claimant made a typo")
+        expect(amendment.created_by).to eq(service_operator)
+
+        expect(claim.teacher_reference_number).to eq("7654321")
+        expect(claim.bank_sort_code).to eq("111213")
+        expect(claim.date_of_birth).to eq(new_date_of_birth)
+      end
+
+      it "saves the normalised value in the amendment when updating bank sort code" do
+        post admin_claim_amendments_url(claim, amendment: {claim: {bank_sort_code: "11 12 13"}, notes: "Claimant made a typo"})
+
+        expect(response).to redirect_to(admin_claim_url(claim))
+
+        expect(claim.reload.amendments.last.claim_changes).to eq({"bank_sort_code" => ["010203", "111213"]})
+        expect(claim.bank_sort_code).to eq("111213")
+      end
+
+      it "doesn't record a change when changing a value from nil to an empty string" do
+        claim.update!(building_society_roll_number: nil)
+
+        post admin_claim_amendments_url(claim, amendment: {claim: {bank_sort_code: "111213", building_society_roll_number: ""},
+                                                           notes: "Claimant made a typo"})
+
+        expect(response).to redirect_to(admin_claim_url(claim))
+
+        expect(claim.reload.amendments.last.claim_changes).to eq({"bank_sort_code" => ["010203", "111213"]})
+      end
+
+      it "displays a validation error and does not update the claim or create an amendment when invalid values are entered" do
+        expect {
+          post admin_claim_amendments_url(claim, amendment: {claim: {teacher_reference_number: "654321", bank_account_number: ""},
+                                                             notes: "Claimant made a typo"})
+        }.not_to change { [claim.reload.teacher_reference_number, claim.amendments.size] }
+
+        expect(response).to have_http_status(:ok)
+
+        expect(response.body).to include("Teacher reference number must contain seven digits")
+        expect(response.body).to include("Enter an account number")
+      end
+
+      it "displays an error message and does not create an amendment when none of the claim’s values are changed" do
+        expect {
+          post admin_claim_amendments_url(claim, amendment: {claim: {teacher_reference_number: claim.teacher_reference_number},
+                                                             notes: "Claimant made a typo"})
+        }.not_to change { [claim.reload.teacher_reference_number, claim.amendments.size] }
+
+        expect(response).to have_http_status(:ok)
+
+        expect(response.body).to include("To amend the claim you must change at least one value")
+      end
+
+      it "raises an error and does not create an amendment or update the claim when attempting to modify an attribute that isn’t in the allowed list" do
+        original_counts = [claim.national_insurance_number, claim.amendments.size]
+
+        expect {
+          post admin_claim_amendments_url(claim, amendment: {claim: {national_insurance_number: generate(:national_insurance_number)},
+                                                             notes: "Claimant made a typo"})
+        }.to raise_error(
+          ActionController::UnpermittedParameters
+        )
+
+        expect([claim.national_insurance_number, claim.amendments.size]).to eq(original_counts)
+      end
+    end
+  end
+
+  context "when signed in as a payroll operator or a support agent" do
+    [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
+      before do
+        sign_in_to_admin_with_role(role)
+      end
+
+      describe "admin_amendments#new" do
+        it "returns a unauthorized response" do
+          get new_admin_claim_amendment_url(claim)
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      describe "admin_amendments#create" do
+        it "returns a unauthorized response and does not create an amendment or change the claim" do
+          expect {
+            post admin_claim_amendments_url(claim, amendment: {claim: {teacher_reference_number: "7654321"}})
+          }.not_to change { [claim.reload.teacher_reference_number, claim.amendments.size] }
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -91,6 +91,17 @@ RSpec.describe "Admin claims", type: :request do
             expect(response.body).not_to include("Amend claim")
           end
         end
+
+        context "when the claim has been amended" do
+          let(:claim) { create(:claim, :submitted, teacher_reference_number: "1234567") }
+          let!(:amendment) { create(:amendment, claim: claim, claim_changes: {"teacher_reference_number" => ["7654321", "1234567"]}) }
+
+          it "renders a timeline of changes" do
+            get admin_claim_path(claim)
+
+            expect(response.body).to include("changed from 7654321 to 1234567")
+          end
+        end
       end
     end
   end

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -71,6 +71,26 @@ RSpec.describe "Admin claims", type: :request do
             expect(response.body).to include(claim_with_matching_attributes.reference)
           end
         end
+
+        context "when the claim is amendable" do
+          let(:claim) { create(:claim, :submitted) }
+
+          it "displays a link to amend the claim" do
+            get admin_claim_path(claim)
+
+            expect(response.body).to include("Amend claim")
+          end
+        end
+
+        context "when the claim is not amendable" do
+          let(:claim) { create(:claim, :rejected) }
+
+          it "does not display a link to amend the claim" do
+            get admin_claim_path(claim)
+
+            expect(response.body).not_to include("Amend claim")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
# Description

This adds an "Amend claim" button which service operators can use to amend certain attributes of a claim. The commit messages give lots of information about this and why we're doing it.

# Opinions wanted

There are couple of technical things I was hoping for opinions on; I've left comments on the PR. Nothing massive.

# Screenshots

## Amend claim link on `admin/claim#show`
![image](https://user-images.githubusercontent.com/53756884/75263703-3e726380-57e6-11ea-9d16-3bbd310563dc.png)

## Amend claim page
![image](https://user-images.githubusercontent.com/53756884/75263597-1f73d180-57e6-11ea-8929-599592e37abe.png)

## Validation errors on amend claim page
![image](https://user-images.githubusercontent.com/53756884/75263796-5fd34f80-57e6-11ea-81e7-17b9b72bb60f.png)

## Amendments timeline
![image](https://user-images.githubusercontent.com/53756884/75264069-c0628c80-57e6-11ea-8ead-decc872b5802.png)