### PR TITLE
Claim checking content tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog]
 
 - Add a task for confirming the student loan amount on Student Loans claims
 - Student Loans claims default to new task-based claim checking interface
+- Claim checking tasks have unique headings
 
 ## [Release 060] - 2020-03-10
 

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -3,7 +3,7 @@
 
   <%= render("admin/claims/info_panel_identity_unconfirmed", school: @claim.school) unless @claim.identity_confirmed? %>
 
-  <%= render "admin/tasks/claim_summary", claim: @claim %>
+  <%= render "admin/tasks/claim_summary", claim: @claim, heading: "Claim decision" %>
 
   <%= render("admin/claims/claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim}) if @matching_claims.any? %>
 

--- a/app/views/admin/tasks/_claim_summary.html.erb
+++ b/app/views/admin/tasks/_claim_summary.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-column-full">
   <span class="govuk-caption-xl"><%= claim.policy.short_name %></span>
   <h1 class="govuk-heading-xl govuk-heading--navigation">
-    <%= claim.reference %>
+    <%= heading %>
     <span class="govuk-body-m">
       <%= link_to "View full claim", admin_claim_path(claim), class: "govuk-link" %>
       <%= link_to "Amend claim", new_admin_claim_amendment_url(claim), class: "govuk-link" if claim.amendable? %>
@@ -54,11 +54,11 @@
     </div>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        Submitted
+        Reference
       </dt>
 
       <dd class="govuk-summary-list__value">
-        <%= l(claim.submitted_at) %>
+        <%= claim.reference %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">

--- a/app/views/admin/tasks/_claim_summary.html.erb
+++ b/app/views/admin/tasks/_claim_summary.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid-column-full">
-  <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
+  <span class="govuk-caption-xl"><%= claim.policy.short_name %></span>
   <h1 class="govuk-heading-xl govuk-heading--navigation">
-    <%= @claim.reference %>
+    <%= claim.reference %>
     <span class="govuk-body-m">
-      <%= link_to "View full claim", admin_claim_path(@claim), class: "govuk-link" %>
-      <%= link_to "Amend claim", new_admin_claim_amendment_url(@claim), class: "govuk-link" if @claim.amendable? %>
+      <%= link_to "View full claim", admin_claim_path(claim), class: "govuk-link" %>
+      <%= link_to "Amend claim", new_admin_claim_amendment_url(claim), class: "govuk-link" if claim.amendable? %>
     </span>
   </h1>
 </div>

--- a/app/views/admin/tasks/employment.html.erb
+++ b/app/views/admin/tasks/employment.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
 
-  <%= render "claim_summary", claim: @claim %>
+  <%= render "claim_summary", claim: @claim, heading: "Employment" %>
 
   <div class="govuk-grid-column-two-thirds">
     <%= render "admin/claims/answer_section",

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
 
-  <%= render "claim_summary", claim: @claim %>
+  <%= render "claim_summary", claim: @claim, heading: @claim.reference %>
 
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/admin/tasks/qualifications.html.erb
+++ b/app/views/admin/tasks/qualifications.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
 
-  <%= render "claim_summary", claim: @claim %>
+  <%= render "claim_summary", claim: @claim, heading: "Qualifications" %>
 
   <div class="govuk-grid-column-two-thirds">
     <%= render "admin/claims/answer_section",

--- a/app/views/admin/tasks/student_loan_amount.html.erb
+++ b/app/views/admin/tasks/student_loan_amount.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
 
-  <%= render "claim_summary", claim: @claim %>
+  <%= render "claim_summary", claim: @claim, heading: "Student loan amount" %>
 
   <div class="govuk-grid-column-two-thirds">
     <%= render "admin/claims/answer_section",


### PR DESCRIPTION
Some content tweaks to more closely follow the prototype. Each task now has a task-specific heading to better orientate the user.

**Before:**
![Screenshot 2020-03-11 at 11 02 50](https://user-images.githubusercontent.com/3687/76410454-dbf19980-6387-11ea-8ea4-e94bfeff034e.png)

**After:**
![Screenshot 2020-03-11 at 11 07 23](https://user-images.githubusercontent.com/3687/76410810-7fdb4500-6388-11ea-9316-208384ee45f3.png)