### PR TITLE
Accessibility testing admin area part 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Links that look like buttons now work if users have JS
 - Manage services page validates in html checker
 - Improve guidance on admin file upload when no file is selected
 - Add visually hidden text to manage services

--- a/app/assets/stylesheets/components/tag.scss
+++ b/app/assets/stylesheets/components/tag.scss
@@ -17,9 +17,15 @@
   background-color: govuk-colour("red");
 }
 
+.tag--information {
+  @extend %tag;
+  background-color: govuk-colour("blue");
+}
+
 .govuk-summary-list {
   .tag--warning,
-  .tag--alert {
+  .tag--alert,
+  .tag--information {
     margin-left: 1em;
   }
 }

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -58,7 +58,7 @@ module Admin
     end
 
     def id_verification_status(claim)
-      claim.identity_confirmed? ? "GOV.UK Verify" : content_tag(:strong, "Unverified", class: "govuk-tag tag--warning")
+      claim.identity_confirmed? ? "GOV.UK Verify" : content_tag(:strong, "Unverified", class: "govuk-tag tag--information")
     end
 
     def matching_attributes(first_claim, second_claim)

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -53,7 +53,7 @@ module Admin
       days_until_decision_deadline = days_between(Date.today, claim.decision_deadline_date)
       return if days_until_decision_deadline.days > Claim::DECISION_DEADLINE_WARNING_POINT
 
-      decision_deadline_warning_class = days_until_decision_deadline < 0 ? "tag--alert" : "tag--warning"
+      decision_deadline_warning_class = days_until_decision_deadline < 0 ? "tag--alert" : "tag--information"
       content_tag(:strong, pluralize(days_until_decision_deadline, "day"), class: "govuk-tag #{decision_deadline_warning_class}")
     end
 

--- a/app/views/admin/amendments/new.html.erb
+++ b/app/views/admin/amendments/new.html.erb
@@ -162,7 +162,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= f.submit "Amend claim", class: "govuk-button", data: {module: "govuk-button"} %>
-      <%= link_to "Cancel", admin_claim_url(@claim), class: "govuk-button govuk-button--secondary", data: {module: "govuk-button"} %>
+      <%= link_to "Cancel", admin_claim_url(@claim), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
     </div>
   </div>
 <% end %>

--- a/app/views/admin/payments/remove.html.erb
+++ b/app/views/admin/payments/remove.html.erb
@@ -16,7 +16,7 @@
                    data: {
                      confirm: "Are you sure you want to remove this payment from the payroll run?"
                     } %>
-      <%= link_to "Cancel", admin_payroll_run_path(@payroll_run), class: "govuk-button govuk-button--secondary govuk-!-margin-left-1" %>
+      <%= link_to "Cancel", admin_payroll_run_path(@payroll_run), class: "govuk-button govuk-button--secondary govuk-!-margin-left-1", role: "button", data: {module: "govuk-button"} %>
     <% end %>
   </div>
 </div>

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -88,7 +88,7 @@ describe Admin::ClaimsHelper do
       end
 
       it "includes the deadline warning" do
-        expect(helper.admin_submission_details(claim)[2].last).to have_selector(".tag--warning")
+        expect(helper.admin_submission_details(claim)[2].last).to have_selector(".tag--information")
       end
     end
   end
@@ -135,7 +135,7 @@ describe Admin::ClaimsHelper do
       let(:claim) { build(:claim, :submitted, submitted_at: (Claim::DECISION_DEADLINE - 1.week).ago) }
 
       it { is_expected.to have_content("7 days") }
-      it { is_expected.to have_selector(".tag--warning") }
+      it { is_expected.to have_selector(".tag--information") }
     end
 
     context "when a claim has passed it's deadline" do
@@ -163,7 +163,7 @@ describe Admin::ClaimsHelper do
       verified_claim = build(:claim, :unverified)
 
       expect(id_verification_status(verified_claim)).to have_content "Unverified"
-      expect(id_verification_status(verified_claim)).to have_selector(".tag--warning")
+      expect(id_verification_status(verified_claim)).to have_selector(".tag--information")
     end
   end
 


### PR DESCRIPTION
This is the last of the PRs for accessibility within the Admin area. I think the current outstanding items would be for a level higher than we need and more costly to implement than we have time to spend.

The main change has been to the Verify without Verify tag shown when viewing claims, which can be seen below. The commit provides some more in-depth information on this.

![image](https://user-images.githubusercontent.com/13239597/75976515-807c6300-5ed2-11ea-84a9-0c140e4c6266.png)

I have also changed the code on the cancel buttons that are styled to look like links, this allows the baked in JS that comes with the design system to honour the expected keyboard behaviour to trigger these buttons.