### PR TITLE
Remove TRN from payment discrepancy attribute list

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -25,7 +25,6 @@ class Payment < ApplicationRecord
     national_insurance_number
   ]
   PERSONAL_DETAILS_ATTRIBUTES_FORBIDDING_DISCREPANCIES = %i[
-    teacher_reference_number
     date_of_birth
     student_loan_plan
     bank_sort_code

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -68,13 +68,6 @@ RSpec.describe Payment do
       expect(subject).to be_valid
     end
 
-    it "is invalid when claims’ teacher reference numbers do not match" do
-      claims[0].teacher_reference_number = "9988776"
-
-      expect(subject).not_to be_valid
-      expect(subject.errors[:claims]).to eq(["#{claims[0].reference} and #{claims[1].reference} have different values for teacher reference number"])
-    end
-
     it "is invalid when claims’ dates of birth do not match" do
       claims[0].date_of_birth = 20.years.ago.to_date
 


### PR DESCRIPTION
When creating payments, claims are grouped by their TRN, which means it doesn't make sense to check them for discrepancies when combining multiple claims into a single payment. TRN appears in the list as a hangover from when we were grouping claims using the national_insurance_number instead.