### PR TITLE
Add the identity confirmation task for claims that didn't go through GOV.UK Verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Add a task to check claims with matching attributes
+- Add a claim checking task to verify identity of claimants who didn’t use
+  GOV.UK Verify
 
 ## [Release 062] - 2020-03-12
 

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -8,6 +8,7 @@ class ClaimCheckingTasks
     employment
     student_loan_amount
     matching_details
+    identity_confirmation
   ].freeze
 
   attr_reader :claim
@@ -20,6 +21,7 @@ class ClaimCheckingTasks
     @applicable_task_names ||= TASK_NAMES.dup.tap do |task_names|
       task_names.delete("student_loan_amount") unless claim.policy == StudentLoans
       task_names.delete("matching_details") unless matching_claims.exists?
+      task_names.delete("identity_confirmation") if claim.identity_confirmed?
     end
   end
 

--- a/app/models/maths_and_physics/admin_tasks_presenter.rb
+++ b/app/models/maths_and_physics/admin_tasks_presenter.rb
@@ -24,6 +24,13 @@ module MathsAndPhysics
       ]
     end
 
+    def identity_confirmation
+      [
+        ["Current school", eligibility.current_school.name],
+        ["Contact number", eligibility.current_school.phone_number]
+      ]
+    end
+
     private
 
     def eligibility

--- a/app/models/student_loans/admin_tasks_presenter.rb
+++ b/app/models/student_loans/admin_tasks_presenter.rb
@@ -31,6 +31,13 @@ module StudentLoans
       ]
     end
 
+    def identity_confirmation
+      [
+        ["Current school", eligibility.current_school.name],
+        ["Contact number", eligibility.current_school.phone_number]
+      ]
+    end
+
     private
 
     def eligibility

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -1,8 +1,6 @@
 <div class="govuk-grid-row">
   <%= render("shared/error_summary", instance: @decision, errored_field_id_overrides: { "result": "decision_result_approved" }) if @decision.errors.any? %>
 
-  <%= render("admin/claims/info_panel_identity_unconfirmed", school: @claim.school) unless @claim.identity_confirmed? %>
-
   <%= render "admin/tasks/claim_summary", claim: @claim, heading: "Claim decision" %>
 
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/tasks/_form.html.erb
+++ b/app/views/admin/tasks/_form.html.erb
@@ -3,9 +3,15 @@
     <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l ">
         <h3 class="govuk-heading-l">
-          <%= I18n.t("#{claim.policy.to_s.underscore}.admin.tasks.#{task_name}.question") %>
+          <%= I18n.t("#{claim.policy.to_s.underscore}.admin.tasks.#{task_name}.question", local_assigns[:question_variables]) %>
         </h3>
       </legend>
+
+      <% if local_assigns.has_key?(:explanation) %>
+        <p class="govuk-body">
+          <%= explanation %>
+        </p>
+      <% end %>
 
       <%= f.hidden_field :passed %>
 

--- a/app/views/admin/tasks/identity_confirmation.html.erb
+++ b/app/views/admin/tasks/identity_confirmation.html.erb
@@ -1,0 +1,27 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} identity confirmation check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<%= render "shared/error_summary", instance: @task, errored_field_id_overrides: { "passed": "task_passed_true" } if @task.errors.any? %>
+
+<div class="govuk-grid-row">
+
+  <%= render "claim_summary", claim: @claim, heading: "Identity confirmation" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "admin/claims/answers", answers: @tasks_presenter.identity_confirmation %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if @task.persisted? %>
+      <%= render "task_outcome", task: @task do %>
+      <% end %>
+    <% else %>
+      <%=
+        render "form",
+          task_name: "identity_confirmation",
+          question_variables: { name: @claim.full_name },
+          claim: @claim,
+          explanation: "The claimant did not complete GOV.UK Verify. Refer to the #{link_to("Confirming a claimant’s identity playbook", confirming_identity_playbook_url, class: "govuk-link")}.".html_safe
+      %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,9 @@ en:
         matching_details:
           summary: "Review matching details from other claims"
           question: "Is this claim still valid despite having matching details with other claims?"
+        identity_confirmation:
+          summary: "Confirm the claimant made the claim"
+          question: "Did %{name} submit the claim?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     policy_short_name: "Student Loans"
@@ -208,3 +211,6 @@ en:
         matching_details:
           summary: "Review matching details from other claims"
           question: "Is this claim still valid despite having matching details with other claims?"
+        identity_confirmation:
+          summary: "Confirm the claimant made the claim"
+          question: "Did %{name} submit the claim?"

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -88,4 +88,37 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
     expect(page).to have_content("You must select ‘Yes’ or ‘No’")
     expect(claim.tasks.find_by(name: "qualifications")).to be_nil
   end
+
+  scenario "service operator checks and approves a Maths & Physics claim where the claimant did not complete GOV.UK Verify" do
+    claim = create(:claim, :unverified, policy: MathsAndPhysics)
+
+    visit admin_claims_path
+    find("a[href='#{admin_claim_tasks_path(claim)}']").click
+
+    expect(page).to have_content("1. Qualifications")
+    expect(page).to have_content("2. Employment")
+    expect(page).to have_content("3. Identity confirmation")
+    expect(page).to have_content("4. Decision")
+
+    click_on I18n.t("maths_and_physics.admin.tasks.identity_confirmation.summary")
+
+    expect(page).to have_content(I18n.t("maths_and_physics.admin.tasks.identity_confirmation.question", name: claim.full_name))
+    expect(page).to have_content(claim.eligibility.current_school.name)
+    expect(page).to have_content(claim.eligibility.current_school.phone_number)
+
+    choose "Yes"
+    click_on "Save and continue"
+
+    expect(claim.tasks.find_by!(name: "identity_confirmation").passed?).to eq(true)
+
+    expect(page).to have_content("Claim decision")
+
+    choose "Approve"
+    fill_in "Decision notes", with: "All checks passed!"
+    click_on "Confirm decision"
+
+    expect(page).to have_content("Claim has been approved successfully")
+    expect(claim.decision).to be_approved
+    expect(claim.decision.created_by).to eq(user)
+  end
 end

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -137,24 +137,6 @@ RSpec.feature "Admin checks a claim" do
         end
       end
 
-      context "and the claimant has not completed GOV.UK Verify" do
-        let!(:claim) { create(:claim, :unverified) }
-
-        scenario "the service operator is told the identity hasn't been confirmed and can approve the claim" do
-          perform_last_task(claim)
-
-          expect(page).to have_content("The claimant did not complete GOV.UK Verify")
-          expect(page).to have_content(claim.school.phone_number)
-
-          choose "Approve"
-          fill_in "Decision notes", with: "Identity confirmed via phone call"
-          click_on "Confirm decision"
-
-          expect(claim.decision.created_by).to eq(user)
-          expect(claim.decision.notes).to eq("Identity confirmed via phone call")
-        end
-      end
-
       def perform_last_task(claim)
         applicable_task_names = ClaimCheckingTasks.new(claim).applicable_task_names
         visit admin_claim_task_path(claim, name: applicable_task_names.last)

--- a/spec/models/claim_checking_tasks_spec.rb
+++ b/spec/models/claim_checking_tasks_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ClaimCheckingTasks do
-  let(:claim) { build(:claim, :submitted, policy: MathsAndPhysics) }
+  let(:claim) { build(:claim, :submitted, :verified, policy: MathsAndPhysics) }
   let(:checking_tasks) { ClaimCheckingTasks.new(claim) }
 
   describe "#applicable_task_names" do
@@ -12,7 +12,7 @@ RSpec.describe ClaimCheckingTasks do
     end
 
     it "includes the a task for student loan amount for a StudentLoans claim" do
-      student_loan_claim = build(:claim, :submitted, policy: StudentLoans)
+      student_loan_claim = build(:claim, :submitted, :verified, policy: StudentLoans)
       student_loan_tasks = ClaimCheckingTasks.new(student_loan_claim)
 
       expect(student_loan_tasks.applicable_task_names).to eq %w[qualifications employment student_loan_amount]
@@ -24,6 +24,20 @@ RSpec.describe ClaimCheckingTasks do
         teacher_reference_number: claim.teacher_reference_number)
 
       expect(checking_tasks.applicable_task_names).to eq %w[qualifications employment matching_details]
+    end
+
+    it "includes a task for identity confirmation for a StudentLoans claim where the claimant didn’t complete GOV.UK Verify" do
+      unverified_claim = build(:claim, :unverified, policy: StudentLoans)
+      unverified_tasks = ClaimCheckingTasks.new(unverified_claim)
+
+      expect(unverified_tasks.applicable_task_names).to eq %w[qualifications employment student_loan_amount identity_confirmation]
+    end
+
+    it "includes a task for identity confirmation for a MathsAndPhysics claim where the claimant didn’t complete GOV.UK Verify" do
+      unverified_claim = build(:claim, :unverified, policy: MathsAndPhysics)
+      unverified_tasks = ClaimCheckingTasks.new(unverified_claim)
+
+      expect(unverified_tasks.applicable_task_names).to eq %w[qualifications employment identity_confirmation]
     end
   end
 

--- a/spec/models/maths_and_physics/admin_tasks_presenter_spec.rb
+++ b/spec/models/maths_and_physics/admin_tasks_presenter_spec.rb
@@ -63,4 +63,13 @@ RSpec.describe MathsAndPhysics::AdminTasksPresenter, type: :model do
       ]
     end
   end
+
+  describe "#identity_confirmation" do
+    it "returns an array of label and values for displaying information for the identity confirmation check" do
+      expect(presenter.identity_confirmation).to eq [
+        ["Current school", school.name],
+        ["Contact number", school.phone_number]
+      ]
+    end
+  end
 end

--- a/spec/models/student_loans/admin_tasks_presenter_spec.rb
+++ b/spec/models/student_loans/admin_tasks_presenter_spec.rb
@@ -47,4 +47,13 @@ RSpec.describe StudentLoans::AdminTasksPresenter, type: :model do
       ]
     end
   end
+
+  describe "#identity_confirmation" do
+    it "returns an array of label and values for displaying information for the identity confirmation check" do
+      expect(presenter.identity_confirmation).to eq [
+        ["Current school", school.name],
+        ["Contact number", school.phone_number]
+      ]
+    end
+  end
 end


### PR DESCRIPTION
This replaces the existing banner which is displayed on the full claim page and on the claim decision page, which tells the service operator to contact the claimant at their school to verify their identity.

# Open question

Was it safe to remove the existing banners? Do we think that there's a chance that a claims checker might still use the full claim page to approve a claim?

# Screenshots

![image](https://user-images.githubusercontent.com/53756884/76616337-b5646780-651b-11ea-9228-15016c0bed06.png)

![image](https://user-images.githubusercontent.com/53756884/76616362-c44b1a00-651b-11ea-816f-c59aaaaf152a.png)