### PR TITLE
Links that looks like buttons work on keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
-- Links that look like buttons now work if users have JS
+- Links that look like buttons now work if users have JS on the claim journey
+- Links styled as buttons now work as expected for keyboard users
 - Manage services page validates in html checker
 - Improve guidance on admin file upload when no file is selected
 - Add visually hidden text to manage services

--- a/app/views/admin/payroll_runs/index.html.erb
+++ b/app/views/admin/payroll_runs/index.html.erb
@@ -14,6 +14,7 @@
           "Run #{Date.today.strftime("%B")} payroll",
           new_admin_payroll_run_path,
           class: "govuk-button",
+          role: "button",
           data: {module: "govuk-button"}
         ) if PayrollRun.this_month.empty? %>
   </div>

--- a/app/views/claims/_school_search_results.html.erb
+++ b/app/views/claims/_school_search_results.html.erb
@@ -48,6 +48,5 @@
   <% end %>
 
   <%= form.submit "Continue", class: "govuk-button" %>
-  <%= link_to "Search again", claim_path, class: "govuk-button govuk-button--secondary" %>
-
+  <%= link_to "Search again", claim_path, class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
 <% end %>

--- a/app/views/claims/timeout.html.erb
+++ b/app/views/claims/timeout.html.erb
@@ -10,6 +10,6 @@
       Your session ended because you haven't done anything for <%= claim_timeout_in_minutes %> minutes
     </h2>
 
-    <%= link_to "Start your application again", start_page_url, class: "govuk-button" %>
+    <%= link_to "Start your application again", start_page_url, class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
   </div>
 </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -40,7 +40,7 @@
         <p class="govuk-cookie-banner__message"><%= t("service_name") %> uses cookies to make the site simpler.</p>
         <div class="govuk-cookie-banner__buttons">
           <button id="accept-cookies" class="govuk-button govuk-button--secondary" type="submit" data-module="govuk-button">Accept cookies</button>
-          <%= link_to('Cookie information', cookies_path(StudentLoans.routing_name), class: "govuk-button govuk-button--secondary ") %>
+          <%= link_to('Cookie information', cookies_path(StudentLoans.routing_name), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"}) %>
         </div>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
         <p class="govuk-cookie-banner__message"><%= policy_service_name(current_policy_routing_name) %> uses cookies to make the site simpler.</p>
         <div class="govuk-cookie-banner__buttons">
           <button id="accept-cookies" class="govuk-button govuk-button--secondary" type="submit" data-module="govuk-button">Accept cookies</button>
-          <%= link_to('Cookie information', cookies_path(current_policy_routing_name), class: "govuk-button govuk-button--secondary ") %>
+          <%= link_to('Cookie information', cookies_path(current_policy_routing_name), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"}) %>
         </div>
       </div>
     </div>

--- a/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_ineligible_claim_school.html.erb
@@ -17,6 +17,6 @@
     to claim.
   </p>
 
-  <%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button", data: {module: "govuk-button"}%>
-  <%= link_to "I've tried all of my schools", claim_path(current_policy_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary", data: {module: "govuk-button"}  %>
+  <%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
+  <%= link_to "I've tried all of my schools", claim_path(current_policy_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
 <% end %>

--- a/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
+++ b/app/views/student_loans/claims/_ineligibility_reason_not_taught_eligible_subjects.html.erb
@@ -29,6 +29,6 @@
     You only need to have worked at one eligible school to claim.
   </p>
 
-  <%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button", data: {module: "govuk-button"} %>
-  <%= link_to "I've tried all of my schools", claim_path(current_policy_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary", data: {module: "govuk-button"} %>
+  <%= link_to "Enter another school", claim_path(current_policy_routing_name, "claim-school", additional_school: true), class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
+  <%= link_to "I've tried all of my schools", claim_path(current_policy_routing_name, "ineligible", no_more_schools: true), class: "govuk-button govuk-button--secondary", role: "button", data: {module: "govuk-button"} %>
 <% end %>

--- a/app/views/verify/authentications/failed.html.erb
+++ b/app/views/verify/authentications/failed.html.erb
@@ -34,6 +34,6 @@
       </li>
     </ul>
 
-    <%= link_to "Try GOV.UK Verify again", new_verify_authentications_path, class: "govuk-button" %>
+    <%= link_to "Try GOV.UK Verify again", new_verify_authentications_path, class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
   </div>
 </div>

--- a/app/views/verify/authentications/no_auth.html.erb
+++ b/app/views/verify/authentications/no_auth.html.erb
@@ -37,6 +37,6 @@
       </li>
     </ul>
 
-    <%= link_to "Try GOV.UK Verify again", new_verify_authentications_path, class: "govuk-button" %>
+    <%= link_to "Try GOV.UK Verify again", new_verify_authentications_path, class: "govuk-button", role: "button", data: {module: "govuk-button"} %>
   </div>
 </div>


### PR DESCRIPTION
This adds some attributes to links that are styled as buttons so that
they will function as expected for keyboard users (press space to
trigger when it has focus).

This does not work for users that do not have JS enabled.
