### PR TITLE
Show incomplete checks warning on decision screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Fix question bug on school search results page
+- Show a list of incomplete checks on the claim decision page
 
 ## [Release 059] - 2020-03-09
 

--- a/app/assets/stylesheets/components/gds_kit_tweaks.scss
+++ b/app/assets/stylesheets/components/gds_kit_tweaks.scss
@@ -27,3 +27,16 @@ $govuk-link-colour: #175b96;
 .govuk-heading--navigation .govuk-link:not(:last-of-type) {
   margin-right: govuk-spacing(2);
 }
+
+.claim-error-summary--warning {
+  border-color: govuk-colour("blue");
+}
+
+.claim-error-summary__list--warning a {
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
+    color: govuk-colour("blue");
+  }
+}

--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -25,7 +25,7 @@ class Admin::DecisionsController < Admin::BaseAdminController
   private
 
   def load_claim
-    @claim = Claim.find(params[:claim_id])
+    @claim = Claim.includes(:checks).find(params[:claim_id])
     @matching_claims = Claim::MatchingAttributeFinder.new(@claim).matching_claims
   end
 

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -283,6 +283,10 @@ class Claim < ApplicationRecord
     submitted? && !decision&.rejected? && !payment && !pii_removed?
   end
 
+  def incomplete_check_names
+    Admin::ChecksController::CHECKS_SEQUENCE - checks.map(&:name)
+  end
+
   private
 
   def normalise_trn

--- a/app/views/admin/checks/employment.html.erb
+++ b/app/views/admin/checks/employment.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "admin/claims/answer_section",
           heading: "Employment",
-          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.employment_check_description"),
+          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.checks.employment.description"),
           answers: @claim_checks.employment %>
   </div>
 

--- a/app/views/admin/checks/index.html.erb
+++ b/app/views/admin/checks/index.html.erb
@@ -16,7 +16,7 @@
         <ul class="app-task-list__items">
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
-              <%= link_to "Check qualification information", admin_claim_check_path(claim_id: @claim.id, check: :qualifications), class: "govuk-link" %>
+              <%= link_to I18n.t("#{@claim.policy.locale_key}.admin.checks.qualifications.summary"), admin_claim_check_path(claim_id: @claim.id, check: :qualifications), class: "govuk-link" %>
             </span>
             <% if @claim.checks.exists?(name: "qualifications") %>
               <strong class="govuk-tag app-task-list__task-completed">Completed</strong>
@@ -31,7 +31,7 @@
         <ul class="app-task-list__items">
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
-              <%= link_to "Check employment information", admin_claim_check_path(claim_id: @claim.id, check: :employment), class: "govuk-link" %>
+              <%= link_to I18n.t("#{@claim.policy.locale_key}.admin.checks.employment.summary"), admin_claim_check_path(claim_id: @claim.id, check: :employment), class: "govuk-link" %>
             </span>
             <% if @claim.checks.exists?(name: "employment") %>
               <strong class="govuk-tag app-task-list__task-completed">Completed</strong>

--- a/app/views/admin/checks/qualifications.html.erb
+++ b/app/views/admin/checks/qualifications.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "admin/claims/answer_section",
           heading: "Qualifications",
-          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.qualification_check_description"),
+          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.checks.qualifications.description"),
           answers: @claim_checks.qualifications %>
   </div>
 

--- a/app/views/admin/decisions/_incomplete_checks.html.erb
+++ b/app/views/admin/decisions/_incomplete_checks.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-error-summary claim-error-summary--warning" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    Some checks have not yet been completed
+  </h2>
+
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list claim-error-summary__list--warning">
+      <% @claim.incomplete_check_names.each do |name| %>
+        <li><%= link_to(t("#{@claim.policy.locale_key}.admin.checks.#{name}.summary"), admin_claim_check_url(check: name)) %></li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -8,6 +8,7 @@
   <%= render("admin/claims/claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim}) if @matching_claims.any? %>
 
   <div class="govuk-grid-column-two-thirds">
+    <%= render("incomplete_checks", {claim: @claim}) if @claim.incomplete_check_names.any? %>
     <%= render "decision_form", claim: @claim, decision: @decision, claims_preventing_payment: @claims_preventing_payment %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,8 +169,10 @@ en:
       formal_performance_action: "Subject to formal performance action?"
       checks:
         qualifications:
+          summary: "Check qualification information"
           description: "Check the claimant's initial teacher training (ITT) qualification year and specialist subject matches the below information from their claim."
         employment:
+          summary: "Check employment information"
           description: "Check the claimant's current school matches the below information from their claim."
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
@@ -204,6 +206,8 @@ en:
       student_loan_repayment_plan: "Student loan repayment plan"
       checks:
         qualifications:
+          summary: "Check qualification information"
           description: "Check the claimant's initial teacher training (ITT) qualification year matches the below information from their claim."
         employment:
+          summary: "Check employment information"
           description: "Check the claimant's previous and current schools match the below information from their claim."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,8 +167,11 @@ en:
       employed_directly: "Employed directly by school?"
       disciplinary_action: "Subject to disciplinary action?"
       formal_performance_action: "Subject to formal performance action?"
-      qualification_check_description: "Check the claimant's initial teacher training (ITT) qualification year and specialist subject matches the below information from their claim."
-      employment_check_description: "Check the claimant's current school matches the below information from their claim."
+      checks:
+        qualifications:
+          description: "Check the claimant's initial teacher training (ITT) qualification year and specialist subject matches the below information from their claim."
+        employment:
+          description: "Check the claimant's current school matches the below information from their claim."
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     policy_short_name: "Student Loans"
@@ -199,5 +202,8 @@ en:
       mostly_performed_leadership_duties: "Mostly performed leadership duties?"
       student_loan_repayment_amount: "Student loan repayment amount"
       student_loan_repayment_plan: "Student loan repayment plan"
-      qualification_check_description: "Check the claimant's initial teacher training (ITT) qualification year matches the below information from their claim."
-      employment_check_description: "Check the claimant's previous and current schools match the below information from their claim."
+      checks:
+        qualifications:
+          description: "Check the claimant's initial teacher training (ITT) qualification year matches the below information from their claim."
+        employment:
+          description: "Check the claimant's previous and current schools match the below information from their claim."

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -717,4 +717,18 @@ RSpec.describe Claim, type: :model do
       expect(claim.amendable?).to eq(false)
     end
   end
+
+  describe "#incomplete_check_names" do
+    Policies.all.each do |policy|
+      it "returns an array of the checks that haven’t been completed on the claim" do
+        claim = build(:claim, :submitted, checks: [
+          build(:check, name: "qualifications")
+        ])
+        expect(claim.incomplete_check_names).to eq(["employment"])
+
+        claim.checks << build(:check, name: "employment")
+        expect(claim.incomplete_check_names).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Summary

This adds a list of incomplete checks to the `admin/decisions#new` screen. If a service operator goes to the decision screen before completing all the checks, they will see this warning.

More details in commit messages.

# Screenshot

![image](https://user-images.githubusercontent.com/53756884/76233383-06284780-6220-11ea-945c-73efe69da936.png)