### PR TITLE
Student Loans Financial year varies based on the currently configured academic year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog]
 - Add visually hidden text to payroll history table
 - Add visually hidden text to GIAS school link
 - Allow service operators to navigate to decision page
+- Financial year for student loans claims varies based on the current academic
+  year
 
 ## [Release 058] - 2020-03-03
 

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -55,10 +55,6 @@ module ClaimsHelper
     end
   end
 
-  def school_search_question(searching_for_additional_school)
-    searching_for_additional_school ? t("student_loans.questions.additional_school") : t("student_loans.questions.claim_school")
-  end
-
   def date_of_birth_string(claim)
     claim.date_of_birth && l(claim.date_of_birth)
   end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -11,4 +11,13 @@ module StudentLoansHelper
       I18n.t("student_loans.questions.claim_school", financial_year: StudentLoans.current_financial_year)
     end
   end
+
+  # Returns the question for the subjects-taugh page in the Student Loans
+  # journey.
+  #
+  # Accepts a `school_name` named parameter that is the school that the claimant
+  # was teaching at during the financial year.
+  def subjects_taught_question(school_name:)
+    I18n.t("student_loans.questions.subjects_taught", school: school_name)
+  end
 end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -18,6 +18,6 @@ module StudentLoansHelper
   # Accepts a `school_name` named parameter that is the school that the claimant
   # was teaching at during the financial year.
   def subjects_taught_question(school_name:)
-    I18n.t("student_loans.questions.subjects_taught", school: school_name)
+    I18n.t("student_loans.questions.subjects_taught", school: school_name, financial_year: StudentLoans.current_financial_year)
   end
 end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -20,4 +20,10 @@ module StudentLoansHelper
   def subjects_taught_question(school_name:)
     I18n.t("student_loans.questions.subjects_taught", school: school_name, financial_year: StudentLoans.current_financial_year)
   end
+
+  # Returns the question for the leadership-position question in the Student
+  # Loans journey.
+  def leadership_position_question
+    I18n.t("student_loans.questions.leadership_position")
+  end
 end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -5,6 +5,10 @@ module StudentLoansHelper
   # `true`, will rephrase the question so it applies to a user searching for an
   # additional school.
   def claim_school_question(additional_school: false)
-    additional_school ? I18n.t("student_loans.questions.additional_school") : I18n.t("student_loans.questions.claim_school")
+    if additional_school
+      I18n.t("student_loans.questions.additional_school", financial_year: StudentLoans.current_financial_year)
+    else
+      I18n.t("student_loans.questions.claim_school", financial_year: StudentLoans.current_financial_year)
+    end
   end
 end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -32,4 +32,10 @@ module StudentLoansHelper
   def mostly_performed_leadership_duties_question
     I18n.t("student_loans.questions.mostly_performed_leadership_duties", financial_year: StudentLoans.current_financial_year)
   end
+
+  # Returns the question for the student-loan-amount question in the Student
+  # Loans journey.
+  def student_loan_amount_question
+    I18n.t("student_loans.questions.student_loan_amount")
+  end
 end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -26,4 +26,10 @@ module StudentLoansHelper
   def leadership_position_question
     I18n.t("student_loans.questions.leadership_position", financial_year: StudentLoans.current_financial_year)
   end
+
+  # Returns the question for the mostly-performed-leadership-duties question in
+  # the Student  Loans journey.
+  def mostly_performed_leadership_duties_question
+    I18n.t("student_loans.questions.mostly_performed_leadership_duties")
+  end
 end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -24,6 +24,6 @@ module StudentLoansHelper
   # Returns the question for the leadership-position question in the Student
   # Loans journey.
   def leadership_position_question
-    I18n.t("student_loans.questions.leadership_position")
+    I18n.t("student_loans.questions.leadership_position", financial_year: StudentLoans.current_financial_year)
   end
 end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -1,0 +1,5 @@
+module StudentLoansHelper
+  def claim_school_question(searching_for_additional_school)
+    searching_for_additional_school ? t("student_loans.questions.additional_school") : t("student_loans.questions.claim_school")
+  end
+end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -5,6 +5,6 @@ module StudentLoansHelper
   # `true`, will rephrase the question so it applies to a user searching for an
   # additional school.
   def claim_school_question(additional_school: false)
-    additional_school ? t("student_loans.questions.additional_school") : t("student_loans.questions.claim_school")
+    additional_school ? I18n.t("student_loans.questions.additional_school") : I18n.t("student_loans.questions.claim_school")
   end
 end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -36,6 +36,6 @@ module StudentLoansHelper
   # Returns the question for the student-loan-amount question in the Student
   # Loans journey.
   def student_loan_amount_question
-    I18n.t("student_loans.questions.student_loan_amount")
+    I18n.t("student_loans.questions.student_loan_amount", financial_year: StudentLoans.current_financial_year)
   end
 end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -1,5 +1,10 @@
 module StudentLoansHelper
-  def claim_school_question(searching_for_additional_school)
-    searching_for_additional_school ? t("student_loans.questions.additional_school") : t("student_loans.questions.claim_school")
+  # Returns the question for the claim-school page in the Student Loans journey.
+  #
+  # Accepts an optional named parameter `additional_school` that, if set to
+  # `true`, will rephrase the question so it applies to a user searching for an
+  # additional school.
+  def claim_school_question(additional_school: false)
+    additional_school ? t("student_loans.questions.additional_school") : t("student_loans.questions.claim_school")
   end
 end

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -30,6 +30,6 @@ module StudentLoansHelper
   # Returns the question for the mostly-performed-leadership-duties question in
   # the Student  Loans journey.
   def mostly_performed_leadership_duties_question
-    I18n.t("student_loans.questions.mostly_performed_leadership_duties")
+    I18n.t("student_loans.questions.mostly_performed_leadership_duties", financial_year: StudentLoans.current_financial_year)
   end
 end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -2,40 +2,43 @@ class ClaimMailer < ApplicationMailer
   helper :application
 
   def submitted(claim)
-    @claim_description = claim_description(claim)
-    view_mail_with_claim_and_subject(claim, "Your claim #{@claim_description} has been received, reference number: #{claim.reference}")
+    @claim = claim
+    @claim_description = claim_description
+    view_mail_with_claim_and_subject("Your claim #{@claim_description} has been received, reference number: #{claim.reference}")
   end
 
   def approved(claim)
-    @claim_description = claim_description(claim)
-    view_mail_with_claim_and_subject(claim, "Your claim #{@claim_description} has been approved, reference number: #{claim.reference}")
+    @claim = claim
+    @claim_description = claim_description
+    view_mail_with_claim_and_subject("Your claim #{@claim_description} has been approved, reference number: #{claim.reference}")
   end
 
   def rejected(claim)
-    @claim_description = claim_description(claim)
-    @possible_rejection_reasons = I18n.t("#{claim.policy.locale_key}.possible_rejection_reasons", qts_year: ineligible_qts_year(claim))
-    view_mail_with_claim_and_subject(claim, "Your claim #{@claim_description} has been rejected, reference number: #{claim.reference}")
+    @claim = claim
+    @claim_description = claim_description
+    @possible_rejection_reasons = I18n.t("#{@claim.policy.locale_key}.possible_rejection_reasons", qts_year: ineligible_qts_year)
+    view_mail_with_claim_and_subject("Your claim #{@claim_description} has been rejected, reference number: #{claim.reference}")
   end
 
   def update_after_three_weeks(claim)
-    @claim_description = claim_description(claim)
-    view_mail_with_claim_and_subject(claim, "We are still reviewing your claim #{@claim_description}, reference number: #{claim.reference}")
+    @claim = claim
+    @claim_description = claim_description
+    view_mail_with_claim_and_subject("We are still reviewing your claim #{@claim_description}, reference number: #{@claim.reference}")
   end
 
   private
 
-  def claim_description(claim)
-    I18n.t("#{claim.policy.locale_key}.claim_description")
+  def claim_description
+    I18n.t("#{@claim.policy.locale_key}.claim_description")
   end
 
-  def ineligible_qts_year(claim)
-    (claim.policy.first_eligible_qts_award_year - 1).to_s(:long)
+  def ineligible_qts_year
+    (@claim.policy.first_eligible_qts_award_year - 1).to_s(:long)
   end
 
-  def view_mail_with_claim_and_subject(claim, subject)
-    @claim = claim
-    @display_name = [claim.first_name, claim.surname].join(" ")
-    @policy = claim.policy
+  def view_mail_with_claim_and_subject(subject)
+    @display_name = [@claim.first_name, @claim.surname].join(" ")
+    @policy = @claim.policy
 
     view_mail(
       NOTIFY_TEMPLATE_ID,

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -16,7 +16,7 @@ class ClaimMailer < ApplicationMailer
   def rejected(claim)
     @claim = claim
     @claim_description = claim_description
-    @possible_rejection_reasons = I18n.t("#{@claim.policy.locale_key}.possible_rejection_reasons", qts_year: ineligible_qts_year)
+    @ineligible_qts_year = @claim.policy.first_eligible_qts_award_year - 1
     view_mail_with_claim_and_subject("Your claim #{@claim_description} has been rejected, reference number: #{claim.reference}")
   end
 
@@ -30,10 +30,6 @@ class ClaimMailer < ApplicationMailer
 
   def claim_description
     I18n.t("#{@claim.policy.locale_key}.claim_description")
-  end
-
-  def ineligible_qts_year
-    (@claim.policy.first_eligible_qts_award_year - 1).to_s(:long)
   end
 
   def view_mail_with_claim_and_subject(subject)

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -18,7 +18,7 @@ class ClaimMailer < ApplicationMailer
   def rejected(claim)
     set_common_instance_variables(claim)
     @subject = "Your claim #{@claim_description} has been rejected, reference number: #{claim.reference}"
-    @ineligible_qts_year = @claim.policy.first_eligible_qts_award_year - 1
+    @ineligible_qts_year = @claim.policy.last_ineligible_qts_award_year
 
     send_mail
   end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -2,44 +2,48 @@ class ClaimMailer < ApplicationMailer
   helper :application
 
   def submitted(claim)
-    @claim = claim
-    @claim_description = claim_description
-    view_mail_with_claim_and_subject("Your claim #{@claim_description} has been received, reference number: #{claim.reference}")
+    set_common_instance_variables(claim)
+    @subject = "Your claim #{@claim_description} has been received, reference number: #{claim.reference}"
+
+    send_mail
   end
 
   def approved(claim)
-    @claim = claim
-    @claim_description = claim_description
-    view_mail_with_claim_and_subject("Your claim #{@claim_description} has been approved, reference number: #{claim.reference}")
+    set_common_instance_variables(claim)
+    @subject = "Your claim #{@claim_description} has been approved, reference number: #{claim.reference}"
+
+    send_mail
   end
 
   def rejected(claim)
-    @claim = claim
-    @claim_description = claim_description
+    set_common_instance_variables(claim)
+    @subject = "Your claim #{@claim_description} has been rejected, reference number: #{claim.reference}"
     @ineligible_qts_year = @claim.policy.first_eligible_qts_award_year - 1
-    view_mail_with_claim_and_subject("Your claim #{@claim_description} has been rejected, reference number: #{claim.reference}")
+
+    send_mail
   end
 
   def update_after_three_weeks(claim)
-    @claim = claim
-    @claim_description = claim_description
-    view_mail_with_claim_and_subject("We are still reviewing your claim #{@claim_description}, reference number: #{@claim.reference}")
+    set_common_instance_variables(claim)
+    @subject = "We are still reviewing your claim #{@claim_description}, reference number: #{claim.reference}"
+
+    send_mail
   end
 
   private
 
-  def claim_description
-    I18n.t("#{@claim.policy.locale_key}.claim_description")
-  end
-
-  def view_mail_with_claim_and_subject(subject)
+  def set_common_instance_variables(claim)
+    @claim = claim
+    @claim_description = I18n.t("#{@claim.policy.locale_key}.claim_description")
     @display_name = [@claim.first_name, @claim.surname].join(" ")
     @policy = @claim.policy
+  end
 
+  def send_mail
     view_mail(
       NOTIFY_TEMPLATE_ID,
       to: @claim.email_address,
-      subject: subject,
+      subject: @subject,
       reply_to_id: @policy.notify_reply_to_id
     )
   end

--- a/app/models/maths_and_physics.rb
+++ b/app/models/maths_and_physics.rb
@@ -56,6 +56,10 @@ module MathsAndPhysics
     claim_year - ELIGIBLE_CAREER_LENGTH
   end
 
+  def last_ineligible_qts_award_year
+    first_eligible_qts_award_year - 1
+  end
+
   def configuration
     PolicyConfiguration.for(self)
   end

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -69,6 +69,10 @@ module StudentLoans
     ].max
   end
 
+  def last_ineligible_qts_award_year
+    first_eligible_qts_award_year - 1
+  end
+
   # Returns human-friendly String for the financial year that Student Loans
   # claims are being made against based on the currently-configured academic
   # year for the StudentLoans policy. For example:

--- a/app/models/student_loans.rb
+++ b/app/models/student_loans.rb
@@ -69,6 +69,18 @@ module StudentLoans
     ].max
   end
 
+  # Returns human-friendly String for the financial year that Student Loans
+  # claims are being made against based on the currently-configured academic
+  # year for the StudentLoans policy. For example:
+  #
+  #   "6 April 2018 and 5 April 2019"
+  def current_financial_year
+    end_year = configuration.current_academic_year.start_year
+    start_year = end_year - 1
+
+    "6 April #{start_year} and 5 April #{end_year}"
+  end
+
   def configuration
     PolicyConfiguration.for(self)
   end

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -67,7 +67,7 @@ module StudentLoans
 
     def leadership_position
       [
-        I18n.t("student_loans.questions.leadership_position"),
+        leadership_position_question,
         (eligibility.had_leadership_position? ? "Yes" : "No"),
         "leadership-position"
       ]

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -59,7 +59,7 @@ module StudentLoans
 
     def subjects_taught
       [
-        I18n.t("student_loans.questions.subjects_taught", school: eligibility.claim_school_name),
+        subjects_taught_question(school_name: eligibility.claim_school_name),
         subject_list(eligibility.subjects_taught),
         "subjects-taught"
       ]

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -1,5 +1,6 @@
 module StudentLoans
   class EligibilityAnswersPresenter
+    include StudentLoansHelper
     include StudentLoans::PresenterMethods
     include ActiveSupport::NumberHelper
 
@@ -42,7 +43,7 @@ module StudentLoans
 
     def claim_school
       [
-        I18n.t("student_loans.questions.claim_school"),
+        claim_school_question,
         eligibility.claim_school_name,
         "claim-school"
       ]

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -75,7 +75,7 @@ module StudentLoans
 
     def mostly_performed_leadership_duties
       [
-        I18n.t("student_loans.questions.mostly_performed_leadership_duties"),
+        mostly_performed_leadership_duties_question,
         (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No"),
         "mostly-performed-leadership-duties"
       ]

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -83,7 +83,7 @@ module StudentLoans
 
     def student_loan_amount
       [
-        I18n.t("student_loans.questions.student_loan_amount"),
+        student_loan_amount_question,
         number_to_currency(eligibility.student_loan_repayment_amount),
         "student-loan-amount"
       ]

--- a/app/views/claim_mailer/rejected.text.erb
+++ b/app/views/claim_mailer/rejected.text.erb
@@ -4,7 +4,7 @@ We have not been able to approve your claim <%= @claim_description %>.
 
 Your claim has not been approved because our records show one of the following:
 
-<%= @possible_rejection_reasons %>
+<%= render "claim_mailer/rejection_reasons/#{@policy.locale_key}" %>
 
 You can find more information about the eligibility criteria for this service at <%= @policy.eligibility_page_url %>
 

--- a/app/views/claim_mailer/rejection_reasons/_maths_and_physics.text.erb
+++ b/app/views/claim_mailer/rejection_reasons/_maths_and_physics.text.erb
@@ -1,0 +1,5 @@
+* you are not employed to teach maths or physics at an eligible state-funded secondary school
+* you did not complete your initial teacher training in maths or physics and you do not have a degree in maths or physics
+* you completed your initial teacher training in or before the academic year <%= @ineligible_qts_year.to_s(:long) %>
+* you’re a supply teacher contracted by a private agency or for less than a full term
+* you are currently subject to formal capability proceedings or disciplinary action

--- a/app/views/claim_mailer/rejection_reasons/_student_loans.text.erb
+++ b/app/views/claim_mailer/rejection_reasons/_student_loans.text.erb
@@ -1,0 +1,4 @@
+* you completed your initial teacher training in or before the academic year <%= @ineligible_qts_year.to_s(:long) %>
+* you did not teach at an eligible school between 6 April 2018 and 5 April 2019
+* you are not currently employed to teach at a state-funded secondary school
+* you did not teach an eligible subject for at least half of your contracted hours

--- a/app/views/claim_mailer/rejection_reasons/_student_loans.text.erb
+++ b/app/views/claim_mailer/rejection_reasons/_student_loans.text.erb
@@ -1,4 +1,4 @@
 * you completed your initial teacher training in or before the academic year <%= @ineligible_qts_year.to_s(:long) %>
-* you did not teach at an eligible school between 6 April 2018 and 5 April 2019
+* you did not teach at an eligible school between <%= StudentLoans.current_financial_year %>
 * you are not currently employed to teach at a state-funded secondary school
 * you did not teach an eligible subject for at least half of your contracted hours

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -21,7 +21,7 @@
               <div class="govuk-radios__item">
                 <%= fields.radio_button(:qts_award_year, :before_cut_off_date, class: "govuk-radios__input") %>
                 <%= fields.label "qts_award_year_before_cut_off_date",
-                      t("answers.qts_award_years.before_cut_off_date", year: (current_policy.first_eligible_qts_award_year - 1).to_s(:long)),
+                      t("answers.qts_award_years.before_cut_off_date", year: current_policy.last_ineligible_qts_award_year.to_s(:long)),
                       class: "govuk-label govuk-radios__label" %>
               </div>
 

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -8,7 +8,7 @@
   <p class="govuk-body">
     <%= current_claim.eligibility.claim_school_name %> is not an eligible
     school. You can only get this payment if you were employed to teach at an
-    eligible school between 6 April 2018 and 5 April 2019.
+    eligible school between <%= StudentLoans.current_financial_year %>
   </p>
 
   <p class="govuk-body">

--- a/app/views/student_loans/claims/_ineligibility_reason_no_more_schools.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_no_more_schools.erb
@@ -4,7 +4,7 @@
 
 <p class="govuk-body">
   You must have been employed to teach an eligible subject at an eligible
-  school for a period of time between 6 April 2018 and 5 April 2019 to claim.
+  school for a period of time between <%= StudentLoans.current_financial_year %> to claim.
 </p>
 
 <p class="govuk-body">

--- a/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -12,7 +12,7 @@
 
   <p class="govuk-body">
     You can only get this payment if you taught one or more of the following
-    subjects between 6 April 2018 and 5 April 2019:
+    subjects between <%= StudentLoans.current_financial_year %>:
   </p>
 
   <ul class="govuk-list govuk-list--bullet">

--- a/app/views/student_loans/claims/_ineligibility_reason_not_taught_enough.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_not_taught_enough.html.erb
@@ -4,7 +4,7 @@
 
 <p class="govuk-body">
   You can only get this payment if you spent less than half your working hours
-  performing leadership duties between 6 April 2018 and 5 April 2019.
+  performing leadership duties between <%= StudentLoans.current_financial_year %>.
 </p>
 
 <p class="govuk-body">

--- a/app/views/student_loans/claims/claim_school.html.erb
+++ b/app/views/student_loans/claims/claim_school.html.erb
@@ -1,11 +1,11 @@
-<% content_for(:page_title, page_title(claim_school_question(params[:additional_school]), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(claim_school_question(additional_school: params[:additional_school]), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @schools.blank? %>
 
       <%= render "school_search",
-                 question: claim_school_question(params[:additional_school]),
+                 question: claim_school_question(additional_school: params[:additional_school]),
                  school_param: :claim_school,
                  school_id_param: :claim_school_id,
                  school_search_value: (current_claim.eligibility.claim_school_name unless params[:additional_school]),

--- a/app/views/student_loans/claims/claim_school.html.erb
+++ b/app/views/student_loans/claims/claim_school.html.erb
@@ -1,11 +1,11 @@
-<% content_for(:page_title, page_title(school_search_question(params[:additional_school]), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(claim_school_question(params[:additional_school]), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @schools.blank? %>
 
       <%= render "school_search",
-                 question: school_search_question(params[:additional_school]),
+                 question: claim_school_question(params[:additional_school]),
                  school_param: :claim_school,
                  school_id_param: :claim_school_id,
                  school_search_value: (current_claim.eligibility.claim_school_name unless params[:additional_school]),

--- a/app/views/student_loans/claims/eligibility_confirmed.html.erb
+++ b/app/views/student_loans/claims/eligibility_confirmed.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">You are eligible to claim back student loan repayments</h1>
-    <p class="govuk-body">Based on your answers, you can claim back the student loan repayments you made between 6 April 2018 and 5 April 2019.</p>
+    <p class="govuk-body">Based on your answers, you can claim back the student loan repayments you made between <%= StudentLoans.current_financial_year %>.</p>
 
     <%= button_to "Continue", claim_path(current_policy_routing_name, next_slug), method: :get, class: "govuk-button" %>
   </div>

--- a/app/views/student_loans/claims/leadership_position.html.erb
+++ b/app/views/student_loans/claims/leadership_position.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.leadership_position"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(leadership_position_question, policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -14,7 +14,7 @@
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("student_loans.questions.leadership_position") %>
+                <%= leadership_position_question %>
               </h1>
             </legend>
 

--- a/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
+++ b/app/views/student_loans/claims/mostly_performed_leadership_duties.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.mostly_performed_leadership_duties"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(mostly_performed_leadership_duties_question, policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -12,7 +12,7 @@
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("student_loans.questions.mostly_performed_leadership_duties") %>
+                <%= mostly_performed_leadership_duties_question %>
               </h1>
             </legend>
 

--- a/app/views/student_loans/claims/student_loan_amount.html.erb
+++ b/app/views/student_loans/claims/student_loan_amount.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.student_loan_amount"), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(student_loan_amount_question, policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -11,7 +11,7 @@
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <span class="govuk-caption-xl">About your student loans</span>
               <h1 class="govuk-fieldset__heading">
-                <%= fields.label :student_loan_repayment_amount, t("student_loans.questions.student_loan_amount"), class: "govuk-label govuk-label--xl" %>
+                <%= fields.label :student_loan_repayment_amount, student_loan_amount_question, class: "govuk-label govuk-label--xl" %>
               </h1>
             </legend>
 

--- a/app/views/student_loans/claims/subjects_taught.html.erb
+++ b/app/views/student_loans/claims/subjects_taught.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, page_title(t("student_loans.questions.subjects_taught", school: current_claim.eligibility.claim_school_name), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
+<% content_for(:page_title, page_title(subjects_taught_question(school_name: current_claim.eligibility.claim_school_name), policy: current_policy_routing_name, show_error: current_claim.errors.any?)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -12,7 +12,7 @@
 
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
-                <%= t("student_loans.questions.subjects_taught", school: current_claim.eligibility.claim_school_name) %>
+                <%= subjects_taught_question(school_name: current_claim.eligibility.claim_school_name) %>
               </h1>
             </legend>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,8 +175,8 @@ en:
     award_description: "claim payment"
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
-      claim_school: "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
-      additional_school: "Which additional school were you employed to teach at between 6 April 2018 and 5 April 2019?"
+      claim_school: "Which school were you employed to teach at between %{financial_year}?"
+      additional_school: "Which additional school were you employed to teach at between %{financial_year}?"
       employment_status: "Are you still employed to teach at a school in England?"
       subjects_taught: "Which of the following subjects did you teach at %{school} between 6 April 2018 and 5 April 2019?"
       leadership_position: "Were you employed in a leadership position between 6 April 2018 and 5 April 2019?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,7 +181,7 @@ en:
     award_description: "claim payment"
     possible_rejection_reasons: |
       * you completed your initial teacher training in or before the academic year %{qts_year}
-      * you did not teach at an eligible school during the financial year 2018 to 2019
+      * you did not teach at an eligible school between 6 April 2018 and 5 April 2019
       * you are not currently employed to teach at a state-funded secondary school
       * you did not teach an eligible subject for at least half of your contracted hours
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,7 +179,7 @@ en:
       additional_school: "Which additional school were you employed to teach at between %{financial_year}?"
       employment_status: "Are you still employed to teach at a school in England?"
       subjects_taught: "Which of the following subjects did you teach at %{school} between %{financial_year}?"
-      leadership_position: "Were you employed in a leadership position between 6 April 2018 and 5 April 2019?"
+      leadership_position: "Were you employed in a leadership position between %{financial_year}?"
       mostly_performed_leadership_duties:
         "Were more than half your working hours spent on leadership duties between 6 April 2018 and 5 April 2019?"
       eligible_subjects:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,7 +178,7 @@ en:
       claim_school: "Which school were you employed to teach at between %{financial_year}?"
       additional_school: "Which additional school were you employed to teach at between %{financial_year}?"
       employment_status: "Are you still employed to teach at a school in England?"
-      subjects_taught: "Which of the following subjects did you teach at %{school} between 6 April 2018 and 5 April 2019?"
+      subjects_taught: "Which of the following subjects did you teach at %{school} between %{financial_year}?"
       leadership_position: "Were you employed in a leadership position between 6 April 2018 and 5 April 2019?"
       mostly_performed_leadership_duties:
         "Were more than half your working hours spent on leadership duties between 6 April 2018 and 5 April 2019?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,12 +128,6 @@ en:
     claim_action: "claim £2,000 for teaching maths or physics"
     award_description: "£2,000 payment"
     support_email_address: "mathsphysicsteacherpayment@digital.education.gov.uk"
-    possible_rejection_reasons: |
-      * you are not employed to teach maths or physics at an eligible state-funded secondary school
-      * you did not complete your initial teacher training in maths or physics and you do not have a degree in maths or physics
-      * you completed your initial teacher training in or before the academic year %{qts_year}
-      * you’re a supply teacher contracted by a private agency or for less than a full term
-      * you are currently subject to formal capability proceedings or disciplinary action
     questions:
       teaching_maths_or_physics: "Do you currently teach any maths or physics?"
       initial_teacher_training_subject: "Which subject did you complete your initial teacher training in?"
@@ -179,11 +173,6 @@ en:
     claim_amount_description: "Student loan repayments you’ve claimed back"
     claim_action: "claim back student loan repayments"
     award_description: "claim payment"
-    possible_rejection_reasons: |
-      * you completed your initial teacher training in or before the academic year %{qts_year}
-      * you did not teach at an eligible school between 6 April 2018 and 5 April 2019
-      * you are not currently employed to teach at a state-funded secondary school
-      * you did not teach an eligible subject for at least half of your contracted hours
     support_email_address: "studentloanteacherpayment@digital.education.gov.uk"
     questions:
       claim_school: "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,8 +180,7 @@ en:
       employment_status: "Are you still employed to teach at a school in England?"
       subjects_taught: "Which of the following subjects did you teach at %{school} between %{financial_year}?"
       leadership_position: "Were you employed in a leadership position between %{financial_year}?"
-      mostly_performed_leadership_duties:
-        "Were more than half your working hours spent on leadership duties between 6 April 2018 and 5 April 2019?"
+      mostly_performed_leadership_duties: "Were more than half your working hours spent on leadership duties between %{financial_year}?"
       eligible_subjects:
         biology_taught: "Biology"
         chemistry_taught: "Chemistry"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,8 +188,7 @@ en:
         computing_taught: "Computing"
         languages_taught: "Languages"
         none_taught: "I did not teach any of these subjects"
-      student_loan_amount:
-        "Exactly how much student loan did you repay while employed as a teacher between 6 April 2018 and 5 April 2019?"
+      student_loan_amount: "Exactly how much student loan did you repay while employed as a teacher between %{financial_year}?"
     admin:
       claim_school: "Claim school"
       subjects_taught: "Subjects taught"

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     expect(claim.eligibility.reload.mostly_performed_leadership_duties).to eq(true)
 
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between 6 April 2018 and 5 April 2019.")
+    expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between #{StudentLoans.current_financial_year}.")
   end
 
   scenario "Teacher edits but does not change an answer which is a dependency of some of the subsequent answers they’ve given" do

--- a/spec/features/changing_answers_spec.rb
+++ b/spec/features/changing_answers_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Changing the answers on a submittable claim" do
+  include StudentLoansHelper
+
   scenario "Teacher changes an answer which is not a dependency of any of the other answers they’ve given, remaining eligible" do
     claim = start_maths_and_physics_claim
     claim.update!(attributes_for(:claim, :submittable))
@@ -128,7 +130,7 @@ RSpec.feature "Changing the answers on a submittable claim" do
     find("a[href='#{claim_path(StudentLoans.routing_name, "student-loan-amount")}']").click
 
     expect(find("#claim_eligibility_attributes_student_loan_repayment_amount").value).to eq("100.10")
-    fill_in I18n.t("student_loans.questions.student_loan_amount"), with: "150.20"
+    fill_in student_loan_amount_question, with: "150.20"
     click_on "Continue"
 
     expect(page).to have_content("£150.20")

--- a/spec/features/govuk_verify_skipped_spec.rb
+++ b/spec/features/govuk_verify_skipped_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Bypassing GOV.UK Verify" do
+  include StudentLoansHelper
+
   before { stub_geckoboard_dataset_update }
 
   scenario "Teacher can submit a claim without going through GOV.UK Verify" do
@@ -62,7 +64,7 @@ RSpec.feature "Bypassing GOV.UK Verify" do
 
     answer_student_loan_plan_questions
 
-    fill_in I18n.t("student_loans.questions.student_loan_amount"), with: "1100"
+    fill_in student_loan_amount_question, with: "1100"
     click_on "Continue"
 
     fill_in I18n.t("questions.email_address"), with: "name@example.tld"

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.taught_eligible_subjects?).to eq(false)
     expect(page).to have_text("You did not select an eligible subject")
-    expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
+    expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between #{StudentLoans.current_financial_year}:")
   end
 
   scenario "was in a leadership position and performed leadership duties for more than half of their time" do

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
+  include StudentLoansHelper
+
   scenario "qualified before the first eligible QTS year" do
     policy_configurations(:student_loans).update!(current_academic_year: "2025/2026")
 
@@ -98,6 +100,6 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     choose_school schools(:penistone_grammar_school)
 
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
+    expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
   end
 end

--- a/spec/features/ineligible_student_loans_claims_spec.rb
+++ b/spec/features/ineligible_student_loans_claims_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Ineligible Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.mostly_performed_leadership_duties?).to eq(true)
     expect(page).to have_text("You’re not eligible")
-    expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between 6 April 2018 and 5 April 2019.")
+    expect(page).to have_text("You can only get this payment if you spent less than half your working hours performing leadership duties between #{StudentLoans.current_financial_year}.")
   end
 
   scenario "claimant can start a fresh claim after being told they are ineligible, by visiting the start page" do

--- a/spec/features/missing_verify_information_spec.rb
+++ b/spec/features/missing_verify_information_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Missing information from GOV.UK Verify" do
+  include StudentLoansHelper
+
   before { stub_geckoboard_dataset_update }
 
   scenario "Claimant is asked a payroll gender question when Verify doesn’t provide their gender" do
@@ -31,7 +33,7 @@ RSpec.feature "Missing information from GOV.UK Verify" do
 
     answer_student_loan_plan_questions
 
-    fill_in I18n.t("student_loans.questions.student_loan_amount"), with: "1100"
+    fill_in student_loan_amount_question, with: "1100"
     click_on "Continue"
 
     fill_in I18n.t("questions.email_address"), with: "name@example.tld"
@@ -86,7 +88,7 @@ RSpec.feature "Missing information from GOV.UK Verify" do
 
     answer_student_loan_plan_questions
 
-    fill_in I18n.t("student_loans.questions.student_loan_amount"), with: "1100"
+    fill_in student_loan_amount_question, with: "1100"
     click_on "Continue"
 
     fill_in I18n.t("questions.email_address"), with: "name@example.tld"

--- a/spec/features/multiple_claim_schools_spec.rb
+++ b/spec/features/multiple_claim_schools_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Applicant worked at multiple schools" do
     choose_school schools(:penistone_grammar_school)
     expect(claim.eligibility.reload.claim_school).to eq schools(:penistone_grammar_school)
 
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
+    expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
   end
 
   scenario "first claim school is ineligible and subsequent school is ineligible too" do

--- a/spec/features/multiple_claim_schools_spec.rb
+++ b/spec/features/multiple_claim_schools_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Applicant worked at multiple schools" do
+  include StudentLoansHelper
+
   let!(:eligible_school) { create(:school, :student_loan_eligible) }
 
   let!(:claim) { start_student_loans_claim }
@@ -15,7 +17,7 @@ RSpec.feature "Applicant worked at multiple schools" do
     click_on "Enter another school"
 
     expect(page).to_not have_css("input[value=\"Hampstead School\"]")
-    expect(page).to have_text(I18n.t("student_loans.questions.additional_school"))
+    expect(page).to have_text(claim_school_question(additional_school: true))
     expect(page).to_not have_text("If you taught at multiple schools")
 
     choose_school schools(:penistone_grammar_school)
@@ -49,7 +51,7 @@ RSpec.feature "Applicant worked at multiple schools" do
     click_on "Enter another school"
 
     expect(page).to_not have_css("input[value=\"Penistone Grammar School\"]")
-    expect(page).to have_text(I18n.t("student_loans.questions.additional_school"))
+    expect(page).to have_text(claim_school_question(additional_school: true))
 
     choose_school eligible_school
 

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     click_on "Continue"
 
     expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
+    expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
   end
 
   scenario "searches again to find school" do
@@ -36,7 +36,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     click_on "Continue"
 
     expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
+    expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
   end
 
   scenario "Claim school search with autocomplete", js: true do
@@ -52,7 +52,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
     click_button "Continue"
 
-    expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
+    expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
   end
 
   scenario "Current school search with autocomplete", js: true do

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
 
     click_button "Continue"
 
-    expect(page).to have_text(I18n.t("student_loans.questions.leadership_position"))
+    expect(page).to have_text(leadership_position_question)
   end
 
   scenario "School search form still works like a normal form if submitted", js: true do

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Searching for school during Teacher Student Loan Repayments claims" do
+  include StudentLoansHelper
+
   scenario "doesn't select a school from the search results the first time around" do
     claim = start_student_loans_claim
 
@@ -40,7 +42,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   scenario "Claim school search with autocomplete", js: true do
     start_student_loans_claim
 
-    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
+    expect(page).to have_text(claim_school_question)
     expect(page).to have_button("Search")
 
     fill_in :school_search, with: "Penistone"
@@ -77,7 +79,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   scenario "School search form still works like a normal form if submitted", js: true do
     start_student_loans_claim
 
-    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
+    expect(page).to have_text(claim_school_question)
     expect(page).to have_button("Search")
 
     fill_in :school_search, with: "Penistone"
@@ -94,7 +96,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   scenario "Editing school search after autocompletion clears last selection", js: true do
     start_student_loans_claim
 
-    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
+    expect(page).to have_text(claim_school_question)
     expect(page).to have_button("Search")
 
     fill_in :school_search, with: "Penistone"
@@ -116,7 +118,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   scenario "Claim school search includes closed schools" do
     start_student_loans_claim
 
-    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
+    expect(page).to have_text(claim_school_question)
     expect(page).to have_button("Search")
 
     fill_in :school_search, with: "Lister"
@@ -143,7 +145,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   scenario "Claim school search with autocomplete includes closed schools", js: true do
     start_student_loans_claim
 
-    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
+    expect(page).to have_text(claim_school_question)
     expect(page).to have_button("Search")
 
     fill_in :school_search, with: "Lister"

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       choose_school schools(:penistone_grammar_school)
       expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)
-      expect(page).to have_text(I18n.t("student_loans.questions.subjects_taught", school: schools(:penistone_grammar_school).name))
+      expect(page).to have_text(subjects_taught_question(school_name: schools(:penistone_grammar_school).name))
 
       check "Physics"
       click_on "Continue"

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -87,8 +87,8 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
       expect(claim.student_loan_start_date).to eq(StudentLoan::BEFORE_1_SEPT_2012)
       expect(claim.student_loan_plan).to eq(StudentLoan::PLAN_1)
 
-      expect(page).to have_text(I18n.t("student_loans.questions.student_loan_amount"))
-      fill_in I18n.t("student_loans.questions.student_loan_amount"), with: "1100"
+      expect(page).to have_text(student_loan_amount_question)
+      fill_in student_loan_amount_question, with: "1100"
       click_on "Continue"
 
       expect(claim.eligibility.reload.student_loan_repayment_amount).to eql(1100.00)

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Teacher Student Loan Repayments claims" do
+  include StudentLoansHelper
+
   before { stub_geckoboard_dataset_update }
 
   [
@@ -18,7 +20,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       expect(claim.eligibility.reload.qts_award_year).to eql("on_or_after_cut_off_date")
 
-      expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
+      expect(page).to have_text(claim_school_question)
 
       choose_school schools(:penistone_grammar_school)
       expect(claim.eligibility.reload.claim_school).to eql schools(:penistone_grammar_school)

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       expect(claim.eligibility.reload.had_leadership_position?).to eq(true)
 
-      expect(page).to have_text(I18n.t("student_loans.questions.mostly_performed_leadership_duties"))
+      expect(page).to have_text(mostly_performed_leadership_duties_question)
       choose "No"
       click_on "Continue"
 

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       expect(claim.eligibility.reload.mostly_performed_leadership_duties?).to eq(false)
 
-      expect(page).to have_text("You are eligible to claim back student loan repayments")
+      expect(page).to have_text("you can claim back the student loan repayments you made between #{StudentLoans.current_financial_year}.")
       click_on "Continue"
 
       expect(page).to have_text("How we will use the information you provide")

--- a/spec/features/student_loans_claim_spec.rb
+++ b/spec/features/student_loans_claim_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
       expect(claim.eligibility.reload.subjects_taught).to eq([:physics_taught])
 
-      expect(page).to have_text(I18n.t("student_loans.questions.leadership_position"))
+      expect(page).to have_text(leadership_position_question)
       choose "Yes"
       click_on "Continue"
 
@@ -150,6 +150,6 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.eligibility.reload.current_school).to eql schools(:hampstead_school)
 
-    expect(page).to have_text(I18n.t("student_loans.questions.leadership_position"))
+    expect(page).to have_text(leadership_position_question)
   end
 end

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       choose "Yes, at Penistone Grammar School"
       click_on "Continue"
 
-      expect(page).to have_text(I18n.t("student_loans.questions.leadership_position"))
+      expect(page).to have_text(leadership_position_question)
     end
   end
 

--- a/spec/features/subjects_taught_spec.rb
+++ b/spec/features/subjects_taught_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments claims" do
+  include StudentLoansHelper
   before do
     start_student_loans_claim
     choose_school schools(:penistone_grammar_school)
@@ -24,7 +25,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You did not select an eligible subject")
-      expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
+      expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between #{StudentLoans.current_financial_year}:")
     end
 
     scenario "checks not applicable and then chooses a subject" do
@@ -55,7 +56,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You did not select an eligible subject")
-      expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
+      expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between #{StudentLoans.current_financial_year}:")
     end
 
     scenario "checks not applicable and then chooses a subject" do
@@ -65,7 +66,7 @@ RSpec.feature "Choosing subjects taught during Teacher Student Loan Repayments c
       click_on "Continue"
 
       expect(page).to have_text("You did not select an eligible subject")
-      expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between 6 April 2018 and 5 April 2019:")
+      expect(page).to have_text("You can only get this payment if you taught one or more of the following subjects between #{StudentLoans.current_financial_year}:")
     end
   end
 end

--- a/spec/features/switching_policies_spec.rb
+++ b/spec/features/switching_policies_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Switching policies" do
+  include StudentLoansHelper
+
   before do
     start_student_loans_claim
     visit new_claim_path(MathsAndPhysics.routing_name)
@@ -20,7 +22,7 @@ RSpec.feature "Switching policies" do
     choose "No, finish the claim I have in progress"
     click_on "Submit"
 
-    expect(page).to have_text(I18n.t("student_loans.questions.claim_school"))
+    expect(page).to have_text(claim_school_question)
   end
 
   scenario "a user does not select an option" do

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -35,4 +35,10 @@ describe StudentLoansHelper do
       expect(helper.leadership_position_question).to eq "Were you employed in a leadership position between 6 April 2024 and 5 April 2025?"
     end
   end
+
+  describe "#student_loan_amount_question" do
+    it "returns the question for the student laon amount question in the Student Loans journey" do
+      expect(helper.student_loan_amount_question).to eq "Exactly how much student loan did you repay while employed as a teacher between 6 April 2018 and 5 April 2019?"
+    end
+  end
 end

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -28,4 +28,10 @@ describe StudentLoansHelper do
       expect(helper.leadership_position_question).to eq "Were you employed in a leadership position between 6 April 2024 and 5 April 2025?"
     end
   end
+
+  describe "#mostly_performed_leadership_duties_question" do
+    it "returns the question for the mostly performed leadership duties question in the Student Loans journey" do
+      expect(helper.mostly_performed_leadership_duties_question).to eq "Were more than half your working hours spent on leadership duties between 6 April 2018 and 5 April 2019?"
+    end
+  end
 end

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe StudentLoansHelper do
+  describe "#claim_school_question" do
+    it "returns the question for claim school question in the Student Loans journey" do
+      expect(helper.claim_school_question(false)).to eq "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
+    end
+
+    it "rewords the question if looking for an additional school" do
+      expect(helper.claim_school_question(true)).to eq "Which additional school were you employed to teach at between 6 April 2018 and 5 April 2019?"
+    end
+  end
+end

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -3,11 +3,12 @@ require "rails_helper"
 describe StudentLoansHelper do
   describe "#claim_school_question" do
     it "returns the question for claim school question in the Student Loans journey" do
-      expect(helper.claim_school_question(false)).to eq "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
+      expect(helper.claim_school_question).to eq "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
+      expect(helper.claim_school_question(additional_school: false)).to eq "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
     end
 
     it "rewords the question if looking for an additional school" do
-      expect(helper.claim_school_question(true)).to eq "Which additional school were you employed to teach at between 6 April 2018 and 5 April 2019?"
+      expect(helper.claim_school_question(additional_school: true)).to eq "Which additional school were you employed to teach at between 6 April 2018 and 5 April 2019?"
     end
   end
 end

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -23,8 +23,9 @@ describe StudentLoansHelper do
   end
 
   describe "#leadership_position_question" do
-    it "returns the question for the leadership position question in the Student Loans journey" do
-      expect(helper.leadership_position_question).to eq "Were you employed in a leadership position between 6 April 2018 and 5 April 2019?"
+    it "returns the question for the leadership position question in the Student Loans journey, based on the configured current academic year" do
+      expect(policy_configurations(:student_loans).current_academic_year).to eq AcademicYear.new("2025/2026")
+      expect(helper.leadership_position_question).to eq "Were you employed in a leadership position between 6 April 2024 and 5 April 2025?"
     end
   end
 end

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -30,8 +30,9 @@ describe StudentLoansHelper do
   end
 
   describe "#mostly_performed_leadership_duties_question" do
-    it "returns the question for the mostly performed leadership duties question in the Student Loans journey" do
-      expect(helper.mostly_performed_leadership_duties_question).to eq "Were more than half your working hours spent on leadership duties between 6 April 2018 and 5 April 2019?"
+    it "returns the question for the mostly performed leadership duties question in the Student Loans journey, based on the configured current academic year" do
+      expect(policy_configurations(:student_loans).current_academic_year).to eq AcademicYear.new("2025/2026")
+      expect(helper.leadership_position_question).to eq "Were you employed in a leadership position between 6 April 2024 and 5 April 2025?"
     end
   end
 end

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -37,8 +37,9 @@ describe StudentLoansHelper do
   end
 
   describe "#student_loan_amount_question" do
-    it "returns the question for the student laon amount question in the Student Loans journey" do
-      expect(helper.student_loan_amount_question).to eq "Exactly how much student loan did you repay while employed as a teacher between 6 April 2018 and 5 April 2019?"
+    it "returns the question for the student laon amount question in the Student Loans journey, based on the configured current academic year" do
+      expect(policy_configurations(:student_loans).current_academic_year).to eq AcademicYear.new("2025/2026")
+      expect(helper.student_loan_amount_question).to eq "Exactly how much student loan did you repay while employed as a teacher between 6 April 2024 and 5 April 2025?"
     end
   end
 end

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -21,4 +21,10 @@ describe StudentLoansHelper do
       expect(helper.subjects_taught_question(school_name: "Edward Tilghman Middle")).to eq "Which of the following subjects did you teach at Edward Tilghman Middle between 6 April 2024 and 5 April 2025?"
     end
   end
+
+  describe "#leadership_position_question" do
+    it "returns the question for the leadership position question in the Student Loans journey" do
+      expect(helper.leadership_position_question).to eq "Were you employed in a leadership position between 6 April 2018 and 5 April 2019?"
+    end
+  end
 end

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -16,8 +16,9 @@ describe StudentLoansHelper do
   end
 
   describe "#subjects_taught_question" do
-    it "returns the question for the subjects taught question in the Student Loans journey mentioning the school" do
-      expect(helper.subjects_taught_question(school_name: "Edward Tilghman Middle")).to eq "Which of the following subjects did you teach at Edward Tilghman Middle between 6 April 2018 and 5 April 2019?"
+    it "returns the question for the subjects taught question in the Student Loans journey mentioning the school, based on the configured current academic year" do
+      expect(policy_configurations(:student_loans).current_academic_year).to eq AcademicYear.new("2025/2026")
+      expect(helper.subjects_taught_question(school_name: "Edward Tilghman Middle")).to eq "Which of the following subjects did you teach at Edward Tilghman Middle between 6 April 2024 and 5 April 2025?"
     end
   end
 end

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -14,4 +14,10 @@ describe StudentLoansHelper do
       expect(helper.claim_school_question(additional_school: true)).to eq "Which additional school were you employed to teach at between 6 April 2024 and 5 April 2025?"
     end
   end
+
+  describe "#subjects_taught_question" do
+    it "returns the question for the subjects taught question in the Student Loans journey mentioning the school" do
+      expect(helper.subjects_taught_question(school_name: "Edward Tilghman Middle")).to eq "Which of the following subjects did you teach at Edward Tilghman Middle between 6 April 2018 and 5 April 2019?"
+    end
+  end
 end

--- a/spec/helpers/student_loans_helper_spec.rb
+++ b/spec/helpers/student_loans_helper_spec.rb
@@ -2,13 +2,16 @@ require "rails_helper"
 
 describe StudentLoansHelper do
   describe "#claim_school_question" do
-    it "returns the question for claim school question in the Student Loans journey" do
+    it "returns the question for claim school question in the Student Loans journey, based on the configured current academic year" do
+      expect(policy_configurations(:student_loans).current_academic_year).to eq AcademicYear.new("2025/2026")
+      expect(helper.claim_school_question).to eq "Which school were you employed to teach at between 6 April 2024 and 5 April 2025?"
+
+      policy_configurations(:student_loans).update!(current_academic_year: "2019/2020")
       expect(helper.claim_school_question).to eq "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
-      expect(helper.claim_school_question(additional_school: false)).to eq "Which school were you employed to teach at between 6 April 2018 and 5 April 2019?"
     end
 
     it "rewords the question if looking for an additional school" do
-      expect(helper.claim_school_question(additional_school: true)).to eq "Which additional school were you employed to teach at between 6 April 2018 and 5 April 2019?"
+      expect(helper.claim_school_question(additional_school: true)).to eq "Which additional school were you employed to teach at between 6 April 2024 and 5 April 2025?"
     end
   end
 end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ClaimMailer, type: :mailer do
           expect(mail.subject).to include("rejected")
           expect(mail.body.encoded).to include("not been able to approve")
 
-          ineligible_year = (policy.first_eligible_qts_award_year - 1).to_s(:long)
+          ineligible_year = policy.last_ineligible_qts_award_year.to_s(:long)
           expect(mail.body.encoded)
             .to include("completed your initial teacher training in or before the academic year #{ineligible_year}")
         end
@@ -81,7 +81,7 @@ RSpec.describe ClaimMailer, type: :mailer do
         it "changes the ITT reason based on the policy's configured current_academic_year" do
           PolicyConfiguration.for(policy).update!(current_academic_year: "2025/2026")
 
-          ineligible_year = (policy.first_eligible_qts_award_year - 1).to_s(:long)
+          ineligible_year = policy.last_ineligible_qts_award_year.to_s(:long)
           expect(mail.body.encoded)
             .to include("completed your initial teacher training in or before the academic year #{ineligible_year}")
         end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -100,4 +100,15 @@ RSpec.describe ClaimMailer, type: :mailer do
       end
     end
   end
+
+  context "with a StudentLoans claim" do
+    describe "#rejected" do
+      let(:claim) { build(:claim, :submitted, policy: StudentLoans) }
+      let(:mail) { ClaimMailer.rejected(claim) }
+
+      it "mentions “the eligible-school during the financial year” reason" do
+        expect(mail.body.encoded).to include("you did not teach at an eligible school between 6 April 2018 and 5 April 2019")
+      end
+    end
+  end
 end

--- a/spec/mailers/claim_mailer_spec.rb
+++ b/spec/mailers/claim_mailer_spec.rb
@@ -107,7 +107,15 @@ RSpec.describe ClaimMailer, type: :mailer do
       let(:mail) { ClaimMailer.rejected(claim) }
 
       it "mentions “the eligible-school during the financial year” reason" do
-        expect(mail.body.encoded).to include("you did not teach at an eligible school between 6 April 2018 and 5 April 2019")
+        # Based on the current academic year set by the policy_configurations.yml fixtures
+        expect(mail.body.encoded).to include("you did not teach at an eligible school between 6 April 2024 and 5 April 2025")
+      end
+
+      it "changes the financial year based on the policy's configured current_academic_year" do
+        policy_configurations(:student_loans).update!(current_academic_year: "2019/2020")
+
+        expect(mail.body.encoded)
+          .to include("you did not teach at an eligible school between 6 April 2018 and 5 April 2019")
       end
     end
   end

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
       [claim_school_question, school.name, "claim-school"],
       [I18n.t("questions.current_school"), school.name, "still-teaching"],
       [subjects_taught_question(school_name: school.name), "Chemistry and Physics", "subjects-taught"],
-      [I18n.t("student_loans.questions.leadership_position"), "Yes", "leadership-position"],
+      [leadership_position_question, "Yes", "leadership-position"],
       [I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "No", "mostly-performed-leadership-duties"],
       [I18n.t("student_loans.questions.student_loan_amount"), "£1,987.65", "student-loan-amount"]
     ]

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
       [subjects_taught_question(school_name: school.name), "Chemistry and Physics", "subjects-taught"],
       [leadership_position_question, "Yes", "leadership-position"],
       [mostly_performed_leadership_duties_question, "No", "mostly-performed-leadership-duties"],
-      [I18n.t("student_loans.questions.student_loan_amount"), "£1,987.65", "student-loan-amount"]
+      [student_loan_amount_question, "£1,987.65", "student-loan-amount"]
     ]
 
     expect(presenter.answers).to eq expected_answers

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
+  include StudentLoansHelper
+
   let(:school) { schools(:penistone_grammar_school) }
   let(:eligibility_attributes) do
     {
@@ -21,7 +23,7 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
   it "returns an array of questions, answers, and slugs for displaying to the user for review" do
     expected_answers = [
       [I18n.t("questions.qts_award_year"), "In or after the academic year 2013 to 2014", "qts-year"],
-      [I18n.t("student_loans.questions.claim_school"), school.name, "claim-school"],
+      [claim_school_question, school.name, "claim-school"],
       [I18n.t("questions.current_school"), school.name, "still-teaching"],
       [I18n.t("student_loans.questions.subjects_taught", school: school.name), "Chemistry and Physics", "subjects-taught"],
       [I18n.t("student_loans.questions.leadership_position"), "Yes", "leadership-position"],

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
       [I18n.t("questions.qts_award_year"), "In or after the academic year 2013 to 2014", "qts-year"],
       [claim_school_question, school.name, "claim-school"],
       [I18n.t("questions.current_school"), school.name, "still-teaching"],
-      [I18n.t("student_loans.questions.subjects_taught", school: school.name), "Chemistry and Physics", "subjects-taught"],
+      [subjects_taught_question(school_name: school.name), "Chemistry and Physics", "subjects-taught"],
       [I18n.t("student_loans.questions.leadership_position"), "Yes", "leadership-position"],
       [I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "No", "mostly-performed-leadership-duties"],
       [I18n.t("student_loans.questions.student_loan_amount"), "£1,987.65", "student-loan-amount"]

--- a/spec/models/student_loans/eligibility_answers_presenter_spec.rb
+++ b/spec/models/student_loans/eligibility_answers_presenter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
       [I18n.t("questions.current_school"), school.name, "still-teaching"],
       [subjects_taught_question(school_name: school.name), "Chemistry and Physics", "subjects-taught"],
       [leadership_position_question, "Yes", "leadership-position"],
-      [I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "No", "mostly-performed-leadership-duties"],
+      [mostly_performed_leadership_duties_question, "No", "mostly-performed-leadership-duties"],
       [I18n.t("student_loans.questions.student_loan_amount"), "£1,987.65", "student-loan-amount"]
     ]
 
@@ -47,8 +47,8 @@ RSpec.describe StudentLoans::EligibilityAnswersPresenter, type: :model do
 
   it "excludes questions skipped from the flow" do
     eligibility.had_leadership_position = false
-    expect(presenter.answers).to_not include([I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "Yes", "mostly-performed-leadership-duties"])
-    expect(presenter.answers).to_not include([I18n.t("student_loans.questions.mostly_performed_leadership_duties"), "No", "mostly-performed-leadership-duties"])
+    expect(presenter.answers).to_not include([mostly_performed_leadership_duties_question, "Yes", "mostly-performed-leadership-duties"])
+    expect(presenter.answers).to_not include([mostly_performed_leadership_duties_question, "No", "mostly-performed-leadership-duties"])
   end
 
   context "with three subjects taught" do

--- a/spec/models/student_loans_spec.rb
+++ b/spec/models/student_loans_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe StudentLoans, type: :model do
-  describe ".first_eligible_qts_award_year" do
-    let(:policy_configuration) { policy_configurations(:student_loans) }
+  let(:policy_configuration) { policy_configurations(:student_loans) }
 
+  describe ".first_eligible_qts_award_year" do
     it "returns 11 years prior to the currently configured academic year, with a floor of the 2013/2014 academic year" do
       policy_configuration.update!(current_academic_year: "2031/2032")
       expect(StudentLoans.first_eligible_qts_award_year).to eq AcademicYear.new(2020)
@@ -20,6 +20,16 @@ RSpec.describe StudentLoans, type: :model do
 
     it "can return the AcademicYear based on a passed-in academic year" do
       expect(StudentLoans.first_eligible_qts_award_year(AcademicYear.new(2030))).to eq AcademicYear.new(2019)
+    end
+  end
+
+  describe ".current_financial_year" do
+    it "returns a human-friendly string for the financial year the policy is currently accepting claims for" do
+      # Based on the current academic year set by the policy_configurations.yml fixtures
+      expect(StudentLoans.current_financial_year).to eq "6 April 2024 and 5 April 2025"
+
+      policy_configuration.update!(current_academic_year: "2020/2021")
+      expect(StudentLoans.current_financial_year).to eq "6 April 2019 and 5 April 2020"
     end
   end
 end


### PR DESCRIPTION
Each academic year when the claim window re-opens, claimants will be claiming for student loans paid in a new financial year. This updates the service so that the content (questions and ineligibility reasons) the user sees reflects the year that they are currently claiming against.

We're now in a position where _almost_ all the questions for student loans have defined helper methods. It may make sense in future work to make it so all questions have defined helpers, rather than a mixture of helper and direct access of locale values, but I think if we decide to do that it should be as a separate and smaller PR.