### PR TITLE
Add a task for checking the student loan amount on student loans claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add a task for confirming the student loan amount on Student Loans claims
+
 ## [Release 060] - 2020-03-10
 
 - Fix question bug on school search results page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Add a task for confirming the student loan amount on Student Loans claims
+- Student Loans claims default to new task-based claim checking interface
 
 ## [Release 060] - 2020-03-10
 

--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -7,11 +7,13 @@ class Admin::DecisionsController < Admin::BaseAdminController
 
   def new
     @decision = Decision.new
+    @claim_checking_tasks = ClaimCheckingTasks.new(@claim)
     @claims_preventing_payment = claims_preventing_payment_finder.claims_preventing_payment
   end
 
   def create
     @decision = @claim.decisions.build(decision_params.merge(created_by: admin_user))
+    @claim_checking_tasks = ClaimCheckingTasks.new(@claim)
     if @decision.save
       send_claim_result_email
       RecordOrUpdateGeckoboardDatasetJob.perform_later([@claim.id])

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -30,13 +30,13 @@ class Admin::TasksController < Admin::BaseAdminController
     params[:name]
   end
 
-  def next_check
+  def next_task_name
     TASKS_SEQUENCE[TASKS_SEQUENCE.index(current_task) + 1]
   end
 
   def next_task_path
-    if next_check.present?
-      admin_claim_task_path(@claim, name: next_check)
+    if next_task_name.present?
+      admin_claim_task_path(@claim, name: next_task_name)
     else
       new_admin_claim_decision_path(@claim)
     end

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -3,6 +3,7 @@ class Admin::TasksController < Admin::BaseAdminController
   before_action :load_claim
 
   def index
+    @claim_checking_tasks = ClaimCheckingTasks.new(@claim)
   end
 
   def show

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -2,8 +2,6 @@ class Admin::TasksController < Admin::BaseAdminController
   before_action :ensure_service_operator
   before_action :load_claim
 
-  TASKS_SEQUENCE = %w[qualifications employment]
-
   def index
   end
 
@@ -14,6 +12,7 @@ class Admin::TasksController < Admin::BaseAdminController
   end
 
   def create
+    @claim_checking_tasks = ClaimCheckingTasks.new(@claim)
     @claim.tasks.create!(name: current_task, created_by: admin_user)
     redirect_to next_task_path
   rescue ActiveRecord::RecordInvalid
@@ -31,7 +30,8 @@ class Admin::TasksController < Admin::BaseAdminController
   end
 
   def next_task_name
-    TASKS_SEQUENCE[TASKS_SEQUENCE.index(current_task) + 1]
+    current_task_index = @claim_checking_tasks.applicable_task_names.index(current_task)
+    @claim_checking_tasks.applicable_task_names[current_task_index + 1]
   end
 
   def next_task_path

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -283,10 +283,6 @@ class Claim < ApplicationRecord
     submitted? && !decision&.rejected? && !payment && !pii_removed?
   end
 
-  def incomplete_task_names
-    ClaimCheckingTasks.new(self).applicable_task_names - tasks.map(&:name)
-  end
-
   private
 
   def normalise_trn

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -284,7 +284,7 @@ class Claim < ApplicationRecord
   end
 
   def incomplete_task_names
-    Admin::TasksController::TASKS_SEQUENCE - tasks.map(&:name)
+    ClaimCheckingTasks.new(self).applicable_task_names - tasks.map(&:name)
   end
 
   private

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -16,4 +16,9 @@ class ClaimCheckingTasks
   def applicable_task_names
     TASK_NAMES
   end
+
+  # Returns an Array of tasks names that have not been completed on the claim.
+  def incomplete_task_names
+    applicable_task_names - claim.tasks.map(&:name)
+  end
 end

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# This models the tasks that need to be performed on a claim as part of the
+# claim checking process.
+class ClaimCheckingTasks
+  TASK_NAMES = %w[qualifications employment].freeze
+
+  attr_reader :claim
+
+  def initialize(claim)
+    @claim = claim
+  end
+
+  # Returns an Array task names that need to be performed on the claim during
+  # claim checking before it should be approved.
+  def applicable_task_names
+    TASK_NAMES
+  end
+end

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -3,7 +3,7 @@
 # This models the tasks that need to be performed on a claim as part of the
 # claim checking process.
 class ClaimCheckingTasks
-  TASK_NAMES = %w[qualifications employment].freeze
+  TASK_NAMES = %w[qualifications employment student_loan_amount].freeze
 
   attr_reader :claim
 
@@ -11,10 +11,10 @@ class ClaimCheckingTasks
     @claim = claim
   end
 
-  # Returns an Array task names that need to be performed on the claim during
-  # claim checking before it should be approved.
   def applicable_task_names
-    TASK_NAMES
+    @applicable_task_names ||= TASK_NAMES.dup.tap do |task_names|
+      task_names.delete("student_loan_amount") unless claim.policy == StudentLoans
+    end
   end
 
   # Returns an Array of tasks names that have not been completed on the claim.

--- a/app/models/student_loans/admin_tasks_presenter.rb
+++ b/app/models/student_loans/admin_tasks_presenter.rb
@@ -3,6 +3,7 @@ module StudentLoans
   # approve or reject a claim.
   class AdminTasksPresenter
     include Admin::PresenterMethods
+    include ActionView::Helpers::NumberHelper
 
     attr_reader :claim
 
@@ -20,6 +21,13 @@ module StudentLoans
       [
         ["6 April 2018 to 5 April 2019", display_school(eligibility.claim_school)],
         [I18n.t("admin.current_school"), display_school(eligibility.current_school)]
+      ]
+    end
+
+    def student_loan_amount
+      [
+        ["Student loan repayment amount", number_to_currency(eligibility.student_loan_repayment_amount)],
+        ["Student loan plan", claim.student_loan_plan.humanize]
       ]
     end
 

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -48,11 +48,7 @@
               <% end %>
               <td class="govuk-table__cell"><%= l(claim.decision_deadline_date) %></td>
               <td class="govuk-table__cell">
-                <% if claim.policy == MathsAndPhysics %>
-                  <%= link_to 'View tasks', admin_claim_tasks_path(claim), class: "govuk-link" %>
-                <% else %>
-                  <%= link_to 'View claim', admin_claim_path(claim), class: "govuk-link" %>
-                <% end %>
+                <%= link_to 'View tasks', admin_claim_tasks_path(claim), class: "govuk-link" %>
               </td>
             </tr>
           <% end %>

--- a/app/views/admin/decisions/_incomplete_tasks.html.erb
+++ b/app/views/admin/decisions/_incomplete_tasks.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list claim-error-summary__list--warning">
       <% incomplete_task_names.each do |name| %>
-        <li><%= link_to(t("#{@claim.policy.locale_key}.admin.checks.#{name}.summary"), admin_claim_task_url(@claim, name: name)) %></li>
+        <li><%= link_to(t("#{claim.policy.locale_key}.admin.checks.#{name}.summary"), admin_claim_task_url(claim, name: name)) %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/admin/decisions/_incomplete_tasks.html.erb
+++ b/app/views/admin/decisions/_incomplete_tasks.html.erb
@@ -5,7 +5,7 @@
 
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list claim-error-summary__list--warning">
-      <% @claim.incomplete_task_names.each do |name| %>
+      <% incomplete_task_names.each do |name| %>
         <li><%= link_to(t("#{@claim.policy.locale_key}.admin.checks.#{name}.summary"), admin_claim_task_url(@claim, name: name)) %></li>
       <% end %>
     </ul>

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -8,7 +8,7 @@
   <%= render("admin/claims/claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim}) if @matching_claims.any? %>
 
   <div class="govuk-grid-column-two-thirds">
-    <%= render("incomplete_tasks", {claim: @claim}) if @claim.incomplete_task_names.any? %>
+    <%= render("incomplete_tasks", claim: @claim, incomplete_task_names: @claim_checking_tasks.incomplete_task_names) if @claim_checking_tasks.incomplete_task_names.any? %>
     <%= render "decision_form", claim: @claim, decision: @decision, claims_preventing_payment: @claims_preventing_payment %>
   </div>
 </div>

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -9,39 +9,28 @@
   <div class="govuk-grid-column-two-thirds">
 
     <ol class="app-task-list">
+
+      <% @claim_checking_tasks.applicable_task_names.each_with_index do |task_name, index| %>
+        <li>
+          <h2 class="app-task-list__section">
+            <span class="app-task-list__section-number"><%= index + 1 %>. </span> <%= task_name.humanize %>
+          </h2>
+          <ul class="app-task-list__items">
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <%= link_to I18n.t("#{@claim.policy.locale_key}.admin.checks.#{task_name}.summary"), admin_claim_task_path(claim_id: @claim.id, name: task_name), class: "govuk-link" %>
+              </span>
+              <% if @claim.tasks.exists?(name: task_name) %>
+                <strong class="govuk-tag app-task-list__task-completed">Completed</strong>
+              <% end %>
+            </li>
+          </ul>
+        </li>
+      <% end %>
+
       <li>
         <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number">1. </span> Qualifications
-        </h2>
-        <ul class="app-task-list__items">
-          <li class="app-task-list__item">
-            <span class="app-task-list__task-name">
-              <%= link_to I18n.t("#{@claim.policy.locale_key}.admin.checks.qualifications.summary"), admin_claim_task_path(claim_id: @claim.id, name: :qualifications), class: "govuk-link" %>
-            </span>
-            <% if @claim.tasks.exists?(name: "qualifications") %>
-              <strong class="govuk-tag app-task-list__task-completed">Completed</strong>
-            <% end %>
-          </li>
-        </ul>
-      </li>
-      <li>
-        <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number">2. </span> Employment
-        </h2>
-        <ul class="app-task-list__items">
-          <li class="app-task-list__item">
-            <span class="app-task-list__task-name">
-              <%= link_to I18n.t("#{@claim.policy.locale_key}.admin.checks.employment.summary"), admin_claim_task_path(claim_id: @claim.id, name: :employment), class: "govuk-link" %>
-            </span>
-            <% if @claim.tasks.exists?(name: "employment") %>
-              <strong class="govuk-tag app-task-list__task-completed">Completed</strong>
-            <% end %>
-          </li>
-        </ul>
-      </li>
-      <li>
-        <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number">3. </span> Decision
+          <span class="app-task-list__section-number"><%= @claim_checking_tasks.applicable_task_names.size + 1 %>. </span> Decision
         </h2>
         <ul class="app-task-list__items">
           <li class="app-task-list__item">

--- a/app/views/admin/tasks/student_loan_amount.html.erb
+++ b/app/views/admin/tasks/student_loan_amount.html.erb
@@ -1,0 +1,23 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} student loan amount check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+
+<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
+<div class="govuk-grid-row">
+
+  <%= render "claim_summary", claim: @claim %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answer_section",
+          heading: "Student loan amount",
+          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.checks.student_loan_amount.description"),
+          answers: @tasks_presenter.student_loan_amount %>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <% if @task.present? %>
+      <%= render "task_outcome", task: @task %>
+    <% else %>
+      <%= button_to "Complete student loan amount check and continue", admin_claim_tasks_path(claim_id: @claim.id, name: :student_loan_amount), class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,3 +211,6 @@ en:
         employment:
           summary: "Check employment information"
           description: "Check the claimant's previous and current schools match the below information from their claim."
+        student_loan_amount:
+          summary: "Check student loan amount"
+          description: "Check the claimant’s student loan amount and plan type match the information we hold about their loan."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
     get "/auth/failure", to: "auth#failure"
 
     resources :claims, only: [:index, :show] do
-      resources :tasks, only: [:index, :show, :create], param: :name, constraints: {name: %r{#{Admin::TasksController::TASKS_SEQUENCE.join("|")}}}
+      resources :tasks, only: [:index, :show, :create], param: :name, constraints: {name: %r{#{ClaimCheckingTasks::TASK_NAMES.join("|")}}}
       resources :decisions, only: [:create, :new]
       resources :amendments, only: [:new, :create]
       get "search", on: :collection

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :task do
-    name { Admin::TasksController::TASKS_SEQUENCE.sample }
+    name { ClaimCheckingTasks.new(claim).applicable_task_names.sample }
     association :created_by, factory: :dfe_signin_user
     association :claim
   end

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
 
     expect(page).to have_content("1. Qualifications")
     expect(page).to have_content("2. Employment")
+    expect(page).to have_content("3. Decision")
 
     click_on "Check qualification information"
     expect(page).to have_content("Qualifications")

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -8,7 +8,13 @@ RSpec.feature "Admin checking a Student Loans claim" do
   end
 
   scenario "service operator checks and approves a Student Loans claim" do
-    claim = create(:claim, :submitted, policy: StudentLoans)
+    claim = create(
+      :claim,
+      :submitted,
+      policy: StudentLoans,
+      student_loan_plan: StudentLoan::PLAN_2,
+      eligibility: build(:student_loans_eligibility, :eligible, student_loan_repayment_amount: "1987.65")
+    )
 
     visit admin_claims_path
     find("a[href='#{admin_claim_path(claim)}']").click
@@ -16,7 +22,8 @@ RSpec.feature "Admin checking a Student Loans claim" do
 
     expect(page).to have_content("1. Qualifications")
     expect(page).to have_content("2. Employment")
-    expect(page).to have_content("3. Decision")
+    expect(page).to have_content("3. Student loan amount")
+    expect(page).to have_content("4. Decision")
 
     click_on "Check qualification information"
     expect(page).to have_content("Qualifications")
@@ -30,6 +37,11 @@ RSpec.feature "Admin checking a Student Loans claim" do
     expect(page).to have_link(claim.eligibility.current_school.name)
 
     click_on "Complete employment check and continue"
+
+    expect(page).to have_content("Student loan amount")
+    expect(page).to have_content("£1,987.65")
+    expect(page).to have_content("Plan 2")
+    click_on "Complete student loan amount check and continue"
 
     expect(page).to have_content("Claim decision")
 

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
 
     expect(page).to have_content("1. Qualifications")
     expect(page).to have_content("2. Employment")
+    expect(page).to have_content("3. Decision")
 
     click_on "Check qualification information"
     expect(page).to have_content("Qualifications")

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -17,8 +17,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
     )
 
     visit admin_claims_path
-    find("a[href='#{admin_claim_path(claim)}']").click
-    click_on "View tasks"
+    find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
     expect(page).to have_content("1. Qualifications")
     expect(page).to have_content("2. Employment")

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature "Admin checks a claim" do
         let!(:claim) { create(:claim, :submitted, payroll_gender: :dont_know) }
 
         scenario "User is informed that the claim cannot be approved" do
-          perform_last_task
+          perform_last_task(claim)
 
           expect(page).to have_field("Approve", disabled: true)
           expect(page).to have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))
@@ -126,7 +126,7 @@ RSpec.feature "Admin checks a claim" do
         let!(:claim) { create(:claim, :submitted, personal_details.merge(bank_sort_code: "582939", bank_account_number: "74727752")) }
 
         scenario "User is informed that the claim cannot be approved" do
-          perform_last_task
+          perform_last_task(claim)
 
           expect(page).to have_field("Approve", disabled: true)
           expect(page).to have_content("This claim cannot currently be approved because we’re already paying another claim (#{approved_claim.reference}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.")
@@ -137,7 +137,7 @@ RSpec.feature "Admin checks a claim" do
         let!(:claim) { create(:claim, :unverified) }
 
         scenario "the service operator is told the identity hasn't been confirmed and can approve the claim" do
-          perform_last_task
+          perform_last_task(claim)
 
           expect(page).to have_content("The claimant did not complete GOV.UK Verify")
           expect(page).to have_content(claim.school.phone_number)
@@ -151,8 +151,9 @@ RSpec.feature "Admin checks a claim" do
         end
       end
 
-      def perform_last_task
-        visit admin_claim_task_path(claim, name: Admin::TasksController::TASKS_SEQUENCE.last)
+      def perform_last_task(claim)
+        applicable_task_names = ClaimCheckingTasks.new(claim).applicable_task_names
+        visit admin_claim_task_path(claim, name: applicable_task_names.last)
         find("input[type='submit']").click
       end
     end

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -19,7 +19,9 @@ RSpec.feature "Admin checks a claim" do
         expect(page).to have_content(claim_to_approve.reference)
         expect(page).to have_content("5 claims awaiting a decision")
 
-        find("a[href='#{admin_claim_path(claim_to_approve)}']").click
+        find("a[href='#{admin_claim_tasks_path(claim_to_approve)}']").click
+        click_on "Approve or reject this claim"
+
         choose "Approve"
         fill_in "Decision notes", with: "Everything matches"
         perform_enqueued_jobs { click_on "Confirm decision" }
@@ -50,7 +52,9 @@ RSpec.feature "Admin checks a claim" do
       expect(page).to have_content(claim_to_reject.reference)
       expect(page).to have_content("5 claims awaiting a decision")
 
-      find("a[href='#{admin_claim_path(claim_to_reject)}']").click
+      find("a[href='#{admin_claim_tasks_path(claim_to_reject)}']").click
+      click_on "Approve or reject this claim"
+
       choose "Reject"
       fill_in "Decision notes", with: "TRN doesn't exist"
       perform_enqueued_jobs { click_on "Confirm decision" }

--- a/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
+++ b/spec/features/admin_claim_with_inconsistent_payroll_information_spec.rb
@@ -24,7 +24,8 @@ RSpec.feature "Admin checking a claim with inconsistent payroll information" do
     second_inconsistent_claim = create(:claim, :submitted, personal_details.merge(bank_sort_code: "582939", bank_account_number: "74727752"))
 
     click_on "View claims"
-    find("a[href='#{admin_claim_path(second_inconsistent_claim)}']").click
+    find("a[href='#{admin_claim_tasks_path(second_inconsistent_claim)}']").click
+    click_on "View full claim"
 
     expect(page).to have_field("Approve", disabled: true)
     expect(page).to have_content("This claim cannot currently be approved because we’re already paying another claim (#{approved_claim.reference}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.")

--- a/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
+++ b/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
@@ -11,7 +11,8 @@ RSpec.feature "Admin checking a claim missing a payroll gender" do
     claim_missing_payroll_gender = create(:claim, :submitted, payroll_gender: :dont_know)
 
     click_on "View claims"
-    find("a[href='#{admin_claim_path(claim_missing_payroll_gender)}']").click
+    find("a[href='#{admin_claim_tasks_path(claim_missing_payroll_gender)}']").click
+    click_on "View full claim"
 
     expect(page).to have_field("Approve", disabled: true)
     expect(page).to have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))

--- a/spec/features/admin_claim_without_verified_identity_spec.rb
+++ b/spec/features/admin_claim_without_verified_identity_spec.rb
@@ -11,7 +11,8 @@ RSpec.feature "Admin checking a claim without a verified identity" do
     claim_without_identity_confirmation = create(:claim, :unverified)
 
     click_on "View claims"
-    find("a[href='#{admin_claim_path(claim_without_identity_confirmation)}']").click
+    find("a[href='#{admin_claim_tasks_path(claim_without_identity_confirmation)}']").click
+    click_on "View full claim"
 
     expect(page).to have_content("The claimant did not complete GOV.UK Verify")
     expect(page).to have_content(claim_without_identity_confirmation.school.phone_number)

--- a/spec/features/admin_duplicate_claims_spec.rb
+++ b/spec/features/admin_duplicate_claims_spec.rb
@@ -21,7 +21,8 @@ RSpec.feature "Service operator can see potential duplicate claims" do
 
     click_on "View claims"
 
-    find("a[href='#{admin_claim_path(claim_to_approve)}']").click
+    find("a[href='#{admin_claim_tasks_path(claim_to_approve)}']").click
+    click_on "View full claim"
 
     expect(page).to have_content("Details in this claim match another Student Loans claim")
     expect(page).to have_content("Student Loans claim with matching details")

--- a/spec/models/claim_checking_tasks_spec.rb
+++ b/spec/models/claim_checking_tasks_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe ClaimCheckingTasks do
     it "returns the tasks that apply to the claim" do
       expect(checking_tasks.applicable_task_names).to eq %w[qualifications employment]
     end
+
+    it "includes the a task for student loan amount for a StudentLoans claim" do
+      student_loan_claim = build(:claim, policy: StudentLoans)
+      student_loan_tasks = ClaimCheckingTasks.new(student_loan_claim)
+
+      expect(student_loan_tasks.applicable_task_names).to eq %w[qualifications employment student_loan_amount]
+    end
   end
 
   describe "#incomplete_task_names" do

--- a/spec/models/claim_checking_tasks_spec.rb
+++ b/spec/models/claim_checking_tasks_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ClaimCheckingTasks do
+  let(:claim) { build(:claim) }
+  let(:checking_tasks) { ClaimCheckingTasks.new(claim) }
+
+  describe "#applicable_task_names" do
+    it "returns the tasks that apply to the claim" do
+      expect(checking_tasks.applicable_task_names).to eq %w[qualifications employment]
+    end
+  end
+end

--- a/spec/models/claim_checking_tasks_spec.rb
+++ b/spec/models/claim_checking_tasks_spec.rb
@@ -3,12 +3,24 @@
 require "rails_helper"
 
 RSpec.describe ClaimCheckingTasks do
-  let(:claim) { build(:claim) }
+  let(:claim) { build(:claim, policy: MathsAndPhysics) }
   let(:checking_tasks) { ClaimCheckingTasks.new(claim) }
 
   describe "#applicable_task_names" do
     it "returns the tasks that apply to the claim" do
       expect(checking_tasks.applicable_task_names).to eq %w[qualifications employment]
+    end
+  end
+
+  describe "#incomplete_task_names" do
+    it "returns an array of the tasks that haven’t been completed on the claim" do
+      expect(checking_tasks.incomplete_task_names).to eq %w[qualifications employment]
+
+      claim.tasks << build(:task, name: "qualifications")
+      expect(checking_tasks.incomplete_task_names).to eq ["employment"]
+
+      claim.tasks << build(:task, name: "employment")
+      expect(checking_tasks.incomplete_task_names).to eq []
     end
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -717,18 +717,4 @@ RSpec.describe Claim, type: :model do
       expect(claim.amendable?).to eq(false)
     end
   end
-
-  describe "#incomplete_task_names" do
-    Policies.all.each do |policy|
-      it "returns an array of the tasks that haven’t been completed on the claim" do
-        claim = build(:claim, :submitted, tasks: [
-          build(:task, name: "qualifications")
-        ])
-        expect(claim.incomplete_task_names).to eq(["employment"])
-
-        claim.tasks << build(:task, name: "employment")
-        expect(claim.incomplete_task_names).to eq([])
-      end
-    end
-  end
 end

--- a/spec/models/student_loans/admin_tasks_presenter_spec.rb
+++ b/spec/models/student_loans/admin_tasks_presenter_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe StudentLoans::AdminTasksPresenter, type: :model do
   let(:claim) do
     build(:claim,
       academic_year: "2019/2020",
+      student_loan_plan: StudentLoan::PLAN_1,
       eligibility: build(
         :student_loans_eligibility,
         qts_award_year: "on_or_after_cut_off_date",
         claim_school: school,
-        current_school: school
+        current_school: school,
+        student_loan_repayment_amount: "670.99"
       ))
   end
   subject(:presenter) { described_class.new(claim) }
@@ -33,6 +35,15 @@ RSpec.describe StudentLoans::AdminTasksPresenter, type: :model do
       expect(presenter.employment).to eq [
         ["6 April 2018 to 5 April 2019", presenter.display_school(eligibility.claim_school)],
         [I18n.t("admin.current_school"), presenter.display_school(eligibility.current_school)]
+      ]
+    end
+  end
+
+  describe "#student_loan_amount" do
+    it "returns an array of label and values for displaying information for the student loan amount check" do
+      expect(presenter.student_loan_amount).to eq [
+        ["Student loan repayment amount", "£670.99"],
+        ["Student loan plan", "Plan 1"]
       ]
     end
   end

--- a/spec/requests/admin_decisions_spec.rb
+++ b/spec/requests/admin_decisions_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Admin decisions", type: :request do
   context "when signed in as a service operator" do
     let(:user) { create(:dfe_signin_user) }
-    let(:claim) { create(:claim, :submitted) }
+    let(:claim) { create(:claim, :submitted, policy: MathsAndPhysics) }
 
     before do
       sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
@@ -19,12 +19,10 @@ RSpec.describe "Admin decisions", type: :request do
       end
 
       context "when all tasks have been completed" do
-        let(:claim) {
-          create(:claim, :submitted, tasks: [
-            build(:task, name: "qualifications"),
-            build(:task, name: "employment")
-          ])
-        }
+        before do
+          create(:task, name: "qualifications", claim: claim)
+          create(:task, name: "employment", claim: claim)
+        end
 
         it "does not warn the service operator about incomplete tasks" do
           get new_admin_claim_decision_path(claim)

--- a/spec/requests/admin_tasks_spec.rb
+++ b/spec/requests/admin_tasks_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Admin tasks", type: :request do
           end
 
           context "when the last check is marked as completed" do
-            let(:last_check) { Admin::TasksController::TASKS_SEQUENCE.last }
+            let(:last_check) { ClaimCheckingTasks.new(claim).applicable_task_names.last }
 
             it "creates the check and redirects to the decision page" do
               expect {


### PR DESCRIPTION
This introduces a task to check the student loan amount on student loans claims. Now that we have this task, we can switch student loans claims to default to the new task-based claim checking interface.

This PR introduces a new `ClaimCheckingTasks` class that we can use to model the various checks that may or may not be possible on any given claim.