### PR TITLE
Add Yes/No option to claim checking tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add Yes/No option to claim checking tasks
+
 ## [Release 061] - 2020-03-11
 
 - Add a task for confirming the student loan amount on Student Loans claims

--- a/app/assets/stylesheets/components/tag.scss
+++ b/app/assets/stylesheets/components/tag.scss
@@ -15,6 +15,10 @@
   &--alert {
     background-color: govuk-colour("red");
   }
+
+  &--inactive {
+    background-color: govuk-colour("dark-grey");
+  }
 }
 
 .tag--warning {

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -1,6 +1,7 @@
 class Admin::TasksController < Admin::BaseAdminController
   before_action :ensure_service_operator
   before_action :load_claim
+  before_action :ensure_task_has_not_already_been_completed, only: [:create]
 
   def index
     @claim_checking_tasks = ClaimCheckingTasks.new(@claim)
@@ -14,16 +15,25 @@ class Admin::TasksController < Admin::BaseAdminController
 
   def create
     @claim_checking_tasks = ClaimCheckingTasks.new(@claim)
-    @claim.tasks.create!(check_params)
-    redirect_to next_task_path
-  rescue ActiveRecord::RecordInvalid
-    redirect_to admin_claim_task_path(@claim, name: current_task_name), alert: "This task has already been completed"
+    @task = @claim.tasks.build(check_params)
+    if @task.save
+      redirect_to next_task_path
+    else
+      @tasks_presenter = @claim.policy::AdminTasksPresenter.new(@claim)
+      render current_task_name
+    end
   end
 
   private
 
   def load_claim
     @claim = Claim.includes(:tasks).find(params[:claim_id])
+  end
+
+  def ensure_task_has_not_already_been_completed
+    if @claim.tasks.find_by(name: current_task_name)
+      redirect_to admin_claim_task_path(@claim, name: current_task_name), alert: "This task has already been completed"
+    end
   end
 
   def current_task_name
@@ -44,7 +54,7 @@ class Admin::TasksController < Admin::BaseAdminController
   end
 
   def check_params
-    params.fetch(:task, {})
+    params.require(:task)
       .permit(:passed)
       .merge(name: current_task_name,
              created_by: admin_user)

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -8,7 +8,7 @@ class Admin::TasksController < Admin::BaseAdminController
 
   def show
     @tasks_presenter = @claim.policy::AdminTasksPresenter.new(@claim)
-    @task = @claim.tasks.find_by(name: current_task_name)
+    @task = @claim.tasks.find_or_initialize_by(name: current_task_name)
     render current_task_name
   end
 

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -69,6 +69,20 @@ module Admin
       matching_attributes.to_h.compact.keys.map(&:humanize).sort
     end
 
+    def task_status_tag(claim, task_name)
+      task = claim.tasks.detect { |t| t.name == task_name }
+
+      if task.present?
+        status = task_status(task)
+        tag_classes = "govuk-tag app-task-list__task-completed"
+      else
+        status = "Incomplete"
+        tag_classes = "govuk-tag app-task-list__task-completed govuk-tag--inactive"
+      end
+
+      content_tag("strong", status, class: tag_classes)
+    end
+
     private
 
     def matching_attributes_for(claim)
@@ -80,6 +94,10 @@ module Admin
 
     def days_between(first_date, second_date)
       (second_date - first_date).to_i
+    end
+
+    def task_status(task)
+      task.passed? ? "Passed" : "Failed"
     end
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,4 +11,5 @@ class Task < ApplicationRecord
   belongs_to :created_by, class_name: "DfeSignIn::User"
 
   validates :name, uniqueness: {scope: :claim_id}
+  validates_inclusion_of :passed, in: [true, false], message: "You must select ‘Yes’ or ‘No’"
 end

--- a/app/views/admin/claims/_answer_section.html.erb
+++ b/app/views/admin/claims/_answer_section.html.erb
@@ -8,16 +8,4 @@
   </p>
 <% end %>
 
-<dl class="govuk-summary-list govuk-!-margin-bottom-9">
-  <%- answers.each do |(label, answer)| %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= label %>
-      </dt>
-
-      <dd class="govuk-summary-list__value">
-        <%= answer %>
-      </dd>
-    </div>
-  <% end %>
-</dl>
+<%= render "admin/claims/answers", { answers: answers } %>

--- a/app/views/admin/claims/_answers.html.erb
+++ b/app/views/admin/claims/_answers.html.erb
@@ -1,0 +1,13 @@
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <%- answers.each do |(label, answer)| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= label %>
+      </dt>
+
+      <dd class="govuk-summary-list__value">
+        <%= answer %>
+      </dd>
+    </div>
+  <% end %>
+</dl>

--- a/app/views/admin/decisions/_incomplete_tasks.html.erb
+++ b/app/views/admin/decisions/_incomplete_tasks.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list claim-error-summary__list--warning">
       <% incomplete_task_names.each do |name| %>
-        <li><%= link_to(t("#{claim.policy.locale_key}.admin.checks.#{name}.summary"), admin_claim_task_url(claim, name: name)) %></li>
+        <li><%= link_to(t("#{claim.policy.locale_key}.admin.tasks.#{name}.summary"), admin_claim_task_url(claim, name: name)) %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/admin/tasks/_form.html.erb
+++ b/app/views/admin/tasks/_form.html.erb
@@ -7,6 +7,8 @@
         </h3>
       </legend>
 
+      <%= f.hidden_field :passed %>
+
       <div class="govuk-radios govuk-radios--inline">
         <div class="govuk-radios__item">
           <%= f.radio_button(:passed, true, class: "govuk-radios__input") %>

--- a/app/views/admin/tasks/_form.html.erb
+++ b/app/views/admin/tasks/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_with url: admin_claim_tasks_path(claim, name: task_name), scope: :task do |f| %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l ">
+        <h3 class="govuk-heading-l">
+          <%= I18n.t("#{claim.policy.to_s.underscore}.admin.tasks.#{task_name}.question") %>
+        </h3>
+      </legend>
+
+      <div class="govuk-radios govuk-radios--inline">
+        <div class="govuk-radios__item">
+          <%= f.radio_button(:passed, true, class: "govuk-radios__input") %>
+          <%= f.label "passed_true", "Yes", class: "govuk-label govuk-radios__label" %>
+        </div>
+
+        <div class="govuk-radios__item">
+          <%= f.radio_button(:passed, false, class: "govuk-radios__input") %>
+          <%= f.label "passed_false", "No", class: "govuk-label govuk-radios__label" %>
+        </div>
+      </div>
+    </fieldset>
+    <%= f.submit "Save and continue", class: "govuk-button", data: {module: "govuk-button"} %>
+  </div>
+<% end %>

--- a/app/views/admin/tasks/employment.html.erb
+++ b/app/views/admin/tasks/employment.html.erb
@@ -6,17 +6,14 @@
   <%= render "claim_summary", claim: @claim, heading: "Employment" %>
 
   <div class="govuk-grid-column-two-thirds">
-    <%= render "admin/claims/answer_section",
-          heading: "Employment",
-          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.tasks.employment.question"),
-          answers: @tasks_presenter.employment %>
+    <%= render "admin/claims/answers", answers: @tasks_presenter.employment %>
   </div>
 
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <% if @task.present? %>
       <%= render "task_outcome", task: @task %>
     <% else %>
-      <%= button_to "Complete employment check and continue", admin_claim_tasks_path(@claim, name: :employment), class: "govuk-button" %>
+      <%= render "form", task_name: "employment", claim: @claim %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/tasks/employment.html.erb
+++ b/app/views/admin/tasks/employment.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} employment check for #{policy_service_name(@claim.policy.routing_name)}") } %>
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/admin/tasks/employment.html.erb
+++ b/app/views/admin/tasks/employment.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    <% if @task.present? %>
+    <% if @task.persisted? %>
       <%= render "task_outcome", task: @task %>
     <% else %>
       <%= render "form", task_name: "employment", claim: @claim %>

--- a/app/views/admin/tasks/employment.html.erb
+++ b/app/views/admin/tasks/employment.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "admin/claims/answer_section",
           heading: "Employment",
-          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.checks.employment.description"),
+          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.tasks.employment.question"),
           answers: @tasks_presenter.employment %>
   </div>
 

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -20,9 +20,7 @@
               <span class="app-task-list__task-name">
                 <%= link_to I18n.t("#{@claim.policy.locale_key}.admin.tasks.#{task_name}.summary"), admin_claim_task_path(claim_id: @claim.id, name: task_name), class: "govuk-link" %>
               </span>
-              <% if @claim.tasks.exists?(name: task_name) %>
-                <strong class="govuk-tag app-task-list__task-completed">Completed</strong>
-              <% end %>
+              <%= task_status_tag(@claim, task_name) %>
             </li>
           </ul>
         </li>

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -18,7 +18,7 @@
           <ul class="app-task-list__items">
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <%= link_to I18n.t("#{@claim.policy.locale_key}.admin.checks.#{task_name}.summary"), admin_claim_task_path(claim_id: @claim.id, name: task_name), class: "govuk-link" %>
+                <%= link_to I18n.t("#{@claim.policy.locale_key}.admin.tasks.#{task_name}.summary"), admin_claim_task_path(claim_id: @claim.id, name: task_name), class: "govuk-link" %>
               </span>
               <% if @claim.tasks.exists?(name: task_name) %>
                 <strong class="govuk-tag app-task-list__task-completed">Completed</strong>

--- a/app/views/admin/tasks/qualifications.html.erb
+++ b/app/views/admin/tasks/qualifications.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    <% if @task.present? %>
+    <% if @task.persisted? %>
       <%= render "task_outcome", task: @task %>
     <% else %>
       <%= render "form", task_name: "qualifications", claim: @claim %>

--- a/app/views/admin/tasks/qualifications.html.erb
+++ b/app/views/admin/tasks/qualifications.html.erb
@@ -7,17 +7,14 @@
   <%= render "claim_summary", claim: @claim, heading: "Qualifications" %>
 
   <div class="govuk-grid-column-two-thirds">
-    <%= render "admin/claims/answer_section",
-          heading: "Qualifications",
-          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.checks.qualifications.question"),
-          answers: @tasks_presenter.qualifications %>
+    <%= render "admin/claims/answers", answers: @tasks_presenter.qualifications %>
   </div>
 
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <% if @task.present? %>
       <%= render "task_outcome", task: @task %>
     <% else %>
-      <%= button_to "Complete qualifications check and continue", admin_claim_tasks_path(claim_id: @claim.id, name: :qualifications), class: "govuk-button" %>
+      <%= render "form", task_name: "qualifications", claim: @claim %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/tasks/qualifications.html.erb
+++ b/app/views/admin/tasks/qualifications.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "admin/claims/answer_section",
           heading: "Qualifications",
-          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.checks.qualifications.description"),
+          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.checks.qualifications.question"),
           answers: @tasks_presenter.qualifications %>
   </div>
 

--- a/app/views/admin/tasks/qualifications.html.erb
+++ b/app/views/admin/tasks/qualifications.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} qualification check for #{policy_service_name(@claim.policy.routing_name)}") } %>
-
 <%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/admin/tasks/student_loan_amount.html.erb
+++ b/app/views/admin/tasks/student_loan_amount.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "admin/claims/answer_section",
           heading: "Student loan amount",
-          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.checks.student_loan_amount.description"),
+          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.tasks.student_loan_amount.question"),
           answers: @tasks_presenter.student_loan_amount %>
   </div>
 

--- a/app/views/admin/tasks/student_loan_amount.html.erb
+++ b/app/views/admin/tasks/student_loan_amount.html.erb
@@ -7,17 +7,14 @@
   <%= render "claim_summary", claim: @claim, heading: "Student loan amount" %>
 
   <div class="govuk-grid-column-two-thirds">
-    <%= render "admin/claims/answer_section",
-          heading: "Student loan amount",
-          description: I18n.t("#{@claim.policy.to_s.underscore}.admin.tasks.student_loan_amount.question"),
-          answers: @tasks_presenter.student_loan_amount %>
+    <%= render "admin/claims/answers", answers: @tasks_presenter.student_loan_amount %>
   </div>
 
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <% if @task.present? %>
       <%= render "task_outcome", task: @task %>
     <% else %>
-      <%= button_to "Complete student loan amount check and continue", admin_claim_tasks_path(claim_id: @claim.id, name: :student_loan_amount), class: "govuk-button" %>
+      <%= render "form", task_name: "student_loan_amount", claim: @claim %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/tasks/student_loan_amount.html.erb
+++ b/app/views/admin/tasks/student_loan_amount.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    <% if @task.present? %>
+    <% if @task.persisted? %>
       <%= render "task_outcome", task: @task %>
     <% else %>
       <%= render "form", task_name: "student_loan_amount", claim: @claim %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,13 +167,13 @@ en:
       employed_directly: "Employed directly by school?"
       disciplinary_action: "Subject to disciplinary action?"
       formal_performance_action: "Subject to formal performance action?"
-      checks:
+      tasks:
         qualifications:
           summary: "Check qualification information"
-          description: "Check the claimant's initial teacher training (ITT) qualification year and specialist subject matches the below information from their claim."
+          question: "Does the claimant’s initial teacher training (ITT) qualification year and specialist subject match the above information from their claim?"
         employment:
           summary: "Check employment information"
-          description: "Check the claimant's current school matches the below information from their claim."
+          question: "Does the claimant’s current school match the above information from their claim?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     policy_short_name: "Student Loans"
@@ -204,13 +204,13 @@ en:
       mostly_performed_leadership_duties: "Mostly performed leadership duties?"
       student_loan_repayment_amount: "Student loan repayment amount"
       student_loan_repayment_plan: "Student loan repayment plan"
-      checks:
+      tasks:
         qualifications:
           summary: "Check qualification information"
-          description: "Check the claimant's initial teacher training (ITT) qualification year matches the below information from their claim."
+          question: "Does the claimant’s initial teacher training (ITT) qualification year match the above information from their claim?"
         employment:
           summary: "Check employment information"
-          description: "Check the claimant's previous and current schools match the below information from their claim."
+          question: "Does the claimant’s previous and current schools match the above information from their claim?"
         student_loan_amount:
           summary: "Check student loan amount"
-          description: "Check the claimant’s student loan amount and plan type match the information we hold about their loan."
+          question: "Does the claimant’s student loan amount and plan type match the information we hold about their loan?"

--- a/db/data/20200311111523_set_passed_status_on_old_tasks.rb
+++ b/db/data/20200311111523_set_passed_status_on_old_tasks.rb
@@ -1,0 +1,2 @@
+# Run me with `rails runner db/data/20200311111523_set_passed_status_on_old_tasks.rb`
+Task.where(passed: nil).update_all(passed: true)

--- a/db/migrate/20200310114405_add_outcome_to_tasks.rb
+++ b/db/migrate/20200310114405_add_outcome_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddOutcomeToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :passed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_094710) do
+ActiveRecord::Schema.define(version: 2020_03_10_114405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -236,6 +236,7 @@ ActiveRecord::Schema.define(version: 2020_03_10_094710) do
     t.uuid "created_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "passed"
     t.index ["claim_id"], name: "index_tasks_on_claim_id"
     t.index ["created_by_id"], name: "index_tasks_on_created_by_id"
     t.index ["name", "claim_id"], name: "index_tasks_on_name_and_claim_id", unique: true

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :task do
     name { ClaimCheckingTasks.new(claim).applicable_task_names.sample }
+    passed { true }
     association :created_by, factory: :dfe_signin_user
     association :claim
   end

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -47,4 +47,18 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
     expect(claim.decision).to be_approved
     expect(claim.decision.created_by).to eq(user)
   end
+
+  scenario "service operator sees an error if they don't choose a Yes/No option on a check" do
+    claim = create(:claim, :submitted, policy: MathsAndPhysics)
+
+    visit admin_claims_path
+    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+
+    click_on "Check qualification information"
+
+    click_on "Save and continue"
+
+    expect(page).to have_content("You must select ‘Yes’ or ‘No’")
+    expect(claim.tasks.find_by(name: "qualifications")).to be_nil
+  end
 end

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -18,17 +18,24 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
     expect(page).to have_content("3. Decision")
 
     click_on "Check qualification information"
-    expect(page).to have_content("Qualifications")
+
+    expect(page).to have_content(I18n.t("maths_and_physics.admin.tasks.qualifications.question"))
     expect(page).to have_content("Award year")
     expect(page).to have_content(claim.eligibility.qts_award_year_answer)
 
-    click_on "Complete qualifications check and continue"
+    choose "Yes"
+    click_on "Save and continue"
 
-    expect(page).to have_content("Employment")
+    expect(claim.tasks.find_by!(name: "qualifications").passed?).to eq(true)
+
+    expect(page).to have_content(I18n.t("maths_and_physics.admin.tasks.employment.question"))
     expect(page).to have_content("Current school")
     expect(page).to have_link(claim.eligibility.current_school.name)
 
-    click_on "Complete employment check and continue"
+    choose "Yes"
+    click_on "Save and continue"
+
+    expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
 
     expect(page).to have_content("Claim decision")
 

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -25,22 +25,33 @@ RSpec.feature "Admin checking a Student Loans claim" do
     expect(page).to have_content("4. Decision")
 
     click_on "Check qualification information"
-    expect(page).to have_content("Qualifications")
+
+    expect(page).to have_content(I18n.t("student_loans.admin.tasks.qualifications.question"))
     expect(page).to have_content("Award year")
     expect(page).to have_content(claim.eligibility.qts_award_year_answer)
 
-    click_on "Complete qualifications check and continue"
+    choose "Yes"
+    click_on "Save and continue"
 
-    expect(page).to have_content("Employment")
+    expect(claim.tasks.find_by!(name: "qualifications").passed?).to eq(true)
+
+    expect(page).to have_content(I18n.t("student_loans.admin.tasks.employment.question"))
     expect(page).to have_content("Current school")
     expect(page).to have_link(claim.eligibility.current_school.name)
 
-    click_on "Complete employment check and continue"
+    choose "Yes"
+    click_on "Save and continue"
 
-    expect(page).to have_content("Student loan amount")
+    expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
+
+    expect(page).to have_content(I18n.t("student_loans.admin.tasks.student_loan_amount.question"))
     expect(page).to have_content("£1,987.65")
     expect(page).to have_content("Plan 2")
-    click_on "Complete student loan amount check and continue"
+
+    choose "Yes"
+    click_on "Save and continue"
+
+    expect(claim.tasks.find_by!(name: "student_loan_amount").passed?).to eq(true)
 
     expect(page).to have_content("Claim decision")
 

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -76,17 +76,17 @@ RSpec.feature "Admin checks a claim" do
       ten_minutes_ago = 10.minutes.ago
       checking_user = create(:dfe_signin_user, given_name: "Fred", family_name: "Smith")
       qualification_task = build(:task, name: "qualifications", created_by: checking_user, created_at: ten_minutes_ago)
-      claim_with_tasks = create(:claim, :submitted, tasks: [qualification_task, build(:task, name: "employment")])
+      claim_with_tasks = create(:claim, :submitted, tasks: [qualification_task, build(:task, name: "employment", passed: false)])
       visit admin_claim_tasks_path(claim_with_tasks)
 
-      expect(page).to have_content("Check qualification information Completed")
-      expect(page).to have_content("Check employment information Completed")
+      expect(page).to have_content("Check qualification information Passed")
+      expect(page).to have_content("Check employment information Failed")
       expect(page).to have_link("Approve or reject this claim", href: new_admin_claim_decision_path(claim_with_tasks))
 
       click_on "Check qualification information"
       expect(page).to have_content("Performed by #{checking_user.full_name}")
       expect(page).to have_content(I18n.l(ten_minutes_ago))
-      expect(page).not_to have_button("Complete qualifications check and continue")
+      expect(page).not_to have_button("Save and continue")
     end
 
     scenario "User can see existing decision details" do

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -158,7 +158,9 @@ RSpec.feature "Admin checks a claim" do
       def perform_last_task(claim)
         applicable_task_names = ClaimCheckingTasks.new(claim).applicable_task_names
         visit admin_claim_task_path(claim, name: applicable_task_names.last)
-        find("input[type='submit']").click
+
+        choose "Yes"
+        click_on "Save and continue"
       end
     end
   end

--- a/spec/helpers/admin/claims_helper_spec.rb
+++ b/spec/helpers/admin/claims_helper_spec.rb
@@ -201,4 +201,32 @@ describe Admin::ClaimsHelper do
       expect(subject).to eq(["Bank account number", "Bank sort code", "National insurance number", "Teacher reference number"])
     end
   end
+
+  describe "#task_status_tag" do
+    let(:claim) { build(:claim) }
+    let(:task_status_tag) { helper.task_status_tag(claim, "employment") }
+
+    it "returns a passed tag if the task has been marked as passed" do
+      claim.tasks << build(:task, name: "employment", passed: true, claim: claim)
+
+      expect(task_status_tag).to match("Passed")
+      expect(task_status_tag).to match("govuk-tag app-task-list__task-completed")
+      expect(task_status_tag).to_not match("govuk-tag--inactive")
+    end
+
+    it "returns a failed tag if the task has been marked as failed" do
+      claim.tasks << build(:task, name: "employment", passed: false, claim: claim)
+
+      expect(task_status_tag).to match("Failed")
+      expect(task_status_tag).to match("govuk-tag app-task-list__task-completed")
+      expect(task_status_tag).to_not match("govuk-tag--inactive")
+    end
+
+    it "returns an incomplete tag if the task has not been done" do
+      claim.tasks = []
+
+      expect(task_status_tag).to match("Incomplete")
+      expect(task_status_tag).to match("govuk-tag app-task-list__task-completed govuk-tag--inactive")
+    end
+  end
 end

--- a/spec/requests/admin_tasks_spec.rb
+++ b/spec/requests/admin_tasks_spec.rb
@@ -81,6 +81,16 @@ RSpec.describe "Admin tasks", type: :request do
             end
           end
 
+          context "when a task's passed flag is not set" do
+            it "doesn't create a task and shows an error" do
+              expect {
+                post admin_claim_tasks_path(claim, name: "qualifications", params: {task: {passed: ""}})
+              }.not_to change { claim.tasks.count }
+
+              expect(response.body).to match("You must select ‘Yes’ or ‘No’")
+            end
+          end
+
           context "when a task has already been marked as completed" do
             it "doesn't create a task and redirects with an error" do
               create(:task, name: "qualifications", claim: claim)

--- a/spec/requests/admin_tasks_spec.rb
+++ b/spec/requests/admin_tasks_spec.rb
@@ -48,40 +48,49 @@ RSpec.describe "Admin tasks", type: :request do
         end
 
         describe "tasks#create" do
-          it "creates a new check and redirects to the next check" do
+          it "creates a new passed task and redirects to the next task" do
             expect {
-              post admin_claim_tasks_path(claim, name: "qualifications")
+              post admin_claim_tasks_path(claim, name: "qualifications", params: {task: {passed: "true"}})
             }.to change { Task.count }.by(1)
 
             expect(claim.tasks.last.name).to eql("qualifications")
+            expect(claim.tasks.last.passed?).to eql(true)
             expect(claim.tasks.last.created_by).to eql(user)
             expect(response).to redirect_to(admin_claim_task_path(claim, name: "employment"))
           end
 
-          context "when the last check is marked as completed" do
-            let(:last_check) { ClaimCheckingTasks.new(claim).applicable_task_names.last }
+          it "creates a new failed task" do
+            post admin_claim_tasks_path(claim, name: "qualifications", params: {task: {passed: "false"}})
 
-            it "creates the check and redirects to the decision page" do
+            expect(claim.tasks.last.name).to eql("qualifications")
+            expect(claim.tasks.last.passed?).to eql(false)
+          end
+
+          context "when the last task is marked as completed" do
+            let(:last_task) { ClaimCheckingTasks.new(claim).applicable_task_names.last }
+
+            it "creates the task and redirects to the decision page" do
               expect {
-                post admin_claim_tasks_path(claim, name: last_check)
+                post admin_claim_tasks_path(claim, name: last_task, params: {task: {passed: "true"}})
               }.to change { Task.count }.by(1)
 
-              expect(claim.tasks.last.name).to eql(last_check)
+              expect(claim.tasks.last.name).to eql(last_task)
+              expect(claim.tasks.last.passed?).to eql(true)
               expect(claim.tasks.last.created_by).to eql(user)
               expect(response).to redirect_to(new_admin_claim_decision_path(claim))
             end
           end
 
-          context "when a check has already been marked as completed" do
-            it "doesn't create a check and redirects with an error" do
+          context "when a task has already been marked as completed" do
+            it "doesn't create a task and redirects with an error" do
               create(:task, name: "qualifications", claim: claim)
 
               expect {
-                post admin_claim_tasks_path(claim, name: "qualifications")
+                post admin_claim_tasks_path(claim, name: "qualifications", params: {task: {passed: "true"}})
               }.not_to change { Task.count }
 
               expect(response).to redirect_to(admin_claim_task_path(claim, name: "qualifications"))
-              expect(flash[:alert]).to eql("This check has already been completed")
+              expect(flash[:alert]).to eql("This task has already been completed")
             end
           end
         end


### PR DESCRIPTION
This updates the claim checking tasks to have a boolean value of `passed` and allows users to set this via a Yes/No interface on each task. It also shows the state of each task on the task list page and has a data migration to update older tasks that have already been created to set an explicit `passed` state.

# Screenshots

![image](https://user-images.githubusercontent.com/109774/76415711-9b971900-6391-11ea-8293-d6456811f1f5.png)

![image](https://user-images.githubusercontent.com/109774/76415747-b23d7000-6391-11ea-9b5b-cd70a1d2a006.png)

