### PR TITLE
Update Admin to show QTS award year answer based on when claim was made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - QTS question will vary based on the year the service is accepting claims for
+- QTS answer will vary in admin based on the year the claim was made
 
 ## [Release 056] - 2020-02-25
 

--- a/app/controllers/admin/checks_controller.rb
+++ b/app/controllers/admin/checks_controller.rb
@@ -8,7 +8,7 @@ class Admin::ChecksController < Admin::BaseAdminController
   end
 
   def show
-    @eligibility_checks = @claim.policy::AdminChecksPresenter.new(@claim.eligibility)
+    @claim_checks = @claim.policy::AdminChecksPresenter.new(@claim)
     @check = @claim.checks.find_by(name: current_check)
     render current_check
   end

--- a/app/helpers/admin/policy_configurations_helper.rb
+++ b/app/helpers/admin/policy_configurations_helper.rb
@@ -1,26 +1,9 @@
+require "academic_year"
+
 module Admin
   module PolicyConfigurationsHelper
-    def start_of_autumn_term
-      Date.new(Date.today.year, 9, 1)
-    end
-
     def options_for_academic_year
-      [current_academic_year, next_academic_year]
-    end
-
-    def current_academic_year
-      if Date.today < start_of_autumn_term
-        [(Date.today.year - 1), Date.today.year].join("/")
-      else
-        [Date.today.year, (Date.today.year + 1)].join("/")
-      end
-    end
-
-    def next_academic_year
-      start_year = current_academic_year.split("/").last.to_i
-      end_year = start_year + 1
-
-      [start_year, end_year].join("/")
+      [AcademicYear.current, (AcademicYear.current + 1)]
     end
   end
 end

--- a/app/helpers/admin/policy_configurations_helper.rb
+++ b/app/helpers/admin/policy_configurations_helper.rb
@@ -1,5 +1,3 @@
-require "academic_year"
-
 module Admin
   module PolicyConfigurationsHelper
     def options_for_academic_year

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -15,6 +15,19 @@ class AcademicYear
 
   attr_reader :start_year, :end_year
 
+  # Defines a custom ActiveRecord::Type for AcademicYear that means we can
+  # define attributes on our models that save and return AcademicYear objects.
+  # See the Claim#academic_year attribute.
+  class Type < ActiveRecord::Type::Value
+    def serialize(value)
+      value.to_s
+    end
+
+    def cast(value)
+      AcademicYear.new(value)
+    end
+  end
+
   class << self
     # Returns the current academic year, based on September 1st being the start
     # of the year.
@@ -44,6 +57,15 @@ class AcademicYear
 
   def <=>(other)
     start_year <=> other.start_year
+  end
+
+  # Generates an Integer hash value for the object.
+  #
+  # Used primarily by the `Hash` class to determine if two objects reference the
+  # same hash key, but also used by the RSpec change matcher when doing
+  # comparison of nested objects.
+  def hash
+    [self.class, start_year].hash
   end
 
   def -(other)

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -258,7 +258,7 @@ class Claim < ApplicationRecord
   end
 
   def policy
-    eligibility&.class&.module_parent
+    eligibility&.policy
   end
 
   def school

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -71,6 +71,9 @@ class Claim < ApplicationRecord
     "student_loan_courses" => "student_loan_start_date",
   }.freeze
 
+  # Use AcademicYear as custom ActiveRecord attribute type
+  attribute :academic_year, AcademicYear::Type.new
+
   enum student_loan_country: StudentLoan::COUNTRIES
   enum student_loan_start_date: StudentLoan::COURSE_START_DATES
   enum student_loan_courses: {one_course: 0, two_or_more_courses: 1}
@@ -90,7 +93,7 @@ class Claim < ApplicationRecord
     male: 2,
   }
 
-  validates :academic_year, format: {with: PolicyConfiguration::ACADEMIC_YEAR_REGEXP}
+  validates :academic_year_before_type_cast, format: {with: PolicyConfiguration::ACADEMIC_YEAR_REGEXP}
 
   validates :payroll_gender, on: [:gender, :submit], presence: {message: "Choose the option for the gender your school’s payroll system associates with you"}
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -82,7 +82,7 @@ class Claim < ApplicationRecord
   has_one :decision
   has_many :checks
 
-  belongs_to :eligibility, polymorphic: true, dependent: :destroy
+  belongs_to :eligibility, polymorphic: true, inverse_of: :claim, dependent: :destroy
   accepts_nested_attributes_for :eligibility, update_only: true
 
   belongs_to :payment, optional: true

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -10,6 +10,8 @@
 module MathsAndPhysics
   extend self
 
+  ELIGIBLE_CAREER_LENGTH = 5
+
   def start_page_url
     if Rails.env.production?
       "https://www.gov.uk/guidance/claim-a-payment-for-teaching-maths-or-physics"
@@ -46,7 +48,7 @@ module MathsAndPhysics
   # Maths & Physics teachers are eligible to claim if they are in the first five
   # years of their career.
   def first_eligible_qts_award_year
-    configuration.current_academic_year - 5
+    configuration.current_academic_year - ELIGIBLE_CAREER_LENGTH
   end
 
   def configuration

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -47,8 +47,9 @@ module MathsAndPhysics
   #
   # Maths & Physics teachers are eligible to claim if they are in the first five
   # years of their career.
-  def first_eligible_qts_award_year
-    configuration.current_academic_year - ELIGIBLE_CAREER_LENGTH
+  def first_eligible_qts_award_year(claim_year = nil)
+    claim_year ||= configuration.current_academic_year
+    claim_year - ELIGIBLE_CAREER_LENGTH
   end
 
   def configuration

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "academic_year"
-
 # Module namespace specific to the policy for claiming a payment for teaching
 # maths or physics.
 #
@@ -48,7 +46,7 @@ module MathsAndPhysics
   # Maths & Physics teachers are eligible to claim if they are in the first five
   # years of their career.
   def first_eligible_qts_award_year
-    AcademicYear.new(configuration.current_academic_year) - 5
+    configuration.current_academic_year - 5
   end
 
   def configuration

--- a/app/models/maths_and_physics/admin_checks_presenter.rb
+++ b/app/models/maths_and_physics/admin_checks_presenter.rb
@@ -1,4 +1,11 @@
 module MathsAndPhysics
+  # Used to display the information a claim checker needs to check to either
+  # approve or reject a claim
+  #
+  # Note this presenter is only intented for use with eligible claims and
+  # therefor makes certain assumptions about the claim and eligibility.
+  # Specifically it assumes the QTS question was answered with
+  # :on_or_after_cut_off_date.
   class AdminChecksPresenter
     include Admin::PresenterMethods
 
@@ -10,7 +17,7 @@ module MathsAndPhysics
 
     def qualifications
       [].tap do |a|
-        a << ["Award year", I18n.t("maths_and_physics.questions.qts_award_years.#{eligibility.qts_award_year}")]
+        a << ["Award year", qts_award_year_answer]
         a << ["ITT subject", (eligibility.initial_teacher_training_subject_specialism || eligibility.initial_teacher_training_subject).humanize]
         a << ["Maths or Physics degree", maths_or_physics_degree] if eligibility.has_uk_maths_or_physics_degree.present?
       end
@@ -34,6 +41,11 @@ module MathsAndPhysics
       elsif eligibility.has_uk_maths_or_physics_degree == "has_non_uk"
         "Non-UK Maths or Physics degree"
       end
+    end
+
+    def qts_award_year_answer
+      qts_cut_off_for_claim = MathsAndPhysics.first_eligible_qts_award_year(claim.academic_year)
+      I18n.t("answers.qts_award_years.on_or_after_cut_off_date", year: qts_cut_off_for_claim.to_s(:long))
     end
   end
 end

--- a/app/models/maths_and_physics/admin_checks_presenter.rb
+++ b/app/models/maths_and_physics/admin_checks_presenter.rb
@@ -1,11 +1,6 @@
 module MathsAndPhysics
   # Used to display the information a claim checker needs to check to either
-  # approve or reject a claim
-  #
-  # Note this presenter is only intented for use with eligible claims and
-  # therefor makes certain assumptions about the claim and eligibility.
-  # Specifically it assumes the QTS question was answered with
-  # :on_or_after_cut_off_date.
+  # approve or reject a claim.
   class AdminChecksPresenter
     include Admin::PresenterMethods
 
@@ -17,7 +12,7 @@ module MathsAndPhysics
 
     def qualifications
       [].tap do |a|
-        a << ["Award year", qts_award_year_answer]
+        a << ["Award year", eligibility.qts_award_year_answer]
         a << ["ITT subject", itt_subject]
         a << ["Maths or Physics degree", maths_or_physics_degree] if eligibility.has_uk_maths_or_physics_degree.present?
       end
@@ -45,11 +40,6 @@ module MathsAndPhysics
       elsif eligibility.has_uk_maths_or_physics_degree == "has_non_uk"
         "Non-UK Maths or Physics degree"
       end
-    end
-
-    def qts_award_year_answer
-      qts_cut_off_for_claim = MathsAndPhysics.first_eligible_qts_award_year(claim.academic_year)
-      I18n.t("answers.qts_award_years.on_or_after_cut_off_date", year: qts_cut_off_for_claim.to_s(:long))
     end
   end
 end

--- a/app/models/maths_and_physics/admin_checks_presenter.rb
+++ b/app/models/maths_and_physics/admin_checks_presenter.rb
@@ -2,10 +2,10 @@ module MathsAndPhysics
   class AdminChecksPresenter
     include Admin::PresenterMethods
 
-    attr_reader :eligibility
+    attr_reader :claim
 
-    def initialize(eligibility)
-      @eligibility = eligibility
+    def initialize(claim)
+      @claim = claim
     end
 
     def qualifications
@@ -23,6 +23,10 @@ module MathsAndPhysics
     end
 
     private
+
+    def eligibility
+      claim.eligibility
+    end
 
     def maths_or_physics_degree
       if eligibility.has_uk_maths_or_physics_degree == "yes"

--- a/app/models/maths_and_physics/admin_checks_presenter.rb
+++ b/app/models/maths_and_physics/admin_checks_presenter.rb
@@ -18,7 +18,7 @@ module MathsAndPhysics
     def qualifications
       [].tap do |a|
         a << ["Award year", qts_award_year_answer]
-        a << ["ITT subject", (eligibility.initial_teacher_training_subject_specialism || eligibility.initial_teacher_training_subject).humanize]
+        a << ["ITT subject", itt_subject]
         a << ["Maths or Physics degree", maths_or_physics_degree] if eligibility.has_uk_maths_or_physics_degree.present?
       end
     end
@@ -33,6 +33,10 @@ module MathsAndPhysics
 
     def eligibility
       claim.eligibility
+    end
+
+    def itt_subject
+      (eligibility.initial_teacher_training_subject_specialism || eligibility.initial_teacher_training_subject).humanize
     end
 
     def maths_or_physics_degree

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -62,6 +62,10 @@ module MathsAndPhysics
 
     delegate :name, to: :current_school, prefix: true, allow_nil: true
 
+    def policy
+      MathsAndPhysics
+    end
+
     def ineligible?
       not_teaching_maths_or_physics? ||
         ineligible_current_school? ||

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -61,6 +61,7 @@ module MathsAndPhysics
     validates :subject_to_formal_performance_action, on: [:"formal-performance-action", :submit], inclusion: {in: [true, false], message: "Select yes if you are subject to formal action for poor performance at work"}
 
     delegate :name, to: :current_school, prefix: true, allow_nil: true
+    delegate :academic_year, to: :claim, prefix: true
 
     def policy
       MathsAndPhysics
@@ -104,6 +105,15 @@ module MathsAndPhysics
 
     def initial_teacher_training_specialised_in_maths_or_physics?
       itt_subject_maths? || itt_subject_physics? || itt_specialism_physics?
+    end
+
+    # Returns a String that is the human-readable answer given for the QTS
+    # question when the claim was made.
+    def qts_award_year_answer
+      year_for_answer = MathsAndPhysics.first_eligible_qts_award_year(claim_academic_year)
+      year_for_answer -= 1 if awarded_qualified_status_before_cut_off_date?
+
+      I18n.t("answers.qts_award_years.#{qts_award_year}", year: year_for_answer.to_s(:long))
     end
 
     private

--- a/app/models/maths_and_physics/eligibility.rb
+++ b/app/models/maths_and_physics/eligibility.rb
@@ -45,6 +45,7 @@ module MathsAndPhysics
       on_or_after_cut_off_date: 1,
     }, _prefix: :awarded_qualified_status
 
+    has_one :claim, as: :eligibility, inverse_of: :eligibility
     belongs_to :current_school, optional: true, class_name: "School"
 
     validates :teaching_maths_or_physics, on: [:"teaching-maths-or-physics", :submit], inclusion: {in: [true, false], message: "Select yes if you teach any maths or physics"}

--- a/app/models/maths_and_physics/eligibility_admin_answers_presenter.rb
+++ b/app/models/maths_and_physics/eligibility_admin_answers_presenter.rb
@@ -72,7 +72,7 @@ module MathsAndPhysics
     def qts_award_year
       [
         I18n.t("admin.qts_award_year"),
-        qts_award_year_answer,
+        eligibility.qts_award_year_answer,
       ]
     end
 
@@ -117,11 +117,6 @@ module MathsAndPhysics
       when "no" then "No"
       else I18n.t("maths_and_physics.answers.has_uk_maths_or_physics_degree.#{eligibility.has_uk_maths_or_physics_degree}")
       end
-    end
-
-    def qts_award_year_answer
-      qts_cut_off_for_claim = MathsAndPhysics.first_eligible_qts_award_year(eligibility.claim.academic_year)
-      I18n.t("answers.qts_award_years.on_or_after_cut_off_date", year: qts_cut_off_for_claim.to_s(:long))
     end
   end
 end

--- a/app/models/maths_and_physics/eligibility_admin_answers_presenter.rb
+++ b/app/models/maths_and_physics/eligibility_admin_answers_presenter.rb
@@ -18,21 +18,98 @@ module MathsAndPhysics
     # [1]: answer text;
     def answers
       [].tap do |a|
-        a << [I18n.t("maths_and_physics.admin.teaching_maths_or_physics"), (eligibility.teaching_maths_or_physics? ? "Yes" : "No")]
-        a << [I18n.t("admin.current_school"), display_school(eligibility.current_school)]
-        a << [I18n.t("maths_and_physics.admin.initial_teacher_training_subject"), I18n.t("maths_and_physics.answers.initial_teacher_training_subject.#{eligibility.initial_teacher_training_subject}")]
-        a << [I18n.t("maths_and_physics.admin.initial_teacher_training_subject_specialism"), I18n.t("maths_and_physics.answers.initial_teacher_training_subject_specialism.#{eligibility.initial_teacher_training_subject_specialism}")] if eligibility.initial_teacher_training_subject_specialism.present?
-        a << [I18n.t("maths_and_physics.admin.has_uk_maths_or_physics_degree"), degree_answer] if eligibility.has_uk_maths_or_physics_degree.present?
-        a << [I18n.t("admin.qts_award_year"), I18n.t("maths_and_physics.questions.qts_award_years.#{eligibility.qts_award_year}")]
-        a << [I18n.t("maths_and_physics.admin.employed_as_supply_teacher"), (eligibility.employed_as_supply_teacher? ? "Yes" : "No")]
-        a << [I18n.t("maths_and_physics.admin.has_entire_term_contract"), (eligibility.has_entire_term_contract? ? "Yes" : "No")] unless eligibility.has_entire_term_contract.nil?
-        a << [I18n.t("maths_and_physics.admin.employed_directly"), I18n.t("maths_and_physics.answers.employed_directly.#{eligibility.employed_directly? ? "yes" : "no"}")] unless eligibility.employed_directly.nil?
-        a << [I18n.t("maths_and_physics.admin.disciplinary_action"), (eligibility.subject_to_disciplinary_action? ? "Yes" : "No")]
-        a << [I18n.t("maths_and_physics.admin.formal_performance_action"), (eligibility.subject_to_formal_performance_action? ? "Yes" : "No")]
+        a << teaching_maths_or_physics
+        a << current_school
+        a << initial_teacher_training_subject
+        a << initial_teacher_training_subject_specialism if eligibility.initial_teacher_training_subject_specialism.present?
+        a << has_uk_maths_or_physics_degree if eligibility.has_uk_maths_or_physics_degree.present?
+        a << qts_award_year
+        a << employed_as_supply_teacher
+        a << has_entire_term_contract if eligibility.has_entire_term_contract.present?
+        a << employed_directly if eligibility.employed_directly.present?
+        a << disciplinary_action
+        a << formal_performance_action
       end
     end
 
     private
+
+    def teaching_maths_or_physics
+      [
+        I18n.t("maths_and_physics.admin.teaching_maths_or_physics"),
+        (eligibility.teaching_maths_or_physics? ? "Yes" : "No"),
+      ]
+    end
+
+    def current_school
+      [
+        I18n.t("admin.current_school"),
+        display_school(eligibility.current_school),
+      ]
+    end
+
+    def initial_teacher_training_subject
+      [
+        I18n.t("maths_and_physics.admin.initial_teacher_training_subject"),
+        I18n.t("maths_and_physics.answers.initial_teacher_training_subject.#{eligibility.initial_teacher_training_subject}"),
+      ]
+    end
+
+    def initial_teacher_training_subject_specialism
+      [
+        I18n.t("maths_and_physics.admin.initial_teacher_training_subject_specialism"),
+        I18n.t("maths_and_physics.answers.initial_teacher_training_subject_specialism.#{eligibility.initial_teacher_training_subject_specialism}"),
+      ]
+    end
+
+    def has_uk_maths_or_physics_degree
+      [
+        I18n.t("maths_and_physics.admin.has_uk_maths_or_physics_degree"),
+        degree_answer,
+      ]
+    end
+
+    def qts_award_year
+      [
+        I18n.t("admin.qts_award_year"),
+        I18n.t("maths_and_physics.questions.qts_award_years.#{eligibility.qts_award_year}"),
+      ]
+    end
+
+    def employed_as_supply_teacher
+      [
+        I18n.t("maths_and_physics.admin.employed_as_supply_teacher"),
+        (eligibility.employed_as_supply_teacher? ? "Yes" : "No"),
+      ]
+    end
+
+    def has_entire_term_contract
+      [
+        I18n.t("maths_and_physics.admin.has_entire_term_contract"),
+        (eligibility.has_entire_term_contract? ? "Yes" : "No"),
+      ]
+    end
+
+    def employed_directly
+      [
+        I18n.t("maths_and_physics.admin.employed_directly"),
+        I18n.t("maths_and_physics.answers.employed_directly.#{eligibility.employed_directly? ? "yes" : "no"}"),
+      ]
+    end
+
+    def disciplinary_action
+      [
+        I18n.t("maths_and_physics.admin.disciplinary_action"),
+        (eligibility.subject_to_disciplinary_action? ? "Yes" : "No"),
+      ]
+    end
+
+    def formal_performance_action
+      [
+        I18n.t("maths_and_physics.admin.formal_performance_action"),
+        (eligibility.subject_to_formal_performance_action? ? "Yes" : "No"),
+      ]
+    end
 
     def degree_answer
       case eligibility.has_uk_maths_or_physics_degree

--- a/app/models/maths_and_physics/eligibility_admin_answers_presenter.rb
+++ b/app/models/maths_and_physics/eligibility_admin_answers_presenter.rb
@@ -72,7 +72,7 @@ module MathsAndPhysics
     def qts_award_year
       [
         I18n.t("admin.qts_award_year"),
-        I18n.t("maths_and_physics.questions.qts_award_years.#{eligibility.qts_award_year}"),
+        qts_award_year_answer,
       ]
     end
 
@@ -117,6 +117,11 @@ module MathsAndPhysics
       when "no" then "No"
       else I18n.t("maths_and_physics.answers.has_uk_maths_or_physics_degree.#{eligibility.has_uk_maths_or_physics_degree}")
       end
+    end
+
+    def qts_award_year_answer
+      qts_cut_off_for_claim = MathsAndPhysics.first_eligible_qts_award_year(eligibility.claim.academic_year)
+      I18n.t("answers.qts_award_years.on_or_after_cut_off_date", year: qts_cut_off_for_claim.to_s(:long))
     end
   end
 end

--- a/app/models/maths_and_physics/eligibility_answers_presenter.rb
+++ b/app/models/maths_and_physics/eligibility_answers_presenter.rb
@@ -76,7 +76,7 @@ module MathsAndPhysics
     def qts_award_year
       [
         I18n.t("questions.qts_award_year"),
-        I18n.t("answers.qts_award_years.#{eligibility.qts_award_year}", year: qts_answer_academic_year.to_s(:long)),
+        eligibility.qts_award_year_answer,
         "qts-year",
       ]
     end
@@ -126,14 +126,6 @@ module MathsAndPhysics
       when "yes" then "Yes"
       when "no" then "No"
       else I18n.t("maths_and_physics.answers.has_uk_maths_or_physics_degree.#{eligibility.has_uk_maths_or_physics_degree}")
-      end
-    end
-
-    def qts_answer_academic_year
-      if eligibility.awarded_qualified_status_on_or_after_cut_off_date?
-        MathsAndPhysics.first_eligible_qts_award_year
-      else
-        MathsAndPhysics.first_eligible_qts_award_year - 1
       end
     end
   end

--- a/app/models/policy_configuration.rb
+++ b/app/models/policy_configuration.rb
@@ -12,8 +12,11 @@
 class PolicyConfiguration < ApplicationRecord
   ACADEMIC_YEAR_REGEXP = /\A20\d{2}\/20\d{2}\z/.freeze
 
+  # Use AcademicYear as custom ActiveRecord attribute type
+  attribute :current_academic_year, AcademicYear::Type.new
+
   validates :policy_type, inclusion: {in: Policies.all.map(&:name)}
-  validates :current_academic_year, format: {with: ACADEMIC_YEAR_REGEXP}
+  validates :current_academic_year_before_type_cast, format: {with: ACADEMIC_YEAR_REGEXP}
 
   def self.for(policy)
     find_by policy_type: policy.name

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -57,10 +57,11 @@ module StudentLoans
   # So to give concrete examples, teachers qualifying in 2013/2014 can make
   # claims up to 2024/2025, and a teacher qualifying in 2014/2015 can make
   # claims up to 2025/2026 and so on.
-  def first_eligible_qts_award_year
+  def first_eligible_qts_award_year(claim_year = nil)
+    claim_year ||= configuration.current_academic_year
     [
       POLICY_START_YEAR,
-      (configuration.current_academic_year - ACADEMIC_YEARS_QUALIFIED_TEACHERS_CAN_CLAIM_FOR),
+      (claim_year - ACADEMIC_YEARS_QUALIFIED_TEACHERS_CAN_CLAIM_FOR),
     ].max
   end
 

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -10,6 +10,9 @@
 module StudentLoans
   extend self
 
+  POLICY_START_YEAR = AcademicYear.new(2013).freeze
+  ACADEMIC_YEARS_QUALIFIED_TEACHERS_CAN_CLAIM_FOR = 11
+
   def start_page_url
     if Rails.env.production?
       "https://www.gov.uk/guidance/teachers-claim-back-your-student-loan-repayments"
@@ -56,8 +59,8 @@ module StudentLoans
   # claims up to 2025/2026 and so on.
   def first_eligible_qts_award_year
     [
-      AcademicYear.new(2013),
-      (configuration.current_academic_year - 11),
+      POLICY_START_YEAR,
+      (configuration.current_academic_year - ACADEMIC_YEARS_QUALIFIED_TEACHERS_CAN_CLAIM_FOR),
     ].max
   end
 

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "academic_year"
-
 # Module namespace specific to the policy for claiming back your student loan
 # payments.
 #
@@ -57,8 +55,10 @@ module StudentLoans
   # claims up to 2024/2025, and a teacher qualifying in 2014/2015 can make
   # claims up to 2025/2026 and so on.
   def first_eligible_qts_award_year
-    eleven_years_prior = AcademicYear.new(configuration.current_academic_year) - 11
-    [AcademicYear.new(2013), eleven_years_prior].max
+    [
+      AcademicYear.new(2013),
+      (configuration.current_academic_year - 11),
+    ].max
   end
 
   def configuration

--- a/app/models/student_loans/admin_checks_presenter.rb
+++ b/app/models/student_loans/admin_checks_presenter.rb
@@ -1,11 +1,6 @@
 module StudentLoans
   # Used to display the information a claim checker needs to check to either
-  # approve or reject a claim
-  #
-  # Note this presenter is only intented for use with eligible claims and
-  # therefor makes certain assumptions about the claim and eligibility.
-  # Specifically it assumes the QTS question was answered with
-  # :on_or_after_cut_off_date.
+  # approve or reject a claim.
   class AdminChecksPresenter
     include Admin::PresenterMethods
 
@@ -17,7 +12,7 @@ module StudentLoans
 
     def qualifications
       [
-        ["Award year", qts_award_year_answer],
+        ["Award year", eligibility.qts_award_year_answer],
       ]
     end
 
@@ -32,11 +27,6 @@ module StudentLoans
 
     def eligibility
       claim.eligibility
-    end
-
-    def qts_award_year_answer
-      qts_cut_off_for_claim = StudentLoans.first_eligible_qts_award_year(claim.academic_year)
-      I18n.t("answers.qts_award_years.on_or_after_cut_off_date", year: qts_cut_off_for_claim.to_s(:long))
     end
   end
 end

--- a/app/models/student_loans/admin_checks_presenter.rb
+++ b/app/models/student_loans/admin_checks_presenter.rb
@@ -1,4 +1,11 @@
 module StudentLoans
+  # Used to display the information a claim checker needs to check to either
+  # approve or reject a claim
+  #
+  # Note this presenter is only intented for use with eligible claims and
+  # therefor makes certain assumptions about the claim and eligibility.
+  # Specifically it assumes the QTS question was answered with
+  # :on_or_after_cut_off_date.
   class AdminChecksPresenter
     include Admin::PresenterMethods
 
@@ -10,7 +17,7 @@ module StudentLoans
 
     def qualifications
       [
-        ["Award year", I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}")],
+        ["Award year", qts_award_year_answer],
       ]
     end
 
@@ -25,6 +32,11 @@ module StudentLoans
 
     def eligibility
       claim.eligibility
+    end
+
+    def qts_award_year_answer
+      qts_cut_off_for_claim = StudentLoans.first_eligible_qts_award_year(claim.academic_year)
+      I18n.t("answers.qts_award_years.on_or_after_cut_off_date", year: qts_cut_off_for_claim.to_s(:long))
     end
   end
 end

--- a/app/models/student_loans/admin_checks_presenter.rb
+++ b/app/models/student_loans/admin_checks_presenter.rb
@@ -2,10 +2,10 @@ module StudentLoans
   class AdminChecksPresenter
     include Admin::PresenterMethods
 
-    attr_reader :eligibility
+    attr_reader :claim
 
-    def initialize(eligibility)
-      @eligibility = eligibility
+    def initialize(claim)
+      @claim = claim
     end
 
     def qualifications
@@ -19,6 +19,12 @@ module StudentLoans
         ["6 April 2018 to 5 April 2019", display_school(eligibility.claim_school)],
         [I18n.t("admin.current_school"), display_school(eligibility.current_school)],
       ]
+    end
+
+    private
+
+    def eligibility
+      claim.eligibility
     end
   end
 end

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -38,6 +38,7 @@ module StudentLoans
       no_school: 2,
     }, _prefix: :employed_at
 
+    has_one :claim, as: :eligibility, inverse_of: :eligibility
     belongs_to :claim_school, optional: true, class_name: "School"
     belongs_to :current_school, optional: true, class_name: "School"
 

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -55,6 +55,10 @@ module StudentLoans
     delegate :name, to: :claim_school, prefix: true, allow_nil: true
     delegate :name, to: :current_school, prefix: true, allow_nil: true
 
+    def policy
+      StudentLoans
+    end
+
     def subjects_taught
       SUBJECT_ATTRIBUTES.select { |attribute_name| public_send("#{attribute_name}?") }
     end

--- a/app/models/student_loans/eligibility.rb
+++ b/app/models/student_loans/eligibility.rb
@@ -54,6 +54,7 @@ module StudentLoans
 
     delegate :name, to: :claim_school, prefix: true, allow_nil: true
     delegate :name, to: :current_school, prefix: true, allow_nil: true
+    delegate :academic_year, to: :claim, prefix: true
 
     def policy
       StudentLoans
@@ -98,6 +99,15 @@ module StudentLoans
         end
       end
       self.current_school = inferred_current_school if employment_status_changed?
+    end
+
+    # Returns a String that is the human-readable answer given for the QTS
+    # question when the claim was made.
+    def qts_award_year_answer
+      year_for_answer = StudentLoans.first_eligible_qts_award_year(claim_academic_year)
+      year_for_answer -= 1 if awarded_qualified_status_before_cut_off_date?
+
+      I18n.t("answers.qts_award_years.#{qts_award_year}", year: year_for_answer.to_s(:long))
     end
 
     private

--- a/app/models/student_loans/eligibility_admin_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_admin_answers_presenter.rb
@@ -33,7 +33,7 @@ module StudentLoans
     def qts_award_year
       [
         I18n.t("admin.qts_award_year"),
-        I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}"),
+        qts_award_year_answer,
       ]
     end
 
@@ -70,6 +70,11 @@ module StudentLoans
         I18n.t("student_loans.admin.mostly_performed_leadership_duties"),
         (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No"),
       ]
+    end
+
+    def qts_award_year_answer
+      qts_cut_off_for_claim = StudentLoans.first_eligible_qts_award_year(eligibility.claim.academic_year)
+      I18n.t("answers.qts_award_years.on_or_after_cut_off_date", year: qts_cut_off_for_claim.to_s(:long))
     end
   end
 end

--- a/app/models/student_loans/eligibility_admin_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_admin_answers_presenter.rb
@@ -33,7 +33,7 @@ module StudentLoans
     def qts_award_year
       [
         I18n.t("admin.qts_award_year"),
-        qts_award_year_answer,
+        eligibility.qts_award_year_answer,
       ]
     end
 
@@ -70,11 +70,6 @@ module StudentLoans
         I18n.t("student_loans.admin.mostly_performed_leadership_duties"),
         (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No"),
       ]
-    end
-
-    def qts_award_year_answer
-      qts_cut_off_for_claim = StudentLoans.first_eligible_qts_award_year(eligibility.claim.academic_year)
-      I18n.t("answers.qts_award_years.on_or_after_cut_off_date", year: qts_cut_off_for_claim.to_s(:long))
     end
   end
 end

--- a/app/models/student_loans/eligibility_admin_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_admin_answers_presenter.rb
@@ -19,13 +19,57 @@ module StudentLoans
     # [1]: answer text;
     def answers
       [].tap do |a|
-        a << [I18n.t("admin.qts_award_year"), I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}")]
-        a << [I18n.t("student_loans.admin.claim_school"), display_school(eligibility.claim_school)]
-        a << [I18n.t("admin.current_school"), display_school(eligibility.current_school)]
-        a << [I18n.t("student_loans.admin.subjects_taught"), subject_list(eligibility.subjects_taught)]
-        a << [I18n.t("student_loans.admin.had_leadership_position"), (eligibility.had_leadership_position? ? "Yes" : "No")]
-        a << [I18n.t("student_loans.admin.mostly_performed_leadership_duties"), (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No")] if eligibility.had_leadership_position?
+        a << qts_award_year
+        a << claim_school
+        a << current_school
+        a << subjects_taught
+        a << had_leadership_position
+        a << mostly_performed_leadership_duties if eligibility.had_leadership_position?
       end
+    end
+
+    private
+
+    def qts_award_year
+      [
+        I18n.t("admin.qts_award_year"),
+        I18n.t("student_loans.questions.qts_award_years.#{eligibility.qts_award_year}"),
+      ]
+    end
+
+    def claim_school
+      [
+        I18n.t("student_loans.admin.claim_school"),
+        display_school(eligibility.claim_school),
+      ]
+    end
+
+    def current_school
+      [
+        I18n.t("admin.current_school"),
+        display_school(eligibility.current_school),
+      ]
+    end
+
+    def subjects_taught
+      [
+        I18n.t("student_loans.admin.subjects_taught"),
+        subject_list(eligibility.subjects_taught),
+      ]
+    end
+
+    def had_leadership_position
+      [
+        I18n.t("student_loans.admin.had_leadership_position"),
+        (eligibility.had_leadership_position? ? "Yes" : "No"),
+      ]
+    end
+
+    def mostly_performed_leadership_duties
+      [
+        I18n.t("student_loans.admin.mostly_performed_leadership_duties"),
+        (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No"),
+      ]
     end
   end
 end

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -35,7 +35,7 @@ module StudentLoans
     def qts_award_year
       [
         I18n.t("questions.qts_award_year"),
-        I18n.t("answers.qts_award_years.#{eligibility.qts_award_year}", year: qts_answer_academic_year.to_s(:long)),
+        eligibility.qts_award_year_answer,
         "qts-year",
       ]
     end
@@ -86,14 +86,6 @@ module StudentLoans
         number_to_currency(eligibility.student_loan_repayment_amount),
         "student-loan-amount",
       ]
-    end
-
-    def qts_answer_academic_year
-      if eligibility.awarded_qualified_status_on_or_after_cut_off_date?
-        StudentLoans.first_eligible_qts_award_year
-      else
-        StudentLoans.first_eligible_qts_award_year - 1
-      end
     end
   end
 end

--- a/app/views/admin/checks/employment.html.erb
+++ b/app/views/admin/checks/employment.html.erb
@@ -9,7 +9,7 @@
     <%= render "admin/claims/answer_section",
           heading: "Employment",
           description: I18n.t("#{@claim.policy.to_s.underscore}.admin.employment_check_description"),
-          answers: @eligibility_checks.employment %>
+          answers: @claim_checks.employment %>
   </div>
 
   <div class="govuk-grid-column-full">

--- a/app/views/admin/checks/qualifications.html.erb
+++ b/app/views/admin/checks/qualifications.html.erb
@@ -10,7 +10,7 @@
     <%= render "admin/claims/answer_section",
           heading: "Qualifications",
           description: I18n.t("#{@claim.policy.to_s.underscore}.admin.qualification_check_description"),
-          answers: @eligibility_checks.qualifications %>
+          answers: @claim_checks.qualifications %>
   </div>
 
   <div class="govuk-grid-column-full">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,9 +139,6 @@ en:
       initial_teacher_training_subject: "Which subject did you complete your initial teacher training in?"
       initial_teacher_training_subject_specialism: "Which science subject did your initial teacher training specialise in?"
       has_uk_maths_or_physics_degree: "Do you have a UK undergraduate or postgraduate degree in maths or physics?"
-      qts_award_years:
-        before_cut_off_date: "In or before the academic year 2013 to 2014"
-        on_or_after_cut_off_date: "In or after the academic year 2014 to 2015"
       employed_as_supply_teacher: "Are you currently employed as a supply teacher?"
       has_entire_term_contract: "Do you have a contract to teach at the same school for an entire term or longer?"
       employed_directly: "Are you employed directly by your school?"
@@ -189,9 +186,6 @@ en:
       * you did not teach an eligible subject for at least half of your contracted hours
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
-      qts_award_years:
-        before_cut_off_date: "In or before the academic year 2012 to 2013"
-        on_or_after_cut_off_date: "In or after the academic year 2013 to 2014"
       claim_school: "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
       additional_school: "Which additional school were you employed to teach at between 6 April 2018 and 5 April 2019?"
       employment_status: "Are you still employed to teach at a school in England?"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,8 +6,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-PolicyConfiguration.create!(policy_type: StudentLoans, current_academic_year: "2018/2019")
-PolicyConfiguration.create!(policy_type: MathsAndPhysics, current_academic_year: "2018/2019")
+PolicyConfiguration.create!(policy_type: StudentLoans, current_academic_year: AcademicYear.current)
+PolicyConfiguration.create!(policy_type: MathsAndPhysics, current_academic_year: AcademicYear.current)
 
 if Rails.env.development? || ENV["ENVIRONMENT_NAME"] == "review"
   ENV["FIXTURES_PATH"] = "spec/fixtures"

--- a/lib/academic_year.rb
+++ b/lib/academic_year.rb
@@ -15,6 +15,20 @@ class AcademicYear
 
   attr_reader :start_year, :end_year
 
+  class << self
+    # Returns the current academic year, based on September 1st being the start
+    # of the year.
+    def current
+      start_of_autumn_term = Date.new(Date.today.year, 9, 1)
+
+      if Date.today < start_of_autumn_term
+        new(Date.today.year - 1)
+      else
+        new(Date.today.year)
+      end
+    end
+  end
+
   def initialize(start_year)
     @start_year = start_year.to_s.split("/").first.to_i
     @end_year = @start_year + 1

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
 
     after(:build) do |claim, evaluator|
       claim.eligibility = build(*evaluator.eligibility_factory) unless claim.eligibility
-      claim.academic_year = "2019/2020" unless claim.academic_year
+      claim.academic_year = "2019/2020" unless claim.academic_year_before_type_cast
     end
 
     trait :submittable do

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "Admin checks a claim" do
       click_on "Check qualification information"
       expect(page).to have_content("Qualifications")
       expect(page).to have_content("Award year")
-      expect(page).to have_content(I18n.t("#{claim.policy.to_s.underscore}.questions.qts_award_years.#{claim.eligibility.qts_award_year}"))
+      expect(page).to have_content(claim.eligibility.qts_award_year_answer)
 
       click_on "Complete qualifications check and continue"
 

--- a/spec/features/admin_configure_services_spec.rb
+++ b/spec/features/admin_configure_services_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Service configuration" do
         expect(page).to have_content("2023/2024")
       end
 
-      expect(policy_configuration.reload.current_academic_year).to eq "2023/2024"
+      expect(policy_configuration.reload.current_academic_year).to eq AcademicYear.new(2023)
     end
   end
 end

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -29,7 +29,8 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     expect(find("#claim_eligibility_attributes_qts_award_year_on_or_after_cut_off_date").checked?).to eq(true)
 
-    choose I18n.t("student_loans.questions.qts_award_years.before_cut_off_date")
+    before_cut_off_question = I18n.t("answers.qts_award_years.before_cut_off_date", year: (StudentLoans.first_eligible_qts_award_year - 1).to_s(:long))
+    choose before_cut_off_question
     click_on "Continue"
 
     expect(claim.eligibility.reload.qts_award_year).to eq("before_cut_off_date")

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     expect(claim.eligibility.reload.qts_award_year).to eq("before_cut_off_date")
 
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year 2013 to 2014.")
+    expect(page).to have_text("You can only get this payment if you completed your initial teacher training in or after the academic year #{StudentLoans.first_eligible_qts_award_year.to_s(:long)}.")
   end
 
   scenario "Teacher changes an answer which is a dependency of some of the subsequent answers they’ve given, remaining eligible" do

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -29,8 +29,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
 
     expect(find("#claim_eligibility_attributes_qts_award_year_on_or_after_cut_off_date").checked?).to eq(true)
 
-    before_cut_off_question = I18n.t("answers.qts_award_years.before_cut_off_date", year: (StudentLoans.first_eligible_qts_award_year - 1).to_s(:long))
-    choose before_cut_off_question
+    choose_qts_year :before_cut_off_date
     click_on "Continue"
 
     expect(claim.eligibility.reload.qts_award_year).to eq("before_cut_off_date")

--- a/spec/features/ineligible_maths_and_physics_claims_spec.rb
+++ b/spec/features/ineligible_maths_and_physics_claims_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Ineligible Maths and Physics claims" do
 
     choose_school schools(:penistone_grammar_school)
     choose_initial_teacher_training_subject
-    choose_qts_year("In or before the academic year 2014 to 2015")
+    choose_qts_year(:before_cut_off_date)
 
     expect(claim.eligibility.reload.qts_award_year).to eql("before_cut_off_date")
     expect(page).to have_text("You’re not eligible")
@@ -53,7 +53,7 @@ RSpec.feature "Ineligible Maths and Physics claims" do
 
     choose_school schools(:penistone_grammar_school)
     choose_initial_teacher_training_subject
-    choose_qts_year("In or after the academic year 2014 to 2015")
+    choose_qts_year(:on_or_after_cut_off_date)
 
     choose "Yes"
     click_on "Continue"
@@ -70,7 +70,7 @@ RSpec.feature "Ineligible Maths and Physics claims" do
 
     choose_school schools(:penistone_grammar_school)
     choose_initial_teacher_training_subject
-    choose_qts_year("In or after the academic year 2014 to 2015")
+    choose_qts_year(:on_or_after_cut_off_date)
 
     choose "Yes"
     click_on "Continue"
@@ -89,7 +89,7 @@ RSpec.feature "Ineligible Maths and Physics claims" do
 
     choose_school schools(:penistone_grammar_school)
     choose_initial_teacher_training_subject
-    choose_qts_year("In or after the academic year 2014 to 2015")
+    choose_qts_year(:on_or_after_cut_off_date)
 
     choose "No"
     click_on "Continue"
@@ -106,7 +106,7 @@ RSpec.feature "Ineligible Maths and Physics claims" do
 
     choose_school schools(:penistone_grammar_school)
     choose_initial_teacher_training_subject
-    choose_qts_year("In or after the academic year 2014 to 2015")
+    choose_qts_year(:on_or_after_cut_off_date)
 
     choose "No"
     click_on "Continue"

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
     policy_configurations(:student_loans).update!(current_academic_year: "2025/2026")
 
     visit new_claim_path(StudentLoans.routing_name)
-    choose_qts_year("In or before the academic year 2013 to 2014")
+    choose_qts_year(:before_cut_off_date)
     claim = Claim.order(:created_at).last
 
     expect(claim.eligibility.reload.qts_award_year).to eql("before_cut_off_date")

--- a/spec/features/maths_and_physics_claim_spec.rb
+++ b/spec/features/maths_and_physics_claim_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Maths & Physics claims" do
       expect(claim.eligibility.reload.initial_teacher_training_subject_specialism).to eql "physics"
 
       expect(page).to have_text(I18n.t("questions.qts_award_year"))
-      choose_qts_year "In or after the academic year 2014 to 2015"
+      choose_qts_year(:on_or_after_cut_off_date)
       expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
 
       expect(page).to have_text(I18n.t("maths_and_physics.questions.employed_as_supply_teacher"))
@@ -236,7 +236,7 @@ RSpec.feature "Maths & Physics claims" do
     expect(claim.eligibility.reload.initial_teacher_training_subject).to eql "physics"
 
     expect(page).to have_text(I18n.t("questions.qts_award_year"))
-    choose_qts_year "In or after the academic year 2014 to 2015"
+    choose_qts_year(:on_or_after_cut_off_date)
     expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
 
     expect(page).to have_text(I18n.t("maths_and_physics.questions.employed_as_supply_teacher"))

--- a/spec/fixtures/policy_configurations.yml
+++ b/spec/fixtures/policy_configurations.yml
@@ -1,7 +1,7 @@
 student_loans:
   policy_type: StudentLoans
-  current_academic_year: "2019/2020"
+  current_academic_year: "2025/2026"
 
 maths_and_physics:
   policy_type: MathsAndPhysics
-  current_academic_year: "2019/2020"
+  current_academic_year: "2020/2021"

--- a/spec/helpers/admin/policy_configurations_helper_spec.rb
+++ b/spec/helpers/admin/policy_configurations_helper_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe Admin::PolicyConfigurationsHelper, type: :helper do
   describe "#options_for_academic_year" do
     it "returns the current and next academic year (based on September 1st being the start of the year)" do
       travel_to Date.new(2018, 8, 31) do
-        expect(helper.options_for_academic_year).to eq ["2017/2018", "2018/2019"]
+        expect(helper.options_for_academic_year).to eq [AcademicYear.new(2017), AcademicYear.new(2018)]
       end
       travel_to Date.new(2018, 9, 1) do
-        expect(helper.options_for_academic_year).to eq ["2018/2019", "2019/2020"]
+        expect(helper.options_for_academic_year).to eq [AcademicYear.new(2018), AcademicYear.new(2019)]
       end
       travel_to Date.new(2020, 9, 1) do
-        expect(helper.options_for_academic_year).to eq ["2020/2021", "2021/2022"]
+        expect(helper.options_for_academic_year).to eq [AcademicYear.new(2020), AcademicYear.new(2021)]
       end
     end
   end

--- a/spec/lib/academic_year_spec.rb
+++ b/spec/lib/academic_year_spec.rb
@@ -2,6 +2,20 @@ require "rails_helper"
 require "academic_year"
 
 RSpec.describe AcademicYear do
+  describe ".current" do
+    it "returns the current academic year (based on September 1st being the start of the year)" do
+      travel_to Date.new(2018, 8, 31) do
+        expect(AcademicYear.current).to eq AcademicYear.new(2017)
+      end
+      travel_to Date.new(2018, 9, 1) do
+        expect(AcademicYear.current).to eq AcademicYear.new(2018)
+      end
+      travel_to Date.new(2020, 9, 1) do
+        expect(AcademicYear.current).to eq AcademicYear.new(2020)
+      end
+    end
+  end
+
   it "can be initialised with the full academic year as a String" do
     expect(AcademicYear.new("2014/2015").start_year).to eq 2014
   end

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require "academic_year"
 
 RSpec.describe AcademicYear do
   describe ".current" do
@@ -12,6 +11,20 @@ RSpec.describe AcademicYear do
       end
       travel_to Date.new(2020, 9, 1) do
         expect(AcademicYear.current).to eq AcademicYear.new(2020)
+      end
+    end
+  end
+
+  describe AcademicYear::Type do
+    describe "#serialize" do
+      it "returns the String representation of an AcademicYear" do
+        expect(AcademicYear::Type.new.serialize(AcademicYear.new(2020))).to eq "2020/2021"
+      end
+    end
+
+    describe "#cast" do
+      it "returns an Academic year based on the provided serialised string version" do
+        expect(AcademicYear::Type.new.cast("2024/2025")).to eq AcademicYear.new(2024)
       end
     end
   end
@@ -54,6 +67,18 @@ RSpec.describe AcademicYear do
       expect(AcademicYear.new(2014).to_s(:long)).to eq "2014 to 2015"
       expect(AcademicYear.new("2020").to_s(:long)).to eq "2020 to 2021"
       expect(AcademicYear.new("2020/2021").to_s(:long)).to eq "2020 to 2021"
+    end
+  end
+
+  describe "#hash" do
+    it "returns the same Integer value for matching AcademicYears" do
+      expect(AcademicYear.new(2014).hash).to be_a(Integer)
+
+      expect(AcademicYear.new(2014).hash).to eql AcademicYear.new(2014).hash
+      expect(AcademicYear.new("2020").hash).to eql AcademicYear.new(2020).hash
+
+      expect(AcademicYear.new(2014).hash).not_to eql AcademicYear.new(2020).hash
+      expect(AcademicYear.new(2014).hash).not_to eql 2014.hash
     end
   end
 end

--- a/spec/models/maths_and_physics/admin_checks_presenter_spec.rb
+++ b/spec/models/maths_and_physics/admin_checks_presenter_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe MathsAndPhysics::AdminChecksPresenter, type: :model do
       expect(presenter.qualifications).to eq expected_array
     end
 
+    it "sets the “Award year” value based on the academic year the claim was made in" do
+      claim.academic_year = "2021/2022"
+
+      expected_qts_answer = presenter.qualifications[0][1]
+      expect(expected_qts_answer).to eq "In or after the academic year 2016 to 2017"
+    end
+
     it "includes the subject specialism if they chose science" do
       eligibility.initial_teacher_training_subject = :science
       eligibility.initial_teacher_training_subject_specialism = :physics

--- a/spec/models/maths_and_physics/admin_checks_presenter_spec.rb
+++ b/spec/models/maths_and_physics/admin_checks_presenter_spec.rb
@@ -2,15 +2,18 @@ require "rails_helper"
 
 RSpec.describe MathsAndPhysics::AdminChecksPresenter, type: :model do
   let(:school) { schools(:penistone_grammar_school) }
-  let(:eligibility) do
-    build(:maths_and_physics_eligibility,
-      teaching_maths_or_physics: true,
-      current_school: school,
-      initial_teacher_training_subject: :maths,
-      initial_teacher_training_subject_specialism: nil,
-      qts_award_year: "on_or_after_cut_off_date")
+  let(:eligibility) { claim.eligibility }
+  let(:claim) do
+    build(:claim,
+      academic_year: "2019/2020",
+      eligibility: build(:maths_and_physics_eligibility,
+        teaching_maths_or_physics: true,
+        current_school: school,
+        initial_teacher_training_subject: :maths,
+        initial_teacher_training_subject_specialism: nil,
+        qts_award_year: "on_or_after_cut_off_date"))
   end
-  subject(:presenter) { described_class.new(eligibility) }
+  subject(:presenter) { described_class.new(claim) }
 
   describe "#qualifications" do
     it "returns an array of label and values for displaying information for qualification checks" do

--- a/spec/models/maths_and_physics/admin_checks_presenter_spec.rb
+++ b/spec/models/maths_and_physics/admin_checks_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MathsAndPhysics::AdminChecksPresenter, type: :model do
   describe "#qualifications" do
     it "returns an array of label and values for displaying information for qualification checks" do
       expected_array = [
-        [I18n.t("admin.qts_award_year"), "In or after the academic year 2014 to 2015"],
+        ["Award year", "In or after the academic year 2014 to 2015"],
         ["ITT subject", "Maths"],
       ]
       expect(presenter.qualifications).to eq expected_array
@@ -26,7 +26,7 @@ RSpec.describe MathsAndPhysics::AdminChecksPresenter, type: :model do
       eligibility.initial_teacher_training_subject_specialism = :physics
 
       expected_array = [
-        [I18n.t("admin.qts_award_year"), "In or after the academic year 2014 to 2015"],
+        ["Award year", "In or after the academic year 2014 to 2015"],
         ["ITT subject", "Physics"],
       ]
       expect(presenter.qualifications).to eq expected_array

--- a/spec/models/maths_and_physics/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_admin_answers_presenter_spec.rb
@@ -2,19 +2,21 @@ require "rails_helper"
 
 RSpec.describe MathsAndPhysics::EligibilityAdminAnswersPresenter, type: :model do
   let(:school) { schools(:penistone_grammar_school) }
-  let(:eligibility) do
-    build(:maths_and_physics_eligibility,
-      teaching_maths_or_physics: true,
-      current_school: school,
-      initial_teacher_training_subject: :maths,
-      initial_teacher_training_subject_specialism: :not_sure,
-      qts_award_year: "on_or_after_cut_off_date",
-      has_uk_maths_or_physics_degree: "has_non_uk",
-      employed_as_supply_teacher: true,
-      has_entire_term_contract: true,
-      employed_directly: true,
-      subject_to_disciplinary_action: true,
-      subject_to_formal_performance_action: true)
+  let(:eligibility) { claim.eligibility }
+  let(:claim) do
+    build(:claim,
+      eligibility: build(:maths_and_physics_eligibility,
+        teaching_maths_or_physics: true,
+        current_school: school,
+        initial_teacher_training_subject: :maths,
+        initial_teacher_training_subject_specialism: :not_sure,
+        qts_award_year: "on_or_after_cut_off_date",
+        has_uk_maths_or_physics_degree: "has_non_uk",
+        employed_as_supply_teacher: true,
+        has_entire_term_contract: true,
+        employed_directly: true,
+        subject_to_disciplinary_action: true,
+        subject_to_formal_performance_action: true))
   end
   subject(:presenter) { described_class.new(eligibility) }
 

--- a/spec/models/maths_and_physics/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_admin_answers_presenter_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe MathsAndPhysics::EligibilityAdminAnswersPresenter, type: :model d
   let(:eligibility) { claim.eligibility }
   let(:claim) do
     build(:claim,
+      academic_year: "2019/2020",
       eligibility: build(:maths_and_physics_eligibility,
         teaching_maths_or_physics: true,
         current_school: school,
@@ -37,6 +38,13 @@ RSpec.describe MathsAndPhysics::EligibilityAdminAnswersPresenter, type: :model d
       ]
 
       expect(presenter.answers).to eq expected_answers
+    end
+
+    it "changes the answer for the QTS question based on the answer academic year the claim was made" do
+      claim.academic_year = "2021/2022"
+
+      expected_qts_answer = presenter.answers[5][1]
+      expect(expected_qts_answer).to eq("In or after the academic year 2016 to 2017")
     end
 
     it "excludes questions skipped from the flow" do

--- a/spec/models/maths_and_physics/eligibility_answers_presenter_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_answers_presenter_spec.rb
@@ -1,16 +1,20 @@
 require "rails_helper"
 
 RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
-  let(:eligibility) do
-    build(:maths_and_physics_eligibility,
+  let(:eligibility_attributes) do
+    {
       teaching_maths_or_physics: true,
       current_school: schools(:penistone_grammar_school),
       initial_teacher_training_subject: :maths,
       qts_award_year: "on_or_after_cut_off_date",
       employed_as_supply_teacher: false,
       subject_to_disciplinary_action: false,
-      subject_to_formal_performance_action: false)
+      subject_to_formal_performance_action: false,
+    }
   end
+  let(:eligibility) { claim.eligibility }
+  let(:claim) { build(:claim, eligibility: build(:maths_and_physics_eligibility, eligibility_attributes)) }
+
   subject(:presenter) { described_class.new(eligibility) }
 
   it "returns an array of questions and answers to be presented to the user for checking" do
@@ -27,19 +31,19 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
     expect(presenter.answers).to eq(expected_answers)
   end
 
-  it "changes the answer for the QTS question based on the answer and the configured academic year" do
-    policy_configurations(:maths_and_physics).update!(current_academic_year: "2021/2022")
+  it "changes the answer for the QTS question based on the answer and the claim's academic year" do
+    claim.academic_year = "2021/2022"
     qts_answer = presenter.answers[3][1]
     expect(qts_answer).to eq("In or after the academic year 2016 to 2017")
 
-    presenter.eligibility.qts_award_year = :before_cut_off_date
+    eligibility.qts_award_year = :before_cut_off_date
     qts_answer = presenter.answers[3][1]
     expect(qts_answer).to eq("In or before the academic year 2015 to 2016")
   end
 
   context "initial teacher training subject not in a science" do
-    let(:eligibility) do
-      build(:maths_and_physics_eligibility,
+    let(:eligibility_attributes) do
+      {
         teaching_maths_or_physics: true,
         current_school: schools(:penistone_grammar_school),
         initial_teacher_training_subject: :none_of_the_subjects,
@@ -47,7 +51,8 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
         qts_award_year: "on_or_after_cut_off_date",
         employed_as_supply_teacher: false,
         subject_to_disciplinary_action: false,
-        subject_to_formal_performance_action: false)
+        subject_to_formal_performance_action: false,
+      }
     end
 
     it "includes the specialism and degree in the questions and answers" do
@@ -67,8 +72,8 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
   end
 
   context "initial teacher training subject specialism and degree questions answered" do
-    let(:eligibility) do
-      build(:maths_and_physics_eligibility,
+    let(:eligibility_attributes) do
+      {
         teaching_maths_or_physics: true,
         current_school: schools(:penistone_grammar_school),
         initial_teacher_training_subject: :science,
@@ -77,7 +82,8 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
         qts_award_year: "on_or_after_cut_off_date",
         employed_as_supply_teacher: false,
         subject_to_disciplinary_action: false,
-        subject_to_formal_performance_action: false)
+        subject_to_formal_performance_action: false,
+      }
     end
 
     it "includes the specialism and degree in the questions and answers" do
@@ -98,8 +104,8 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
   end
 
   context "employed as supply teacher" do
-    let(:eligibility) do
-      build(:maths_and_physics_eligibility,
+    let(:eligibility_attributes) do
+      {
         teaching_maths_or_physics: true,
         current_school: schools(:penistone_grammar_school),
         initial_teacher_training_subject: :physics,
@@ -109,7 +115,8 @@ RSpec.describe MathsAndPhysics::EligibilityAnswersPresenter do
         has_entire_term_contract: true,
         employed_directly: true,
         subject_to_disciplinary_action: false,
-        subject_to_formal_performance_action: false)
+        subject_to_formal_performance_action: false,
+      }
     end
 
     it "includes supply teacher questions" do

--- a/spec/models/maths_and_physics/eligibility_spec.rb
+++ b/spec/models/maths_and_physics/eligibility_spec.rb
@@ -178,6 +178,22 @@ RSpec.describe MathsAndPhysics::Eligibility, type: :model do
     end
   end
 
+  describe "#qts_award_year_answer" do
+    it "returns a String representing the answer of the QTS question based on qts_award_year and the academic year the claim was made in" do
+      claim = Claim.new(academic_year: 2019)
+      eligibility = MathsAndPhysics::Eligibility.new(claim: claim)
+
+      eligibility.qts_award_year = :before_cut_off_date
+      expect(eligibility.qts_award_year_answer).to eq "In or before the academic year 2013 to 2014"
+
+      eligibility.qts_award_year = :on_or_after_cut_off_date
+      expect(eligibility.qts_award_year_answer).to eq "In or after the academic year 2014 to 2015"
+
+      claim.academic_year = "2020/2021"
+      expect(eligibility.qts_award_year_answer).to eq "In or after the academic year 2015 to 2016"
+    end
+  end
+
   # Validation contexts
   context "when saving in the “teaching-maths-or-physics” context" do
     it "is not valid without a value for teaching_maths_or_physics" do

--- a/spec/models/maths_and_physics_spec.rb
+++ b/spec/models/maths_and_physics_spec.rb
@@ -11,5 +11,9 @@ RSpec.describe MathsAndPhysics, type: :model do
       policy_configuration.update!(current_academic_year: "2025/2026")
       expect(MathsAndPhysics.first_eligible_qts_award_year).to eq AcademicYear.new(2020)
     end
+
+    it "can return the AcademicYear based on a passed-in academic year" do
+      expect(MathsAndPhysics.first_eligible_qts_award_year(AcademicYear.new(2021))).to eq AcademicYear.new(2016)
+    end
   end
 end

--- a/spec/models/student_loans/admin_checks_presenter_spec.rb
+++ b/spec/models/student_loans/admin_checks_presenter_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe StudentLoans::AdminChecksPresenter, type: :model do
     it "returns an array of label and values for displaying information for qualification checks" do
       expect(presenter.qualifications).to eq [["Award year", "In or after the academic year 2013 to 2014"]]
     end
+
+    it "sets the “Award year” value based on the academic year the claim was made in" do
+      claim.academic_year = "2030/2031"
+
+      expected_qts_answer = presenter.qualifications[0][1]
+      expect(expected_qts_answer).to eq "In or after the academic year 2019 to 2020"
+    end
   end
 
   describe "#employment" do

--- a/spec/models/student_loans/admin_checks_presenter_spec.rb
+++ b/spec/models/student_loans/admin_checks_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe StudentLoans::AdminChecksPresenter, type: :model do
 
   describe "#qualifications" do
     it "returns an array of label and values for displaying information for qualification checks" do
-      expect(presenter.qualifications).to eq [[I18n.t("admin.qts_award_year"), "In or after the academic year 2013 to 2014"]]
+      expect(presenter.qualifications).to eq [["Award year", "In or after the academic year 2013 to 2014"]]
     end
   end
 

--- a/spec/models/student_loans/admin_checks_presenter_spec.rb
+++ b/spec/models/student_loans/admin_checks_presenter_spec.rb
@@ -2,15 +2,18 @@ require "rails_helper"
 
 RSpec.describe StudentLoans::AdminChecksPresenter, type: :model do
   let(:school) { schools(:penistone_grammar_school) }
-  let(:eligibility) do
-    build(
-      :student_loans_eligibility,
-      qts_award_year: "on_or_after_cut_off_date",
-      claim_school: school,
-      current_school: school,
-    )
+  let(:eligibility) { claim.eligibility }
+  let(:claim) do
+    build(:claim,
+      academic_year: "2019/2020",
+      eligibility: build(
+        :student_loans_eligibility,
+        qts_award_year: "on_or_after_cut_off_date",
+        claim_school: school,
+        current_school: school,
+      ))
   end
-  subject(:presenter) { described_class.new(eligibility) }
+  subject(:presenter) { described_class.new(claim) }
 
   describe "#qualifications" do
     it "returns an array of label and values for displaying information for qualification checks" do

--- a/spec/models/student_loans/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_admin_answers_presenter_spec.rb
@@ -2,18 +2,18 @@ require "rails_helper"
 
 RSpec.describe StudentLoans::EligibilityAdminAnswersPresenter, type: :model do
   let(:school) { schools(:penistone_grammar_school) }
-  let(:eligibility) do
-    build(
-      :student_loans_eligibility,
-      qts_award_year: "on_or_after_cut_off_date",
-      claim_school: school,
-      current_school: school,
-      chemistry_taught: true,
-      physics_taught: true,
-      had_leadership_position: true,
-      mostly_performed_leadership_duties: false,
-      student_loan_repayment_amount: 1987.65,
-    )
+  let(:eligibility) { claim.eligibility }
+  let(:claim) do
+    build(:claim,
+      eligibility: build(:student_loans_eligibility,
+        qts_award_year: "on_or_after_cut_off_date",
+        claim_school: school,
+        current_school: school,
+        chemistry_taught: true,
+        physics_taught: true,
+        had_leadership_position: true,
+        mostly_performed_leadership_duties: false,
+        student_loan_repayment_amount: 1987.65))
   end
   subject(:presenter) { described_class.new(eligibility) }
 

--- a/spec/models/student_loans/eligibility_admin_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_admin_answers_presenter_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe StudentLoans::EligibilityAdminAnswersPresenter, type: :model do
   let(:eligibility) { claim.eligibility }
   let(:claim) do
     build(:claim,
+      academic_year: "2019/2020",
       eligibility: build(:student_loans_eligibility,
         qts_award_year: "on_or_after_cut_off_date",
         claim_school: school,
@@ -29,6 +30,13 @@ RSpec.describe StudentLoans::EligibilityAdminAnswersPresenter, type: :model do
       ]
 
       expect(presenter.answers).to eq expected_answers
+    end
+
+    it "changes the answer for the QTS question based on the answer academic year the claim was made" do
+      claim.academic_year = "2029/2030"
+
+      expected_qts_answer = presenter.answers[0][1]
+      expect(expected_qts_answer).to eq("In or after the academic year 2018 to 2019")
     end
 
     it "excludes questions skipped from the flow" do

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -13,12 +13,9 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
     }.merge(subject_attributes)
   end
   let(:subject_attributes) { {chemistry_taught: true, physics_taught: true} }
-  let(:eligibility) do
-    build(
-      :student_loans_eligibility,
-      eligibility_attributes
-    )
-  end
+  let(:eligibility) { claim.eligibility }
+  let(:claim) { build(:claim, eligibility: build(:student_loans_eligibility, eligibility_attributes)) }
+
   subject(:presenter) { described_class.new(eligibility) }
 
   it "returns an array of questions, answers, and slugs for displaying to the user for review" do
@@ -35,13 +32,13 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
     expect(presenter.answers).to eq expected_answers
   end
 
-  it "changes the answer for the QTS question, based on the configured academic year" do
-    policy_configurations(:student_loans).update!(current_academic_year: "2027/2028")
+  it "changes the answer for the QTS question based on the answer and the claim's academic year" do
+    claim.academic_year = "2027/2028"
 
     qts_answer = presenter.answers[0][1]
     expect(qts_answer).to eq("In or after the academic year 2016 to 2017")
 
-    presenter.eligibility.qts_award_year = :before_cut_off_date
+    eligibility.qts_award_year = :before_cut_off_date
     qts_answer = presenter.answers[0][1]
     expect(qts_answer).to eq("In or before the academic year 2015 to 2016")
   end

--- a/spec/models/student_loans/eligibility_spec.rb
+++ b/spec/models/student_loans/eligibility_spec.rb
@@ -226,6 +226,22 @@ RSpec.describe StudentLoans::Eligibility, type: :model do
     end
   end
 
+  describe "#qts_award_year_answer" do
+    it "returns a String representing the answer of the QTS question based on qts_award_year and the academic year the claim was made in" do
+      claim = Claim.new(academic_year: 2019)
+      eligibility = StudentLoans::Eligibility.new(claim: claim)
+
+      eligibility.qts_award_year = :before_cut_off_date
+      expect(eligibility.qts_award_year_answer).to eq "In or before the academic year 2012 to 2013"
+
+      eligibility.qts_award_year = :on_or_after_cut_off_date
+      expect(eligibility.qts_award_year_answer).to eq "In or after the academic year 2013 to 2014"
+
+      claim.academic_year = "2025/2026"
+      expect(eligibility.qts_award_year_answer).to eq "In or after the academic year 2014 to 2015"
+    end
+  end
+
   # Validation contexts
   context "when saving in the “qts-year” context" do
     it "is not valid without a value for qts_award_year" do

--- a/spec/models/student_loans_spec.rb
+++ b/spec/models/student_loans_spec.rb
@@ -17,5 +17,9 @@ RSpec.describe StudentLoans, type: :model do
       policy_configuration.update!(current_academic_year: "2023/2024")
       expect(StudentLoans.first_eligible_qts_award_year).to eq AcademicYear.new(2013)
     end
+
+    it "can return the AcademicYear based on a passed-in academic year" do
+      expect(StudentLoans.first_eligible_qts_award_year(AcademicYear.new(2030))).to eq AcademicYear.new(2019)
+    end
   end
 end

--- a/spec/requests/admin_checks_spec.rb
+++ b/spec/requests/admin_checks_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Admin checks", type: :request do
           it "renders the requested page" do
             get admin_claim_check_path(claim, "qualifications")
             expect(response.body).to include(I18n.t("admin.qts_award_year"))
-            expect(response.body).to include(I18n.t("#{claim.policy.to_s.underscore}.questions.qts_award_years.#{claim.eligibility.qts_award_year}"))
+            expect(response.body).to include(claim.eligibility.qts_award_year_answer)
 
             get admin_claim_check_path(claim, "employment")
             expect(response.body).to include(I18n.t("admin.current_school"))

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Admin claims", type: :request do
           expect(response.body).to include(claim.reference)
           expect(response.body).to include(claim.teacher_reference_number)
           expect(response.body).to include(claim.eligibility.current_school_name)
-          expect(response.body).to include(I18n.t("#{policy.to_s.underscore}.questions.qts_award_years.#{claim.eligibility.qts_award_year}"))
+          expect(response.body).to include(claim.eligibility.qts_award_year_answer)
         end
 
         context "when another claim has matching attributes" do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -31,8 +31,8 @@ module FeatureHelpers
     Claim.order(:created_at).last
   end
 
-  def choose_qts_year(year = "In or after the academic year 2013 to 2014")
-    choose year
+  def choose_qts_year(option = :on_or_after_cut_off_date)
+    choose "claim_eligibility_attributes_qts_award_year_#{option}"
     click_on "Continue"
   end
 


### PR DESCRIPTION
This is the second part of the work to support future claim windows. It updates the back-office screens so that the QTS award year displayed to claim checkers will reflect the year the claim was made. For example, an eligible Maths & Physics claim made this year (2019/2020) will show the claimant's answer as "In or after the academic year 2014 to 2015", whilst a Maths & Physics claim made next year (2020/2021) will show "In or after the academic year 2015 to 2016".