### PR TITLE
Show the academic year when viewing a claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Show the academic year when viewing a claim
+
 ## [Release 064] - 2020-03-18
 
 - Add "Back" link and page title to claim decision screen

--- a/app/views/admin/amendments/new.html.erb
+++ b/app/views/admin/amendments/new.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
+    <span class="govuk-caption-xl"><%= @claim.policy.short_name %> (<%= @claim.academic_year %>)</span>
     <h1 class="govuk-heading-xl">
       Amend claim <%= @claim.reference %>
     </h1>

--- a/app/views/admin/amendments/not_amendable.html.erb
+++ b/app/views/admin/amendments/not_amendable.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
+    <span class="govuk-caption-xl"><%= @claim.policy.short_name %> (<%= @claim.academic_year %>)</span>
     <h1 class="govuk-heading-xl">
       Amend claim <%= @claim.reference %>
     </h1>

--- a/app/views/admin/claims/show.html.erb
+++ b/app/views/admin/claims/show.html.erb
@@ -26,7 +26,7 @@
       </div>
     <% end %>
 
-    <span class="govuk-caption-xl"><%= @claim.policy.short_name %></span>
+    <span class="govuk-caption-xl"><%= @claim.policy.short_name %>  (<%= @claim.academic_year %>)</span>
     <h1 class="govuk-heading-xl govuk-heading--navigation">
       <%= @claim.reference %>
       <span class="govuk-body-m">

--- a/app/views/admin/tasks/_claim_summary.html.erb
+++ b/app/views/admin/tasks/_claim_summary.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-column-full">
-  <span class="govuk-caption-xl"><%= claim.policy.short_name %></span>
+  <span class="govuk-caption-xl"><%= claim.policy.short_name %> (<%= claim.academic_year %>)</span>
   <h1 class="govuk-heading-xl govuk-heading--navigation">
     <%= heading %>
     <span class="govuk-body-m">


### PR DESCRIPTION
When the new claim window opens we will start accepting claims for the
new academic year and want a way to easily distinguish between claims
made in different academic years:

<img width="1094" alt="Screenshot 2020-03-18 at 15 26 27" src="https://user-images.githubusercontent.com/3687/76977148-d7e7ed80-692c-11ea-891e-34bcd36e43b4.png">
