### PR TITLE
Remove `linuxFxVersion` from app service

### DIFF
--- a/azure/templates/app.json
+++ b/azure/templates/app.json
@@ -183,7 +183,6 @@
         "httpsOnly": true,
         "siteConfig": {
           "alwaysOn": "[parameters('appServiceAlwaysOn')]",
-          "linuxFxVersion": "[parameters('appServiceRuntimeStack')]",
           "appSettings": "[parameters('appServiceEnvironmentVariables')]"
         }
       }

--- a/azure/templates/vsp.json
+++ b/azure/templates/vsp.json
@@ -94,7 +94,6 @@
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
         "siteConfig": {
           "alwaysOn": "[parameters('appServiceAlwaysOn')]",
-          "linuxFxVersion": "[parameters('appServiceRuntimeStack')]",
           "appSettings": "[parameters('appServiceEnvironmentVariables')]",
           "copy": [
             {


### PR DESCRIPTION
The presence of `linuxFxVersion` (which is the Docker image) is telling the app service to deploy straight away. If we remove this, it keeps the previous version running in the background and only pulls down the latest version and starts the container once the slots have been swapped.

<!-- Do you need to update CHANGELOG.md? -->
