### PR TITLE
Claim decision page is shown at the end of the checks process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog]
 
 - QTS question will vary based on the year the service is accepting claims for
 - QTS answer will vary in admin based on the year the claim was made
+- Claim decision page is shown at the end of the checks process
 
 ## [Release 056] - 2020-02-25
 

--- a/app/controllers/admin/checks_controller.rb
+++ b/app/controllers/admin/checks_controller.rb
@@ -38,7 +38,7 @@ class Admin::ChecksController < Admin::BaseAdminController
     if next_check.present?
       admin_claim_check_path(@claim, check: next_check)
     else
-      admin_claim_path(@claim, anchor: "claim_decision_form")
+      new_admin_claim_decision_path(@claim)
     end
   end
 end

--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -7,6 +7,7 @@ class Admin::DecisionsController < Admin::BaseAdminController
 
   def new
     @decision = Decision.new
+    @claims_preventing_payment = claims_preventing_payment_finder.claims_preventing_payment
   end
 
   def create

--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -2,8 +2,12 @@ class Admin::DecisionsController < Admin::BaseAdminController
   before_action :ensure_service_operator
   before_action :load_claim
   before_action :reject_decided_claims
-  before_action :reject_missing_payroll_gender
-  before_action :reject_if_claims_preventing_payment
+  before_action :reject_missing_payroll_gender, only: [:create]
+  before_action :reject_if_claims_preventing_payment, only: [:create]
+
+  def new
+    @decision = Decision.new
+  end
 
   def create
     @decision = @claim.build_decision(decision_params.merge(created_by: admin_user))
@@ -13,7 +17,7 @@ class Admin::DecisionsController < Admin::BaseAdminController
       redirect_to admin_claims_path, notice: "Claim has been #{@claim.decision.result} successfully"
     else
       @claims_preventing_payment = claims_preventing_payment_finder.claims_preventing_payment
-      render "admin/claims/show"
+      render "new"
     end
   end
 

--- a/app/views/admin/claims/_claims_with_matching_details.html.erb
+++ b/app/views/admin/claims/_claims_with_matching_details.html.erb
@@ -1,0 +1,23 @@
+<table id="claims-with-matches" class="govuk-table govuk-!-margin-bottom-9">
+  <caption class="govuk-table__caption govuk-heading-l">Claims with matching details</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Claim</th>
+      <th scope="col" class="govuk-table__header">Matching details</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% matching_claims.each do |matching_claim| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header"><%= link_to matching_claim.reference, [:admin, matching_claim], class: "govuk-link" %>
+        <td class="govuk-table__cell">
+          <ul class="govuk-list">
+            <% matching_attributes(claim, matching_claim).each do |attribute| %>
+              <li><%= attribute %></li>
+            <% end %>
+          </ul>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -42,16 +42,6 @@
 
     <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
 
-    <% if @claim.payroll_gender_missing? && !@claim.decision_made? %>
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive">Warning</span>
-          <%= t("admin.unknown_payroll_gender_preventing_approval_message") %>
-        </strong>
-      </div>
-    <% end %>
-
     <% if @matching_claims.any? %>
       <table id="claims-with-matches" class="govuk-table govuk-!-margin-bottom-9">
         <caption class="govuk-table__caption govuk-heading-l">Claims with matching details</caption>
@@ -78,61 +68,10 @@
       </table>
     <% end %>
 
-    <% if @claims_preventing_payment.any? %>
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive">Warning</span>
-          <%= t('admin.claims_preventing_payment_message', count: @claims_preventing_payment.count, claim_references: @claims_preventing_payment.map(&:reference).to_sentence) %>
-        </strong>
-      </div>
-    <% end %>
-
     <% if @decision.persisted? %>
       <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>
     <% else %>
-      <%= form_for @decision, url: admin_claim_decisions_path(@claim), html: { id: "claim_decision_form" } do |form| %>
-        <%= form_group_tag @decision do %>
-          <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-6">
-              <h2 class="govuk-fieldset__heading">
-                Claim decision
-              </h2>
-            </legend>
-
-            <% unless @claim.identity_confirmed? %>
-              <div class="govuk-warning-text">
-                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong class="govuk-warning-text__text">
-                  <span class="govuk-warning-text__assistive">Warning</span>
-                  This claimant did not complete GOV.UK Verify. Approve the
-                  claim only if the claimant's identity has been confirmed by
-                  an alternative method.
-                </strong>
-              </div>
-            <% end %>
-
-            <%= errors_tag @decision, :result %>
-            <div class="govuk-radios">
-              <%= form.hidden_field :result %>
-              <div class="govuk-radios__item">
-                <%= form.radio_button(:result, "approved", class: "govuk-radios__input", disabled: !@claim.approvable?) %>
-                <%= form.label "result_approved", "Approve", class: "govuk-label govuk-radios__label" %>
-              </div>
-              <div class="govuk-radios__item">
-                <%= form.radio_button(:result, "rejected", class: "govuk-radios__input") %>
-                <%= form.label "result_rejected", "Reject", class: "govuk-label govuk-radios__label" %>
-              </div>
-            </div>
-          </fieldset>
-          <%= form.label :notes, "Decision notes", class: "govuk-label govuk-label--m" %>
-          <span class="govuk-hint" id="notes-hint">
-            Please write a brief note explaining why this claim has been rejected or approved.
-          </span>
-          <%= form.text_area :notes, class: "govuk-textarea", "aria-describedby" => "notes-hint", rows: 5 %>
-          <%= form.submit "Submit", class: "govuk-button" %>
-        <% end %>
-      <% end %>
-    <% end %>
+      <%= render "admin/decisions/decision_form", claim: @claim, decision: @decision, claims_preventing_payment: @claims_preventing_payment %>
+  <% end %>
   </div>
 </div>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -42,31 +42,7 @@
 
     <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
 
-    <% if @matching_claims.any? %>
-      <table id="claims-with-matches" class="govuk-table govuk-!-margin-bottom-9">
-        <caption class="govuk-table__caption govuk-heading-l">Claims with matching details</caption>
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Claim</th>
-            <th scope="col" class="govuk-table__header">Matching details</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <% @matching_claims.each do |matching_claim| %>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header"><%= link_to matching_claim.reference, [:admin, matching_claim], class: "govuk-link" %>
-              <td class="govuk-table__cell">
-                <ul class="govuk-list">
-                <% matching_attributes(@claim, matching_claim).each do |attribute| %>
-                  <li><%= attribute %></li>
-                <% end %>
-                </ul>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    <% end %>
+    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim}) if @matching_claims.any? %>
 
     <% if @decision.persisted? %>
       <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>

--- a/app/views/admin/decisions/_decision_form.html.erb
+++ b/app/views/admin/decisions/_decision_form.html.erb
@@ -1,0 +1,52 @@
+<div class="govuk-grid-column-two-thirds">
+  <% if claim.payroll_gender_missing? && !claim.decision_made? %>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        <%= t("admin.unknown_payroll_gender_preventing_approval_message") %>
+      </strong>
+    </div>
+  <% end %>
+
+  <% if claims_preventing_payment.any? %>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        <%= t('admin.claims_preventing_payment_message', count: claims_preventing_payment.count, claim_references: claims_preventing_payment.map(&:reference).to_sentence) %>
+      </strong>
+    </div>
+  <% end %>
+
+  <%= form_for decision, url: admin_claim_decisions_path(claim), html: { id: "claim_decision_form" } do |form| %>
+    <%= form_group_tag decision do %>
+      <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-6">
+          <h2 class="govuk-fieldset__heading">
+            Claim decision
+          </h2>
+        </legend>
+
+        <%= errors_tag decision, :result %>
+        <div class="govuk-radios govuk-radios--inline">
+          <%= form.hidden_field :result %>
+          <div class="govuk-radios__item">
+            <%= form.radio_button(:result, "approved", class: "govuk-radios__input", disabled: !claim.approvable?) %>
+            <%= form.label "result_approved", "Approve", class: "govuk-label govuk-radios__label" %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= form.radio_button(:result, "rejected", class: "govuk-radios__input") %>
+            <%= form.label "result_rejected", "Reject", class: "govuk-label govuk-radios__label" %>
+          </div>
+        </div>
+      </fieldset>
+      <%= form.label :notes, "Decision notes", class: "govuk-label govuk-label--m" %>
+      <span class="govuk-hint" id="notes-hint">
+        Please write a brief note explaining why this claim has been rejected or approved.
+      </span>
+      <%= form.text_area :notes, class: "govuk-textarea", "aria-describedby" => "notes-hint", rows: 5 %>
+      <%= form.submit "Confirm decision", class: "govuk-button" %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -1,9 +1,32 @@
 <div class="govuk-grid-row">
   <%= render("shared/error_summary", instance: @decision, errored_field_id_overrides: { "result": "decision_result_approved" }) if @decision.errors.any? %>
 
+  <%= render("admin/claims/info_panel_identity_unconfirmed", school: @claim.school) unless @claim.identity_confirmed? %>
+
   <%= render "admin/checks/claim_summary", claim: @claim %>
 
   <div class="govuk-grid-column-two-thirds">
+
+
+  <% if @claim.payroll_gender_missing? && !@claim.decision_made? %>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        <%= t("admin.unknown_payroll_gender_preventing_approval_message") %>
+      </strong>
+    </div>
+  <% end %>
+
+  <% if @claims_preventing_payment.any? %>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        <%= t('admin.claims_preventing_payment_message', count: @claims_preventing_payment.count, claim_references: @claims_preventing_payment.map(&:reference).to_sentence) %>
+      </strong>
+    </div>
+  <% end %>
 
   <%= form_for @decision, url: admin_claim_decisions_path(@claim), html: { id: "claim_decision_form" } do |form| %>
     <%= form_group_tag @decision do %>

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -1,0 +1,39 @@
+<div class="govuk-grid-row">
+  <%= render("shared/error_summary", instance: @decision, errored_field_id_overrides: { "result": "decision_result_approved" }) if @decision.errors.any? %>
+
+  <%= render "admin/checks/claim_summary", claim: @claim %>
+
+  <div class="govuk-grid-column-two-thirds">
+
+  <%= form_for @decision, url: admin_claim_decisions_path(@claim), html: { id: "claim_decision_form" } do |form| %>
+    <%= form_group_tag @decision do %>
+      <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-6">
+          <h2 class="govuk-fieldset__heading">
+            Claim decision
+          </h2>
+        </legend>
+
+        <%= errors_tag @decision, :result %>
+        <div class="govuk-radios govuk-radios--inline">
+          <%= form.hidden_field :result %>
+          <div class="govuk-radios__item">
+            <%= form.radio_button(:result, "approved", class: "govuk-radios__input", disabled: !@claim.approvable?) %>
+            <%= form.label "result_approved", "Approve", class: "govuk-label govuk-radios__label" %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= form.radio_button(:result, "rejected", class: "govuk-radios__input") %>
+            <%= form.label "result_rejected", "Reject", class: "govuk-label govuk-radios__label" %>
+          </div>
+        </div>
+      </fieldset>
+      <%= form.label :notes, "Decision notes", class: "govuk-label govuk-label--m" %>
+      <span class="govuk-hint" id="notes-hint">
+        Please write a brief note explaining why this claim has been rejected or approved.
+      </span>
+      <%= form.text_area :notes, class: "govuk-textarea", "aria-describedby" => "notes-hint", rows: 5 %>
+      <%= form.submit "Confirm decision", class: "govuk-button" %>
+    <% end %>
+  <% end %>
+  </div>
+</div>

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -5,5 +5,7 @@
 
   <%= render "admin/checks/claim_summary", claim: @claim %>
 
+  <%= render("admin/claims/claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim}) if @matching_claims.any? %>
+
   <%= render "decision_form", claim: @claim, decision: @decision, claims_preventing_payment: @claims_preventing_payment %>
 </div>

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -5,58 +5,5 @@
 
   <%= render "admin/checks/claim_summary", claim: @claim %>
 
-  <div class="govuk-grid-column-two-thirds">
-
-
-  <% if @claim.payroll_gender_missing? && !@claim.decision_made? %>
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        <%= t("admin.unknown_payroll_gender_preventing_approval_message") %>
-      </strong>
-    </div>
-  <% end %>
-
-  <% if @claims_preventing_payment.any? %>
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        <%= t('admin.claims_preventing_payment_message', count: @claims_preventing_payment.count, claim_references: @claims_preventing_payment.map(&:reference).to_sentence) %>
-      </strong>
-    </div>
-  <% end %>
-
-  <%= form_for @decision, url: admin_claim_decisions_path(@claim), html: { id: "claim_decision_form" } do |form| %>
-    <%= form_group_tag @decision do %>
-      <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-6">
-          <h2 class="govuk-fieldset__heading">
-            Claim decision
-          </h2>
-        </legend>
-
-        <%= errors_tag @decision, :result %>
-        <div class="govuk-radios govuk-radios--inline">
-          <%= form.hidden_field :result %>
-          <div class="govuk-radios__item">
-            <%= form.radio_button(:result, "approved", class: "govuk-radios__input", disabled: !@claim.approvable?) %>
-            <%= form.label "result_approved", "Approve", class: "govuk-label govuk-radios__label" %>
-          </div>
-          <div class="govuk-radios__item">
-            <%= form.radio_button(:result, "rejected", class: "govuk-radios__input") %>
-            <%= form.label "result_rejected", "Reject", class: "govuk-label govuk-radios__label" %>
-          </div>
-        </div>
-      </fieldset>
-      <%= form.label :notes, "Decision notes", class: "govuk-label govuk-label--m" %>
-      <span class="govuk-hint" id="notes-hint">
-        Please write a brief note explaining why this claim has been rejected or approved.
-      </span>
-      <%= form.text_area :notes, class: "govuk-textarea", "aria-describedby" => "notes-hint", rows: 5 %>
-      <%= form.submit "Confirm decision", class: "govuk-button" %>
-    <% end %>
-  <% end %>
-  </div>
+  <%= render "decision_form", claim: @claim, decision: @decision, claims_preventing_payment: @claims_preventing_payment %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,7 @@ Rails.application.routes.draw do
 
     resources :claims, only: [:index, :show] do
       resources :checks, only: [:index, :show, :create], param: :check, constraints: {check: %r{#{Admin::ChecksController::CHECKS_SEQUENCE.join("|")}}}
-      resources :decisions, only: [:create]
+      resources :decisions, only: [:create, :new]
       get "search", on: :collection
     end
 

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Admin checks a claim" do
         find("a[href='#{admin_claim_path(claim_to_approve)}']").click
         choose "Approve"
         fill_in "Decision notes", with: "Everything matches"
-        perform_enqueued_jobs { click_on "Submit" }
+        perform_enqueued_jobs { click_on "Confirm decision" }
 
         expect(claim_to_approve.decision.created_by).to eq(user)
         expect(claim_to_approve.decision.notes).to eq("Everything matches")
@@ -53,7 +53,7 @@ RSpec.feature "Admin checks a claim" do
       find("a[href='#{admin_claim_path(claim_to_reject)}']").click
       choose "Reject"
       fill_in "Decision notes", with: "TRN doesn't exist"
-      perform_enqueued_jobs { click_on "Submit" }
+      perform_enqueued_jobs { click_on "Confirm decision" }
 
       expect(claim_to_reject.decision.created_by).to eq(user)
       expect(claim_to_reject.decision.notes).to eq("TRN doesn't exist")
@@ -121,7 +121,7 @@ RSpec.feature "Admin checks a claim" do
       claim_with_decision = create(:claim, :submitted, decision: build(:decision, result: :approved, notes: "Everything matches"))
       visit admin_claim_path(claim_with_decision)
 
-      expect(page).not_to have_button("Submit")
+      expect(page).not_to have_button("Confirm decision")
       expect(page).to have_content("Claim decision")
       expect(page).to have_content("Approved")
       expect(page).to have_content(claim_with_decision.decision.notes)
@@ -201,7 +201,7 @@ RSpec.feature "Admin checks a claim" do
 
         choose "Approve"
         fill_in "Decision notes", with: "Identity confirmed via phone call"
-        click_on "Submit"
+        click_on "Confirm decision"
 
         expect(claim_without_identity_confirmation.decision.created_by).to eq(user)
         expect(claim_without_identity_confirmation.decision.notes).to eq("Identity confirmed via phone call")

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Admin checks a claim" do
       expect(mail.body.raw_source).to match("not been able to approve")
     end
 
-    scenario "User can see checks for a claim" do
+    scenario "User can complete the claim checks and approve a claim" do
       claim = create(:claim, :submitted, policy: MathsAndPhysics)
 
       visit admin_claims_path
@@ -91,6 +91,14 @@ RSpec.feature "Admin checks a claim" do
       click_on "Complete employment check and continue"
 
       expect(page).to have_content("Claim decision")
+
+      choose "Approve"
+      fill_in "Decision notes", with: "All checks passed!"
+      click_on "Confirm decision"
+
+      expect(page).to have_content("Claim has been approved successfully")
+      expect(claim.decision).to be_approved
+      expect(claim.decision.created_by).to eq(user)
     end
 
     scenario "User can see completed checks" do

--- a/spec/requests/admin_checks_spec.rb
+++ b/spec/requests/admin_checks_spec.rb
@@ -51,14 +51,14 @@ RSpec.describe "Admin checks", type: :request do
           context "when the last check is marked as completed" do
             let(:last_check) { Admin::ChecksController::CHECKS_SEQUENCE.last }
 
-            it "creates the check and redirects to the claims#show page" do
+            it "creates the check and redirects to the decision page" do
               expect {
                 post admin_claim_checks_path(claim, check: last_check)
               }.to change { Check.count }.by(1)
 
               expect(claim.checks.last.name).to eql(last_check)
               expect(claim.checks.last.created_by).to eql(user)
-              expect(response).to redirect_to(admin_claim_path(claim, anchor: "claim_decision_form"))
+              expect(response).to redirect_to(new_admin_claim_decision_path(claim))
             end
           end
 


### PR DESCRIPTION
As part of the changes to the new admin checks we want to show the claim decision form after the last check has been completed. There's currently no other way to get to this page, this might need revisiting later.

We've included the warnings associated with making a decision on a claim in the new decision form. The idea is to move these warnings in to their own checks, but until we get there it's important information for a service operator deciding on a claim's outcome.

<img width="1467" alt="Screenshot 2020-02-27 at 15 19 57" src="https://user-images.githubusercontent.com/2804149/75457679-a9ea3b80-5974-11ea-9f03-a060cb21c204.png">

Prototype for reference: https://fast-shelf-85846.herokuapp.com/claim/student-loan/decision