### PR TITLE
Update static error pages to make them policy-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog]
 
 - QTS question will vary based on the year the service is accepting claims for
 - QTS answer will vary in admin based on the year the claim was made
+- Update static error pages (404, 422, 500) to make them policy-agnostic
 
 ## [Release 056] - 2020-02-25
 

--- a/public/404.html
+++ b/public/404.html
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
   <head>
     <meta charset="utf-8" />
-    <title>Page not found – Teachers: claim back your student loan repayments – GOV.UK</title>
+    <title>Page not found – Claim additional payments for teaching – GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0b0c0c" />
 
@@ -55,7 +55,7 @@
         </div>
         <div class="govuk-header__content">
           <a href="/" class="govuk-header__link govuk-header__link--service-name">
-            Teachers: claim back your student loan repayments
+            Claim additional payments for teaching
           </a>
         </div>
       </div>

--- a/public/404.html
+++ b/public/404.html
@@ -71,7 +71,7 @@
             This is a new service – your
             <a
               class="govuk-link"
-              href="https://docs.google.com/forms/d/e/1FAIpQLSetTeh9vgaRDc2artdnhMrvmdc7EP8veKgEqUik2ZQfhaJDgg/viewform"
+              href="mailto:additionalteachingpayment@digital.education.gov.uk"
               >feedback</a
             >
             will help us to improve it.

--- a/public/404.html
+++ b/public/404.html
@@ -106,33 +106,6 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-visually-hidden">Support links</h2>
-            <ul class="govuk-footer__inline-list">
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/contact_us">
-                  Contact us
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/cookies">
-                  Cookies
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/terms_conditions">
-                  Terms and conditions
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/privacy_notice">
-                  Privacy Notice
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/accessibility_statement">
-                  Accessibility Statement
-                </a>
-              </li>
-            </ul>
 
             <p>
               Problems using this service? Email

--- a/public/422.html
+++ b/public/422.html
@@ -108,33 +108,6 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-visually-hidden">Support links</h2>
-            <ul class="govuk-footer__inline-list">
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/contact_us">
-                  Contact us
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/cookies">
-                  Cookies
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/terms_conditions">
-                  Terms and conditions
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/privacy_notice">
-                  Privacy Notice
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/accessibility_statement">
-                  Accessibility Statement
-                </a>
-              </li>
-            </ul>
 
             <p>
               Problems using this service? Email

--- a/public/422.html
+++ b/public/422.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>
-      Sorry, there is a problem with the service – Teachers: claim back your student loan repayments – GOV.UK
+      Sorry, there is a problem with the service – Claim additional payments for teaching – GOV.UK
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0b0c0c" />
@@ -57,7 +57,7 @@
         </div>
         <div class="govuk-header__content">
           <a href="/" class="govuk-header__link govuk-header__link--service-name">
-            Teachers: claim back your student loan repayments
+            Claim additional payments for teaching
           </a>
         </div>
       </div>

--- a/public/422.html
+++ b/public/422.html
@@ -73,7 +73,7 @@
             This is a new service – your
             <a
               class="govuk-link"
-              href="https://docs.google.com/forms/d/e/1FAIpQLSetTeh9vgaRDc2artdnhMrvmdc7EP8veKgEqUik2ZQfhaJDgg/viewform"
+              href="mailto:additionalteachingpayment@digital.education.gov.uk"
               >feedback</a
             >
             will help us to improve it.

--- a/public/500.html
+++ b/public/500.html
@@ -74,7 +74,7 @@
             This is a new service – your
             <a
               class="govuk-link"
-              href="https://docs.google.com/forms/d/e/1FAIpQLSetTeh9vgaRDc2artdnhMrvmdc7EP8veKgEqUik2ZQfhaJDgg/viewform"
+              href="mailto:additionalteachingpayment@digital.education.gov.uk"
               >feedback</a
             >
             will help us to improve it.

--- a/public/500.html
+++ b/public/500.html
@@ -109,33 +109,6 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-visually-hidden">Support links</h2>
-            <ul class="govuk-footer__inline-list">
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/contact_us">
-                  Contact us
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/cookies">
-                  Cookies
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/terms_conditions">
-                  Terms and conditions
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/privacy_notice">
-                  Privacy Notice
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/accessibility_statement">
-                  Accessibility Statement
-                </a>
-              </li>
-            </ul>
 
             <p>
               Problems using this service? Email

--- a/public/500.html
+++ b/public/500.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>
-      Sorry, there is a problem with the service – Teachers: claim back your student loan repayments – GOV.UK
+      Sorry, there is a problem with the service – Claim additional payments for teaching – GOV.UK
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0b0c0c" />
@@ -58,7 +58,7 @@
         </div>
         <div class="govuk-header__content">
           <a href="/" class="govuk-header__link govuk-header__link--service-name">
-            Teachers: claim back your student loan repayments
+            Claim additional payments for teaching
           </a>
         </div>
       </div>


### PR DESCRIPTION
The 404, 422 and 500 pages contain broken links and hardcoded references to the student loans policy. This PR makes them more generic. More details in commit messages.
