### PR TITLE
Allow service operators to navigate to decision page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog]
 - Screen reader improvements when viewing payrun
 - Add visually hidden text to payroll history table
 - Add visually hidden text to GIAS school link
+- Allow service operators to navigate to decision page
 
 ## [Release 058] - 2020-03-03
 

--- a/app/assets/stylesheets/components/tag.scss
+++ b/app/assets/stylesheets/components/tag.scss
@@ -7,14 +7,24 @@
   text-align: center;
 }
 
+.govuk-tag {
+  &--warning {
+    background-color: govuk-colour("orange");
+  }
+
+  &--alert {
+    background-color: govuk-colour("red");
+  }
+}
+
 .tag--warning {
   @extend %tag;
-  background-color: govuk-colour("orange");
+  @extend .govuk-tag--warning;
 }
 
 .tag--alert {
   @extend %tag;
-  background-color: govuk-colour("red");
+  @extend .govuk-tag--alert;
 }
 
 .govuk-summary-list {

--- a/app/views/admin/checks/index.html.erb
+++ b/app/views/admin/checks/index.html.erb
@@ -39,6 +39,23 @@
           </li>
         </ul>
       </li>
+      <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number">3. </span> Decision
+        </h2>
+        <ul class="app-task-list__items">
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <%= link_to "Approve or reject this claim", new_admin_claim_decision_path(@claim), class: "govuk-link" %>
+            </span>
+            <% if @claim.decision&.approved? %>
+              <strong class="govuk-tag app-task-list__task-completed">Approved</strong>
+            <% elsif @claim.decision&.rejected? %>
+              <strong class="govuk-tag app-task-list__task-completed govuk-tag--alert">Rejected</strong>
+            <% end %>
+          </li>
+        </ul>
+      </li>
     </ol>
 
   </div>

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -110,6 +110,7 @@ RSpec.feature "Admin checks a claim" do
 
       expect(page).to have_content("Check qualification information Completed")
       expect(page).to have_content("Check employment information Completed")
+      expect(page).to have_link("Approve or reject this claim", href: new_admin_claim_decision_path(claim_with_checks))
 
       click_on "Check qualification information"
       expect(page).to have_content("Checked by #{checking_user.full_name}")

--- a/spec/requests/admin_checks_spec.rb
+++ b/spec/requests/admin_checks_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe "Admin checks", type: :request do
         expect(response.body).to include("Qualifications")
         expect(response.body).to include("Employment")
       end
+
+      context "when the claim has a decision" do
+        let(:claim) { create(:claim, :approved) }
+
+        it "shows the outcome of the decision" do
+          get admin_claim_checks_path(claim_id: claim.id)
+
+          expect(response.body).to include("Approved")
+        end
+      end
     end
 
     # Compatible with claims from each policy


### PR DESCRIPTION
Currently if a service operator exits the journey on the last check they
are unable to navigate back to the decision page.

So that service operators can get back to the decision page at any time
we now include a link to the decision on the index of tasks
along with the result of the decision if there is one.

I've extracted out `govuk-tag--warning` and `govuk-tag--alert` as these
supplement the GOV.UK tag component and reused the classes in our
custom tag component styles.

The link to "Approve or reject this claim" exists on claims that already
have a decision. If a user clicks this link on decided claims they will
see a notice saying "Claim outcome already decided" and redirects to
the claim#show page. This isn't a great user experience but it's a bit
of an edge case in the current system, there's no obvious user journey
to get to this point. In the future we may want to introduce a
decisions#show page to display information about the decision.

### Screenshot

<img width="1029" alt="Screenshot 2020-03-04 at 15 34 33" src="https://user-images.githubusercontent.com/2804149/75895539-b61b4080-5e2d-11ea-8f02-595da68f0c1a.png">
