### PR TITLE
Include NI number in claim summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog]
 - Add a task for confirming the student loan amount on Student Loans claims
 - Student Loans claims default to new task-based claim checking interface
 - Claim checking tasks have unique headings
+- Show NI number in the claim summary
 
 ## [Release 060] - 2020-03-10
 

--- a/app/views/admin/tasks/_claim_summary.html.erb
+++ b/app/views/admin/tasks/_claim_summary.html.erb
@@ -38,18 +38,26 @@
         <%= l(claim.date_of_birth, format: :day_month_year) %>
       </dd>
     </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Submitted
+      </dt>
+
+      <dd class="govuk-summary-list__value">
+        <%= l(claim.submitted_at) %>
+      </dd>
+    </div>
   </dl>
 </div>
 <div class="govuk-grid-column-one-half">
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        SLA
+        NI number
       </dt>
 
       <dd class="govuk-summary-list__value">
-        <%= l(claim.decision_deadline_date) %>
-        <%= decision_deadline_warning(claim) %>
+        <%= claim.national_insurance_number %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -68,6 +76,16 @@
 
       <dd class="govuk-summary-list__value">
         <%= claim.email_address %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        SLA
+      </dt>
+
+      <dd class="govuk-summary-list__value">
+        <%= l(claim.decision_deadline_date) %>
+        <%= decision_deadline_warning(claim) %>
       </dd>
     </div>
   </dl>


### PR DESCRIPTION
This was a request from claim checkers. If a claimant's TRN can't be found in our systems they will often search using their NI number instead. Putting this information front-and-center makes it easier for them to do so without switching to another screen.

**Before:**
![Screenshot 2020-03-11 at 11 20 33](https://user-images.githubusercontent.com/3687/76411748-558a8700-638a-11ea-909a-6b9983ce78b6.png)

**After:**
![Screenshot 2020-03-11 at 11 12 55](https://user-images.githubusercontent.com/3687/76411763-5b806800-638a-11ea-9138-a4fd72669b7d.png)
