### PR TITLE
Add the missing payroll gender task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog]
 
 - Add "Back" link and page title to claim decision screen
 - Link claim tasks view back to the list of claims
+- Add a Missing Payroll Gender task to allow service operators to update a
+  claim's Payroll Gender if it's not specified
 
 ## [Release 063] - 2020-03-16
 

--- a/app/controllers/admin/payroll_gender_tasks_controller.rb
+++ b/app/controllers/admin/payroll_gender_tasks_controller.rb
@@ -1,0 +1,29 @@
+class Admin::PayrollGenderTasksController < Admin::TasksController
+  def create
+    @claim_checking_tasks = ClaimCheckingTasks.new(@claim)
+    @task = @claim.tasks.build(check_params)
+    @claim.attributes = claim_params
+
+    if claim_and_task_saved?
+      redirect_to next_task_path
+    else
+      @tasks_presenter = @claim.policy::AdminTasksPresenter.new(@claim)
+      render current_task_name
+    end
+  end
+
+  private
+
+  def claim_params
+    params.require(:claim).permit(:payroll_gender)
+  end
+
+  def claim_and_task_saved?
+    ActiveRecord::Base.transaction do
+      @claim.save!(context: :"payroll-gender-task")
+      @task.save!
+    end
+  rescue ActiveRecord::RecordInvalid
+    false
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -147,6 +147,8 @@ class Claim < ApplicationRecord
   validates :bank_sort_code, on: [:"bank-details", :submit], presence: {message: "Enter a sort code"}
   validates :bank_account_number, on: [:"bank-details", :submit], presence: {message: "Enter an account number"}
 
+  validates :payroll_gender, on: [:"payroll-gender-task", :submit], presence: {message: "You must select a gender that will be passed to HMRC"}
+
   validate :bank_account_number_must_be_eight_digits
   validate :bank_sort_code_must_be_six_digits
   validate :building_society_roll_number_must_be_between_one_and_eighteen_digits

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -30,7 +30,6 @@ class Claim < ApplicationRecord
   ].freeze
   AMENDABLE_ATTRIBUTES = %i[
     teacher_reference_number
-    payroll_gender
     date_of_birth
     student_loan_plan
     bank_sort_code

--- a/app/models/claim_checking_tasks.rb
+++ b/app/models/claim_checking_tasks.rb
@@ -9,6 +9,7 @@ class ClaimCheckingTasks
     student_loan_amount
     matching_details
     identity_confirmation
+    payroll_gender
   ].freeze
 
   attr_reader :claim
@@ -22,15 +23,20 @@ class ClaimCheckingTasks
       task_names.delete("student_loan_amount") unless claim.policy == StudentLoans
       task_names.delete("matching_details") unless matching_claims.exists?
       task_names.delete("identity_confirmation") if claim.identity_confirmed?
+      task_names.delete("payroll_gender") unless claim.payroll_gender_missing? || task_names_for_claim.include?("payroll_gender")
     end
   end
 
   # Returns an Array of tasks names that have not been completed on the claim.
   def incomplete_task_names
-    applicable_task_names - claim.tasks.map(&:name)
+    applicable_task_names - task_names_for_claim
   end
 
   private
+
+  def task_names_for_claim
+    claim.tasks.map(&:name)
+  end
 
   def matching_claims
     @matching_claims ||= Claim::MatchingAttributeFinder.new(claim).matching_claims

--- a/app/views/admin/amendments/new.html.erb
+++ b/app/views/admin/amendments/new.html.erb
@@ -34,20 +34,6 @@
     </div>
 
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <%= form_group_tag(@amendment, :payroll_gender) do %>
-          <%= claim_form.label :payroll_gender, class: "govuk-label" %>
-          <%= errors_tag @amendment, :payroll_gender %>
-        <% end %>
-      </div>
-      <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-form-group">
-          <%= claim_form.select :payroll_gender, [["Female", :female], ["Male", :male], ["Don’t know", :dont_know]], {}, { class: "govuk-select" } %>
-        </div>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row">
       <fieldset class="govuk-fieldset">
         <div class="govuk-grid-column-one-third">
           <%= form_group_tag(@amendment, :date_of_birth) do %>

--- a/app/views/admin/decisions/_decision_form.html.erb
+++ b/app/views/admin/decisions/_decision_form.html.erb
@@ -1,13 +1,3 @@
-<% if claim.payroll_gender_missing? && !claim.decision_made? %>
-  <div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-      <span class="govuk-warning-text__assistive">Warning</span>
-      <%= t("admin.unknown_payroll_gender_preventing_approval_message") %>
-    </strong>
-  </div>
-<% end %>
-
 <% if claims_preventing_payment.any? %>
   <div class="govuk-warning-text">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/admin/tasks/payroll_gender.html.erb
+++ b/app/views/admin/tasks/payroll_gender.html.erb
@@ -1,0 +1,46 @@
+<% content_for(:page_title) { page_title("Claim #{@claim.reference} payroll gender check for #{policy_service_name(@claim.policy.routing_name)}") } %>
+
+<%= link_to "Back", admin_claim_tasks_path(claim_id: @claim.id), class: "govuk-back-link" %>
+<%= render "shared/error_summary", instance: @claim, errored_field_id_overrides: { "payroll_gender": "claim_payroll_gender_female" } if @claim.errors.any? %>
+
+<div class="govuk-grid-row">
+
+  <%= render "claim_summary", claim: @claim, heading: "Payroll gender" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if @task.persisted? %>
+      <%= render "task_outcome", task: @task %>
+    <% else %>
+      <div class="govuk-form-group">
+        <%= form_with url: admin_claim_payroll_gender_tasks_path(@claim), scope: :claim do |f| %>
+          <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l ">
+              <h3 class="govuk-heading-l">
+                What gender should be passed to payroll and HMRC?
+              </h3>
+            </legend>
+
+            <p class="govuk-body">
+              The claimant answered ‘Don't know’ to the question ‘What gender does your school's payroll system associate with you?’
+            </p>
+
+            <%= hidden_field_tag "task[passed]", "true" %>
+            <%= f.hidden_field :payroll_gender, value: "" %>
+
+            <div class="govuk-radios govuk-radios--inline">
+              <div class="govuk-radios__item">
+                <%= f.radio_button(:payroll_gender, :female, class: "govuk-radios__input") %>
+                <%= f.label :payroll_gender_female, "Female", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= f.radio_button(:payroll_gender, :male, class: "govuk-radios__input") %>
+                <%= f.label :payroll_gender_male, "Male", class: "govuk-label govuk-radios__label" %>
+              </div>
+            </div>
+          </fieldset>
+          <%= f.submit "Save and continue", class: "govuk-button", data: {module: "govuk-button"} %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,6 +168,8 @@ en:
         identity_confirmation:
           summary: "Confirm the claimant made the claim"
           question: "Did %{name} submit the claim?"
+        payroll_gender:
+          summary: "Add a payroll gender for HMRC"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     policy_short_name: "Student Loans"
@@ -214,3 +216,5 @@ en:
         identity_confirmation:
           summary: "Confirm the claimant made the claim"
           question: "Did %{name} submit the claim?"
+        payroll_gender:
+          summary: "Add a payroll gender for HMRC"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
 
     resources :claims, only: [:index, :show] do
       resources :tasks, only: [:index, :show, :create], param: :name, constraints: {name: %r{#{ClaimCheckingTasks::TASK_NAMES.join("|")}}}
+      resources :payroll_gender_tasks, only: [:create], param: :name, name: "payroll_gender"
       resources :decisions, only: [:create, :new]
       resources :amendments, only: [:new, :create]
       get "search", on: :collection

--- a/spec/features/admin_amend_claim_spec.rb
+++ b/spec/features/admin_amend_claim_spec.rb
@@ -24,7 +24,6 @@ RSpec.feature "Admin amends a claim" do
     new_date_of_birth = 30.years.ago.to_date
 
     fill_in "Teacher reference number", with: "7654321"
-    select "Male", from: "Payroll gender"
     fill_in "Day", with: new_date_of_birth.day
     fill_in "Month", with: new_date_of_birth.month
     fill_in "Year", with: new_date_of_birth.year
@@ -40,7 +39,6 @@ RSpec.feature "Admin amends a claim" do
     amendment = claim.amendments.last
     expect(amendment.claim_changes).to eq({
       "teacher_reference_number" => ["1234567", "7654321"],
-      "payroll_gender" => ["dont_know", "male"],
       "date_of_birth" => [date_of_birth, new_date_of_birth],
       "student_loan_plan" => ["plan_1", "plan_2"],
       "bank_sort_code" => ["010203", "111213"],
@@ -51,7 +49,6 @@ RSpec.feature "Admin amends a claim" do
     expect(amendment.created_by).to eq(service_operator)
 
     expect(claim.reload.teacher_reference_number).to eq("7654321")
-    expect(claim.payroll_gender).to eq("male")
     expect(claim.date_of_birth).to eq(new_date_of_birth)
     expect(claim.student_loan_plan).to eq("plan_2")
     expect(claim.bank_sort_code).to eq("111213")
@@ -61,7 +58,6 @@ RSpec.feature "Admin amends a claim" do
     expect(current_url).to eq(admin_claim_url(claim))
 
     expect(page).to have_content("Teacher reference number\nchanged from 1234567 to 7654321")
-    expect(page).to have_content("Payroll gender\nchanged from don’t know to male")
     expect(page).to have_content("Date of birth\nchanged from #{I18n.l(date_of_birth, format: :day_month_year)} to #{I18n.l(new_date_of_birth, format: :day_month_year)}")
     expect(page).to have_content("Student loan repayment plan\nchanged from Plan 1 to Plan 2")
     expect(page).to have_content("Bank sort code\nchanged from 010203 to 111213")

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -102,17 +102,6 @@ RSpec.feature "Admin checks a claim" do
     end
 
     context "when the service operator completes the last checking task" do
-      context "and the payroll gender is missing" do
-        let!(:claim) { create(:claim, :submitted, payroll_gender: :dont_know) }
-
-        scenario "User is informed that the claim cannot be approved" do
-          perform_last_task(claim)
-
-          expect(page).to have_field("Approve", disabled: true)
-          expect(page).to have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))
-        end
-      end
-
       context "and the claimant has another approved claim in the same payroll window, with inconsistent personal details" do
         let(:personal_details) do
           {

--- a/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
+++ b/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
@@ -7,27 +7,40 @@ RSpec.feature "Admin checking a claim missing a payroll gender" do
     sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
   end
 
-  scenario "cannot approve a claim whilst the payroll gender is missing" do
-    claim_missing_payroll_gender = create(:claim, :submitted, payroll_gender: :dont_know)
+  scenario "service operator can add a payroll gender as part of the checking process" do
+    claim = create(:claim, :submitted, policy: StudentLoans, payroll_gender: :dont_know)
 
-    click_on "View claims"
-    find("a[href='#{admin_claim_tasks_path(claim_missing_payroll_gender)}']").click
-    click_on "View full claim"
+    visit admin_claims_path
+    find("a[href='#{admin_claim_tasks_path(claim)}']").click
 
-    expect(page).to have_field("Approve", disabled: true)
-    expect(page).to have_content(I18n.t("admin.unknown_payroll_gender_preventing_approval_message"))
+    expect(page).to have_content("1. Qualifications")
+    expect(page).to have_content("2. Employment")
+    expect(page).to have_content("3. Student loan amount")
+    expect(page).to have_content("4. Payroll gender")
+    expect(page).to have_content("5. Decision")
 
-    click_on "Amend claim"
-    select "Male", from: "Payroll gender"
-    fill_in "Change notes", with: "Got payroll gender from pensions data"
-    click_on "Amend claim"
+    click_on I18n.t("student_loans.admin.tasks.payroll_gender.summary")
 
-    expect(claim_missing_payroll_gender.reload).to be_approvable
+    expect(page).to have_content("What gender should be passed to payroll and HMRC?")
+
+    click_on "Save and continue"
+
+    expect(page).to have_content("You must select a gender that will be passed to HMRC")
+
+    choose "Female"
+    click_on "Save and continue"
+
+    expect(claim.reload.payroll_gender).to eq("female")
+    expect(claim.tasks.find_by!(name: "payroll_gender").passed?).to eq(true)
+
+    expect(page).to have_content("Claim decision")
 
     choose "Approve"
-    fill_in "Decision notes", with: "Everything matches"
+    fill_in "Decision notes", with: "All checks passed!"
     click_on "Confirm decision"
 
     expect(page).to have_content("Claim has been approved successfully")
+    expect(claim.decision).to be_approved
+    expect(claim.decision.created_by).to eq(user)
   end
 end

--- a/spec/models/amendment_spec.rb
+++ b/spec/models/amendment_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe Amendment, type: :model do
   end
 
   describe ".amend_claim" do
-    let(:claim) { create(:claim, :submitted, teacher_reference_number: "1234567", payroll_gender: :male, bank_sort_code: "111213", building_society_roll_number: nil) }
+    let(:claim) { create(:claim, :submitted, teacher_reference_number: "1234567", bank_sort_code: "111213", bank_account_number: "12345678", building_society_roll_number: nil) }
     let(:dfe_signin_user) { create(:dfe_signin_user) }
 
     context "given valid claim attributes and valid amendment attributes" do
       let(:claim_attributes) do
         {
           teacher_reference_number: "7654321",
-          payroll_gender: :female
+          bank_account_number: "87654321"
         }
       end
       let(:amendment_attributes) do
@@ -48,13 +48,13 @@ RSpec.describe Amendment, type: :model do
 
         expect(amendment).to be_persisted
         expect(amendment.claim_changes).to be_an_instance_of(Hash)
-        expect(amendment.claim_changes).to eq("teacher_reference_number" => ["1234567", "7654321"], "payroll_gender" => ["male", "female"])
+        expect(amendment.claim_changes).to eq("teacher_reference_number" => ["1234567", "7654321"], "bank_account_number" => ["12345678", "87654321"])
         expect(amendment.notes).to eq("This is a change")
         expect(amendment.created_by).to eq(dfe_signin_user)
 
         expect(claim.reload.amendments).to eq([amendment])
         expect(claim.teacher_reference_number).to eq("7654321")
-        expect(claim.payroll_gender).to eq("female")
+        expect(claim.bank_account_number).to eq("87654321")
       end
     end
 
@@ -62,7 +62,7 @@ RSpec.describe Amendment, type: :model do
       let(:claim_attributes) do
         {
           teacher_reference_number: "7654321",
-          payroll_gender: :female
+          bank_account_number: "87654321"
         }
       end
       let(:amendment_attributes) do
@@ -76,15 +76,15 @@ RSpec.describe Amendment, type: :model do
 
         expect(amendment).to_not be_persisted
         expect(amendment.claim_changes).to be_an_instance_of(Hash)
-        expect(amendment.claim_changes).to eq("teacher_reference_number" => ["1234567", "7654321"], "payroll_gender" => ["male", "female"])
+        expect(amendment.claim_changes).to eq("teacher_reference_number" => ["1234567", "7654321"], "bank_account_number" => ["12345678", "87654321"])
         expect(amendment.created_by).to eq(dfe_signin_user)
 
         expect(claim.teacher_reference_number).to eq("7654321")
-        expect(claim.payroll_gender).to eq("female")
+        expect(claim.bank_account_number).to eq("87654321")
 
         expect(claim.reload.amendments).to be_empty
         expect(claim.teacher_reference_number).to eq("1234567")
-        expect(claim.payroll_gender).to eq("male")
+        expect(claim.bank_account_number).to eq("12345678")
 
         expect(amendment.errors.keys).to eq([:notes])
       end
@@ -94,7 +94,7 @@ RSpec.describe Amendment, type: :model do
       let(:claim_attributes) do
         {
           teacher_reference_number: "765432",
-          payroll_gender: :female
+          bank_account_number: "87654321"
         }
       end
       let(:amendment_attributes) do
@@ -111,11 +111,11 @@ RSpec.describe Amendment, type: :model do
         expect(amendment.created_by).to eq(dfe_signin_user)
 
         expect(claim.teacher_reference_number).to eq("765432")
-        expect(claim.payroll_gender).to eq("female")
+        expect(claim.bank_account_number).to eq("87654321")
 
         expect(claim.reload.amendments).to be_empty
         expect(claim.teacher_reference_number).to eq("1234567")
-        expect(claim.payroll_gender).to eq("male")
+        expect(claim.bank_account_number).to eq("12345678")
 
         expect(amendment.errors.keys).to match_array([:teacher_reference_number])
       end
@@ -125,7 +125,7 @@ RSpec.describe Amendment, type: :model do
       let(:claim_attributes) do
         {
           teacher_reference_number: "765432",
-          payroll_gender: :female
+          bank_account_number: "87654321"
         }
       end
       let(:amendment_attributes) do
@@ -141,11 +141,11 @@ RSpec.describe Amendment, type: :model do
         expect(amendment.created_by).to eq(dfe_signin_user)
 
         expect(claim.teacher_reference_number).to eq("765432")
-        expect(claim.payroll_gender).to eq("female")
+        expect(claim.bank_account_number).to eq("87654321")
 
         expect(claim.reload.amendments).to be_empty
         expect(claim.teacher_reference_number).to eq("1234567")
-        expect(claim.payroll_gender).to eq("male")
+        expect(claim.bank_account_number).to eq("12345678")
 
         expect(amendment.errors.keys).to match_array([:notes, :teacher_reference_number])
       end

--- a/spec/models/claim_checking_tasks_spec.rb
+++ b/spec/models/claim_checking_tasks_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe ClaimCheckingTasks do
 
       expect(unverified_tasks.applicable_task_names).to eq %w[qualifications employment identity_confirmation]
     end
+
+    it "includes a task for payroll gender when the claim does not have a binary value for it" do
+      claim.payroll_gender = :dont_know
+
+      expect(checking_tasks.applicable_task_names).to eq %w[qualifications employment payroll_gender]
+    end
+
+    it "includes a task for payroll gender when a payroll gender task has previously been completed" do
+      claim.tasks << build(:task, name: "payroll_gender")
+
+      expect(checking_tasks.applicable_task_names).to eq %w[qualifications employment payroll_gender]
+    end
   end
 
   describe "#incomplete_task_names" do

--- a/spec/requests/admin_payroll_gender_tasks_spec.rb
+++ b/spec/requests/admin_payroll_gender_tasks_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe "Admin tasks", type: :request do
+  let(:claim) { create(:claim, :submitted) }
+
+  context "when signed in as a service operator" do
+    let(:user) { create(:dfe_signin_user) }
+
+    before do
+      sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE, user.dfe_sign_in_id)
+    end
+
+    Policies.all.each do |policy|
+      context "with a #{policy} claim" do
+        describe "payroll_gender_tasks#create" do
+          let(:claim) { create(:claim, :submitted, policy: policy, payroll_gender: :dont_know) }
+          let(:params) {
+            {
+              claim: {
+                payroll_gender: "male"
+              },
+              task: {
+                passed: true
+              }
+            }
+          }
+
+          it "updates the claimant's payroll gender, creates a task and redirects to the decision page" do
+            expect {
+              post admin_claim_payroll_gender_tasks_path(claim, params: params)
+            }.to change { Task.count }.by(1)
+
+            expect(claim.reload.payroll_gender).to eq("male")
+            expect(claim.tasks.last.name).to eql("payroll_gender")
+            expect(claim.tasks.last.passed?).to eql(true)
+            expect(claim.tasks.last.created_by).to eql(user)
+            expect(response).to redirect_to(new_admin_claim_decision_path(claim))
+          end
+
+          context "when a payroll gender is not set" do
+            it "doesn't create a task and shows an error" do
+              params[:claim][:payroll_gender] = ""
+
+              expect {
+                post admin_claim_payroll_gender_tasks_path(claim, params: params)
+              }.not_to change { claim.tasks.count }
+
+              expect(response.body).to match("You must select a gender that will be passed to HMRC")
+            end
+          end
+
+          context "when the task has already been marked as completed" do
+            it "doesn't create a task, or update the gender and redirects with an error" do
+              create(:task, name: "payroll_gender", claim: claim)
+              claim.payroll_gender = "female"
+              claim.save
+
+              expect {
+                post admin_claim_payroll_gender_tasks_path(claim, params: params)
+              }.not_to change { claim.tasks.count }
+
+              expect(response).to redirect_to(admin_claim_task_path(claim, name: "payroll_gender"))
+              expect(flash[:alert]).to eql("This task has already been completed")
+              expect(claim.reload.payroll_gender).to eq("female")
+            end
+          end
+        end
+      end
+    end
+  end
+
+  context "when signed in as a payroll operator or a support agent" do
+    describe "payroll_gender_tasks#create" do
+      [DfeSignIn::User::SUPPORT_AGENT_DFE_SIGN_IN_ROLE_CODE, DfeSignIn::User::PAYROLL_OPERATOR_DFE_SIGN_IN_ROLE_CODE].each do |role|
+        it "does not allow the task to be created" do
+          sign_in_to_admin_with_role(role)
+          post admin_claim_tasks_path(claim_id: claim.id)
+
+          expect(response.code).to eq("401")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/admin_tasks_spec.rb
+++ b/spec/requests/admin_tasks_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Admin tasks", type: :request do
                 post admin_claim_tasks_path(claim, name: last_task, params: {task: {passed: "true"}})
               }.to change { Task.count }.by(1)
 
-              expect(claim.tasks.last.name).to eql(last_task)
+              expect(claim.tasks.reload.last.name).to eql(last_task)
               expect(claim.tasks.last.passed?).to eql(true)
               expect(claim.tasks.last.created_by).to eql(user)
               expect(response).to redirect_to(new_admin_claim_decision_path(claim))


### PR DESCRIPTION
This adds another task to the claim checking workflow to allow a user to specify the gender that HMRC have recorded for an applicant for payroll purposes. It's slightly different to other tasks in that, as well as creating a completed task, it also updates the user's payroll gender according to their response:

![image](https://user-images.githubusercontent.com/109774/76944799-8b36ef00-68f9-11ea-80ba-a5ae99aad601.png)

![image](https://user-images.githubusercontent.com/109774/76944834-9b4ece80-68f9-11ea-8d1b-3706ea868dd1.png)

~Two~ One question~s~:

- I'm a bit unhappy about the way the routes are written - currently, as it stands, a user could _potentially_ bypass this task and mark it as passed by POSTing to the normal Tasks#create endpoint, or we could end up with a regression if a future dev misses that payroll gender tasks are created differently
- ~We now have **two** ways of updating the payroll gender - this way, or we can edit a claim. After discussion with Mark, we decided that this option was the best way of handling the updates in a task-based way, as prompting the user to edit the claim directly could cause a bit of confusion. Do we want to remove the ability to edit a payroll genders in this way?~