### PR TITLE
Deploy to development in pipelines

### DIFF
--- a/azure-deploy-template.yml
+++ b/azure-deploy-template.yml
@@ -1,0 +1,76 @@
+parameters:
+  azureSubscription:
+  resourceGroupPrefix:
+  environmentName:
+  slackWebhookUrl:
+
+jobs:
+  - job: run_deploy_script
+    displayName: Run deploy script
+    steps:
+      - task: UseRubyVersion@0
+        displayName: 'Use Ruby >= 2.4'
+      - task: AzureCLI@1
+        displayName: 'Deploy Azure'
+        inputs:
+          azureSubscription: ${{parameters.azureSubscription}}
+          scriptPath: './bin/azure-deploy'
+          arguments: '${{parameters.environmentName}} --skip-login --skip-confirmation --docker-tag=$(Build.BuildNumber)'
+  - job: swap_app_service_slots
+    dependsOn: run_deploy_script
+    displayName: Swap app service slots
+    steps:
+      - task: AzureAppServiceManage@0
+        displayName: 'Swap Slots: ${{parameters.resourceGroupPrefix}}-app-as'
+        inputs:
+          azureSubscription: ${{parameters.azureSubscription}}
+          WebAppName: '${{parameters.resourceGroupPrefix}}-app-as'
+          ResourceGroupName: '${{parameters.resourceGroupPrefix}}-app'
+          SourceSlot: staging
+      - task: AzureAppServiceManage@0
+        displayName: 'Swap Slots: ${{parameters.resourceGroupPrefix}}-app-vsp-as'
+        inputs:
+          azureSubscription: ${{parameters.azureSubscription}}
+          WebAppName: '${{parameters.resourceGroupPrefix}}-app-vsp-as'
+          ResourceGroupName: '${{parameters.resourceGroupPrefix}}-app'
+          SourceSlot: staging
+  - job: clean_up
+    dependsOn:
+      - run_deploy_script
+      - swap_app_service_slots
+    displayName: Clean up
+    steps:
+      - task: AzureCLI@1
+        displayName: 'Delete migration runner container'
+        inputs:
+          azureSubscription: ${{parameters.azureSubscription}}
+          scriptLocation: inlineScript
+          inlineScript: 'az container delete --name ${{parameters.resourceGroupPrefix}}-app-migration-runner-aci --resource-group ${{parameters.resourceGroupPrefix}}-app -y'
+  - job: send_slack_success_message
+    dependsOn:
+      - run_deploy_script
+      - swap_app_service_slots
+      - clean_up
+    condition: succeeded()
+    displayName: Send Slack notification
+    steps:
+      - task: Bash@3
+        displayName: 'Send Slack Notification'
+        inputs:
+          targetType: filePath
+          filePath: './bin/slack-alert'
+          arguments: '${{parameters.environmentName}} $(Build.BuildNumber) $(Build.BuildId) ${{parameters.slackWebhookUrl}} SUCCESS'
+  - job: send_slack_failure_message
+    displayName: Send Slack failure notification
+    dependsOn:
+      - run_deploy_script
+      - swap_app_service_slots
+      - clean_up
+    condition: failed()
+    steps:
+      - task: Bash@3
+        displayName: 'Send Slack Failure Notification'
+        inputs:
+          targetType: filePath
+          filePath: './bin/slack-alert'
+          arguments: '${{parameters.environmentName}} $(Build.BuildNumber) $(Build.BuildId) ${{parameters.slackWebhookUrl}} FAILURE'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,23 +28,30 @@ stages:
               git reset --hard
               git clean -xdf
             displayName: Clean repository
-      - job: build_and_push_web_dependencies
+      - job: docker_tasks
         dependsOn: run_tests
-        displayName: Build and push web dependencies
+        displayName: Docker tasks
         steps:
           - script: docker login -u $(dockerId) -p $pass
             env:
               pass: $(dockerPassword)
             displayName: Login to DockerHub
           - script: |
-              ./bin/build-docker-images "ref/heads/master" \
-                $(Build.SourceVersion) \
+              ./bin/build-docker-images $(Build.SourceVersion) \
                 $(dockerRegistry)/$(dockerImageName) \
                 $(Build.BuildNumber)
             displayName: Prepare and push Docker images
+            condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+          - script: |
+              ./bin/cache-docker-images $(Build.SourceVersion) \
+                $(dockerRegistry)/$(dockerImageName) \
+                $(Build.BuildNumber)
+            displayName: Prepare Docker images for caching
+            condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
       - job: publish_repository
-        dependsOn: build_and_push_web_dependencies
+        dependsOn: docker_tasks
         displayName: Publish repository
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
         steps:
           - publish: $(System.DefaultWorkingDirectory)
             artifact: repository

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,106 +6,58 @@ pool:
 variables:
   - group: docker-settings
 
-steps:
-  # Login to DockerHub
-  - script: docker login -u $(dockerId) -p $pass
-    env:
-      pass: $(dockerPassword)
-    displayName: Login to DockerHub
+stages:
+  - stage: ci_build
+    displayName: Run tests and publish artifacts
+    jobs:
+      - job: run_tests
+        displayName: Run tests
+        steps:
+          # Build and run tests
+          - script: |
+              docker pull $(dockerRegistry)/$(dockerImageName):cache-test-dependencies || true
+              docker pull $(dockerRegistry)/$(dockerImageName):cache-test || true
 
-  # Build and run tests
-  - script: |
-      docker pull $(dockerRegistry)/$(dockerImageName):cache-test-dependencies || true
-      docker pull $(dockerRegistry)/$(dockerImageName):cache-test || true
+              docker-compose --file=docker-compose.test.yml build
+            displayName: Build test Docker image
+          - script: docker-compose --file=docker-compose.test.yml run --rm test
+            displayName: Run tests on Docker
 
-      docker-compose --file=docker-compose.test.yml build
-    displayName: Build test Docker image
-  - script: docker-compose --file=docker-compose.test.yml run --rm test
-    displayName: Run tests on Docker
-
-  # Clean up
-  - script: |
-      git reset --hard
-      git clean -xdf
-    displayName: Clean repository
-
-  # Publish
-  - publish: $(System.DefaultWorkingDirectory)
-    artifact: repository
-    displayName: Publish repository as artifact
-
-  # Build web dependencies
-  - script: |
-      docker pull $(dockerRegistry)/$(dockerImageName):cache-web-dependencies || true
-
-      docker build \
-        --file=Dockerfile \
-        --cache-from=$(dockerRegistry)/$(dockerImageName):cache-web-dependencies \
-        --tag=local/dfe-teachers-payment-service:web-dependencies \
-        --target=dependencies \
-        .
-    displayName: Build web dependencies Docker image using 'cache-web-dependencies' as cache
-    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
-  - script: |
-      docker build \
-        --file=Dockerfile \
-        --tag=local/dfe-teachers-payment-service:web-dependencies \
-        --target=dependencies \
-        .
-    displayName: Build web dependencies Docker image without cache
+          # Clean up
+          - script: |
+              git reset --hard
+              git clean -xdf
+            displayName: Clean repository
+      - job: build_and_push_web_dependencies
+        dependsOn: run_tests
+        displayName: Build and push web dependencies
+        steps:
+          - script: docker login -u $(dockerId) -p $pass
+            env:
+              pass: $(dockerPassword)
+            displayName: Login to DockerHub
+          - script: |
+              ./bin/build-docker-images "ref/heads/master" \
+                $(Build.SourceVersion) \
+                $(dockerRegistry)/$(dockerImageName) \
+                $(Build.BuildNumber)
+            displayName: Prepare and push Docker images
+      - job: publish_repository
+        dependsOn: build_and_push_web_dependencies
+        displayName: Publish repository
+        steps:
+          - publish: $(System.DefaultWorkingDirectory)
+            artifact: repository
+            displayName: Publish repository as artifact
+  - stage: deploy_to_development
+    displayName: Deploy to development
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-
-  # Build web
-  - script: |
-      docker pull $(dockerRegistry)/$(dockerImageName):latest || true
-
-      docker build \
-        --file=Dockerfile \
-        --cache-from=local/dfe-teachers-payment-service:web-dependencies \
-        --cache-from=$(dockerRegistry)/$(dockerImageName):latest \
-        --tag=local/dfe-teachers-payment-service:web \
-        --target=web \
-        --build-arg GIT_COMMIT_HASH=$(Build.SourceVersion) \
-        .
-    displayName: Build web Docker image using 'latest' as cache
-    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
-  - script: |
-      docker build \
-        --file=Dockerfile \
-        --cache-from=local/dfe-teachers-payment-service:web-dependencies \
-        --tag=local/dfe-teachers-payment-service:web \
-        --target=web \
-        --build-arg GIT_COMMIT_HASH=$(Build.SourceVersion) \
-        .
-    displayName: Build web Docker image without cache
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-
-  # Push test images
-  - script: |
-      docker tag local/dfe-teachers-payment-service:test-dependencies $(dockerRegistry)/$(dockerImageName):cache-test-dependencies
-
-      docker push $(dockerRegistry)/$(dockerImageName):cache-test-dependencies
-    displayName: Push test dependencies Docker image for caching
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-  - script: |
-      docker tag local/dfe-teachers-payment-service:test $(dockerRegistry)/$(dockerImageName):cache-test
-
-      docker push $(dockerRegistry)/$(dockerImageName):cache-test
-    displayName: Push test Docker image for caching
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-
-  # Push web images
-  - script: |
-      docker tag local/dfe-teachers-payment-service:web-dependencies $(dockerRegistry)/$(dockerImageName):cache-web-dependencies
-
-      docker push $(dockerRegistry)/$(dockerImageName):cache-web-dependencies
-    displayName: Push web dependencies Docker image for caching
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-  - script: |
-      docker tag local/dfe-teachers-payment-service:web $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber)
-      docker tag local/dfe-teachers-payment-service:web $(dockerRegistry)/$(dockerImageName):latest
-
-      docker push $(dockerRegistry)/$(dockerImageName):$(Build.BuildNumber)
-      docker push $(dockerRegistry)/$(dockerImageName):latest
-    displayName: Push web Docker image
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    variables:
+      - group: deployment-settings
+    jobs:
+    - template: azure-deploy-template.yml
+      parameters:
+        azureSubscription: azdo.pipelines.cip.S118D.armfe1ef140-8bef-4043-b5ee-c449e6f951ef
+        resourceGroupPrefix: s118d01
+        environmentName: development
+        slackWebhookUrl: $(slackWebhookUrl)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,11 @@ stages:
       - job: run_tests
         displayName: Run tests
         steps:
+            # Login to DockerHub
+          - script: docker login -u $(dockerId) -p $pass
+            env:
+              pass: $(dockerPassword)
+            displayName: Login to DockerHub
           # Build and run tests
           - script: |
               docker pull $(dockerRegistry)/$(dockerImageName):cache-test-dependencies || true

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+BRANCH=$1
+GIT_COMMIT_HASH=$2
+DOCKER_REPOSITORY=$3
+BUILD_NUMBER=$4
+
+if [ "$BRANCH" == "ref/heads/master" ]; then
+  echo "Building web dependencies Docker image without cache..."
+  docker build \
+    --file=Dockerfile \
+    --tag=local/dfe-teachers-payment-service:web-dependencies \
+    --target=dependencies \
+    .
+
+  echo "Building web Docker image without cache"
+  docker build \
+    --file=Dockerfile \
+    --cache-from=local/dfe-teachers-payment-service:web-dependencies \
+    --tag=local/dfe-teachers-payment-service:web \
+    --target=web \
+    --build-arg GIT_COMMIT_HASH="$GIT_COMMIT_HASH" \
+    .
+
+  echo "Pushing test dependencies Docker image for caching"
+  docker tag local/dfe-teachers-payment-service:test-dependencies "$DOCKER_REPOSITORY:cache-test-dependencies"
+  docker push "$DOCKER_REPOSITORY:cache-test-dependencies"
+
+  echo "Pushing test Docker image for caching"
+  docker tag local/dfe-teachers-payment-service:test "$DOCKER_REPOSITORY:cache-test"
+  docker push "$DOCKER_REPOSITORY:cache-test"
+
+  echo "Pushing web dependencies Docker image for caching"
+  docker tag local/dfe-teachers-payment-service:web-dependencies "$DOCKER_REPOSITORY:cache-web-dependencies"
+  docker push "$DOCKER_REPOSITORY:cache-web-dependencies"
+
+  echo "Pushing web Docker image"
+  docker tag local/dfe-teachers-payment-service:web "$DOCKER_REPOSITORY:$BUILD_NUMBER"
+  docker tag local/dfe-teachers-payment-service:web "$DOCKER_REPOSITORY:latest"
+  docker push "$DOCKER_REPOSITORY:$BUILD_NUMBER"
+  docker push "$DOCKER_REPOSITORY:latest"
+else
+  echo "Building web dependencies Docker image using 'cache-web-dependencies' as cache"
+  docker pull "$DOCKER_REPOSITORY:cache-web-dependencies" || true
+  docker build \
+    --file=Dockerfile \
+    --cache-from="$DOCKER_REPOSITORY:cache-web-dependencies" \
+    --tag=local/dfe-teachers-payment-service:web-dependencies \
+    --target=dependencies \
+    .
+
+  echo "Building web Docker image using 'latest' as cache"
+  docker pull "$DOCKER_REPOSITORY:latest" || true
+  docker build \
+    --file=Dockerfile \
+    --cache-from=local/dfe-teachers-payment-service:web-dependencies \
+    --cache-from="$DOCKER_REPOSITORY:latest" \
+    --tag=local/dfe-teachers-payment-service:web \
+    --target=web \
+    --build-arg GIT_COMMIT_HASH="$GIT_COMMIT_HASH" \
+    .
+fi

--- a/bin/build-docker-images
+++ b/bin/build-docker-images
@@ -1,62 +1,39 @@
 #!/bin/bash
 
-BRANCH=$1
-GIT_COMMIT_HASH=$2
-DOCKER_REPOSITORY=$3
-BUILD_NUMBER=$4
+GIT_COMMIT_HASH=$1
+DOCKER_REPOSITORY=$2
+BUILD_NUMBER=$3
 
-if [ "$BRANCH" == "ref/heads/master" ]; then
-  echo "Building web dependencies Docker image without cache..."
-  docker build \
-    --file=Dockerfile \
-    --tag=local/dfe-teachers-payment-service:web-dependencies \
-    --target=dependencies \
-    .
+echo "Building web dependencies Docker image without cache..."
+docker build \
+  --file=Dockerfile \
+  --tag=local/dfe-teachers-payment-service:web-dependencies \
+  --target=dependencies \
+  .
 
-  echo "Building web Docker image without cache"
-  docker build \
-    --file=Dockerfile \
-    --cache-from=local/dfe-teachers-payment-service:web-dependencies \
-    --tag=local/dfe-teachers-payment-service:web \
-    --target=web \
-    --build-arg GIT_COMMIT_HASH="$GIT_COMMIT_HASH" \
-    .
+echo "Building web Docker image without cache"
+docker build \
+  --file=Dockerfile \
+  --cache-from=local/dfe-teachers-payment-service:web-dependencies \
+  --tag=local/dfe-teachers-payment-service:web \
+  --target=web \
+  --build-arg GIT_COMMIT_HASH="$GIT_COMMIT_HASH" \
+  .
 
-  echo "Pushing test dependencies Docker image for caching"
-  docker tag local/dfe-teachers-payment-service:test-dependencies "$DOCKER_REPOSITORY:cache-test-dependencies"
-  docker push "$DOCKER_REPOSITORY:cache-test-dependencies"
+echo "Pushing test dependencies Docker image for caching"
+docker tag local/dfe-teachers-payment-service:test-dependencies "$DOCKER_REPOSITORY:cache-test-dependencies"
+docker push "$DOCKER_REPOSITORY:cache-test-dependencies"
 
-  echo "Pushing test Docker image for caching"
-  docker tag local/dfe-teachers-payment-service:test "$DOCKER_REPOSITORY:cache-test"
-  docker push "$DOCKER_REPOSITORY:cache-test"
+echo "Pushing test Docker image for caching"
+docker tag local/dfe-teachers-payment-service:test "$DOCKER_REPOSITORY:cache-test"
+docker push "$DOCKER_REPOSITORY:cache-test"
 
-  echo "Pushing web dependencies Docker image for caching"
-  docker tag local/dfe-teachers-payment-service:web-dependencies "$DOCKER_REPOSITORY:cache-web-dependencies"
-  docker push "$DOCKER_REPOSITORY:cache-web-dependencies"
+echo "Pushing web dependencies Docker image for caching"
+docker tag local/dfe-teachers-payment-service:web-dependencies "$DOCKER_REPOSITORY:cache-web-dependencies"
+docker push "$DOCKER_REPOSITORY:cache-web-dependencies"
 
-  echo "Pushing web Docker image"
-  docker tag local/dfe-teachers-payment-service:web "$DOCKER_REPOSITORY:$BUILD_NUMBER"
-  docker tag local/dfe-teachers-payment-service:web "$DOCKER_REPOSITORY:latest"
-  docker push "$DOCKER_REPOSITORY:$BUILD_NUMBER"
-  docker push "$DOCKER_REPOSITORY:latest"
-else
-  echo "Building web dependencies Docker image using 'cache-web-dependencies' as cache"
-  docker pull "$DOCKER_REPOSITORY:cache-web-dependencies" || true
-  docker build \
-    --file=Dockerfile \
-    --cache-from="$DOCKER_REPOSITORY:cache-web-dependencies" \
-    --tag=local/dfe-teachers-payment-service:web-dependencies \
-    --target=dependencies \
-    .
-
-  echo "Building web Docker image using 'latest' as cache"
-  docker pull "$DOCKER_REPOSITORY:latest" || true
-  docker build \
-    --file=Dockerfile \
-    --cache-from=local/dfe-teachers-payment-service:web-dependencies \
-    --cache-from="$DOCKER_REPOSITORY:latest" \
-    --tag=local/dfe-teachers-payment-service:web \
-    --target=web \
-    --build-arg GIT_COMMIT_HASH="$GIT_COMMIT_HASH" \
-    .
-fi
+echo "Pushing web Docker image"
+docker tag local/dfe-teachers-payment-service:web "$DOCKER_REPOSITORY:$BUILD_NUMBER"
+docker tag local/dfe-teachers-payment-service:web "$DOCKER_REPOSITORY:latest"
+docker push "$DOCKER_REPOSITORY:$BUILD_NUMBER"
+docker push "$DOCKER_REPOSITORY:latest"

--- a/bin/cache-docker-images
+++ b/bin/cache-docker-images
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+GIT_COMMIT_HASH=$1
+DOCKER_REPOSITORY=$2
+
+echo "Building web dependencies Docker image using 'cache-web-dependencies' as cache"
+docker pull "$DOCKER_REPOSITORY:cache-web-dependencies" || true
+docker build \
+  --file=Dockerfile \
+  --cache-from="$DOCKER_REPOSITORY:cache-web-dependencies" \
+  --tag=local/dfe-teachers-payment-service:web-dependencies \
+  --target=dependencies \
+  .
+
+echo "Building web Docker image using 'latest' as cache"
+docker pull "$DOCKER_REPOSITORY:latest" || true
+docker build \
+  --file=Dockerfile \
+  --cache-from=local/dfe-teachers-payment-service:web-dependencies \
+  --cache-from="$DOCKER_REPOSITORY:latest" \
+  --tag=local/dfe-teachers-payment-service:web \
+  --target=web \
+  --build-arg GIT_COMMIT_HASH="$GIT_COMMIT_HASH" \
+  .

--- a/bin/slack-alert
+++ b/bin/slack-alert
@@ -2,11 +2,11 @@
 
 ENVIRONMENT_NAME=$1
 BUILD_NUMBER=$2
-RELEASE_ID=$3
+BUILD_ID=$3
 WEBHOOK_URL=$4
 RESULT=$5
 
-RELEASE_URL="https://dev.azure.com/dfe-ssp/S118-Teacher-Payments-Service/_releaseProgress?_a=release-pipeline-progress&releaseId=$RELEASE_ID"
+RELEASE_URL="https://dfe-ssp.visualstudio.com/S118-Teacher-Payments-Service/_build/results?buildId=$BUILD_ID&view=results"
 
 if [ "$RESULT" == "SUCCESS" ]; then
   MESSAGE=":ship: Build $BUILD_NUMBER is deployed to $ENVIRONMENT_NAME! $RELEASE_URL :rocket:"


### PR DESCRIPTION
This uses the Azure Pipeline to deploy as well as run the tests if the branch is master. This keeps the two things tightly coupled, and also allows us to keep our deployment steps tightly coupled to our code, rather than having them defined in Azure DevOps via a UI. This can also be adapted to deploy to production when we're ready to do so.

I've also put all our Docker-related tasks in a seperate bin script, so it's easier to follow, rather than having to parse a massive bunch of YAML.
