### PR TITLE
Fix log formatting simplification

### DIFF
--- a/config/initializers/logstash.rb
+++ b/config/initializers/logstash.rb
@@ -1,6 +1,7 @@
 if ENV["LOGSTASH_HOST"].present?
   LogStashLogger.configure do |logstash_config|
     logstash_config.customize_event do |event|
+      event["named_tags"] ||= {}
       event["named_tags"]["environment"] = ENV.fetch("ENVIRONMENT_NAME")
     end
   end


### PR DESCRIPTION
The `event` hash doesn't, by default, have a `named_tags` hash, so settting `event["named_tags"]["environment"] =` breaks logging as things currently stand