### PR TITLE
Re organise claim checking specs

### DIFF
--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.feature "Admin checking a Maths & Physics claim" do
+  let(:user) { create(:dfe_signin_user) }
+
+  before do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+  end
+
+  scenario "service operator checks and approves a Maths & Physics claim" do
+    claim = create(:claim, :submitted, policy: MathsAndPhysics)
+
+    visit admin_claims_path
+    find("a[href='#{admin_claim_checks_path(claim)}']").click
+
+    expect(page).to have_content("1. Qualifications")
+    expect(page).to have_content("2. Employment")
+
+    click_on "Check qualification information"
+    expect(page).to have_content("Qualifications")
+    expect(page).to have_content("Award year")
+    expect(page).to have_content(claim.eligibility.qts_award_year_answer)
+
+    click_on "Complete qualifications check and continue"
+
+    expect(page).to have_content("Employment")
+    expect(page).to have_content("Current school")
+    expect(page).to have_link(claim.eligibility.current_school.name)
+
+    click_on "Complete employment check and continue"
+
+    expect(page).to have_content("Claim decision")
+
+    choose "Approve"
+    fill_in "Decision notes", with: "All checks passed!"
+    click_on "Confirm decision"
+
+    expect(page).to have_content("Claim has been approved successfully")
+    expect(claim.decision).to be_approved
+    expect(claim.decision.created_by).to eq(user)
+  end
+end

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.feature "Admin checking a Student Loans claim" do
+  let(:user) { create(:dfe_signin_user) }
+
+  before do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+  end
+
+  scenario "service operator checks and approves a Student Loans claim" do
+    claim = create(:claim, :submitted, policy: StudentLoans)
+
+    visit admin_claims_path
+    find("a[href='#{admin_claim_path(claim)}']").click
+    click_on "View checks"
+
+    expect(page).to have_content("1. Qualifications")
+    expect(page).to have_content("2. Employment")
+
+    click_on "Check qualification information"
+    expect(page).to have_content("Qualifications")
+    expect(page).to have_content("Award year")
+    expect(page).to have_content(claim.eligibility.qts_award_year_answer)
+
+    click_on "Complete qualifications check and continue"
+
+    expect(page).to have_content("Employment")
+    expect(page).to have_content("Current school")
+    expect(page).to have_link(claim.eligibility.current_school.name)
+
+    click_on "Complete employment check and continue"
+
+    expect(page).to have_content("Claim decision")
+
+    choose "Approve"
+    fill_in "Decision notes", with: "All checks passed!"
+    click_on "Confirm decision"
+
+    expect(page).to have_content("Claim has been approved successfully")
+    expect(claim.decision).to be_approved
+    expect(claim.decision.created_by).to eq(user)
+  end
+end

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -143,28 +143,6 @@ RSpec.feature "Admin checks a claim" do
       end
     end
 
-    context "When the payroll gender is missing" do
-      let!(:claim_missing_payroll_gender) { create(:claim, :submitted, payroll_gender: :dont_know) }
-
-      scenario "User is informed that the claim cannot be approved" do
-        click_on "View claims"
-        find("a[href='#{admin_claim_path(claim_missing_payroll_gender)}']").click
-
-        expect(page).to have_field("Approve", disabled: true)
-        expect(page).to have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))
-      end
-
-      context "When a decision has been made" do
-        let!(:claim_missing_payroll_gender_with_decision) { create(:claim, :rejected, payroll_gender: :dont_know) }
-
-        scenario "User is not informed that the claim cannot be approved" do
-          visit admin_claim_path(claim_missing_payroll_gender_with_decision)
-
-          expect(page).to_not have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))
-        end
-      end
-    end
-
     context "with a mixture of policy types" do
       let!(:maths_and_physics_claims) { create_list(:claim, 3, :submitted, policy: MathsAndPhysics) }
       let!(:student_loan_claims) { create_list(:claim, 2, :submitted, policy: StudentLoans) }

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -190,25 +190,6 @@ RSpec.feature "Admin checks a claim" do
       end
     end
 
-    context "When the claimant has not completed GOV.UK Verify" do
-      let!(:claim_without_identity_confirmation) { create(:claim, :unverified) }
-
-      scenario "the service operator is told the identity hasn't been confirmed and can approve the claim" do
-        click_on "View claims"
-        find("a[href='#{admin_claim_path(claim_without_identity_confirmation)}']").click
-
-        expect(page).to have_content("The claimant did not complete GOV.UK Verify")
-        expect(page).to have_content(claim_without_identity_confirmation.school.phone_number)
-
-        choose "Approve"
-        fill_in "Decision notes", with: "Identity confirmed via phone call"
-        click_on "Confirm decision"
-
-        expect(claim_without_identity_confirmation.decision.created_by).to eq(user)
-        expect(claim_without_identity_confirmation.decision.notes).to eq("Identity confirmed via phone call")
-      end
-    end
-
     context "with a mixture of policy types" do
       let!(:maths_and_physics_claims) { create_list(:claim, 3, :submitted, policy: MathsAndPhysics) }
       let!(:student_loan_claims) { create_list(:claim, 2, :submitted, policy: StudentLoans) }

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -130,19 +130,6 @@ RSpec.feature "Admin checks a claim" do
       expect(page).to have_content(user.full_name)
     end
 
-    context "When the claim has had PII removed" do
-      let!(:claim_with_pii_removed) { create(:claim, :rejected, :pii_removed) }
-
-      scenario "User can see where a claim has had PII removed" do
-        visit admin_claim_path(claim_with_pii_removed)
-        expect(page).to have_content("personally identifiable information removed")
-        expect(page).to have_content("Full name Removed")
-        expect(page).to have_content("Date of birth Removed")
-        expect(page).to have_content("National Insurance number Removed")
-        expect(page).to have_content("Address Removed")
-      end
-    end
-
     context "with a mixture of policy types" do
       let!(:maths_and_physics_claims) { create_list(:claim, 3, :submitted, policy: MathsAndPhysics) }
       let!(:student_loan_claims) { create_list(:claim, 2, :submitted, policy: StudentLoans) }

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -68,39 +68,6 @@ RSpec.feature "Admin checks a claim" do
       expect(mail.body.raw_source).to match("not been able to approve")
     end
 
-    scenario "User can complete the claim checks and approve a claim" do
-      claim = create(:claim, :submitted, policy: MathsAndPhysics)
-
-      visit admin_claims_path
-      find("a[href='#{admin_claim_checks_path(claim)}']").click
-
-      expect(page).to have_content("1. Qualifications")
-      expect(page).to have_content("2. Employment")
-
-      click_on "Check qualification information"
-      expect(page).to have_content("Qualifications")
-      expect(page).to have_content("Award year")
-      expect(page).to have_content(claim.eligibility.qts_award_year_answer)
-
-      click_on "Complete qualifications check and continue"
-
-      expect(page).to have_content("Employment")
-      expect(page).to have_content("Current school")
-      expect(page).to have_link(claim.eligibility.current_school.name)
-
-      click_on "Complete employment check and continue"
-
-      expect(page).to have_content("Claim decision")
-
-      choose "Approve"
-      fill_in "Decision notes", with: "All checks passed!"
-      click_on "Confirm decision"
-
-      expect(page).to have_content("Claim has been approved successfully")
-      expect(claim.decision).to be_approved
-      expect(claim.decision.created_by).to eq(user)
-    end
-
     scenario "User can see completed checks" do
       ten_minutes_ago = 10.minutes.ago
       checking_user = create(:dfe_signin_user, given_name: "Fred", family_name: "Smith")

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -165,31 +165,6 @@ RSpec.feature "Admin checks a claim" do
       end
     end
 
-    context "When the claimant has another approved claim in the same payroll window, with inconsistent personal details" do
-      let(:personal_details) do
-        {
-          national_insurance_number: generate(:national_insurance_number),
-          teacher_reference_number: generate(:teacher_reference_number),
-          date_of_birth: 30.years.ago.to_date,
-          student_loan_plan: StudentLoan::PLAN_1,
-          email_address: "email@example.com",
-          bank_sort_code: "112233",
-          bank_account_number: "95928482",
-          building_society_roll_number: nil
-        }
-      end
-      let!(:claim) { create(:claim, :submitted, personal_details.merge(bank_sort_code: "582939", bank_account_number: "74727752")) }
-      let!(:approved_claim) { create(:claim, :approved, personal_details.merge(bank_sort_code: "112233", bank_account_number: "29482823")) }
-
-      scenario "User is informed that the claim cannot be approved" do
-        click_on "View claims"
-        find("a[href='#{admin_claim_path(claim)}']").click
-
-        expect(page).to have_field("Approve", disabled: true)
-        expect(page).to have_content("This claim cannot currently be approved because we’re already paying another claim (#{approved_claim.reference}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.")
-      end
-    end
-
     context "with a mixture of policy types" do
       let!(:maths_and_physics_claims) { create_list(:claim, 3, :submitted, policy: MathsAndPhysics) }
       let!(:student_loan_claims) { create_list(:claim, 2, :submitted, policy: StudentLoans) }

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -130,32 +130,6 @@ RSpec.feature "Admin checks a claim" do
       expect(page).to have_content(user.full_name)
     end
 
-    context "with a mixture of policy types" do
-      let!(:maths_and_physics_claims) { create_list(:claim, 3, :submitted, policy: MathsAndPhysics) }
-      let!(:student_loan_claims) { create_list(:claim, 2, :submitted, policy: StudentLoans) }
-
-      it "shows the policy types on the index page" do
-        click_on "View claims"
-
-        expect(page.find("table")).to have_content("Maths and Physics").exactly(3).times
-        expect(page.find("table")).to have_content("Student Loans").exactly(2).times
-      end
-
-      it "can filter by claim type" do
-        click_on "View claims"
-        select "Maths and Physics", from: "policy"
-        click_on "Go"
-
-        maths_and_physics_claims.each do |c|
-          expect(page).to have_content(c.reference)
-        end
-
-        student_loan_claims.each do |c|
-          expect(page).to_not have_content(c.reference)
-        end
-      end
-    end
-
     context "when the service operator completes the last check" do
       context "and the payroll gender is missing" do
         let!(:claim) { create(:claim, :submitted, payroll_gender: :dont_know) }

--- a/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
+++ b/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.feature "Admin checking a claim with inconsistent payroll information" do
+  let(:user) { create(:dfe_signin_user) }
+  let(:personal_details) do
+    {
+      national_insurance_number: generate(:national_insurance_number),
+      teacher_reference_number: generate(:teacher_reference_number),
+      date_of_birth: 30.years.ago.to_date,
+      student_loan_plan: StudentLoan::PLAN_1,
+      email_address: "email@example.com",
+      bank_sort_code: "112233",
+      bank_account_number: "95928482",
+      building_society_roll_number: nil
+    }
+  end
+
+  before do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+  end
+
+  scenario "cannot approve a second claim from an individual if the payroll information on the claims is inconsistent" do
+    approved_claim = create(:claim, :approved, personal_details.merge(bank_sort_code: "112233", bank_account_number: "29482823"))
+    second_inconsistent_claim = create(:claim, :submitted, personal_details.merge(bank_sort_code: "582939", bank_account_number: "74727752"))
+
+    click_on "View claims"
+    find("a[href='#{admin_claim_path(second_inconsistent_claim)}']").click
+
+    expect(page).to have_field("Approve", disabled: true)
+    expect(page).to have_content("This claim cannot currently be approved because we’re already paying another claim (#{approved_claim.reference}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.")
+  end
+end

--- a/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
+++ b/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.feature "Admin checking a claim missing a payroll gender" do
+  let(:user) { create(:dfe_signin_user) }
+
+  before do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+  end
+
+  scenario "cannot approve a claim whilst the payroll gender is missing" do
+    claim_missing_payroll_gender = create(:claim, :submitted, payroll_gender: :dont_know)
+
+    click_on "View claims"
+    find("a[href='#{admin_claim_path(claim_missing_payroll_gender)}']").click
+
+    expect(page).to have_field("Approve", disabled: true)
+    expect(page).to have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))
+  end
+end

--- a/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
+++ b/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
@@ -15,5 +15,18 @@ RSpec.feature "Admin checking a claim missing a payroll gender" do
 
     expect(page).to have_field("Approve", disabled: true)
     expect(page).to have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))
+
+    click_on "Amend claim"
+    select "Male", from: "Payroll gender"
+    fill_in "Change notes", with: "Got payroll gender from pensions data"
+    click_on "Amend claim"
+
+    expect(claim_missing_payroll_gender.reload).to be_approvable
+
+    choose "Approve"
+    fill_in "Decision notes", with: "Everything matches"
+    click_on "Confirm decision"
+
+    expect(page).to have_content("Claim has been approved successfully")
   end
 end

--- a/spec/features/admin_claim_without_personal_data_spec.rb
+++ b/spec/features/admin_claim_without_personal_data_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.feature "Admin checking a claim with personal data removed" do
+  let(:user) { create(:dfe_signin_user) }
+
+  before do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+  end
+
+  scenario "the service operator sees that the personal data has been removed" do
+    claim_with_pii_removed = create(:claim, :rejected, :pii_removed)
+
+    visit admin_claim_path(claim_with_pii_removed)
+    expect(page).to have_content("personally identifiable information removed")
+    expect(page).to have_content("Full name Removed")
+    expect(page).to have_content("Date of birth Removed")
+    expect(page).to have_content("National Insurance number Removed")
+    expect(page).to have_content("Address Removed")
+  end
+end

--- a/spec/features/admin_claim_without_verified_identity_spec.rb
+++ b/spec/features/admin_claim_without_verified_identity_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "Admin checking a claim without a verified identity" do
+  let(:user) { create(:dfe_signin_user) }
+
+  before do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+  end
+
+  scenario "the service operator is told the identity hasn't been confirmed and can approve the claim" do
+    claim_without_identity_confirmation = create(:claim, :unverified)
+
+    click_on "View claims"
+    find("a[href='#{admin_claim_path(claim_without_identity_confirmation)}']").click
+
+    expect(page).to have_content("The claimant did not complete GOV.UK Verify")
+    expect(page).to have_content(claim_without_identity_confirmation.school.phone_number)
+
+    choose "Approve"
+    fill_in "Decision notes", with: "Identity confirmed via phone call"
+    click_on "Confirm decision"
+
+    expect(claim_without_identity_confirmation.decision.created_by).to eq(user)
+    expect(claim_without_identity_confirmation.decision.notes).to eq("Identity confirmed via phone call")
+  end
+end

--- a/spec/features/admin_claims_filtering_spec.rb
+++ b/spec/features/admin_claims_filtering_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.feature "Admin claim filtering" do
+  let(:user) { create(:dfe_signin_user) }
+
+  before do
+    sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+  end
+
+  scenario "the service operator can filter claims by policy" do
+    maths_and_physics_claims = create_list(:claim, 3, :submitted, policy: MathsAndPhysics)
+    student_loan_claims = create_list(:claim, 2, :submitted, policy: StudentLoans)
+
+    click_on "View claims"
+
+    expect(page.find("table")).to have_content("Maths and Physics").exactly(3).times
+    expect(page.find("table")).to have_content("Student Loans").exactly(2).times
+
+    click_on "View claims"
+    select "Maths and Physics", from: "policy"
+    click_on "Go"
+
+    maths_and_physics_claims.each do |c|
+      expect(page).to have_content(c.reference)
+    end
+
+    student_loan_claims.each do |c|
+      expect(page).to_not have_content(c.reference)
+    end
+  end
+end

--- a/spec/fixtures/schools.yml
+++ b/spec/fixtures/schools.yml
@@ -13,6 +13,7 @@ penistone_grammar_school:
   town: Sheffield
   county: South Yorkshire
   postcode: S36 7BX
+  phone_number: 01226762114
 
 ## Closed schools
 
@@ -29,6 +30,7 @@ the_samuel_lister_academy:
   town: Bingley
   county: West Yorkshire
   postcode: BD16 1TZ
+  phone_number: 01274567281
 
 # Student loans ineligible as claim school, Maths and Physics Ineligible
 
@@ -44,6 +46,7 @@ hampstead_school:
   locality: Hampstead
   town: London
   postcode: NW2 3RT
+  phone_number: 02077948133
 
 # Student loans ineligible as current school
 
@@ -58,3 +61,4 @@ bradford_grammar_school:
   street: Keighley Road
   town: Bradford
   postcode: BD9 4JP
+  phone_number: 01274542492


### PR DESCRIPTION
This splits out some of the high-level claim-checking features into their own feature files:

- admin_claim_with_inconsistent_payroll_information_spec.rb
- admin_claim_with_missing_payroll_gender_spec.rb
- admin_claim_without_personal_information_spec.rb
- admin_claim_without_verified_identity_spec.rb

Plus two separate feature files for checking each type of policy.

The aim is to reduce the size and scope of the existing `admin_claim_check_spec.rb` so it does less and is more focused. What's left relates to: approving/rejecting claims the old way, plus some specs related to claim checks with the new interface. We'll be able to tidy these specs up further once we've got the remaining checks in place and have replaced the existing warning messages.