### PR TITLE
Refactory admin tasks locales

### DIFF
--- a/app/views/admin/decisions/_incomplete_tasks.html.erb
+++ b/app/views/admin/decisions/_incomplete_tasks.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list claim-error-summary__list--warning">
       <% incomplete_task_names.each do |name| %>
-        <li><%= link_to(t("#{claim.policy.locale_key}.admin.tasks.#{name}.summary"), admin_claim_task_url(claim, name: name)) %></li>
+        <li><%= link_to(t("admin.tasks.#{name}"), admin_claim_task_url(claim, name: name)) %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/admin/tasks/_form.html.erb
+++ b/app/views/admin/tasks/_form.html.erb
@@ -3,7 +3,7 @@
     <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l ">
         <h3 class="govuk-heading-l">
-          <%= I18n.t("#{claim.policy.to_s.underscore}.admin.tasks.#{task_name}.question", local_assigns[:question_variables]) %>
+          <%= I18n.t("#{claim.policy.to_s.underscore}.admin.task_questions.#{task_name}", local_assigns[:question_variables]) %>
         </h3>
       </legend>
 

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -18,7 +18,7 @@
           <ul class="app-task-list__items">
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <%= link_to I18n.t("#{@claim.policy.locale_key}.admin.tasks.#{task_name}.summary"), admin_claim_task_path(claim_id: @claim.id, name: task_name), class: "govuk-link" %>
+                <%= link_to I18n.t("admin.tasks.#{task_name}"), admin_claim_task_path(claim_id: @claim.id, name: task_name), class: "govuk-link" %>
               </span>
               <%= task_status_tag(@claim, task_name) %>
             </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,13 @@ en:
       one: Details in this claim match another %{policy} claim
       other: Details in this claim match other %{policy} claims
     unknown_payroll_gender_preventing_approval_message: This claim cannot be approved, the payroll gender is missing and the claim will need to be referred
+    tasks:
+      qualifications: "Check qualification information"
+      employment: "Check employment information"
+      matching_details: "Review matching details from other claims"
+      identity_confirmation: "Confirm the claimant made the claim"
+      payroll_gender: "Add a payroll gender for HMRC"
+      student_loan_amount: "Check student loan amount"
   answers:
     qts_award_years:
       before_cut_off_date: "In or before the academic year %{year}"
@@ -157,19 +164,13 @@ en:
       formal_performance_action: "Subject to formal performance action?"
       tasks:
         qualifications:
-          summary: "Check qualification information"
           question: "Does the claimant’s initial teacher training (ITT) qualification year and specialist subject match the above information from their claim?"
         employment:
-          summary: "Check employment information"
           question: "Does the claimant’s current school match the above information from their claim?"
         matching_details:
-          summary: "Review matching details from other claims"
           question: "Is this claim still valid despite having matching details with other claims?"
         identity_confirmation:
-          summary: "Confirm the claimant made the claim"
           question: "Did %{name} submit the claim?"
-        payroll_gender:
-          summary: "Add a payroll gender for HMRC"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     policy_short_name: "Student Loans"
@@ -202,19 +203,12 @@ en:
       student_loan_repayment_plan: "Student loan repayment plan"
       tasks:
         qualifications:
-          summary: "Check qualification information"
           question: "Does the claimant’s initial teacher training (ITT) qualification year match the above information from their claim?"
         employment:
-          summary: "Check employment information"
           question: "Does the claimant’s previous and current schools match the above information from their claim?"
         student_loan_amount:
-          summary: "Check student loan amount"
           question: "Does the claimant’s student loan amount and plan type match the information we hold about their loan?"
         matching_details:
-          summary: "Review matching details from other claims"
           question: "Is this claim still valid despite having matching details with other claims?"
         identity_confirmation:
-          summary: "Confirm the claimant made the claim"
           question: "Did %{name} submit the claim?"
-        payroll_gender:
-          summary: "Add a payroll gender for HMRC"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,15 +162,11 @@ en:
       employed_directly: "Employed directly by school?"
       disciplinary_action: "Subject to disciplinary action?"
       formal_performance_action: "Subject to formal performance action?"
-      tasks:
-        qualifications:
-          question: "Does the claimant’s initial teacher training (ITT) qualification year and specialist subject match the above information from their claim?"
-        employment:
-          question: "Does the claimant’s current school match the above information from their claim?"
-        matching_details:
-          question: "Is this claim still valid despite having matching details with other claims?"
-        identity_confirmation:
-          question: "Did %{name} submit the claim?"
+      task_questions:
+        qualifications: "Does the claimant’s initial teacher training (ITT) qualification year and specialist subject match the above information from their claim?"
+        employment: "Does the claimant’s current school match the above information from their claim?"
+        matching_details: "Is this claim still valid despite having matching details with other claims?"
+        identity_confirmation: "Did %{name} submit the claim?"
   student_loans:
     policy_name: "Teachers: claim back your student loan repayments"
     policy_short_name: "Student Loans"
@@ -201,14 +197,9 @@ en:
       mostly_performed_leadership_duties: "Mostly performed leadership duties?"
       student_loan_repayment_amount: "Student loan repayment amount"
       student_loan_repayment_plan: "Student loan repayment plan"
-      tasks:
-        qualifications:
-          question: "Does the claimant’s initial teacher training (ITT) qualification year match the above information from their claim?"
-        employment:
-          question: "Does the claimant’s previous and current schools match the above information from their claim?"
-        student_loan_amount:
-          question: "Does the claimant’s student loan amount and plan type match the information we hold about their loan?"
-        matching_details:
-          question: "Is this claim still valid despite having matching details with other claims?"
-        identity_confirmation:
-          question: "Did %{name} submit the claim?"
+      task_question:
+        qualifications: "Does the claimant’s initial teacher training (ITT) qualification year match the above information from their claim?"
+        employment: "Does the claimant’s previous and current schools match the above information from their claim?"
+        student_loan_amount: "Does the claimant’s student loan amount and plan type match the information we hold about their loan?"
+        matching_details: "Is this claim still valid despite having matching details with other claims?"
+        identity_confirmation: "Did %{name} submit the claim?"

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
     expect(page).to have_content("3. Matching details")
     expect(page).to have_content("4. Decision")
 
-    click_on I18n.t("maths_and_physics.admin.tasks.matching_details.summary")
+    click_on I18n.t("admin.tasks.matching_details")
 
     expect(page).to have_content(I18n.t("maths_and_physics.admin.tasks.matching_details.question"))
     expect(page).to have_content(claim_with_matching_details.reference)
@@ -100,7 +100,7 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
     expect(page).to have_content("3. Identity confirmation")
     expect(page).to have_content("4. Decision")
 
-    click_on I18n.t("maths_and_physics.admin.tasks.identity_confirmation.summary")
+    click_on I18n.t("admin.tasks.identity_confirmation")
 
     expect(page).to have_content(I18n.t("maths_and_physics.admin.tasks.identity_confirmation.question", name: claim.full_name))
     expect(page).to have_content(claim.eligibility.current_school.name)

--- a/spec/features/admin_checks_maths_and_physics_claim_spec.rb
+++ b/spec/features/admin_checks_maths_and_physics_claim_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
 
     click_on "Check qualification information"
 
-    expect(page).to have_content(I18n.t("maths_and_physics.admin.tasks.qualifications.question"))
+    expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.qualifications"))
     expect(page).to have_content("Award year")
     expect(page).to have_content(claim.eligibility.qts_award_year_answer)
 
@@ -28,7 +28,7 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
 
     expect(claim.tasks.find_by!(name: "qualifications").passed?).to eq(true)
 
-    expect(page).to have_content(I18n.t("maths_and_physics.admin.tasks.employment.question"))
+    expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.employment"))
     expect(page).to have_content("Current school")
     expect(page).to have_link(claim.eligibility.current_school.name)
 
@@ -63,7 +63,7 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
 
     click_on I18n.t("admin.tasks.matching_details")
 
-    expect(page).to have_content(I18n.t("maths_and_physics.admin.tasks.matching_details.question"))
+    expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.matching_details"))
     expect(page).to have_content(claim_with_matching_details.reference)
     expect(page).to have_content("Teacher reference number")
 
@@ -102,7 +102,7 @@ RSpec.feature "Admin checking a Maths & Physics claim" do
 
     click_on I18n.t("admin.tasks.identity_confirmation")
 
-    expect(page).to have_content(I18n.t("maths_and_physics.admin.tasks.identity_confirmation.question", name: claim.full_name))
+    expect(page).to have_content(I18n.t("maths_and_physics.admin.task_questions.identity_confirmation", name: claim.full_name))
     expect(page).to have_content(claim.eligibility.current_school.name)
     expect(page).to have_content(claim.eligibility.current_school.phone_number)
 

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
 
     click_on "Check qualification information"
 
-    expect(page).to have_content(I18n.t("student_loans.admin.tasks.qualifications.question"))
+    expect(page).to have_content(I18n.t("student_loans.admin.task_questions.qualifications"))
     expect(page).to have_content("Award year")
     expect(page).to have_content(claim.eligibility.qts_award_year_answer)
 
@@ -37,7 +37,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
 
     expect(claim.tasks.find_by!(name: "qualifications").passed?).to eq(true)
 
-    expect(page).to have_content(I18n.t("student_loans.admin.tasks.employment.question"))
+    expect(page).to have_content(I18n.t("student_loans.admin.task_questions.employment"))
     expect(page).to have_content("Current school")
     expect(page).to have_link(claim.eligibility.current_school.name)
 
@@ -46,7 +46,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
 
     expect(claim.tasks.find_by!(name: "employment").passed?).to eq(true)
 
-    expect(page).to have_content(I18n.t("student_loans.admin.tasks.student_loan_amount.question"))
+    expect(page).to have_content(I18n.t("student_loans.admin.task_questions.student_loan_amount"))
     expect(page).to have_content("£1,987.65")
     expect(page).to have_content("Plan 2")
 
@@ -81,7 +81,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
 
     click_on I18n.t("admin.tasks.matching_details")
 
-    expect(page).to have_content(I18n.t("student_loans.admin.tasks.matching_details.question"))
+    expect(page).to have_content(I18n.t("student_loans.admin.task_questions.matching_details"))
     expect(page).to have_content(claim_with_matching_details.reference)
     expect(page).to have_content("Teacher reference number")
 
@@ -113,7 +113,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
 
     click_on I18n.t("admin.tasks.identity_confirmation")
 
-    expect(page).to have_content(I18n.t("student_loans.admin.tasks.identity_confirmation.question", name: claim.full_name))
+    expect(page).to have_content(I18n.t("student_loans.admin.task_questions.identity_confirmation", name: claim.full_name))
     expect(page).to have_content(claim.eligibility.current_school.name)
     expect(page).to have_content(claim.eligibility.current_school.phone_number)
 

--- a/spec/features/admin_checks_student_loan_claim_spec.rb
+++ b/spec/features/admin_checks_student_loan_claim_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
     expect(page).to have_content("4. Matching details")
     expect(page).to have_content("5. Decision")
 
-    click_on I18n.t("student_loans.admin.tasks.matching_details.summary")
+    click_on I18n.t("admin.tasks.matching_details")
 
     expect(page).to have_content(I18n.t("student_loans.admin.tasks.matching_details.question"))
     expect(page).to have_content(claim_with_matching_details.reference)
@@ -111,7 +111,7 @@ RSpec.feature "Admin checking a Student Loans claim" do
     expect(page).to have_content("4. Identity confirmation")
     expect(page).to have_content("5. Decision")
 
-    click_on I18n.t("student_loans.admin.tasks.identity_confirmation.summary")
+    click_on I18n.t("admin.tasks.identity_confirmation")
 
     expect(page).to have_content(I18n.t("student_loans.admin.tasks.identity_confirmation.question", name: claim.full_name))
     expect(page).to have_content(claim.eligibility.current_school.name)

--- a/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
+++ b/spec/features/admin_claim_with_missing_payroll_gender_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Admin checking a claim missing a payroll gender" do
     expect(page).to have_content("4. Payroll gender")
     expect(page).to have_content("5. Decision")
 
-    click_on I18n.t("student_loans.admin.tasks.payroll_gender.summary")
+    click_on I18n.t("admin.tasks.payroll_gender")
 
     expect(page).to have_content("What gender should be passed to payroll and HMRC?")
 


### PR DESCRIPTION
Reduces some duplication and nesting of the locale data that we use for displaying the claim checking tasks.