### PR TITLE
Use question helper when displaying search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fix question bug on school search results page
+
 ## [Release 059] - 2020-03-09
 
 - Links that look like buttons now work if users have JS on the claim journey

--- a/app/views/student_loans/claims/claim_school.html.erb
+++ b/app/views/student_loans/claims/claim_school.html.erb
@@ -14,7 +14,7 @@
 
     <% else %>
       <%= render "school_search_results",
-                 question: t("student_loans.questions.claim_school"),
+                 question: claim_school_question(additional_school: params[:additional_school]),
                  school_param: :claim_school,
                  school_id_param: :claim_school_id
       %>


### PR DESCRIPTION
This was accessing the locale directly, instead of using the question helper, which was resulting in a visual regression for the question as the `financial_year` interpolation value wasn't being provided.