### PR TITLE
Support searching for claims with more than just the reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Support searching for claims with more than just the reference
+
 ## [Release 065] - 2020-03-24
 
 - Show the academic year when viewing a claim

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -22,14 +22,14 @@ class Admin::ClaimsController < Admin::BaseAdminController
   end
 
   def search
-    return unless params[:reference].present?
+    return unless params[:query].present?
 
-    claim = Claim.find_by(reference: params[:reference].upcase)
+    @claims = Claim::Search.new(params[:query]).claims.includes(:eligibility)
 
-    if claim
-      redirect_to(admin_claim_url(claim))
-    else
-      flash.now[:notice] = "Cannot find a claim with reference \"#{params[:reference]}\""
+    if @claims.none?
+      flash.now[:notice] = "Cannot find a claim for query \"#{params[:query]}\""
+    elsif @claims.one?
+      redirect_to(admin_claim_url(@claims.first))
     end
   end
 

--- a/app/models/claim/search.rb
+++ b/app/models/claim/search.rb
@@ -1,0 +1,31 @@
+class Claim
+  # Accepts a search term and returns all Claims that match against any of the
+  # attributes defined in the `SEARCHABLE_ATTRIBUTES` constant. Both subject
+  # and attribute are downcased, so the search is case-insensitive.
+  class Search
+    attr_accessor :search_term
+
+    SEARCHABLE_ATTRIBUTES = %w[
+      reference
+      email_address
+      surname
+      teacher_reference_number
+    ]
+
+    def initialize(search_term)
+      @search_term = search_term
+    end
+
+    def claims
+      SEARCHABLE_ATTRIBUTES.inject(Claim.none) do |relation, attribute|
+        relation.or(search_by(attribute))
+      end
+    end
+
+    private
+
+    def search_by(attribute)
+      Claim.where("LOWER(#{attribute}) = LOWER(?)", search_term)
+    end
+  end
+end

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -10,7 +10,7 @@
     <%= form_with url: search_admin_claims_path, method: :get do |form| %>
       <div class="govuk-form-group">
         <%= form.label :query, "Enter a reference, email address, Teacher Reference Number, or surname", class: "govuk-label" %>
-        <%= form.text_field :query, class: "govuk-input" %>
+        <%= form.text_field :query, class: "govuk-input govuk-input--width-20" %>
       </div>
 
       <div class="govuk-form-group">

--- a/app/views/admin/claims/search.html.erb
+++ b/app/views/admin/claims/search.html.erb
@@ -9,8 +9,8 @@
 
     <%= form_with url: search_admin_claims_path, method: :get do |form| %>
       <div class="govuk-form-group">
-        <%= form.label :reference, "Enter a reference", class: "govuk-label" %>
-        <%= form.text_field :reference, class: "govuk-input" %>
+        <%= form.label :query, "Enter a reference, email address, Teacher Reference Number, or surname", class: "govuk-label" %>
+        <%= form.text_field :query, class: "govuk-input" %>
       </div>
 
       <div class="govuk-form-group">
@@ -18,5 +18,33 @@
       </div>
     <% end %>
 
+    <% if @claims && @claims.any? %>
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Reference</th>
+            <th scope="col" class="govuk-table__header">Applicant Name</th>
+            <th scope="col" class="govuk-table__header">Service</th>
+            <th scope="col" class="govuk-table__header">Academic Year</th>
+            <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @claims.each do |claim| %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header"><%= claim.reference %></th>
+              <td class="govuk-table__cell"><%= claim.full_name %></td>
+              <td class="govuk-table__cell"><%= claim.policy.short_name %></td>
+              <td class="govuk-table__cell"><%= claim.academic_year %></td>
+              <td class="govuk-table__cell">
+                <%= link_to "View details", admin_claim_tasks_path(claim), class: "govuk-link" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+    <% end %>
   </div>
 </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,11 +3,31 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "46bfd0a9d4a19eb048a883184b501b060aa4d6006accc3c76bbfc00722b44dbf",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/claim/search.rb",
+      "line": 28,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Claim.where(\"LOWER(#{attribute}) = LOWER(?)\", search_term)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Search",
+        "method": "search_by"
+      },
+      "user_input": "attribute",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "aac74520956533997d73d1c601c2bcde5d3cd501f14401fb9cb8e2bfdc7862fa",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/claim/matching_attribute_finder.rb",
-      "line": 26,
+      "line": 31,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "Claim.where(\"LOWER(#{\"CONCAT(#{attributes.join(\",\")})\"}) = LOWER(?)\", values_for_attributes(attributes).join)",
       "render_path": null,
@@ -41,6 +61,6 @@
       "note": "We generate the filename based on non-user input so we can ignore this"
     }
   ],
-  "updated": "2019-12-17 11:26:22 +0000",
-  "brakeman_version": "4.7.2"
+  "updated": "2020-03-24 11:25:44 +0000",
+  "brakeman_version": "4.8.0"
 }

--- a/spec/features/admin_search_spec.rb
+++ b/spec/features/admin_search_spec.rb
@@ -5,14 +5,30 @@ RSpec.feature "Admin search" do
     sign_in_to_admin_with_role(DfeSignIn::User::SERVICE_OPERATOR_DFE_SIGN_IN_ROLE_CODE)
   end
 
-  it "redirects to the claim" do
-    claim = create(:claim, :submitted)
+  let!(:claim1) { create(:claim, :submitted, surname: "Wayne") }
+  let!(:claim2) { create(:claim, :submitted, surname: "Wayne") }
 
+  scenario "redirects a service operator to the claim if there is only one match" do
     visit search_admin_claims_path
 
-    fill_in :reference, with: claim.reference
+    fill_in :reference, with: claim1.reference
     click_button "Search"
 
-    expect(page).to have_content(claim.reference)
+    expect(page).to have_content(claim1.reference)
+    expect(page).to have_content(claim1.teacher_reference_number)
+  end
+
+  scenario "it lists claims if there is more than one match" do
+    visit search_admin_claims_path
+
+    fill_in :reference, with: "wayne"
+    click_button "Search"
+
+    expect(page).to have_content(claim1.reference)
+    expect(page).to have_content(claim2.reference)
+
+    find("a[href='#{admin_claim_tasks_path(claim1)}']").click
+
+    expect(page).to have_content(claim1.teacher_reference_number)
   end
 end

--- a/spec/models/claim/search_spec.rb
+++ b/spec/models/claim/search_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe Claim::Search do
+  subject(:search) { Claim::Search.new(query) }
+
+  let!(:other_claim) { create(:claim, :submitted) }
+
+  context "when searching by reference" do
+    let(:reference) { "ABC123" }
+    let(:claim) { create(:claim, :submitted, reference: reference) }
+
+    let(:query) { "ABC123" }
+
+    it "finds a claim that matches that reference" do
+      expect(search.claims).to match_array(claim)
+    end
+
+    context "when the reference is lowercase" do
+      let(:query) { "abc123" }
+
+      it "finds a claim that matches that reference" do
+        expect(search.claims).to match_array(claim)
+      end
+    end
+  end
+
+  context "when searching by email" do
+    let(:email) { "foo@example.com" }
+    let(:claim) { create(:claim, :submitted, email_address: email) }
+
+    let(:query) { "foo@example.com" }
+
+    it "finds claims that match that email address" do
+      expect(search.claims).to match_array(claim)
+    end
+  end
+
+  context "when searching by surname" do
+    let(:surname) { "Wayne" }
+    let(:claim) { create(:claim, :submitted, surname: surname) }
+
+    let(:query) { "Wayne" }
+
+    it "finds claims that match that surname" do
+      expect(search.claims).to match_array(claim)
+    end
+
+    context "when the surname is lowercase" do
+      let(:query) { "wayne" }
+
+      it "finds a claim that matches that reference" do
+        expect(search.claims).to match_array(claim)
+      end
+    end
+  end
+
+  context "when searching by teacher reference" do
+    let(:reference) { "1234567" }
+    let(:claim) { create(:claim, :submitted, teacher_reference_number: reference) }
+
+    let(:query) { "1234567" }
+
+    it "finds claims that match that email address" do
+      expect(search.claims).to match_array(claim)
+    end
+  end
+end

--- a/spec/requests/admin_claims_spec.rb
+++ b/spec/requests/admin_claims_spec.rb
@@ -107,19 +107,27 @@ RSpec.describe "Admin claims", type: :request do
   end
 
   describe "claims#search" do
-    let(:claim) { create(:claim, :submitted) }
+    let!(:claim1) { create(:claim, :submitted, surname: "Wayne") }
+    let!(:claim2) { create(:claim, :submitted, surname: "Wayne") }
 
     it "redirects to a claim when one exists" do
-      get search_admin_claims_path(reference: claim.reference)
+      get search_admin_claims_path(query: claim1.reference)
 
-      expect(response).to redirect_to(admin_claim_path(claim))
+      expect(response).to redirect_to(admin_claim_path(claim1))
+    end
+
+    it "shows a list of matching claims if there are more than one" do
+      get search_admin_claims_path(query: "Wayne")
+
+      expect(response.body).to include(claim1.reference)
+      expect(response.body).to include(claim2.reference)
     end
 
     it "shows an error if a claim can't be found" do
       reference = "12345678"
-      get search_admin_claims_path(reference: reference)
+      get search_admin_claims_path(query: reference)
 
-      expected_flash = CGI.escapeHTML("Cannot find a claim with reference \"#{reference}\"")
+      expected_flash = CGI.escapeHTML("Cannot find a claim for query \"#{reference}\"")
       expect(response.body).to include(expected_flash)
     end
   end


### PR DESCRIPTION
This adds a class to search claims for a number of different attributes, and updates the search 
page to list the search results, rather than just redirecting to a single claim.

![image](https://user-images.githubusercontent.com/109774/77308113-5f00e100-6cf2-11ea-8d4e-368e051cffe8.png)

![image](https://user-images.githubusercontent.com/109774/77308148-6aeca300-6cf2-11ea-9018-c9eb02e7b47e.png)
