### PR TITLE
Exclude claims for the other policy from claims with matching details

### DIFF
--- a/app/views/admin/claims/_claims_with_matching_details.html.erb
+++ b/app/views/admin/claims/_claims_with_matching_details.html.erb
@@ -1,5 +1,7 @@
 <table id="claims-with-matches" class="govuk-table govuk-!-margin-bottom-9">
-  <caption class="govuk-table__caption govuk-heading-l">Claims with matching details</caption>
+  <caption class="govuk-table__caption govuk-heading-l">
+    <%= @claim.policy.short_name %> <%= "claim".pluralize(@matching_claims.count) %> with matching details
+  </caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Claim</th>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -20,7 +20,9 @@
 
     <% if @matching_claims.any? %>
       <div class="govuk-body-l govuk-flash__warning">
-        <a href="#claims-with-matches">Details in this claim match those in other claims</a>
+        <a href="#claims-with-matches">
+          <%= t("admin.duplicate_attributes_message", count: @matching_claims.count, policy: @claim.policy.short_name) %>
+        </a>
       </div>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,9 @@ en:
     payment_deletion_claim_warning:
       one: This means claim %{references} will no longer be included in this pay run.
       other: This means claims %{references} will no longer be included in this pay run.
+    duplicate_attributes_message:
+      one: Details in this claim match another %{policy} claim
+      other: Details in this claim match other %{policy} claims
     payment_deleted_title:
       one: You have removed a claim from the payroll run
       other: You have removed %{count} claims from the payroll run

--- a/spec/features/admin_duplicate_claims_spec.rb
+++ b/spec/features/admin_duplicate_claims_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature "Service operator can see potential duplicate claims" do
 
     find("a[href='#{admin_claim_path(claim_to_approve)}']").click
 
-    expect(page).to have_content("Details in this claim match those in other claims")
-    expect(page).to have_content("Claims with matching details")
+    expect(page).to have_content("Details in this claim match another Student Loans claim")
+    expect(page).to have_content("Student Loans claim with matching details")
 
     expect(page).to have_content("#{claim_with_matching_teacher_reference_number.reference}\nTeacher reference number")
   end

--- a/spec/models/claim/matching_attribute_finder_spec.rb
+++ b/spec/models/claim/matching_attribute_finder_spec.rb
@@ -3,23 +3,37 @@ require "rails_helper"
 RSpec.describe Claim::MatchingAttributeFinder do
   describe "#matching_claims" do
     let(:source_claim) {
-      create(
-        :claim,
+      create(:claim,
         teacher_reference_number: "0902344",
         national_insurance_number: "QQ891011C",
         email_address: "genghis.khan@mongol-empire.com",
         bank_account_number: "34682151",
         bank_sort_code: "972654",
-        building_society_roll_number: "123456789/ABCD"
-      )
+        building_society_roll_number: "123456789/ABCD",
+        policy: StudentLoans)
     }
-
-    let!(:claim_with_no_matching_attributes) { create(:claim, :submitted) }
-    let!(:unsubmitted_claim_with_matching_teacher_reference_number) { create(:claim, :submittable, teacher_reference_number: source_claim.teacher_reference_number) }
 
     subject(:matching_claims) { Claim::MatchingAttributeFinder.new(source_claim).matching_claims }
 
-    it "does not include the source claim, or claims that do not match, or claims that are not submitted" do
+    it "does not include the source claim" do
+      expect(matching_claims).to be_empty
+    end
+
+    it "does not include claims that do not match" do
+      create(:claim, :submitted)
+
+      expect(matching_claims).to be_empty
+    end
+
+    it "does not include unsubmitted claims with matching attributes" do
+      create(:claim, :submittable, teacher_reference_number: source_claim.teacher_reference_number)
+
+      expect(matching_claims).to be_empty
+    end
+
+    it "does not include claims that match, but have a different policy" do
+      create(:claim, :submitted, teacher_reference_number: source_claim.teacher_reference_number, policy: MathsAndPhysics)
+
       expect(matching_claims).to be_empty
     end
 


### PR DESCRIPTION
We've had reports of a number of false positives when searching for matching attributes, because a number of applicants are eligible for both policies.

This adds the source claim's policy to the `claims_to_compare` query, ensuring that only claims for the source claim's policy are returned when searching for potential duplicate claims.

I've also removed the optional `claims_to_compare` parameter as it's not used anywhere, and complicates the class somewhat without any real benefit.

This also comes with some slight copy tweaks, which should make things easier to understand:

![image](https://user-images.githubusercontent.com/109774/76208010-c6009f00-61f6-11ea-945a-3b8b0195e4b8.png)

![image](https://user-images.githubusercontent.com/109774/76208026-cbf68000-61f6-11ea-9bf8-b0cac2584e60.png)
