### PR TITLE
Run deployment as part of the CI pipeline

### DIFF
--- a/azure-deploy-template.yml
+++ b/azure-deploy-template.yml
@@ -1,0 +1,66 @@
+parameters:
+  azureSubscription:
+  resourceGroupPrefix:
+  environmentName:
+  slackWebhookUrl:
+
+jobs:
+  - job: run_deploy_script
+    displayName: Run deploy script
+    steps:
+      - task: UseRubyVersion@0
+        displayName: 'Use Ruby >= 2.4'
+      - task: AzureCLI@1
+        displayName: 'Deploy Azure'
+        inputs:
+          azureSubscription: ${{parameters.azureSubscription}}
+          scriptPath: '$(System.DefaultWorkingDirectory)/Build/repository/bin/azure-deploy'
+          arguments: 'test --skip-login --skip-confirmation --docker-tag=$(Build.BuildNumber)'
+          workingDirectory: '$(System.DefaultWorkingDirectory)/Build/repository'
+        env:
+          GIT_COMMIT_HASH: $(Release.Artifacts.Build.SourceVersion)
+  - job: swap_app_service_slots
+    dependsOn: run_deploy_script
+    displayName: Swap app service slots
+    steps:
+      - task: AzureAppServiceManage@0
+        displayName: 'Swap Slots: ${{parameters.resourceGroupPrefix}}-app-as'
+        inputs:
+          azureSubscription: ${{parameters.azureSubscription}}
+          WebAppName: '${{parameters.resourceGroupPrefix}}-app-as'
+          ResourceGroupName: '${{parameters.resourceGroupPrefix}}-app'
+          SourceSlot: staging
+      - task: AzureAppServiceManage@0
+        displayName: 'Swap Slots: ${{parameters.resourceGroupPrefix}}-app-vsp-as'
+        inputs:
+          azureSubscription: 'azdo.pipelines.cip.S118T.arm03ce3ff5-9a61-4525-a063-6ecde34874cf'
+          WebAppName: '${{parameters.resourceGroupPrefix}}-app-vsp-as'
+          ResourceGroupName: '${{parameters.resourceGroupPrefix}}-app'
+          SourceSlot: staging
+  - job: clean_up
+    dependsOn: swap_app_service_slots
+    displayName: Clean up
+    steps:
+      - task: AzureCLI@1
+        displayName: 'Delete migration runner container'
+        inputs:
+          azureSubscription: ${{parameters.azureSubscription}}
+          scriptLocation: inlineScript
+          inlineScript: 'az container delete --name ${{parameters.resourceGroupPrefix}}-app-migration-runner-aci --resource-group s118t01-app -y'
+  - job: send_slack_notification
+    dependsOn: clean_up
+    displayName: Send Slack notification
+    steps:
+      - task: Bash@3
+        displayName: 'Send Slack Notification'
+        inputs:
+          targetType: filePath
+          filePath: './$(System.DefaultWorkingDirectory)/Build/repository/bin/slack-alert'
+          arguments: 'test $(Build.BuildNumber) $(Release.ReleaseId) ${{parameters.slackWebhookUrl}} SUCCESS'
+      - task: Bash@3
+        displayName: 'Send Slack Failure Notification'
+        inputs:
+          targetType: filePath
+          filePath: './$(System.DefaultWorkingDirectory)/Build/repository/bin/slack-alert'
+          arguments: 'test $(Build.BuildNumber) $(Release.ReleaseId) ${{parameters.slackWebhookUrl}} FAILURE'
+        condition: failed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,111 +1,143 @@
 pr: none
 
+trigger:
+  branches:
+    include:
+    - '*'
+  tags:
+    include:
+    - '*'
+
 pool:
   vmImage: ubuntu-latest
 
 variables:
   - group: docker-settings
 
-steps:
-  # Login to DockerHub
-  - script: docker login -u $(dockerId) -p $pass
-    env:
-      pass: $(dockerPassword)
-    displayName: Login to DockerHub
+stages:
+  - stage: ci_build
+    displayName: Run tests and publish artifacts
+    jobs:
+      - job: run_tests
+        displayName: Run tests
+        steps:
+          # Login to DockerHub
+          - script: docker login -u $(dockerId) -p $pass
+            env:
+              pass: $(dockerPassword)
+            displayName: Login to DockerHub
 
-  # Build and run tests
-  - script: |
-      docker pull $(dockerRegistry)/$(dockerImageName):cache-test-dependencies || true
-      docker pull $(dockerRegistry)/$(dockerImageName):cache-test || true
+          # Build and run tests
+          - script: |
+              docker pull $(dockerRegistry)/$(dockerImageName):cache-test-dependencies || true
+              docker pull $(dockerRegistry)/$(dockerImageName):cache-test || true
 
-      docker-compose --file=docker-compose.test.yml build
-    displayName: Build test Docker image
-  - script: docker-compose --file=docker-compose.test.yml run --rm test
-    displayName: Run tests on Docker
+              docker-compose --file=docker-compose.test.yml build
+            displayName: Build test Docker image
+          - script: docker-compose --file=docker-compose.test.yml run --rm test
+            displayName: Run tests on Docker
 
-  # Clean up
-  - script: |
-      git reset --hard
-      git clean -xdf
-    displayName: Clean repository
+          # Clean up
+          - script: |
+              git reset --hard
+              git clean -xdf
+            displayName: Clean repository
 
-  # Publish
-  - publish: $(System.DefaultWorkingDirectory)
-    artifact: repository
-    displayName: Publish repository as artifact
+      - job: build_and_push_web_dependencies
+        dependsOn: run_tests
+        displayName: Build and push web dependencies
+        steps:
+          # Build web dependencies
+          - script: |
+              docker pull $(dockerRegistry)/$(dockerImageName):cache-web-dependencies || true
 
-  # Build web dependencies
-  - script: |
-      docker pull $(dockerRegistry)/$(dockerImageName):cache-web-dependencies || true
+              docker build \
+                --file=Dockerfile \
+                --cache-from=$(dockerRegistry)/$(dockerImageName):cache-web-dependencies \
+                --tag=local/dfe-teachers-payment-service:web-dependencies \
+                --target=dependencies \
+                .
+            displayName: Build web dependencies Docker image using 'cache-web-dependencies' as cache
+            condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+          - script: |
+              docker build \
+                --file=Dockerfile \
+                --tag=local/dfe-teachers-payment-service:web-dependencies \
+                --target=dependencies \
+                .
+            displayName: Build web dependencies Docker image without cache
+            condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
-      docker build \
-        --file=Dockerfile \
-        --cache-from=$(dockerRegistry)/$(dockerImageName):cache-web-dependencies \
-        --tag=local/dfe-teachers-payment-service:web-dependencies \
-        --target=dependencies \
-        .
-    displayName: Build web dependencies Docker image using 'cache-web-dependencies' as cache
-    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
-  - script: |
-      docker build \
-        --file=Dockerfile \
-        --tag=local/dfe-teachers-payment-service:web-dependencies \
-        --target=dependencies \
-        .
-    displayName: Build web dependencies Docker image without cache
+          # Build web
+          - script: |
+              docker pull $(dockerRegistry)/$(dockerImageName):latest || true
+
+              docker build \
+                --file=Dockerfile \
+                --cache-from=local/dfe-teachers-payment-service:web-dependencies \
+                --cache-from=$(dockerRegistry)/$(dockerImageName):latest \
+                --tag=local/dfe-teachers-payment-service:web \
+                --target=web \
+                --build-arg GIT_COMMIT_HASH=$(Build.SourceVersion) \
+                .
+            displayName: Build web Docker image using 'latest' as cache
+            condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+          - script: |
+              docker build \
+                --file=Dockerfile \
+                --cache-from=local/dfe-teachers-payment-service:web-dependencies \
+                --tag=local/dfe-teachers-payment-service:web \
+                --target=web \
+                --build-arg GIT_COMMIT_HASH=$(Build.SourceVersion) \
+                .
+            displayName: Build web Docker image without cache
+            condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+
+          # Push test images
+          - script: |
+              docker tag local/dfe-teachers-payment-service:test-dependencies $(dockerRegistry)/$(dockerImageName):cache-test-dependencies
+
+              docker push $(dockerRegistry)/$(dockerImageName):cache-test-dependencies
+            displayName: Push test dependencies Docker image for caching
+            condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+          - script: |
+              docker tag local/dfe-teachers-payment-service:test $(dockerRegistry)/$(dockerImageName):cache-test
+
+              docker push $(dockerRegistry)/$(dockerImageName):cache-test
+            displayName: Push test Docker image for caching
+            condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+         # Push web images
+          - script: |
+              docker tag local/dfe-teachers-payment-service:web-dependencies $(dockerRegistry)/$(dockerImageName):cache-web-dependencies
+
+              docker push $(dockerRegistry)/$(dockerImageName):cache-web-dependencies
+            displayName: Push web dependencies Docker image for caching
+            condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+          - script: |
+              docker tag local/dfe-teachers-payment-service:web $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber)
+              docker tag local/dfe-teachers-payment-service:web $(dockerRegistry)/$(dockerImageName):latest
+
+              docker push $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber)
+              docker push $(dockerRegistry)/$(dockerImageName):latest
+            displayName: Push web Docker image
+            condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      - job: publish_repository
+        dependsOn: build_and_push_web_dependencies
+        displayName: Publish repository
+        steps:
+          - publish: $(System.DefaultWorkingDirectory)
+            artifact: repository
+            displayName: Publish repository as artifact
+  - stage: deploy_to_development
+    displayName: Deploy to development
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    variables:
+      - group: deployment-settings
+    jobs:
+    - template: azure-deploy-template.yml
+      parameters:
+        azureSubscription: azdo.pipelines.cip.S118D.armfe1ef140-8bef-4043-b5ee-c449e6f951ef
+        resourceGroupPrefix: s118d01
+        environmentName: development
+        slackWebhookUrl: $(slackWebhookUrl)
 
-  # Build web
-  - script: |
-      docker pull $(dockerRegistry)/$(dockerImageName):latest || true
-
-      docker build \
-        --file=Dockerfile \
-        --cache-from=local/dfe-teachers-payment-service:web-dependencies \
-        --cache-from=$(dockerRegistry)/$(dockerImageName):latest \
-        --tag=local/dfe-teachers-payment-service:web \
-        --target=web \
-        --build-arg GIT_COMMIT_HASH=$(Build.SourceVersion) \
-        .
-    displayName: Build web Docker image using 'latest' as cache
-    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
-  - script: |
-      docker build \
-        --file=Dockerfile \
-        --cache-from=local/dfe-teachers-payment-service:web-dependencies \
-        --tag=local/dfe-teachers-payment-service:web \
-        --target=web \
-        --build-arg GIT_COMMIT_HASH=$(Build.SourceVersion) \
-        .
-    displayName: Build web Docker image without cache
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-
-  # Push test images
-  - script: |
-      docker tag local/dfe-teachers-payment-service:test-dependencies $(dockerRegistry)/$(dockerImageName):cache-test-dependencies
-
-      docker push $(dockerRegistry)/$(dockerImageName):cache-test-dependencies
-    displayName: Push test dependencies Docker image for caching
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-  - script: |
-      docker tag local/dfe-teachers-payment-service:test $(dockerRegistry)/$(dockerImageName):cache-test
-
-      docker push $(dockerRegistry)/$(dockerImageName):cache-test
-    displayName: Push test Docker image for caching
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-
-  # Push web images
-  - script: |
-      docker tag local/dfe-teachers-payment-service:web-dependencies $(dockerRegistry)/$(dockerImageName):cache-web-dependencies
-
-      docker push $(dockerRegistry)/$(dockerImageName):cache-web-dependencies
-    displayName: Push web dependencies Docker image for caching
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-  - script: |
-      docker tag local/dfe-teachers-payment-service:web $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber)
-      docker tag local/dfe-teachers-payment-service:web $(dockerRegistry)/$(dockerImageName):latest
-
-      docker push $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber)
-      docker push $(dockerRegistry)/$(dockerImageName):latest
-    displayName: Push web Docker image
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')


### PR DESCRIPTION
This commit refactors the CI pipeline so it has three distinct stages:

- The first stage is as before - build the Docker container and run tests
- The second stage then only runs on a push to the master branch, and deploys the app to development
- The third stage only runs when a tag has been pushed, and this deploys the app to production

Both deploy stages use the `azure-deploy-template.yml` file, which DRYsthings up quite a bit.
