### PR TITLE
Get the Azure deployment slots feature working

### DIFF
--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -107,10 +107,6 @@
       "type": "bool",
       "defaultValue": true
     },
-    "azureBuildNumber": {
-      "type": "string",
-      "defaultValue": ""
-    },
     "RAILS_ENV": {
       "type": "string",
       "defaultValue": "production"
@@ -437,10 +433,6 @@
               {
                 "name": "RAILS_SERVE_STATIC_FILES",
                 "value": "[parameters('RAILS_SERVE_STATIC_FILES')]"
-              },
-              {
-                "name": "BUILD_NUMBER",
-                "value": "[parameters('azureBuildNumber')]"
               },
               {
                 "name": "CANONICAL_HOSTNAME",

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -43,19 +43,16 @@ case $ENVIRONMENT_NAME in
   "development")
     SUBSCRIPTION_ID="8655985a-2f87-44d7-a541-0be9a8c2779d"
     RESOURCE_GROUP_PREFIX="s118d01"
-    DOCKER_IMAGE_TAG="development"
     VSP_DOCKER_IMAGE_TAG="20191030.1"
     ;;
   "test")
     SUBSCRIPTION_ID="e9299169-9666-4f15-9da9-5332680145af"
     RESOURCE_GROUP_PREFIX="s118t01"
-    DOCKER_IMAGE_TAG="development"
     VSP_DOCKER_IMAGE_TAG="20191030.1"
     ;;
   "production")
     SUBSCRIPTION_ID="88bd392f-df19-458b-a100-22b4429060ed"
     RESOURCE_GROUP_PREFIX="s118p01"
-    DOCKER_IMAGE_TAG="production"
     VSP_DOCKER_IMAGE_TAG="20191030.1"
     ;;
   *)
@@ -96,6 +93,9 @@ while [ "$2" ]; do
     "--recover-keyvault")
       RECOVER_KEY_VAULT=1
       ;;
+    --docker-tag=*)
+      DOCKER_TAG="${2#*=}"
+      ;;
     *)
       echo "Unexpected argument: $2"
       exit 1
@@ -104,6 +104,10 @@ while [ "$2" ]; do
 
   shift
 done
+
+if [ -z "$DOCKER_TAG" ]; then
+  DOCKER_TAG="latest"
+fi
 
 GIT_COMMIT_HASH=${GIT_COMMIT_HASH:-$(git rev-parse --verify HEAD)}
 SCRIPT_PATH=$(cd "$(dirname "$0")" ; pwd -P)
@@ -216,7 +220,7 @@ echo "Rewriting app parameters file for $ENVIRONMENT_NAME..."
 sed \
     -e "s|\${keyVaultId}|$KEY_VAULT_ID|g" \
     -e "s|\${vspDockerImageTag}|$VSP_DOCKER_IMAGE_TAG|g" \
-    -e "s|\${appServiceDockerImageTag}|$DOCKER_IMAGE_TAG|g" \
+    -e "s|\${appServiceDockerImageTag}|$DOCKER_TAG|g" \
     "$APP_PARAMETERS_TEMPLATE_FILE_PATH" > "$APP_PARAMETERS_FILE_PATH"
 
 if [ $CONFIRM_BEFORE_DEPLOY ]; then

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -240,7 +240,6 @@ APP_DEPLOYMENT_RESULT=$(
     --template-file "$APP_TEMPLATE_FILE_PATH" \
     --parameters "@$APP_PARAMETERS_FILE_PATH" \
     --parameters "gitCommitHash=$GIT_COMMIT_HASH" \
-    --parameters "azureBuildNumber=$AZURE_BUILD_NUMBER" \
     --parameters "secretsResourceGroupName=$SECRETS_RESOURCE_GROUP_NAME" \
     --parameters "$(
       filter-azure-outputs \

--- a/bin/docker-release
+++ b/bin/docker-release
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-
-DOCKER_SOURCE=$1
-DOCKER_TARGET=$2
-
-docker pull "$DOCKER_SOURCE"
-docker tag "$DOCKER_SOURCE" "$DOCKER_TARGET"
-docker push "$DOCKER_TARGET"


### PR DESCRIPTION
This updates our deployment script to deploy the Docker images that have been tagged with build numbers directly. 

Previously we'd pull down the image that has been tagged with a specific build number, and then tag it with `development` or `production` as part of our deployment process. This caused problems because once an infrastructure deploy had happened, this triggered a restart on our app services, which then pulled down the latest version of the code, rather than waiting for the slots to be swapped over. 

Doing it this way ensures that each version of the app service is tightly coupled to the version of the code, so changes don't sneak in too early.

**Once this is approved, I'll need to make changes to the deployment script before merging.**