### PR TITLE
Make decisions on a claim undoable

### DIFF
--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -16,7 +16,7 @@ class Admin::ClaimsController < Admin::BaseAdminController
 
   def show
     @claim = Claim.find(params[:id])
-    @decision = @claim.decision || Decision.new
+    @decision = @claim.latest_decision || Decision.new
     @matching_claims = Claim::MatchingAttributeFinder.new(@claim).matching_claims
     @claims_preventing_payment = Claim::ClaimsPreventingPaymentFinder.new(@claim).claims_preventing_payment
   end

--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -17,7 +17,7 @@ class Admin::DecisionsController < Admin::BaseAdminController
     if @decision.save
       send_claim_result_email
       RecordOrUpdateGeckoboardDatasetJob.perform_later([@claim.id])
-      redirect_to admin_claims_path, notice: "Claim has been #{@claim.decision.result} successfully"
+      redirect_to admin_claims_path, notice: "Claim has been #{@claim.latest_decision.result} successfully"
     else
       @claims_preventing_payment = claims_preventing_payment_finder.claims_preventing_payment
       render "new"
@@ -36,7 +36,7 @@ class Admin::DecisionsController < Admin::BaseAdminController
   end
 
   def reject_decided_claims
-    if @claim.decision.present?
+    if @claim.latest_decision.present?
       redirect_to admin_claim_path(@claim), notice: "Claim outcome already decided"
     end
   end
@@ -54,8 +54,8 @@ class Admin::DecisionsController < Admin::BaseAdminController
   end
 
   def send_claim_result_email
-    ClaimMailer.approved(@claim).deliver_later if @claim.decision.result == "approved"
-    ClaimMailer.rejected(@claim).deliver_later if @claim.decision.result == "rejected"
+    ClaimMailer.approved(@claim).deliver_later if @claim.latest_decision.result == "approved"
+    ClaimMailer.rejected(@claim).deliver_later if @claim.latest_decision.result == "rejected"
   end
 
   def decision_params

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -200,7 +200,7 @@ class Claim < ApplicationRecord
   end
 
   def decision_made?
-    decision&.persisted?
+    decision.present? && decision.persisted?
   end
 
   def payroll_gender_missing?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -257,6 +257,14 @@ class Claim < ApplicationRecord
     personal_data_removed_at.present?
   end
 
+  def payrolled?
+    payment.present?
+  end
+
+  def scheduled_for_payment?
+    scheduled_payment_date.present?
+  end
+
   def full_name
     [first_name, middle_name, surname].compact.join(" ")
   end
@@ -281,7 +289,7 @@ class Claim < ApplicationRecord
   end
 
   def amendable?
-    submitted? && !decision&.rejected? && !payment && !personal_data_removed?
+    submitted? && !decision&.rejected? && !payrolled? && !personal_data_removed?
   end
 
   private

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -195,12 +195,12 @@ class Claim < ApplicationRecord
     submitted? && !payroll_gender_missing? && !decision_made? && !payment_prevented_by_other_claims?
   end
 
-  def decision
-    decisions.where(undone: false).last
+  def latest_decision
+    decisions.active.last
   end
 
   def decision_made?
-    decision.present? && decision.persisted?
+    latest_decision.present? && latest_decision.persisted?
   end
 
   def payroll_gender_missing?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -289,7 +289,7 @@ class Claim < ApplicationRecord
   end
 
   def amendable?
-    submitted? && !decision&.rejected? && !payrolled? && !personal_data_removed?
+    submitted? && !decision_made? && !payrolled? && !personal_data_removed?
   end
 
   def decision_undoable?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -292,6 +292,10 @@ class Claim < ApplicationRecord
     submitted? && !decision&.rejected? && !payrolled? && !personal_data_removed?
   end
 
+  def decision_undoable?
+    decision_made? && !payrolled? && !personal_data_removed?
+  end
+
   private
 
   def normalise_trn

--- a/app/models/claim/geckoboard_dataset.rb
+++ b/app/models/claim/geckoboard_dataset.rb
@@ -46,7 +46,7 @@ class Claim
           check: claim.decision.present? ? claim.decision.result : "unchecked",
           checked_at: claim.decision.present? ? claim.decision.created_at : placeholder_date_for_nil_value,
           number_of_days_to_check: claim.decision&.number_of_days_since_claim_submitted,
-          paid: claim.scheduled_payment_date.present?.to_s,
+          paid: claim.scheduled_for_payment?.to_s,
           paid_at: claim.scheduled_payment_date.presence || placeholder_date_for_nil_value,
           award_amount: claim.eligibility.present? ? (claim.award_amount * 100).to_i : nil # Geckoboard expects currency as an integer of pence - see https://api-docs.geckoboard.com/#money-format
         }

--- a/app/models/claim/geckoboard_dataset.rb
+++ b/app/models/claim/geckoboard_dataset.rb
@@ -43,9 +43,9 @@ class Claim
           policy: claim.policy.to_s,
           submitted_at: claim.submitted_at,
           sla_status: sla_status_string(claim),
-          check: claim.decision.present? ? claim.decision.result : "unchecked",
-          checked_at: claim.decision.present? ? claim.decision.created_at : placeholder_date_for_nil_value,
-          number_of_days_to_check: claim.decision&.number_of_days_since_claim_submitted,
+          check: claim.latest_decision.present? ? claim.latest_decision.result : "unchecked",
+          checked_at: claim.latest_decision.present? ? claim.latest_decision.created_at : placeholder_date_for_nil_value,
+          number_of_days_to_check: claim.latest_decision&.number_of_days_since_claim_submitted,
           paid: claim.scheduled_for_payment?.to_s,
           paid_at: claim.scheduled_payment_date.presence || placeholder_date_for_nil_value,
           award_amount: claim.eligibility.present? ? (claim.award_amount * 100).to_i : nil # Geckoboard expects currency as an integer of pence - see https://api-docs.geckoboard.com/#money-format

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -4,6 +4,9 @@ class Decision < ApplicationRecord
 
   validates :result, :created_by, presence: {message: "Make a decision to approve or reject the claim"}
   validate :claim_must_be_approvable, if: :approved?, on: :create
+  validate :claim_must_have_undoable_decision, if: :undone?, on: :update
+
+  scope :active, -> { where(undone: false) }
 
   enum result: {
     approved: 0,
@@ -11,7 +14,7 @@ class Decision < ApplicationRecord
   }
 
   def readonly?
-    persisted?
+    persisted? && !undone
   end
 
   def number_of_days_since_claim_submitted
@@ -22,5 +25,9 @@ class Decision < ApplicationRecord
 
   def claim_must_be_approvable
     errors.add(:base, "This claim cannot be approved") unless claim.approvable?
+  end
+
+  def claim_must_have_undoable_decision
+    errors.add(:base, "This claim cannot have its decision undone") unless claim.decision_undoable?
   end
 end

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -35,9 +35,9 @@
             <span class="app-task-list__task-name">
               <%= link_to "Approve or reject this claim", new_admin_claim_decision_path(@claim), class: "govuk-link" %>
             </span>
-            <% if @claim.decision&.approved? %>
+            <% if @claim.latest_decision&.approved? %>
               <strong class="govuk-tag app-task-list__task-completed">Approved</strong>
-            <% elsif @claim.decision&.rejected? %>
+            <% elsif @claim.latest_decision&.rejected? %>
               <strong class="govuk-tag app-task-list__task-completed govuk-tag--alert">Rejected</strong>
             <% end %>
           </li>

--- a/db/migrate/20200316100421_make_decisions_undoable.rb
+++ b/db/migrate/20200316100421_make_decisions_undoable.rb
@@ -1,0 +1,5 @@
+class MakeDecisionsUndoable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decisions, :undone, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_114405) do
+ActiveRecord::Schema.define(version: 2020_03_16_100421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2020_03_10_114405) do
     t.datetime "updated_at", null: false
     t.text "notes"
     t.uuid "created_by_id"
+    t.boolean "undone", default: false
     t.index ["claim_id"], name: "index_decisions_on_claim_id"
     t.index ["created_at"], name: "index_decisions_on_created_at"
     t.index ["created_by_id"], name: "index_decisions_on_created_by_id"

--- a/spec/factories/decisions.rb
+++ b/spec/factories/decisions.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
     trait :rejected do
       result { :rejected }
     end
+
+    trait :undone do
+      undone { true }
+    end
   end
 end

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -44,8 +44,8 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
     click_on "Confirm decision"
 
     expect(page).to have_content("Claim has been approved successfully")
-    expect(claim.decision).to be_approved
-    expect(claim.decision.created_by).to eq(user)
+    expect(claim.latest_decision).to be_approved
+    expect(claim.latest_decision.created_by).to eq(user)
   end
 
   scenario "service operator can check a claim with matching details" do
@@ -118,7 +118,7 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
     click_on "Confirm decision"
 
     expect(page).to have_content("Claim has been approved successfully")
-    expect(claim.decision).to be_approved
-    expect(claim.decision.created_by).to eq(user)
+    expect(claim.latest_decision).to be_approved
+    expect(claim.latest_decision.created_by).to eq(user)
   end
 end

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -62,8 +62,8 @@ RSpec.feature "Admin checking a Student Loans claim" do
     click_on "Confirm decision"
 
     expect(page).to have_content("Claim has been approved successfully")
-    expect(claim.decision).to be_approved
-    expect(claim.decision.created_by).to eq(user)
+    expect(claim.latest_decision).to be_approved
+    expect(claim.latest_decision.created_by).to eq(user)
   end
 
   scenario "service operator can check a claim with matching details" do

--- a/spec/features/admin_claim_check_spec.rb
+++ b/spec/features/admin_claim_check_spec.rb
@@ -26,8 +26,8 @@ RSpec.feature "Admin checks a claim" do
         fill_in "Decision notes", with: "Everything matches"
         perform_enqueued_jobs { click_on "Confirm decision" }
 
-        expect(claim_to_approve.decision.created_by).to eq(user)
-        expect(claim_to_approve.decision.notes).to eq("Everything matches")
+        expect(claim_to_approve.latest_decision.created_by).to eq(user)
+        expect(claim_to_approve.latest_decision.notes).to eq("Everything matches")
 
         expect(page).to have_content("Claim has been approved successfully")
         expect(page).to_not have_content(claim_to_approve.reference)
@@ -59,8 +59,8 @@ RSpec.feature "Admin checks a claim" do
       fill_in "Decision notes", with: "TRN doesn't exist"
       perform_enqueued_jobs { click_on "Confirm decision" }
 
-      expect(claim_to_reject.decision.created_by).to eq(user)
-      expect(claim_to_reject.decision.notes).to eq("TRN doesn't exist")
+      expect(claim_to_reject.latest_decision.created_by).to eq(user)
+      expect(claim_to_reject.latest_decision.notes).to eq("TRN doesn't exist")
 
       expect(page).to have_content("Claim has been rejected successfully")
       expect(page).to_not have_content(claim_to_reject.reference)
@@ -96,7 +96,7 @@ RSpec.feature "Admin checks a claim" do
       expect(page).not_to have_button("Confirm decision")
       expect(page).to have_content("Claim decision")
       expect(page).to have_content("Approved")
-      expect(page).to have_content(claim_with_decision.decision.notes)
+      expect(page).to have_content(claim_with_decision.latest_decision.notes)
       expect(page).to have_content("Created by")
       expect(page).to have_content(user.full_name)
     end

--- a/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
+++ b/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Admin checking a claim missing a payroll gender" do
     click_on "Confirm decision"
 
     expect(page).to have_content("Claim has been approved successfully")
-    expect(claim.decision).to be_approved
-    expect(claim.decision.created_by).to eq(user)
+    expect(claim.latest_decision).to be_approved
+    expect(claim.latest_decision.created_by).to eq(user)
   end
 end

--- a/spec/features/admin_claim_without_verified_identity_spec.rb
+++ b/spec/features/admin_claim_without_verified_identity_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Admin checking a claim without a verified identity" do
     fill_in "Decision notes", with: "Identity confirmed via phone call"
     click_on "Confirm decision"
 
-    expect(claim_without_identity_confirmation.decision.created_by).to eq(user)
-    expect(claim_without_identity_confirmation.decision.notes).to eq("Identity confirmed via phone call")
+    expect(claim_without_identity_confirmation.latest_decision.created_by).to eq(user)
+    expect(claim_without_identity_confirmation.latest_decision.notes).to eq("Identity confirmed via phone call")
   end
 end

--- a/spec/models/amendment_spec.rb
+++ b/spec/models/amendment_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Amendment, type: :model do
   end
 
   it "is invalid if its claim is not amendable" do
-    amendment = build(:amendment, claim: build(:claim, :rejected))
+    amendment = build(:amendment, claim: create(:claim, :rejected))
     expect(amendment).not_to be_valid
 
     amendment.claim = build(:claim, :approved)

--- a/spec/models/claim/personal_data_scrubber_spec.rb
+++ b/spec/models/claim/personal_data_scrubber_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Claim::PersonalDataScrubber, type: :model do
   it "also deletes expected details from the scrubbed claims’ amendments, setting a personal_data_removed_at timestamp on the amendments" do
     claim, amendment = nil
     travel_to over_two_months_ago - 1.week do
-      claim = create(:claim, :approved)
+      claim = create(:claim, :submitted)
       amendment = create(:amendment, claim: claim, claim_changes: {
         "teacher_reference_number" => [generate(:teacher_reference_number).to_s, claim.teacher_reference_number],
         "payroll_gender" => ["male", claim.payroll_gender],
@@ -107,6 +107,7 @@ RSpec.describe Claim::PersonalDataScrubber, type: :model do
         "bank_account_number" => ["84818482", claim.bank_account_number],
         "building_society_roll_number" => ["123456789/ABCD", claim.building_society_roll_number]
       })
+      create(:decision, :approved, claim: claim, created_at: over_two_months_ago)
       create(:payment, :with_figures, claims: [claim], scheduled_payment_date: over_two_months_ago)
     end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -506,14 +506,14 @@ RSpec.describe Claim, type: :model do
       create(:decision, result: "approved", claim: claim, created_at: 7.days.ago)
       create(:decision, result: "rejected", claim: claim, created_at: DateTime.now)
 
-      expect(claim.decision.result).to eq "rejected"
+      expect(claim.latest_decision.result).to eq "rejected"
     end
 
     it "returns only decisions which haven't been undone" do
       claim = create(:claim, :submitted)
       create(:decision, :undone, result: "rejected", claim: claim)
 
-      expect(claim.decision).to be_nil
+      expect(claim.latest_decision).to be_nil
     end
   end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -416,35 +416,28 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe "awaiting_decision" do
-    let!(:submitted_claims) { create_list(:claim, 5, :submitted) }
-    let!(:unsubmitted_claims) { create_list(:claim, 2, :submittable) }
-    let!(:approved_claims) { create_list(:claim, 5, :approved) }
-
-    it "returns submitted claims awaiting a decision" do
-      expect(Claim.awaiting_decision).to match_array(submitted_claims)
-    end
-  end
-
-  describe "approved" do
+  describe "scopes" do
     let!(:submitted_claims) { create_list(:claim, 5, :submitted) }
     let!(:unsubmitted_claims) { create_list(:claim, 2, :submittable) }
     let!(:approved_claims) { create_list(:claim, 5, :approved) }
     let!(:rejected_claims) { create_list(:claim, 5, :rejected) }
 
-    it "returns approved claims" do
-      expect(Claim.approved).to match_array(approved_claims)
+    describe "awaiting_decision" do
+      it "returns submitted claims awaiting a decision" do
+        expect(Claim.awaiting_decision).to match_array(submitted_claims)
+      end
     end
-  end
 
-  describe "rejected" do
-    let!(:submitted_claims) { create_list(:claim, 5, :submitted) }
-    let!(:unsubmitted_claims) { create_list(:claim, 2, :submittable) }
-    let!(:approved_claims) { create_list(:claim, 5, :approved) }
-    let!(:rejected_claims) { create_list(:claim, 5, :rejected) }
+    describe "approved" do
+      it "returns approved claims" do
+        expect(Claim.approved).to match_array(approved_claims)
+      end
+    end
 
-    it "returns rejected claims" do
-      expect(Claim.rejected).to match_array(rejected_claims)
+    describe "rejected" do
+      it "returns rejected claims" do
+        expect(Claim.rejected).to match_array(rejected_claims)
+      end
     end
   end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -555,6 +555,18 @@ RSpec.describe Claim, type: :model do
     end
   end
 
+  describe "#personal_data_removed?" do
+    it "returns false if a claim has not had its personal data removed" do
+      claim = create(:claim, :approved)
+      expect(claim.personal_data_removed?).to eq false
+    end
+
+    it "returns true if a claim has the time personal data was removed recorded" do
+      claim = create(:claim, :approved, personal_data_removed_at: Time.zone.now)
+      expect(claim.personal_data_removed?).to eq true
+    end
+  end
+
   describe "#full_name" do
     it "joins the first name and surname together" do
       expect(Claim.new(first_name: "Isambard", surname: "Brunel").full_name).to eq "Isambard Brunel"

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -745,9 +745,9 @@ RSpec.describe Claim, type: :model do
       expect(claim.amendable?).to eq(true)
     end
 
-    it "returns true for an approved claim that isn’t payrolled" do
-      claim = build(:claim, :approved)
-      expect(claim.amendable?).to eq(true)
+    it "returns false for an approved claim" do
+      claim = create(:claim, :approved)
+      expect(claim.amendable?).to eq(false)
     end
 
     it "returns false for a payrolled claim" do
@@ -758,7 +758,7 @@ RSpec.describe Claim, type: :model do
     end
 
     it "returns false for a rejected claim" do
-      claim = build(:claim, :rejected)
+      claim = create(:claim, :rejected)
       expect(claim.amendable?).to eq(false)
     end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -767,4 +767,26 @@ RSpec.describe Claim, type: :model do
       expect(claim.amendable?).to eq(false)
     end
   end
+
+  describe "#decision_made?" do
+    it "returns false for a claim that hasn’t been submitted" do
+      claim = create(:claim, :submittable)
+      expect(claim.decision_made?).to eq(false)
+    end
+
+    it "returns false for a claim that has been submitted but not decided" do
+      claim = create(:claim, :submitted)
+      expect(claim.decision_made?).to eq(false)
+    end
+
+    it "returns true for a claim that has been approved" do
+      claim = create(:claim, :approved)
+      expect(claim.decision_made?).to eq(true)
+    end
+
+    it "returns true for a claim that has been rejected" do
+      claim = create(:claim, :rejected)
+      expect(claim.decision_made?).to eq(true)
+    end
+  end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -567,6 +567,44 @@ RSpec.describe Claim, type: :model do
     end
   end
 
+  describe "#payrolled?" do
+    it "returns false if a claim has not been added to payroll" do
+      claim = create(:claim, :approved)
+      expect(claim.payrolled?).to eq false
+    end
+
+    it "returns true if a claim has been added to payroll but is not yet paid" do
+      claim = create(:claim, :approved)
+      create(:payment, claims: [claim])
+      expect(claim.payrolled?).to eq true
+    end
+
+    it "returns true if a claim has been scheduled for payment" do
+      claim = create(:claim, :approved)
+      create(:payment, :with_figures, claims: [claim])
+      expect(claim.payrolled?).to eq true
+    end
+  end
+
+  describe "#scheduled_for_payment?" do
+    it "returns false if a claim has not been added to payroll" do
+      claim = create(:claim, :approved)
+      expect(claim.scheduled_for_payment?).to eq false
+    end
+
+    it "returns false if a claim has been added to payroll but is not yet paid" do
+      claim = create(:claim, :approved)
+      create(:payment, claims: [claim])
+      expect(claim.scheduled_for_payment?).to eq false
+    end
+
+    it "returns true if a claim has been scheduled for payment" do
+      claim = create(:claim, :approved)
+      create(:payment, :with_figures, claims: [claim])
+      expect(claim.scheduled_for_payment?).to eq true
+    end
+  end
+
   describe "#full_name" do
     it "joins the first name and surname together" do
       expect(Claim.new(first_name: "Isambard", surname: "Brunel").full_name).to eq "Isambard Brunel"

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -789,4 +789,38 @@ RSpec.describe Claim, type: :model do
       expect(claim.decision_made?).to eq(true)
     end
   end
+
+  describe "#decision_undoable?" do
+    it "returns false for a claim that hasn’t been submitted" do
+      claim = create(:claim, :submittable)
+      expect(claim.decision_undoable?).to eq(false)
+    end
+
+    it "returns false for a submitted but undecided claim" do
+      claim = create(:claim, :submitted)
+      expect(claim.decision_undoable?).to eq(false)
+    end
+
+    it "returns true for a rejected claim" do
+      claim = create(:claim, :rejected)
+      expect(claim.decision_undoable?).to eq(true)
+    end
+
+    it "returns true for an approved claim that isn’t payrolled" do
+      claim = create(:claim, :approved)
+      expect(claim.decision_undoable?).to eq(true)
+    end
+
+    it "returns false for a payrolled claim" do
+      claim = create(:claim, :approved)
+      create(:payment, claims: [claim])
+
+      expect(claim.decision_undoable?).to eq(false)
+    end
+
+    it "returns false for a claim that’s had its personal data removed" do
+      claim = create(:claim, :personal_data_removed)
+      expect(claim.decision_undoable?).to eq(false)
+    end
+  end
 end

--- a/spec/models/decision_spec.rb
+++ b/spec/models/decision_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe Decision, type: :model do
     expect(decision.errors.messages[:base]).to eq(["This claim cannot be approved"])
   end
 
+  it "prevents a decision being marked as undone when a claim cannot have its decision undone" do
+    claim = create(:claim, :submitted)
+    decision = create(:decision, claim: claim, result: "approved")
+    create(:payment, claims: [claim])
+    decision.undone = true
+    decision.save
+
+    expect(decision).not_to be_valid
+    expect(decision.errors.messages[:base]).to eq(["This claim cannot have its decision undone"])
+  end
+
   it "prevents a claim with matching bank details from being approved" do
     personal_details = {
       teacher_reference_number: generate(:teacher_reference_number),

--- a/spec/requests/admin_decisions_spec.rb
+++ b/spec/requests/admin_decisions_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe "Admin decisions", type: :request do
 
         expect(response.body).to include("Claim has been approved successfully")
 
-        expect(claim.decision.created_by).to eq(user)
-        expect(claim.decision.result).to eq("approved")
+        expect(claim.latest_decision.created_by).to eq(user)
+        expect(claim.latest_decision.result).to eq("approved")
       end
 
       it "can reject a claim" do
@@ -80,8 +80,8 @@ RSpec.describe "Admin decisions", type: :request do
 
         expect(response.body).to include("Claim has been rejected successfully")
 
-        expect(claim.decision.created_by).to eq(user)
-        expect(claim.decision.result).to eq("rejected")
+        expect(claim.latest_decision.created_by).to eq(user)
+        expect(claim.latest_decision.result).to eq("rejected")
       end
 
       it "updates the claim dataset on Geckoboard" do
@@ -97,7 +97,7 @@ RSpec.describe "Admin decisions", type: :request do
           post admin_claim_decisions_path(claim_id: claim.id, decision: {notes: "Something"})
 
           expect(response.body).to include("Make a decision to approve or reject the claim")
-          expect(claim.reload.decision).to be_nil
+          expect(claim.reload.latest_decision).to be_nil
         end
       end
 

--- a/spec/support/geckoboard_helpers.rb
+++ b/spec/support/geckoboard_helpers.rb
@@ -89,12 +89,12 @@ module GeckoboardHelpers
                         else
                           "ok"
                         end,
-        "check" => claim.decision.present? ? claim.decision.result : "unchecked",
-        "checked_at" => (claim.decision.present? ? claim.decision.created_at : DateTime.parse("1970-01-01")).strftime("%Y-%m-%dT%H:%M:%S%:z"),
-        "number_of_days_to_check" => claim.decision&.number_of_days_since_claim_submitted,
-        "award_amount" => claim.eligibility.present? ? (claim.award_amount * 100).to_i : nil,
+        "check" => claim.latest_decision.present? ? claim.latest_decision.result : "unchecked",
+        "checked_at" => (claim.latest_decision.present? ? claim.latest_decision.created_at : DateTime.parse("1970-01-01")).strftime("%Y-%m-%dT%H:%M:%S%:z"),
+        "number_of_days_to_check" => claim.latest_decision&.number_of_days_since_claim_submitted,
         "paid" => claim.scheduled_for_payment?.to_s,
-        "paid_at" => (claim.scheduled_for_payment? ? claim.scheduled_payment_date : DateTime.parse("1970-01-01")).strftime("%Y-%m-%dT%H:%M:%S%:z")
+        "paid_at" => (claim.scheduled_for_payment? ? claim.scheduled_payment_date : DateTime.parse("1970-01-01")).strftime("%Y-%m-%dT%H:%M:%S%:z"),
+        "award_amount" => claim.eligibility.present? ? (claim.award_amount * 100).to_i : nil
       }
     }.sort_by { |d| d["reference"] }
 

--- a/spec/support/geckoboard_helpers.rb
+++ b/spec/support/geckoboard_helpers.rb
@@ -92,9 +92,9 @@ module GeckoboardHelpers
         "check" => claim.decision.present? ? claim.decision.result : "unchecked",
         "checked_at" => (claim.decision.present? ? claim.decision.created_at : DateTime.parse("1970-01-01")).strftime("%Y-%m-%dT%H:%M:%S%:z"),
         "number_of_days_to_check" => claim.decision&.number_of_days_since_claim_submitted,
-        "paid" => claim.payment.present?.to_s,
-        "paid_at" => (claim.payment.present? ? claim.scheduled_payment_date : DateTime.parse("1970-01-01")).strftime("%Y-%m-%dT%H:%M:%S%:z"),
-        "award_amount" => claim.eligibility.present? ? (claim.award_amount * 100).to_i : nil
+        "award_amount" => claim.eligibility.present? ? (claim.award_amount * 100).to_i : nil,
+        "paid" => claim.scheduled_for_payment?.to_s,
+        "paid_at" => (claim.scheduled_for_payment? ? claim.scheduled_payment_date : DateTime.parse("1970-01-01")).strftime("%Y-%m-%dT%H:%M:%S%:z")
       }
     }.sort_by { |d| d["reference"] }
 


### PR DESCRIPTION
All decisions now have a boolean `undone` column which defaults to `false`. Setting this to `true` indicates that a decision has been undone.

When a decision is marked as `undone` it is no longer included in any of the scopes which return `accepted`/`rejected`/`awaiting decision` claims, nor in a `Claim`'s `decision` method (which returns the latest valid decisions).

Changes to specs are to reflect the fact that these scopes now rely on an actual database query, which doesn't apply to objects brought into existence with `build` instead of `create`.