### PR TITLE
Expose Git commit hash in Rollbar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,9 @@ RUN if [ ${RAILS_ENV} = "production" ]; then \
 
 EXPOSE 3000
 
+ARG GIT_COMMIT_HASH
+ENV GIT_COMMIT_HASH ${GIT_COMMIT_HASH}
+
 CMD [ "bundle", "exec", "rails", "server" ]
 
 # ------------------------------------------------------------------------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,7 @@ steps:
         --cache-from=$(dockerRegistry)/$(dockerImageName):latest \
         --tag=local/dfe-teachers-payment-service:web \
         --target=web \
+        --build-arg GIT_COMMIT_HASH=$(Build.SourceVersion) \
         .
     displayName: Build web Docker image using 'latest' as cache
     condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
@@ -74,6 +75,7 @@ steps:
         --cache-from=local/dfe-teachers-payment-service:web-dependencies \
         --tag=local/dfe-teachers-payment-service:web \
         --target=web \
+        --build-arg GIT_COMMIT_HASH=$(Build.SourceVersion) \
         .
     displayName: Build web Docker image without cache
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -71,4 +71,6 @@ Rollbar.configure do |config|
   # setup for Heroku. See:
   # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
   config.environment = ENV["ENVIRONMENT_NAME"].presence || Rails.env
+
+  config.code_version = ENV["GIT_COMMIT_HASH"]
 end


### PR DESCRIPTION
When investigating a previous error in Rollbar, I wanted to know which
version of the code was running when the error occurred. We can achieve
this by setting Rollbar’s `config.code_version`.

I think it makes sense to bake the Git commit hash into the Docker
image, since it provides metadata about which code is contained inside
the image and the context in which the image was built. I’ve put the
ENV instruction below the COPY instructions for caching reasons, since
the commit hash changes more frequently than the copied files.

I haven’t found a way to test this end to end. I’ve confirmed that the
`web` image built by CI, which gets pushed to Docker Hub, contains the
GIT_COMMIT_HASH environment variable, but I don't know if there's an
easy way to actually test that the exceptions triggered end up tagged
properly in Rollbar.
