### PR TITLE
Make static error pages policy-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog]
 - QTS answer will vary in admin based on the year the claim was made
 - Claim decision page is shown at the end of the checks process
 - A service operator can amend a claim
+- Update static error pages (404, 422, 500) to make them policy-agnostic
 
 ## [Release 056] - 2020-02-25
 

--- a/public/404.html
+++ b/public/404.html
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
   <head>
     <meta charset="utf-8" />
-    <title>Page not found – Teachers: claim back your student loan repayments – GOV.UK</title>
+    <title>Page not found – Claim additional payments for teaching – GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0b0c0c" />
 
@@ -55,7 +55,7 @@
         </div>
         <div class="govuk-header__content">
           <a href="/" class="govuk-header__link govuk-header__link--service-name">
-            Teachers: claim back your student loan repayments
+            Claim additional payments for teaching
           </a>
         </div>
       </div>

--- a/public/404.html
+++ b/public/404.html
@@ -69,11 +69,7 @@
           </strong>
           <span class="govuk-phase-banner__text">
             This is a new service – your
-            <a
-              class="govuk-link"
-              href="https://docs.google.com/forms/d/e/1FAIpQLSetTeh9vgaRDc2artdnhMrvmdc7EP8veKgEqUik2ZQfhaJDgg/viewform"
-              >feedback</a
-            >
+            <a class="govuk-link" href="mailto:additionalteachingpayment@digital.education.gov.uk">feedback</a>
             will help us to improve it.
           </span>
         </p>

--- a/public/404.html
+++ b/public/404.html
@@ -102,33 +102,6 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-visually-hidden">Support links</h2>
-            <ul class="govuk-footer__inline-list">
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/contact_us">
-                  Contact us
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/cookies">
-                  Cookies
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/terms_conditions">
-                  Terms and conditions
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/privacy_notice">
-                  Privacy Notice
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/accessibility_statement">
-                  Accessibility Statement
-                </a>
-              </li>
-            </ul>
 
             <p>
               Problems using this service? Email

--- a/public/422.html
+++ b/public/422.html
@@ -71,11 +71,7 @@
           </strong>
           <span class="govuk-phase-banner__text">
             This is a new service – your
-            <a
-              class="govuk-link"
-              href="https://docs.google.com/forms/d/e/1FAIpQLSetTeh9vgaRDc2artdnhMrvmdc7EP8veKgEqUik2ZQfhaJDgg/viewform"
-              >feedback</a
-            >
+            <a class="govuk-link" href="mailto:additionalteachingpayment@digital.education.gov.uk">feedback</a>
             will help us to improve it.
           </span>
         </p>

--- a/public/422.html
+++ b/public/422.html
@@ -104,33 +104,6 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-visually-hidden">Support links</h2>
-            <ul class="govuk-footer__inline-list">
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/contact_us">
-                  Contact us
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/cookies">
-                  Cookies
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/terms_conditions">
-                  Terms and conditions
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/privacy_notice">
-                  Privacy Notice
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/accessibility_statement">
-                  Accessibility Statement
-                </a>
-              </li>
-            </ul>
 
             <p>
               Problems using this service? Email

--- a/public/422.html
+++ b/public/422.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>
-      Sorry, there is a problem with the service – Teachers: claim back your student loan repayments – GOV.UK
+      Sorry, there is a problem with the service – Claim additional payments for teaching – GOV.UK
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0b0c0c" />
@@ -57,7 +57,7 @@
         </div>
         <div class="govuk-header__content">
           <a href="/" class="govuk-header__link govuk-header__link--service-name">
-            Teachers: claim back your student loan repayments
+            Claim additional payments for teaching
           </a>
         </div>
       </div>

--- a/public/500.html
+++ b/public/500.html
@@ -105,33 +105,6 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-visually-hidden">Support links</h2>
-            <ul class="govuk-footer__inline-list">
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/contact_us">
-                  Contact us
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/cookies">
-                  Cookies
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/terms_conditions">
-                  Terms and conditions
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/privacy_notice">
-                  Privacy Notice
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/accessibility_statement">
-                  Accessibility Statement
-                </a>
-              </li>
-            </ul>
 
             <p>
               Problems using this service? Email

--- a/public/500.html
+++ b/public/500.html
@@ -72,11 +72,7 @@
           </strong>
           <span class="govuk-phase-banner__text">
             This is a new service – your
-            <a
-              class="govuk-link"
-              href="https://docs.google.com/forms/d/e/1FAIpQLSetTeh9vgaRDc2artdnhMrvmdc7EP8veKgEqUik2ZQfhaJDgg/viewform"
-              >feedback</a
-            >
+            <a class="govuk-link" href="mailto:additionalteachingpayment@digital.education.gov.uk">feedback</a>
             will help us to improve it.
           </span>
         </p>

--- a/public/500.html
+++ b/public/500.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>
-      Sorry, there is a problem with the service – Teachers: claim back your student loan repayments – GOV.UK
+      Sorry, there is a problem with the service – Claim additional payments for teaching – GOV.UK
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0b0c0c" />
@@ -58,7 +58,7 @@
         </div>
         <div class="govuk-header__content">
           <a href="/" class="govuk-header__link govuk-header__link--service-name">
-            Teachers: claim back your student loan repayments
+            Claim additional payments for teaching
           </a>
         </div>
       </div>


### PR DESCRIPTION
The 404, 422 and 500 pages contain broken links and hardcoded references to the student loans policy. This PR makes them more generic. More details in commit messages.
