### PR TITLE
Fix deployments

### DIFF
--- a/azure/resource_groups/app/template.json
+++ b/azure/resource_groups/app/template.json
@@ -615,7 +615,7 @@
               },
               {
                 "name": "SERVICE_ENTITY_IDS",
-                "value": "[string(createArray(parameters('VSP.VERIFY_ENTITY_ID')))]"
+                "value": "[concat('[', '''', parameters('VSP.VERIFY_ENTITY_ID'), '''', ']')]"
               },
               {
                 "name": "SAML_SIGNING_KEY",

--- a/bin/azure-deploy
+++ b/bin/azure-deploy
@@ -144,7 +144,7 @@ fi
 echo "Starting ProjectCore deployment..."
 
 PROJECT_CORE_DEPLOYMENT_RESULT=$(
-  az group deployment create \
+  az deployment group create \
     --name "$PROJECT_CORE_DEPLOYMENT_NAME" \
     --resource-group "$PROJECT_CORE_RESOURCE_GROUP_NAME" \
     --template-file "$PROJECT_CORE_TEMPLATE_FILE_PATH" \
@@ -184,7 +184,7 @@ fi
 echo "Starting secrets deployment with KeyVault createMode: $KEYVAULT_CREATE_MODE..."
 
 SECRETS_DEPLOYMENT_RESULT=$(
-  az group deployment create \
+  az deployment group create \
     --name "$SECRETS_DEPLOYMENT_NAME" \
     --resource-group "$SECRETS_RESOURCE_GROUP_NAME" \
     --template-file "$SECRETS_TEMPLATE_FILE_PATH" \
@@ -234,7 +234,7 @@ fi
 echo "Starting app deployment..."
 
 APP_DEPLOYMENT_RESULT=$(
-  az group deployment create \
+  az deployment group create \
     --name "$APP_DEPLOYMENT_NAME" \
     --resource-group "$APP_RESOURCE_GROUP_NAME" \
     --template-file "$APP_TEMPLATE_FILE_PATH" \
@@ -281,7 +281,7 @@ if [ $DEPLOY_ALERTS ]; then
   echo "Starting alerts deployment..."
 
   ALERTS_DEPLOYMENT_RESULT=$(
-    az group deployment create \
+    az deployment group create \
       --name "$ALERTS_DEPLOYMENT_NAME" \
       --resource-group "$ALERTS_RESOURCE_GROUP_NAME" \
       --template-file "$ALERTS_TEMPLATE_FILE_PATH" \


### PR DESCRIPTION
We're having issues deploying due to a change in the way ARM templates are handled. For some reason, running `string` against a created array now appears to flatten out the array into a comma seperated list, so we need to change how we build the `SERVICE_ENTITY_IDS` JSON array. This builds up the array using a combination of a `[`, an (escaped) single quote `''`, the VSP entity ID and a `]`. The means if the value of `VSP.VERIFY_ENTITY_ID` was `http://example.com`, the resulting JSON string would be `['http://example.com']`.

I've also updated the command we use to create deployments, as we were getting a deprecation warning.
