### PR TITLE
Adjust back links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Add "Back" link and page title to claim decision screen
+- Link claim tasks view back to the list of claims
 
 ## [Release 063] - 2020-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add "Back" link and page title to claim decision screen
+
 ## [Release 063] - 2020-03-16
 
 - Add a task to check claims with matching attributes

--- a/app/views/admin/decisions/new.html.erb
+++ b/app/views/admin/decisions/new.html.erb
@@ -1,3 +1,6 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} decision") } %>
+<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+
 <div class="govuk-grid-row">
   <%= render("shared/error_summary", instance: @decision, errored_field_id_overrides: { "result": "decision_result_approved" }) if @decision.errors.any? %>
 

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_title) { page_title("Claim #{@claim.reference} checks for #{policy_service_name(@claim.policy.routing_name)}") } %>
 
-<%= link_to "Back", admin_claim_path(@claim), class: "govuk-back-link" %>
+<%= link_to "Back", admin_claims_path, class: "govuk-back-link" %>
 
 <div class="govuk-grid-row">
 


### PR DESCRIPTION
A couple of small usability issues fixed:

- Add "Back" link and page title to claim decision screen
- Link claim tasks view back to the list of claims