### PR TITLE
Allow claims to have multiple decisions

### DIFF
--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -2,7 +2,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
   before_action :ensure_service_operator
 
   def index
-    @claims = Claim.includes(:decision, eligibility: [:claim_school, :current_school]).awaiting_decision.order(:submitted_at)
+    @claims = Claim.includes(:decisions, eligibility: [:claim_school, :current_school]).awaiting_decision.order(:submitted_at)
     @claims = @claims.by_policy(filtered_policy) if filtered_policy
 
     respond_to do |format|

--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -11,7 +11,7 @@ class Admin::DecisionsController < Admin::BaseAdminController
   end
 
   def create
-    @decision = @claim.build_decision(decision_params.merge(created_by: admin_user))
+    @decision = @claim.decisions.build(decision_params.merge(created_by: admin_user))
     if @decision.save
       send_claim_result_email
       RecordOrUpdateGeckoboardDatasetJob.perform_later([@claim.id])

--- a/app/models/claim/pii_scrubber.rb
+++ b/app/models/claim/pii_scrubber.rb
@@ -45,7 +45,7 @@ class Claim
 
     def old_claims_rejected_or_paid
       Claim.left_outer_joins(payment: [:payroll_run])
-        .joins(:decision)
+        .joins(:decisions)
         .where(pii_removed_at: nil)
         .where(
           "(decisions.result = :rejected AND decisions.created_at < :minimum_time) OR scheduled_payment_date < :minimum_time",

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -15,7 +15,7 @@ class Decision < ApplicationRecord
   end
 
   def number_of_days_since_claim_submitted
-    (claim.decision.created_at.to_date - claim.submitted_at.to_date).to_i
+    (created_at.to_date - claim.submitted_at.to_date).to_i
   end
 
   private

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -56,12 +56,16 @@ FactoryBot.define do
 
     trait :approved do
       submitted
-      association(:decision, factory: [:decision, :approved], strategy: :build)
+      after(:build) do |claim|
+        claim.decisions.append(build(:decision, :approved))
+      end
     end
 
     trait :rejected do
       submitted
-      association(:decision, factory: [:decision, :rejected], strategy: :build)
+      after(:build) do |claim|
+        claim.decisions.append(build(:decision, :rejected))
+      end
     end
 
     trait :ineligible do

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -118,7 +118,7 @@ RSpec.feature "Admin checks a claim" do
     end
 
     scenario "User can see existing decision details" do
-      claim_with_decision = create(:claim, :submitted, decision: build(:decision, result: :approved, notes: "Everything matches"))
+      claim_with_decision = create(:claim, :submitted, decisions: [build(:decision, result: :approved, notes: "Everything matches")])
       visit admin_claim_path(claim_with_decision)
 
       expect(page).not_to have_button("Confirm decision")

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -426,6 +426,28 @@ RSpec.describe Claim, type: :model do
     end
   end
 
+  describe "approved" do
+    let!(:submitted_claims) { create_list(:claim, 5, :submitted) }
+    let!(:unsubmitted_claims) { create_list(:claim, 2, :submittable) }
+    let!(:approved_claims) { create_list(:claim, 5, :approved) }
+    let!(:rejected_claims) { create_list(:claim, 5, :rejected) }
+
+    it "returns approved claims" do
+      expect(subject.class.approved).to match_array(approved_claims)
+    end
+  end
+
+  describe "rejected" do
+    let!(:submitted_claims) { create_list(:claim, 5, :submitted) }
+    let!(:unsubmitted_claims) { create_list(:claim, 2, :submittable) }
+    let!(:approved_claims) { create_list(:claim, 5, :approved) }
+    let!(:rejected_claims) { create_list(:claim, 5, :rejected) }
+
+    it "returns rejected claims" do
+      expect(subject.class.rejected).to match_array(rejected_claims)
+    end
+  end
+
   describe "#submittable?" do
     it "returns true when the claim is valid and has not been submitted" do
       claim = build(:claim, :submittable)

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -422,7 +422,7 @@ RSpec.describe Claim, type: :model do
     let!(:approved_claims) { create_list(:claim, 5, :approved) }
 
     it "returns submitted claims awaiting a decision" do
-      expect(subject.class.awaiting_decision).to match_array(submitted_claims)
+      expect(Claim.awaiting_decision).to match_array(submitted_claims)
     end
   end
 
@@ -433,7 +433,7 @@ RSpec.describe Claim, type: :model do
     let!(:rejected_claims) { create_list(:claim, 5, :rejected) }
 
     it "returns approved claims" do
-      expect(subject.class.approved).to match_array(approved_claims)
+      expect(Claim.approved).to match_array(approved_claims)
     end
   end
 
@@ -444,7 +444,7 @@ RSpec.describe Claim, type: :model do
     let!(:rejected_claims) { create_list(:claim, 5, :rejected) }
 
     it "returns rejected claims" do
-      expect(subject.class.rejected).to match_array(rejected_claims)
+      expect(Claim.rejected).to match_array(rejected_claims)
     end
   end
 
@@ -486,6 +486,16 @@ RSpec.describe Claim, type: :model do
       create(:claim, :approved, teacher_reference_number: teacher_reference_number, date_of_birth: 20.years.ago)
 
       expect(create(:claim, :submitted, teacher_reference_number: teacher_reference_number, date_of_birth: 30.years.ago).approvable?).to eq false
+    end
+  end
+
+  describe "#decision" do
+    it "returns the latest decision on a claim" do
+      claim = build(:claim, :submitted)
+      claim.decisions.append(build(:decision, result: "approved", created_at: 7.days.ago))
+      claim.decisions.append(build(:decision, result: "rejected", created_at: DateTime.now))
+
+      expect(claim.decision.result).to eq "rejected"
     end
   end
 
@@ -651,7 +661,7 @@ RSpec.describe Claim, type: :model do
     let!(:second_unpayrolled_claim) { create(:claim, :approved) }
 
     it "returns approved claims that are not associated with a payroll run" do
-      expect(described_class.payrollable).to match_array([first_unpayrolled_claim, second_unpayrolled_claim])
+      expect(Claim.payrollable).to match_array([first_unpayrolled_claim, second_unpayrolled_claim])
     end
   end
 

--- a/spec/models/decision_spec.rb
+++ b/spec/models/decision_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe Decision, type: :model do
     expect(decision.errors.messages[:base]).to eq(["This claim cannot be approved"])
   end
 
+  it "prevents a claim with matching bank details from being approved" do
+    personal_details = {
+      teacher_reference_number: generate(:teacher_reference_number),
+      bank_sort_code: "112233"
+    }
+
+    create(:claim, :approved, personal_details.merge(bank_account_number: "12345678"))
+    claim_to_approve = create(:claim, :submitted, personal_details.merge(bank_account_number: "99999999"))
+    decision = build(:decision, claim: claim_to_approve, result: "approved")
+
+    expect(decision).not_to be_valid
+    expect(decision.errors.messages[:base]).to eq(["This claim cannot be approved"])
+  end
+
   it "returns the number of days between the claim being submitted and the claim being decisioned" do
     claim = create(:claim, :submitted, submitted_at: 12.days.ago)
     decision = build(:decision, claim: claim, created_at: DateTime.now)

--- a/spec/requests/admin_payroll_runs_spec.rb
+++ b/spec/requests/admin_payroll_runs_spec.rb
@@ -32,23 +32,6 @@ RSpec.describe "Admin payroll runs" do
 
         expect(response).to redirect_to(admin_payroll_run_path(payroll_run))
       end
-
-      context "when a payroll run contains claims from the same person with different bank details" do
-        it "doesn’t create a payroll run and shows an error" do
-          personal_details = {
-            teacher_reference_number: generate(:teacher_reference_number),
-            bank_sort_code: "112233"
-          }
-          claims = [
-            create(:claim, :approved, personal_details.merge(bank_account_number: "12345678")),
-            create(:claim, :approved, personal_details.merge(bank_account_number: "99999999"))
-          ]
-
-          expect { post admin_payroll_runs_path(claim_ids: claims.map(&:id)) }.to change { PayrollRun.count }.by(0)
-          follow_redirect!
-          expect(response.body).to include("Claims #{claims[0].reference} and #{claims[1].reference} have different values for bank account number")
-        end
-      end
     end
 
     describe "admin_payroll_runs#show" do


### PR DESCRIPTION
This lays the groundwork for decisions being undoable (setting the claim back to an undecided status) and allowing a subsequent change of decision whilst still retaining a complete history of decision changes.

The new `decision` method returns the latest decision on a `Claim`, and is functionally identical to current behaviour.

There is one notable pair of changes to specs, which is the removal of the spec ensuring payroll runs cannot be generated when there would be two claims containing the same personal details but different bank numbers. Reaching this point should not be possible, as claims with matching details but different bank numbers cannot be approved. This behaviour is now explicitly tested in `decision_spec.rb` to prevent regressions.

The original test now fails where it previously passed since `:approved` and `:rejected` traits in the claims factory now use `create` instead of `build`. This change ensures tests pass where previously they would fail due to reliance on the `decision` relation within a `Claim` returning values even when unsaved.

There should be no user-facing changes or changes to behaviour as a result of this pull request.
