### PR TITLE
Add specific trigger to pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,10 @@
 pr: none
 
+trigger:
+  branches:
+    include:
+    - '*'
+
 pool:
   vmImage: ubuntu-latest
 


### PR DESCRIPTION
There's currently an [issue with Azure Devops pipelines](https://status.dev.azure.com/_event/179641421), which means that builds without a specific trigger aren't getting built. This commit adds that specific trigger. It can be removed once this is fixed, but it can't hurt to leave it in either.

<!-- Do you need to update CHANGELOG.md? -->
