### PR TITLE
Add CPU and memory alerts for worker container instance

### DIFF
--- a/azure/resource_groups/alerts/template.json
+++ b/azure/resource_groups/alerts/template.json
@@ -31,6 +31,9 @@
     "appServicePlanId": {
       "type": "string"
     },
+    "workerContainerInstanceId": {
+      "type": "string"
+    },
     "vspAppServiceId": {
       "type": "string"
     },
@@ -127,6 +130,9 @@
           },
           "appServicePlanId": {
             "value": "[parameters('appServicePlanId')]"
+          },
+          "workerContainerInstanceId": {
+            "value": "[parameters('workerContainerInstanceId')]"
           },
           "enableAlerts": {
             "value": "[parameters('enableAlerts')]"

--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -664,6 +664,10 @@
       "type": "string",
       "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))).outputs.appServiceId.value]"
     },
+    "workerContainerInstanceId": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('appDeploymentName'))).outputs.workerContainerInstanceId.value]"
+    },
     "vspAppServicePlanId": {
       "type": "string",
       "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('vspDeploymentName'))).outputs.appServicePlanId.value]"

--- a/azure/templates/app.json
+++ b/azure/templates/app.json
@@ -329,6 +329,10 @@
       "type": "string",
       "value": "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"
     },
+    "workerContainerInstanceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.ContainerInstance/containerGroups', parameters('workerContainerInstanceName'))]"
+    },
     "appServicePossibleOutboundIpAddresses": {
       "type": "array",
       "value": "[split(reference(resourceId('Microsoft.Web/sites', parameters('appServiceName'))).possibleOutboundIpAddresses, ',')]"

--- a/azure/templates/app_alerts.json
+++ b/azure/templates/app_alerts.json
@@ -14,6 +14,10 @@
     "appServicePlanId": {
       "type": "string"
     },
+    "workerContainerInstanceId": {
+      "type": "string",
+      "defaultValue": ""
+    },
     "enableAlerts": {
       "type": "bool"
     }
@@ -27,7 +31,12 @@
     "appServicePlanName": "[last(split(parameters('appServicePlanId'), '/'))]",
     "appServicePlanAlertPrefix": "[concat(parameters('alertNamePrefix'), '-', variables('appServicePlanName'))]",
     "appServicePlanHighCpuAlertName": "[concat(variables('appServicePlanAlertPrefix'), '-high-cpu')]",
-    "appServicePlanHighMemoryAlertName": "[concat(variables('appServicePlanAlertPrefix'), '-high-memory')]"
+    "appServicePlanHighMemoryAlertName": "[concat(variables('appServicePlanAlertPrefix'), '-high-memory')]",
+
+    "workerContainerInstanceName": "[last(split(parameters('workerContainerInstanceId'), '/'))]",
+    "workerContainerInstanceAlertPrefix": "[concat(parameters('alertNamePrefix'), '-', variables('workerContainerInstanceName'))]",
+    "workerContainerInstanceHighCpuAlertName": "[concat(variables('workerContainerInstanceAlertPrefix'), '-high-cpu')]",
+    "workerContainerInstanceHighMemoryAlertName": "[concat(variables('workerContainerInstanceAlertPrefix'), '-high-memory')]"
   },
   "resources": [
     {
@@ -159,6 +168,78 @@
               "metricName": "MemoryPercentage",
               "operator": "GreaterThan",
               "threshold": 80,
+              "timeAggregation": "Average"
+            }
+          ]
+        },
+        "actions": [
+          {
+            "actionGroupId": "[parameters('actionGroupId')]"
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Insights/metricAlerts",
+      "apiVersion": "2018-03-01",
+      "name": "[variables('workerContainerInstanceHighCpuAlertName')]",
+      "condition": "[greater(length(parameters('workerContainerInstanceId')), 0)]",
+      "location": "global",
+      "properties": {
+        "scopes": ["[parameters('workerContainerInstanceId')]"],
+        "enabled": "[parameters('enableAlerts')]",
+        "description": "[concat('Alert when average CPU utilization for ', variables('workerContainerInstanceName'), ' is greater than 80%.')]",
+        "severity": 1,
+        "evaluationFrequency": "PT5M",
+        "windowSize": "PT15M",
+        "targetResourceType": "Microsoft.ContainerInstance/containerGroups",
+        "targetResourceRegion": "[resourceGroup().location]",
+        "criteria": {
+          "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+          "allOf": [
+            {
+              "criterionType": "StaticThresholdCriterion",
+              "name": "high-cpu",
+              "metricNamespace": "Microsoft.ContainerInstance/containerGroups",
+              "metricName": "CpuUsage",
+              "operator": "GreaterThan",
+              "threshold": 800,
+              "timeAggregation": "Average"
+            }
+          ]
+        },
+        "actions": [
+          {
+            "actionGroupId": "[parameters('actionGroupId')]"
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Insights/metricAlerts",
+      "apiVersion": "2018-03-01",
+      "name": "[variables('workerContainerInstanceHighMemoryAlertName')]",
+      "condition": "[greater(length(parameters('workerContainerInstanceId')), 0)]",
+      "location": "global",
+      "properties": {
+        "scopes": ["[parameters('workerContainerInstanceId')]"],
+        "enabled": "[parameters('enableAlerts')]",
+        "description": "[concat('Alert when average memory utilization for ', variables('workerContainerInstanceName'), ' is greater than 80%.')]",
+        "severity": 1,
+        "evaluationFrequency": "PT5M",
+        "windowSize": "PT15M",
+        "targetResourceType": "Microsoft.ContainerInstance/containerGroups",
+        "targetResourceRegion": "[resourceGroup().location]",
+        "criteria": {
+          "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+          "allOf": [
+            {
+              "criterionType": "StaticThresholdCriterion",
+              "name": "high-memory",
+              "metricNamespace": "Microsoft.ContainerInstance/containerGroups",
+              "metricName": "MemoryUsage",
+              "operator": "GreaterThan",
+              "threshold": "[mul(1200, 1000000)]",
               "timeAggregation": "Average"
             }
           ]

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -299,7 +299,7 @@ if [ $DEPLOY_ALERTS ]; then
       --parameters "$(
         filter-azure-outputs \
           "$APP_DEPLOYMENT_RESULT" \
-          "['appServiceId', 'appServicePlanId', 'databaseServerId', 'vspAppServiceId', 'vspAppServicePlanId']" \
+          "['appServiceId', 'appServicePlanId', 'workerContainerInstanceId', 'databaseServerId', 'vspAppServiceId', 'vspAppServicePlanId']" \
           "{'resourceGroupId' => 'appResourceGroupId'}"
       )" \
       --mode Complete \


### PR DESCRIPTION



Unfortunately `CpuPercentage` and `MemoryPercentage` metrics aren't
available for container instance monitoring. We have to use `CpuUsage` and
`MemoryUsage` instead, this means the threshold has to be a concrete
value rather than a proportion.

- CpuUsage is measured in millicores (1,000 per core)
- MemoryUsage is measured in bytes (1,000,000 per MB)

I've set the values as 800 millicores (80% of our 1 core) and
1200MB (80% of our 1500MB available memory).

We could parameterise these units in the container instance deploy and
pass them in to the app_alerts.json then use `[mul(value, 0.8)]` however
these values aren't likely to change so it feels like overkill.

https://docs.microsoft.com/en-gb/azure/azure-monitor/platform/metrics-supported#microsoftcontainerinstancecontainergroups
