### PR TITLE
Update payment removal content

### DIFF
--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -5,13 +5,14 @@ module Admin
     before_action :find_payment
 
     def remove
+      @claims = @payment.claims
     end
 
     def destroy
       if @payroll_run.confirmation_report_uploaded?
         redirect_to admin_payroll_run_path(@payroll_run), alert: "A payment cannot be removed from an already confirmed payroll run"
       else
-        @claim_references = @payment.claims.pluck(:reference)
+        @claims = @payment.claims.to_a
         @payment.destroy
       end
     end

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -2,6 +2,10 @@ module Admin
   module ClaimsHelper
     include StudentLoans::PresenterMethods
 
+    def claim_links(claims)
+      claims.map { |claim| link_to(claim.reference, admin_claim_path(claim), class: "govuk-link") }.to_sentence.html_safe
+    end
+
     def confirming_identity_playbook_url
       "https://docs.google.com/document/d/1wZh68_RV_FTJLxXIDPr3XFtJHW3vRgiXGaBDUo1Q1ZU"
     end

--- a/app/views/admin/payments/destroy.html.erb
+++ b/app/views/admin/payments/destroy.html.erb
@@ -7,7 +7,7 @@
     <p class="govuk-body-m">
       Payment <strong><%= @payment.id %></strong> belonging to
       <%= "claim".pluralize(@claims.size) %>
-      <%= @claims.map(&:reference).to_sentence %>
+      <%= claim_links(@claims) %>
       <%= "is".pluralize(@claims.size) %> no longer included in this
       payroll run.
     </p>
@@ -24,7 +24,7 @@
     <p class="govuk-body-m">
       Contact the claimant for
       <%= "claim".pluralize(@claims.size) %>
-      <%= @claims.map(&:reference).to_sentence %> to get their correct bank details
+      <%= claim_links(@claims) %> to get their correct bank details
       before the next payroll run, otherwise their payment will fail again.
     </p>
 
@@ -41,7 +41,7 @@
     <p class="govuk-body-m">
       You’ll need to reverse the approved decision on
       <%= "claim".pluralize(@claims.size) %>
-      <%= @claims.map(&:reference).to_sentence %> to prevent
+      <%= claim_links(@claims) %> to prevent
       <%= "it".pluralize(@claims.size) %>
       being automatically added to the next payroll run.
     </p>

--- a/app/views/admin/payments/destroy.html.erb
+++ b/app/views/admin/payments/destroy.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <%= t("admin.payment_deleted_title",
             count: @claim_references.count) %>

--- a/app/views/admin/payments/destroy.html.erb
+++ b/app/views/admin/payments/destroy.html.erb
@@ -1,25 +1,50 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= t("admin.payment_deleted_title",
-            count: @claim_references.count) %>
+      You have removed a payment from the payroll run
     </h1>
 
-    <p class="govuk-body-l">
-      <%= t("admin.payment_deleted_outcome_message",
-            count: @claim_references.count,
-            references: @claim_references.to_sentence) %>
+    <p class="govuk-body-m">
+      Payment <strong><%= @payment.id %></strong> belonging to
+      <%= "claim".pluralize(@claim_references.size) %>
+      <%= @claim_references.to_sentence %>
+      <%= "is".pluralize(@claim_references.size) %> no longer included in this
+      payroll run.
     </p>
 
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-          <%= t("admin.payment_deleted_claim_next_steps_message",
-                count: @claim_references.count) %>
-        </span>
-      </strong>
-    </div>
+    <h2 class="govuk-heading-m">
+      If Cantium had a problem paying this claimant
+    </h2>
+
+    <p class="govuk-body-m">
+      The <%= "claim".pluralize(@claim_references.size) %> will be
+      automatically added to the next payroll run.
+    </p>
+
+    <p class="govuk-body-m">
+      Contact the claimant for
+      <%= "claim".pluralize(@claim_references.size) %>
+      <%= @claim_references.to_sentence %> to get their correct bank details
+      before the next payroll run, otherwise their payment will fail again.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      If we no longer want Cantium to pay this claim
+    </h2>
+
+    <p class="govuk-body-m">
+      If you’ve already sent the payroll file to Cantium, contact Cantium and
+      ask them to remove payment <strong><%= @payment.id %></strong> from the
+      payroll run.
+    </p>
+
+    <p class="govuk-body-m">
+      You’ll need to reverse the approved decision on
+      <%= "claim".pluralize(@claim_references.size) %>
+      <%= @claim_references.to_sentence %> to prevent
+      <%= "it".pluralize(@claim_references.size) %>
+      being automatically added to the next payroll run.
+    </p>
 
     <p class="govuk-body">
       <%= link_to "Back to payroll run", admin_payroll_run_path(@payroll_run), class: "govuk-link" %>

--- a/app/views/admin/payments/destroy.html.erb
+++ b/app/views/admin/payments/destroy.html.erb
@@ -6,9 +6,9 @@
 
     <p class="govuk-body-m">
       Payment <strong><%= @payment.id %></strong> belonging to
-      <%= "claim".pluralize(@claim_references.size) %>
-      <%= @claim_references.to_sentence %>
-      <%= "is".pluralize(@claim_references.size) %> no longer included in this
+      <%= "claim".pluralize(@claims.size) %>
+      <%= @claims.map(&:reference).to_sentence %>
+      <%= "is".pluralize(@claims.size) %> no longer included in this
       payroll run.
     </p>
 
@@ -17,14 +17,14 @@
     </h2>
 
     <p class="govuk-body-m">
-      The <%= "claim".pluralize(@claim_references.size) %> will be
+      The <%= "claim".pluralize(@claims.size) %> will be
       automatically added to the next payroll run.
     </p>
 
     <p class="govuk-body-m">
       Contact the claimant for
-      <%= "claim".pluralize(@claim_references.size) %>
-      <%= @claim_references.to_sentence %> to get their correct bank details
+      <%= "claim".pluralize(@claims.size) %>
+      <%= @claims.map(&:reference).to_sentence %> to get their correct bank details
       before the next payroll run, otherwise their payment will fail again.
     </p>
 
@@ -40,9 +40,9 @@
 
     <p class="govuk-body-m">
       You’ll need to reverse the approved decision on
-      <%= "claim".pluralize(@claim_references.size) %>
-      <%= @claim_references.to_sentence %> to prevent
-      <%= "it".pluralize(@claim_references.size) %>
+      <%= "claim".pluralize(@claims.size) %>
+      <%= @claims.map(&:reference).to_sentence %> to prevent
+      <%= "it".pluralize(@claims.size) %>
       being automatically added to the next payroll run.
     </p>
 

--- a/app/views/admin/payments/remove.html.erb
+++ b/app/views/admin/payments/remove.html.erb
@@ -5,9 +5,9 @@
     </h1>
 
     <p class="govuk-body-l">
-      <%= t("admin.payment_deletion_claim_warning",
-            count: @payment.claims.count,
-            references: @payment.claims.pluck(:reference).to_sentence) %>
+      This means <%= "claim".pluralize(@payment.claims.size) %>
+      <%= @payment.claims.pluck(:reference).to_sentence %> will no longer be included in this
+      payroll run.
     </p>
 
     <%= form_with url: admin_payroll_run_payment_path(id: @payment.id, payroll_run_id: @payment.payroll_run.id), method: :delete do |f| %>

--- a/app/views/admin/payments/remove.html.erb
+++ b/app/views/admin/payments/remove.html.erb
@@ -6,7 +6,7 @@
 
     <p class="govuk-body-l">
       This means <%= "claim".pluralize(@claims.size) %>
-      <%= @claims.map(&:reference).to_sentence %> will no longer be included in this
+      <%= claim_links(@claims) %> will no longer be included in this
       payroll run.
     </p>
 

--- a/app/views/admin/payments/remove.html.erb
+++ b/app/views/admin/payments/remove.html.erb
@@ -11,11 +11,7 @@
     </p>
 
     <%= form_with url: admin_payroll_run_payment_path(id: @payment.id, payroll_run_id: @payment.payroll_run.id), method: :delete do |f| %>
-      <%= f.submit "Remove payment",
-                   class: "govuk-button govuk-button--warning",
-                   data: {
-                     confirm: "Are you sure you want to remove this payment from the payroll run?"
-                    } %>
+      <%= f.submit "Remove payment", class: "govuk-button govuk-button--warning" %>
       <%= link_to "Cancel", admin_payroll_run_path(@payroll_run), class: "govuk-button govuk-button--secondary govuk-!-margin-left-1", role: "button", data: {module: "govuk-button"} %>
     <% end %>
   </div>

--- a/app/views/admin/payments/remove.html.erb
+++ b/app/views/admin/payments/remove.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       Are you sure you want to remove payment <%= @payment.id %> from the payroll run?
     </h1>

--- a/app/views/admin/payments/remove.html.erb
+++ b/app/views/admin/payments/remove.html.erb
@@ -5,8 +5,8 @@
     </h1>
 
     <p class="govuk-body-l">
-      This means <%= "claim".pluralize(@payment.claims.size) %>
-      <%= @payment.claims.pluck(:reference).to_sentence %> will no longer be included in this
+      This means <%= "claim".pluralize(@claims.size) %>
+      <%= @claims.map(&:reference).to_sentence %> will no longer be included in this
       payroll run.
     </p>
 

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,9 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+# inflections.rb
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.irregular "it", "them"
+  inflect.irregular "is", "are"
+  inflect.irregular "this", "these"
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,9 +78,6 @@ en:
     claims_preventing_payment_message:
       one: This claim cannot currently be approved because we’re already paying another claim (%{claim_references}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.
       other: This claim cannot currently be approved because we’re already paying other claims (%{claim_references}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.
-    payment_deletion_claim_warning:
-      one: This means claim %{references} will no longer be included in this payroll run.
-      other: This means claims %{references} will no longer be included in this payroll run.
     duplicate_attributes_message:
       one: Details in this claim match another %{policy} claim
       other: Details in this claim match other %{policy} claims

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,8 +79,8 @@ en:
       one: This claim cannot currently be approved because we’re already paying another claim (%{claim_references}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.
       other: This claim cannot currently be approved because we’re already paying other claims (%{claim_references}) to this claimant in this payroll month using different payment details. Please speak to a Grade 7.
     payment_deletion_claim_warning:
-      one: This means claim %{references} will no longer be included in this pay run.
-      other: This means claims %{references} will no longer be included in this pay run.
+      one: This means claim %{references} will no longer be included in this payroll run.
+      other: This means claims %{references} will no longer be included in this payroll run.
     duplicate_attributes_message:
       one: Details in this claim match another %{policy} claim
       other: Details in this claim match other %{policy} claims

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,15 +84,6 @@ en:
     duplicate_attributes_message:
       one: Details in this claim match another %{policy} claim
       other: Details in this claim match other %{policy} claims
-    payment_deleted_title:
-      one: You have removed a claim from the payroll run
-      other: You have removed %{count} claims from the payroll run
-    payment_deleted_outcome_message:
-      one: Claim %{references} is no longer included in this pay run. This claim will be automatically added to the next pay run.
-      other: Claims %{references} are no longer included in this pay run. These claims will be automatically added to the next pay run.
-    payment_deleted_claim_next_steps_message:
-      one: Please make a note of this claim and contact the claimant to resolve the problems with their payment before the next pay run.
-      other: Please make a note of these claims and contact the claimant to resolve the problems with their payment before the next pay run.
     unknown_payroll_gender_preventing_approval_message: This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
   answers:
     qts_award_years:

--- a/spec/features/admin_payroll_runs_spec.rb
+++ b/spec/features/admin_payroll_runs_spec.rb
@@ -118,7 +118,7 @@ RSpec.feature "Payroll" do
 
     expect(payroll_run.reload.payments).to_not include(payment_to_delete)
 
-    expect(page).to have_content("You have removed a claim from the payroll run")
+    expect(page).to have_content("You have removed a payment from the payroll run")
     expect(page).to have_content(claim_reference)
   end
 

--- a/spec/requests/admin_payroll_run_payments_spec.rb
+++ b/spec/requests/admin_payroll_run_payments_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "Admin payroll run payments" do
   end
 
   describe "destroy" do
-    it "deletes a payroll run and shows a message" do
-      reference = payment.claims.first.reference
+    it "deletes the payment, playing back the claim reference" do
+      claim = payment.claims.first
 
       expect {
         delete admin_payroll_run_payment_path(
@@ -36,7 +36,8 @@ RSpec.describe "Admin payroll run payments" do
       expect(payroll_run.payments).to_not include(payment)
 
       expect(response.body).to include("You have removed a claim from the payroll run")
-      expect(response.body).to include(reference)
+
+      expect(response.body).to include(claim.reference)
     end
 
     it "cannot delete a payment from an already confirmed payroll run" do

--- a/spec/requests/admin_payroll_run_payments_spec.rb
+++ b/spec/requests/admin_payroll_run_payments_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Admin payroll run payments" do
   end
 
   describe "destroy" do
-    it "deletes the payment, playing back the claim reference" do
+    it "deletes the payment, playing back the payment ID and claim reference" do
       claim = payment.claims.first
 
       expect {
@@ -35,8 +35,8 @@ RSpec.describe "Admin payroll run payments" do
 
       expect(payroll_run.payments).to_not include(payment)
 
-      expect(response.body).to include("You have removed a claim from the payroll run")
-
+      expect(response.body).to include("You have removed a payment from the payroll run")
+      expect(response.body).to include(payment.id)
       expect(response.body).to include(claim.reference)
     end
 


### PR DESCRIPTION
Some adjustments to the content when removing a payment to make it clearer to the service operator what the next steps might be.

**Before**
<img width="978" alt="Screenshot 2020-03-12 at 15 59 28" src="https://user-images.githubusercontent.com/3687/76540761-821dcc00-647a-11ea-8875-307a9a611a88.png">

**After**
<img width="990" alt="Screenshot 2020-03-12 at 16 03 21" src="https://user-images.githubusercontent.com/3687/76541144-053f2200-647b-11ea-96f2-a0c73af583ed.png">
