### PR TITLE
Remove the last sentence from closed page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Adjust content on the service closed page
+
 ## [Release 057] - 2020-03-03
 
 - QTS question will vary based on the year the service is accepting claims for

--- a/app/views/static_pages/closed_for_submissions.html.erb
+++ b/app/views/static_pages/closed_for_submissions.html.erb
@@ -16,7 +16,7 @@
 
     <p class="govuk-body">
       If you started a claim but did not send it, we have not saved your
-      answers. You’ll need to start again when the service is available.
+      answers.
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
This sentence is potentially confusing for users that have missed the claim window as it suggests they'll be able to claim for the current year when the claim window re-opens for the next year.
