### PR TITLE
Handle byte order mark when reading payment confirmation CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog]
 - Update school eligibility to include City Technology Colleges
 - Service operators are taken straight to the tasks list when checking a Maths
   and Physics claim
+- Handle byte order mark when reading payment confirmation CSV
 
 ## [Release 055] - 2020-02-24
 

--- a/app/models/payment_confirmation_csv.rb
+++ b/app/models/payment_confirmation_csv.rb
@@ -34,7 +34,7 @@ class PaymentConfirmationCsv
       errors.append("You must provide a file")
       nil
     else
-      CSV.read(file.to_io, headers: true)
+      CSV.read(file.to_io, headers: true, encoding: "BOM|UTF-8")
     end
   rescue CSV::MalformedCSVError
     errors.append("The selected file must be a CSV")

--- a/spec/models/payment_confirmation_csv_spec.rb
+++ b/spec/models/payment_confirmation_csv_spec.rb
@@ -58,4 +58,27 @@ RSpec.describe PaymentConfirmationCsv do
       expect(subject.errors).to eq(["You must provide a file"])
     end
   end
+
+  context "The CSV contains a byte order mark (BOM)" do
+    let(:file) do
+      tempfile = Tempfile.new
+      tempfile.write(byte_order_mark + csv)
+      tempfile.rewind
+      tempfile
+    end
+    let(:byte_order_mark) { "\xEF\xBB\xBF" }
+    let(:csv) do
+      <<~CSV
+        Payroll Reference,Gross Value,Payment ID,NI,Employers NI,Student Loans,Tax,Net Pay
+        DFE00001,487.48,88b5dba7-ccf1-4ffd-a3ce-20bd3ce1e500,33.9,38.98,0,89.6,325
+      CSV
+    end
+
+    it "has no errors and parses the CSV" do
+      expect(subject.errors).to be_empty
+
+      expect(subject.rows.count).to eq(1)
+      expect(subject.rows.first["Payroll Reference"]).to eq("DFE00001")
+    end
+  end
 end


### PR DESCRIPTION
The Payment Confirmation Report that Cantium sent for February 2019
contains a byte order mark. We weren't stripping out these characters
so the CSV was failing to parse correctly.

By passing an encoding of "BOM|UTF-8" to `CSV#read` we can handle when
a byte order mark is both present and absent.

https://bugs.ruby-lang.org/issues/15210

