### PR TITLE
Add the claims with matching details task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add a task to check claims with matching attributes
+
 ## [Release 062] - 2020-03-12
 
 - Add Yes/No option to claim checking tasks

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -2,6 +2,7 @@ class Admin::TasksController < Admin::BaseAdminController
   before_action :ensure_service_operator
   before_action :load_claim
   before_action :ensure_task_has_not_already_been_completed, only: [:create]
+  before_action :load_matching_claims, only: [:show], if: -> { current_task_name == "matching_details" }
 
   def index
     @claim_checking_tasks = ClaimCheckingTasks.new(@claim)
@@ -58,5 +59,9 @@ class Admin::TasksController < Admin::BaseAdminController
       .permit(:passed)
       .merge(name: current_task_name,
              created_by: admin_user)
+  end
+
+  def load_matching_claims
+    @matching_claims = Claim::MatchingAttributeFinder.new(@claim).matching_claims
   end
 end

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -3,7 +3,12 @@
 # This models the tasks that need to be performed on a claim as part of the
 # claim checking process.
 class ClaimCheckingTasks
-  TASK_NAMES = %w[qualifications employment student_loan_amount].freeze
+  TASK_NAMES = %w[
+    qualifications
+    employment
+    student_loan_amount
+    matching_details
+  ].freeze
 
   attr_reader :claim
 
@@ -14,11 +19,18 @@ class ClaimCheckingTasks
   def applicable_task_names
     @applicable_task_names ||= TASK_NAMES.dup.tap do |task_names|
       task_names.delete("student_loan_amount") unless claim.policy == StudentLoans
+      task_names.delete("matching_details") unless matching_claims.exists?
     end
   end
 
   # Returns an Array of tasks names that have not been completed on the claim.
   def incomplete_task_names
     applicable_task_names - claim.tasks.map(&:name)
+  end
+
+  private
+
+  def matching_claims
+    @matching_claims ||= Claim::MatchingAttributeFinder.new(claim).matching_claims
   end
 end

--- a/app/views/admin/claims/_claims_with_matching_details.html.erb
+++ b/app/views/admin/claims/_claims_with_matching_details.html.erb
@@ -1,7 +1,10 @@
 <table id="claims-with-matches" class="govuk-table govuk-!-margin-bottom-9">
-  <caption class="govuk-table__caption govuk-heading-l">
-    <%= @claim.policy.short_name %> <%= "claim".pluralize(@matching_claims.count) %> with matching details
-  </caption>
+  <% if show_caption %>
+    <caption class="govuk-table__caption govuk-heading-l">
+      <%= @claim.policy.short_name %> <%= "claim".pluralize(@matching_claims.count) %> with matching details
+    </caption>
+  <% end %>
+
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Claim</th>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -50,7 +50,7 @@
 
     <%= render "admin/claims/answer_section", {heading: "Submission details", answers: admin_submission_details(@claim)} %>
 
-    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim}) if @matching_claims.any? %>
+    <%= render("claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
 
     <% if @decision.persisted? %>
       <%= render "admin/claims/answer_section", {heading: "Claim decision details", answers: admin_decision_details(@decision)} %>

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -5,7 +5,7 @@
 
   <%= render "admin/tasks/claim_summary", claim: @claim, heading: "Claim decision" %>
 
-  <%= render("admin/claims/claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim}) if @matching_claims.any? %>
+  <%= render("admin/claims/claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
 
   <div class="govuk-grid-column-two-thirds">
     <%= render("incomplete_tasks", claim: @claim, incomplete_task_names: @claim_checking_tasks.incomplete_task_names) if @claim_checking_tasks.incomplete_task_names.any? %>

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -5,8 +5,6 @@
 
   <%= render "admin/tasks/claim_summary", claim: @claim, heading: "Claim decision" %>
 
-  <%= render("admin/claims/claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: true}) if @matching_claims.any? %>
-
   <div class="govuk-grid-column-two-thirds">
     <%= render("incomplete_tasks", claim: @claim, incomplete_task_names: @claim_checking_tasks.incomplete_task_names) if @claim_checking_tasks.incomplete_task_names.any? %>
     <%= render "decision_form", claim: @claim, decision: @decision, claims_preventing_payment: @claims_preventing_payment %>

--- a/app/views/admin/tasks/matching_details.html.erb
+++ b/app/views/admin/tasks/matching_details.html.erb
@@ -1,0 +1,20 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} matching details check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
+
+<div class="govuk-grid-row">
+
+  <%= render "claim_summary", claim: @claim, heading: "Claims with matching details" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("admin/claims/claims_with_matching_details", {matching_claims: @matching_claims, claim: @claim, show_caption: false}) %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if @task.persisted? %>
+      <%= render "task_outcome", task: @task %>
+    <% else %>
+      <%= render "form", task_name: "matching_details", claim: @claim %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,9 @@ en:
         employment:
           summary: "Check employment information"
           question: "Does the claimant’s current school match the above information from their claim?"
+        matching_details:
+          summary: "Review matching details from other claims"
+          question: "Is this claim still valid despite having matching details with other claims?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     policy_short_name: "Student Loans"
@@ -202,3 +205,6 @@ en:
         student_loan_amount:
           summary: "Check student loan amount"
           question: "Does the claimant’s student loan amount and plan type match the information we hold about their loan?"
+        matching_details:
+          summary: "Review matching details from other claims"
+          question: "Is this claim still valid despite having matching details with other claims?"

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.feature "Admin checking a Maths & Physics claim" do
   let(:user) { create(:dfe_signin_user) }
 
+  let!(:claim) { create(:claim, :submitted, policy: MathsAndPhysics) }
+
   before do
     sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
   end
 
   scenario "service operator checks and approves a Maths & Physics claim" do
-    claim = create(:claim, :submitted, policy: MathsAndPhysics)
-
     visit admin_claims_path
     find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
@@ -46,6 +46,33 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
     expect(page).to have_content("Claim has been approved successfully")
     expect(claim.decision).to be_approved
     expect(claim.decision.created_by).to eq(user)
+  end
+
+  scenario "service operator can check a claim with matching details" do
+    claim_with_matching_details = create(:claim, :submitted,
+      teacher_reference_number: claim.teacher_reference_number,
+      policy: MathsAndPhysics)
+
+    visit admin_claims_path
+    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+
+    expect(page).to have_content("1. Qualifications")
+    expect(page).to have_content("2. Employment")
+    expect(page).to have_content("3. Matching details")
+    expect(page).to have_content("4. Decision")
+
+    click_on I18n.t("maths_and_physics.admin.tasks.matching_details.summary")
+
+    expect(page).to have_content(I18n.t("maths_and_physics.admin.tasks.matching_details.question"))
+    expect(page).to have_content(claim_with_matching_details.reference)
+    expect(page).to have_content("Teacher reference number")
+
+    choose "Yes"
+    click_on "Save and continue"
+
+    expect(claim.tasks.find_by!(name: "matching_details").passed?).to eq(true)
+
+    expect(page).to have_content("Claim decision")
   end
 
   scenario "service operator sees an error if they don't choose a Yes/No option on a check" do

--- a/spec/models/claim_checking_tasks_spec.rb
+++ b/spec/models/claim_checking_tasks_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ClaimCheckingTasks do
-  let(:claim) { build(:claim, policy: MathsAndPhysics) }
+  let(:claim) { build(:claim, :submitted, policy: MathsAndPhysics) }
   let(:checking_tasks) { ClaimCheckingTasks.new(claim) }
 
   describe "#applicable_task_names" do
@@ -12,10 +12,18 @@ RSpec.describe ClaimCheckingTasks do
     end
 
     it "includes the a task for student loan amount for a StudentLoans claim" do
-      student_loan_claim = build(:claim, policy: StudentLoans)
+      student_loan_claim = build(:claim, :submitted, policy: StudentLoans)
       student_loan_tasks = ClaimCheckingTasks.new(student_loan_claim)
 
       expect(student_loan_tasks.applicable_task_names).to eq %w[qualifications employment student_loan_amount]
+    end
+
+    it "includes the matching details task when there are claims with matching details" do
+      create(:claim, :submitted,
+        policy: MathsAndPhysics,
+        teacher_reference_number: claim.teacher_reference_number)
+
+      expect(checking_tasks.applicable_task_names).to eq %w[qualifications employment matching_details]
     end
   end
 


### PR DESCRIPTION
This adds the a new task that allows service operators to review any claims with matching details before approving a claim.

# Screenshots

![image](https://user-images.githubusercontent.com/109774/76544072-53562480-647f-11ea-9ccd-21cc1e757a57.png)

![image](https://user-images.githubusercontent.com/109774/76544097-5ea95000-647f-11ea-983c-c4a325cc7ea7.png)

