### PR TITLE
Fix Slack deployment failure notifications

### DIFF
--- a/azure-deploy-template.yml
+++ b/azure-deploy-template.yml
@@ -46,7 +46,7 @@ jobs:
           azureSubscription: ${{parameters.azureSubscription}}
           scriptLocation: inlineScript
           inlineScript: 'az container delete --name ${{parameters.resourceGroupPrefix}}-app-migration-runner-aci --resource-group s118t01-app -y'
-  - job: send_slack_notification
+  - job: send_slack_success_message
     dependsOn: clean_up
     displayName: Send Slack notification
     steps:
@@ -56,10 +56,13 @@ jobs:
           targetType: filePath
           filePath: './$(System.DefaultWorkingDirectory)/Build/repository/bin/slack-alert'
           arguments: '${{parameters.environmentName}} $(Build.BuildNumber) $(Release.ReleaseId) ${{parameters.slackWebhookUrl}} SUCCESS'
+  - job: send_slack_failure_message
+    displayName: Send Slack failure notification
+    condition: failed()
+    steps:
       - task: Bash@3
         displayName: 'Send Slack Failure Notification'
         inputs:
           targetType: filePath
           filePath: './$(System.DefaultWorkingDirectory)/Build/repository/bin/slack-alert'
           arguments: '${{parameters.environmentName}} $(Build.BuildNumber) $(Release.ReleaseId) ${{parameters.slackWebhookUrl}} FAILURE'
-        condition: failed()


### PR DESCRIPTION
Previously, both Slack notification steps were wrapped in one job, which had a `dependsOn` of the previous job. This meant that the job would only run if `clean_up` had run successfully. Moving the failure message to its own job with a `condition` of `failed()` means this job only runs if any of the previous jobs have failed.
