### PR TITLE
Remove old column from Payroll Runs

### DIFF
--- a/db/migrate/20200304101213_remove_confirmation_report_uploaded_by_from_payroll_runs.rb
+++ b/db/migrate/20200304101213_remove_confirmation_report_uploaded_by_from_payroll_runs.rb
@@ -1,0 +1,5 @@
+class RemoveConfirmationReportUploadedByFromPayrollRuns < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :payroll_runs, :confirmation_report_uploaded_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_27_160303) do
+ActiveRecord::Schema.define(version: 2020_03_04_101213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -172,7 +172,6 @@ ActiveRecord::Schema.define(version: 2020_02_27_160303) do
   create_table "payroll_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "confirmation_report_uploaded_by"
     t.datetime "downloaded_at"
     t.uuid "created_by_id"
     t.uuid "downloaded_by_id"


### PR DESCRIPTION
This removes the `confirmation_report_uploaded_by` column from the PayrollRuns table, which has been superceded by the `confirmation_report_uploaded_by_id` column, which references an actual user in the database.

