### PR TITLE
Use Rails’ translate method over I18n.translate

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -46,7 +46,7 @@ class ClaimsController < BasePublicController
   end
 
   def start_new
-    new_policy_description = I18n.t("#{params[:policy].underscore}.claim_description")
+    new_policy_description = translate("#{params[:policy].underscore}.claim_description")
 
     return redirect_to existing_session_path, alert: "Select yes if you want to start a claim #{new_policy_description}" unless params[:start_new_claim].present?
 

--- a/app/helpers/admin/claims_helper.rb
+++ b/app/helpers/admin/claims_helper.rb
@@ -20,36 +20,36 @@ module Admin
 
     def admin_personal_details(claim)
       [
-        [t("admin.teacher_reference_number"), claim.teacher_reference_number],
-        [t("govuk_verify_fields.full_name").capitalize, claim.personal_data_removed? ? personal_data_removed_text : claim.full_name],
-        [t("govuk_verify_fields.date_of_birth").capitalize, claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth, format: :day_month_year)],
-        [t("admin.national_insurance_number"), claim.personal_data_removed? ? personal_data_removed_text : claim.national_insurance_number],
-        [t("govuk_verify_fields.address").capitalize, claim.personal_data_removed? ? personal_data_removed_text : sanitize(claim.address("<br>").html_safe, tags: %w[br])],
-        [t("admin.email_address"), claim.email_address]
+        [translate("admin.teacher_reference_number"), claim.teacher_reference_number],
+        [translate("govuk_verify_fields.full_name").capitalize, claim.personal_data_removed? ? personal_data_removed_text : claim.full_name],
+        [translate("govuk_verify_fields.date_of_birth").capitalize, claim.personal_data_removed? ? personal_data_removed_text : l(claim.date_of_birth, format: :day_month_year)],
+        [translate("admin.national_insurance_number"), claim.personal_data_removed? ? personal_data_removed_text : claim.national_insurance_number],
+        [translate("govuk_verify_fields.address").capitalize, claim.personal_data_removed? ? personal_data_removed_text : sanitize(claim.address("<br>").html_safe, tags: %w[br])],
+        [translate("admin.email_address"), claim.email_address]
       ]
     end
 
     def admin_student_loan_details(claim)
       [].tap do |a|
-        a << [t("student_loans.admin.student_loan_repayment_amount"), number_to_currency(claim.eligibility.student_loan_repayment_amount)] if claim.eligibility.respond_to?(:student_loan_repayment_amount)
-        a << [t("student_loans.admin.student_loan_repayment_plan"), claim.student_loan_plan&.humanize]
+        a << [translate("student_loans.admin.student_loan_repayment_amount"), number_to_currency(claim.eligibility.student_loan_repayment_amount)] if claim.eligibility.respond_to?(:student_loan_repayment_amount)
+        a << [translate("student_loans.admin.student_loan_repayment_plan"), claim.student_loan_plan&.humanize]
       end
     end
 
     def admin_submission_details(claim)
       [
-        [t("admin.started_at"), l(claim.created_at)],
-        [t("admin.submitted_at"), l(claim.submitted_at)],
-        [t("admin.decision_deadline"), [l(claim.decision_deadline_date), decision_deadline_warning(claim)].compact.join.html_safe]
+        [translate("admin.started_at"), l(claim.created_at)],
+        [translate("admin.submitted_at"), l(claim.submitted_at)],
+        [translate("admin.decision_deadline"), [l(claim.decision_deadline_date), decision_deadline_warning(claim)].compact.join.html_safe]
       ]
     end
 
     def admin_decision_details(decision)
       [].tap do |a|
-        a << [t("admin.decision.created_at"), l(decision.created_at)]
-        a << [t("admin.decision.result"), decision.result.capitalize]
-        a << [t("admin.decision.notes"), simple_format(decision.notes, class: "govuk-body")] if decision.notes.present?
-        a << [t("admin.decision.created_by"), user_details(decision.created_by)]
+        a << [translate("admin.decision.created_at"), l(decision.created_at)]
+        a << [translate("admin.decision.result"), decision.result.capitalize]
+        a << [translate("admin.decision.notes"), simple_format(decision.notes, class: "govuk-body")] if decision.notes.present?
+        a << [translate("admin.decision.created_by"), user_details(decision.created_by)]
       end
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,7 @@ module ApplicationHelper
   end
 
   def policy_description(policy)
-    I18n.t("#{policy.underscore}.claim_description")
+    translate("#{policy.underscore}.claim_description")
   end
 
   def feedback_url

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -1,12 +1,12 @@
 module ClaimsHelper
   def fields_from_govuk_verify(claim)
     fields = []
-    fields << I18n.t("govuk_verify_fields.first_name") if claim.govuk_verify_fields.include?("first_name")
-    fields << I18n.t("govuk_verify_fields.middle_name") if claim.govuk_verify_fields.include?("middle_name")
-    fields << I18n.t("govuk_verify_fields.surname") if claim.govuk_verify_fields.include?("surname")
-    fields << I18n.t("govuk_verify_fields.address") if claim.address_from_govuk_verify?
-    fields << I18n.t("govuk_verify_fields.date_of_birth") if claim.govuk_verify_fields.include?("date_of_birth")
-    fields << I18n.t("govuk_verify_fields.payroll_gender") if claim.payroll_gender_verified?
+    fields << translate("govuk_verify_fields.first_name") if claim.govuk_verify_fields.include?("first_name")
+    fields << translate("govuk_verify_fields.middle_name") if claim.govuk_verify_fields.include?("middle_name")
+    fields << translate("govuk_verify_fields.surname") if claim.govuk_verify_fields.include?("surname")
+    fields << translate("govuk_verify_fields.address") if claim.address_from_govuk_verify?
+    fields << translate("govuk_verify_fields.date_of_birth") if claim.govuk_verify_fields.include?("date_of_birth")
+    fields << translate("govuk_verify_fields.payroll_gender") if claim.payroll_gender_verified?
     fields.to_sentence
   end
 
@@ -16,33 +16,33 @@ module ClaimsHelper
 
   def verify_answers(claim)
     [].tap do |a|
-      a << [I18n.t("govuk_verify_fields.first_name").capitalize, claim.first_name] if claim.name_verified?
-      a << [I18n.t("govuk_verify_fields.middle_name").capitalize, claim.middle_name] if claim.name_verified? && claim.middle_name.present?
-      a << [I18n.t("govuk_verify_fields.surname").capitalize, claim.surname] if claim.name_verified?
-      a << [I18n.t("govuk_verify_fields.address").capitalize, sanitize(claim.address("<br>").html_safe, tags: %w[br])] if claim.address_from_govuk_verify?
-      a << [I18n.t("govuk_verify_fields.date_of_birth").capitalize, l(claim.date_of_birth)] if claim.date_of_birth_verified?
-      a << [I18n.t("govuk_verify_fields.payroll_gender").capitalize, t("answers.payroll_gender.#{claim.payroll_gender}")] if claim.payroll_gender_verified?
+      a << [translate("govuk_verify_fields.first_name").capitalize, claim.first_name] if claim.name_verified?
+      a << [translate("govuk_verify_fields.middle_name").capitalize, claim.middle_name] if claim.name_verified? && claim.middle_name.present?
+      a << [translate("govuk_verify_fields.surname").capitalize, claim.surname] if claim.name_verified?
+      a << [translate("govuk_verify_fields.address").capitalize, sanitize(claim.address("<br>").html_safe, tags: %w[br])] if claim.address_from_govuk_verify?
+      a << [translate("govuk_verify_fields.date_of_birth").capitalize, l(claim.date_of_birth)] if claim.date_of_birth_verified?
+      a << [translate("govuk_verify_fields.payroll_gender").capitalize, t("answers.payroll_gender.#{claim.payroll_gender}")] if claim.payroll_gender_verified?
     end
   end
 
   def identity_answers(claim)
     [].tap do |a|
-      a << [t("questions.name"), claim.full_name, "name"] unless claim.name_verified?
-      a << [t("questions.address"), claim.address, "address"] unless claim.address_from_govuk_verify?
-      a << [t("questions.date_of_birth"), date_of_birth_string(claim), "date-of-birth"] unless claim.date_of_birth_verified?
-      a << [t("questions.payroll_gender"), t("answers.payroll_gender.#{claim.payroll_gender}"), "gender"] unless claim.payroll_gender_verified?
-      a << [t("questions.teacher_reference_number"), claim.teacher_reference_number, "teacher-reference-number"]
-      a << [t("questions.national_insurance_number"), claim.national_insurance_number, "national-insurance-number"]
-      a << [t("questions.email_address"), claim.email_address, "email-address"]
+      a << [translate("questions.name"), claim.full_name, "name"] unless claim.name_verified?
+      a << [translate("questions.address"), claim.address, "address"] unless claim.address_from_govuk_verify?
+      a << [translate("questions.date_of_birth"), date_of_birth_string(claim), "date-of-birth"] unless claim.date_of_birth_verified?
+      a << [translate("questions.payroll_gender"), t("answers.payroll_gender.#{claim.payroll_gender}"), "gender"] unless claim.payroll_gender_verified?
+      a << [translate("questions.teacher_reference_number"), claim.teacher_reference_number, "teacher-reference-number"]
+      a << [translate("questions.national_insurance_number"), claim.national_insurance_number, "national-insurance-number"]
+      a << [translate("questions.email_address"), claim.email_address, "email-address"]
     end
   end
 
   def student_loan_answers(claim)
     [].tap do |a|
-      a << [t("questions.has_student_loan"), (claim.has_student_loan ? "Yes" : "No"), "student-loan"]
-      a << [t("questions.student_loan_country"), claim.student_loan_country.titleize, "student-loan-country"] if claim.student_loan_country.present?
-      a << [t("questions.student_loan_how_many_courses"), claim.student_loan_courses.humanize, "student-loan-how-many-courses"] if claim.student_loan_courses.present?
-      a << [t("questions.student_loan_start_date.#{claim.student_loan_courses}"), t("answers.student_loan_start_date.#{claim.student_loan_courses}.#{claim.student_loan_start_date}"), "student-loan-start-date"] if claim.student_loan_courses.present?
+      a << [translate("questions.has_student_loan"), (claim.has_student_loan ? "Yes" : "No"), "student-loan"]
+      a << [translate("questions.student_loan_country"), claim.student_loan_country.titleize, "student-loan-country"] if claim.student_loan_country.present?
+      a << [translate("questions.student_loan_how_many_courses"), claim.student_loan_courses.humanize, "student-loan-how-many-courses"] if claim.student_loan_courses.present?
+      a << [translate("questions.student_loan_start_date.#{claim.student_loan_courses}"), t("answers.student_loan_start_date.#{claim.student_loan_courses}.#{claim.student_loan_start_date}"), "student-loan-start-date"] if claim.student_loan_courses.present?
     end
   end
 

--- a/app/helpers/student_loans_helper.rb
+++ b/app/helpers/student_loans_helper.rb
@@ -1,4 +1,6 @@
 module StudentLoansHelper
+  include ActionView::Helpers::TranslationHelper
+
   # Returns the question for the claim-school page in the Student Loans journey.
   #
   # Accepts an optional named parameter `additional_school` that, if set to
@@ -6,9 +8,9 @@ module StudentLoansHelper
   # additional school.
   def claim_school_question(additional_school: false)
     if additional_school
-      I18n.t("student_loans.questions.additional_school", financial_year: StudentLoans.current_financial_year)
+      translate("student_loans.questions.additional_school", financial_year: StudentLoans.current_financial_year)
     else
-      I18n.t("student_loans.questions.claim_school", financial_year: StudentLoans.current_financial_year)
+      translate("student_loans.questions.claim_school", financial_year: StudentLoans.current_financial_year)
     end
   end
 
@@ -18,24 +20,24 @@ module StudentLoansHelper
   # Accepts a `school_name` named parameter that is the school that the claimant
   # was teaching at during the financial year.
   def subjects_taught_question(school_name:)
-    I18n.t("student_loans.questions.subjects_taught", school: school_name, financial_year: StudentLoans.current_financial_year)
+    translate("student_loans.questions.subjects_taught", school: school_name, financial_year: StudentLoans.current_financial_year)
   end
 
   # Returns the question for the leadership-position question in the Student
   # Loans journey.
   def leadership_position_question
-    I18n.t("student_loans.questions.leadership_position", financial_year: StudentLoans.current_financial_year)
+    translate("student_loans.questions.leadership_position", financial_year: StudentLoans.current_financial_year)
   end
 
   # Returns the question for the mostly-performed-leadership-duties question in
   # the Student  Loans journey.
   def mostly_performed_leadership_duties_question
-    I18n.t("student_loans.questions.mostly_performed_leadership_duties", financial_year: StudentLoans.current_financial_year)
+    translate("student_loans.questions.mostly_performed_leadership_duties", financial_year: StudentLoans.current_financial_year)
   end
 
   # Returns the question for the student-loan-amount question in the Student
   # Loans journey.
   def student_loan_amount_question
-    I18n.t("student_loans.questions.student_loan_amount", financial_year: StudentLoans.current_financial_year)
+    translate("student_loans.questions.student_loan_amount", financial_year: StudentLoans.current_financial_year)
   end
 end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -34,7 +34,7 @@ class ClaimMailer < ApplicationMailer
 
   def set_common_instance_variables(claim)
     @claim = claim
-    @claim_description = I18n.t("#{@claim.policy.locale_key}.claim_description")
+    @claim_description = translate("#{@claim.policy.locale_key}.claim_description")
     @display_name = [@claim.first_name, @claim.surname].join(" ")
     @policy = @claim.policy
   end

--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -17,7 +17,7 @@ class PaymentMailer < ApplicationMailer
 
   def confirmation_for_single_claim
     claim = @payment.claims.first
-    @claim_description = I18n.t("#{claim.policy.locale_key}.claim_description")
+    @claim_description = translate("#{claim.policy.locale_key}.claim_description")
     @reference = claim.reference
     @policy = claim.policy
 

--- a/app/models/admin/presenter_methods.rb
+++ b/app/models/admin/presenter_methods.rb
@@ -1,6 +1,7 @@
 module Admin
   module PresenterMethods
     include ActionView::Helpers::UrlHelper
+    include ActionView::Helpers::TranslationHelper
 
     def display_school(school)
       html = [

--- a/app/models/maths_and_physics/admin_tasks_presenter.rb
+++ b/app/models/maths_and_physics/admin_tasks_presenter.rb
@@ -20,7 +20,7 @@ module MathsAndPhysics
 
     def employment
       [
-        [I18n.t("admin.current_school"), display_school(eligibility.current_school)]
+        [translate("admin.current_school"), display_school(eligibility.current_school)]
       ]
     end
 

--- a/app/models/maths_and_physics/eligibility_admin_answers_presenter.rb
+++ b/app/models/maths_and_physics/eligibility_admin_answers_presenter.rb
@@ -36,77 +36,77 @@ module MathsAndPhysics
 
     def teaching_maths_or_physics
       [
-        I18n.t("maths_and_physics.admin.teaching_maths_or_physics"),
+        translate("maths_and_physics.admin.teaching_maths_or_physics"),
         (eligibility.teaching_maths_or_physics? ? "Yes" : "No")
       ]
     end
 
     def current_school
       [
-        I18n.t("admin.current_school"),
+        translate("admin.current_school"),
         display_school(eligibility.current_school)
       ]
     end
 
     def initial_teacher_training_subject
       [
-        I18n.t("maths_and_physics.admin.initial_teacher_training_subject"),
-        I18n.t("maths_and_physics.answers.initial_teacher_training_subject.#{eligibility.initial_teacher_training_subject}")
+        translate("maths_and_physics.admin.initial_teacher_training_subject"),
+        translate("maths_and_physics.answers.initial_teacher_training_subject.#{eligibility.initial_teacher_training_subject}")
       ]
     end
 
     def initial_teacher_training_subject_specialism
       [
-        I18n.t("maths_and_physics.admin.initial_teacher_training_subject_specialism"),
-        I18n.t("maths_and_physics.answers.initial_teacher_training_subject_specialism.#{eligibility.initial_teacher_training_subject_specialism}")
+        translate("maths_and_physics.admin.initial_teacher_training_subject_specialism"),
+        translate("maths_and_physics.answers.initial_teacher_training_subject_specialism.#{eligibility.initial_teacher_training_subject_specialism}")
       ]
     end
 
     def has_uk_maths_or_physics_degree
       [
-        I18n.t("maths_and_physics.admin.has_uk_maths_or_physics_degree"),
+        translate("maths_and_physics.admin.has_uk_maths_or_physics_degree"),
         degree_answer
       ]
     end
 
     def qts_award_year
       [
-        I18n.t("admin.qts_award_year"),
+        translate("admin.qts_award_year"),
         eligibility.qts_award_year_answer
       ]
     end
 
     def employed_as_supply_teacher
       [
-        I18n.t("maths_and_physics.admin.employed_as_supply_teacher"),
+        translate("maths_and_physics.admin.employed_as_supply_teacher"),
         (eligibility.employed_as_supply_teacher? ? "Yes" : "No")
       ]
     end
 
     def has_entire_term_contract
       [
-        I18n.t("maths_and_physics.admin.has_entire_term_contract"),
+        translate("maths_and_physics.admin.has_entire_term_contract"),
         (eligibility.has_entire_term_contract? ? "Yes" : "No")
       ]
     end
 
     def employed_directly
       [
-        I18n.t("maths_and_physics.admin.employed_directly"),
-        I18n.t("maths_and_physics.answers.employed_directly.#{eligibility.employed_directly? ? "yes" : "no"}")
+        translate("maths_and_physics.admin.employed_directly"),
+        translate("maths_and_physics.answers.employed_directly.#{eligibility.employed_directly? ? "yes" : "no"}")
       ]
     end
 
     def disciplinary_action
       [
-        I18n.t("maths_and_physics.admin.disciplinary_action"),
+        translate("maths_and_physics.admin.disciplinary_action"),
         (eligibility.subject_to_disciplinary_action? ? "Yes" : "No")
       ]
     end
 
     def formal_performance_action
       [
-        I18n.t("maths_and_physics.admin.formal_performance_action"),
+        translate("maths_and_physics.admin.formal_performance_action"),
         (eligibility.subject_to_formal_performance_action? ? "Yes" : "No")
       ]
     end
@@ -115,7 +115,7 @@ module MathsAndPhysics
       case eligibility.has_uk_maths_or_physics_degree
       when "yes" then "Yes"
       when "no" then "No"
-      else I18n.t("maths_and_physics.answers.has_uk_maths_or_physics_degree.#{eligibility.has_uk_maths_or_physics_degree}")
+      else translate("maths_and_physics.answers.has_uk_maths_or_physics_degree.#{eligibility.has_uk_maths_or_physics_degree}")
       end
     end
   end

--- a/app/models/maths_and_physics/eligibility_answers_presenter.rb
+++ b/app/models/maths_and_physics/eligibility_answers_presenter.rb
@@ -1,5 +1,7 @@
 module MathsAndPhysics
   class EligibilityAnswersPresenter
+    include ActionView::Helpers::TranslationHelper
+
     attr_reader :eligibility
 
     def initialize(eligibility)
@@ -35,7 +37,7 @@ module MathsAndPhysics
 
     def teaching_maths_or_physics
       [
-        I18n.t("maths_and_physics.questions.teaching_maths_or_physics"),
+        translate("maths_and_physics.questions.teaching_maths_or_physics"),
         (eligibility.teaching_maths_or_physics? ? "Yes" : "No"),
         "teaching-maths-or-physics"
       ]
@@ -43,7 +45,7 @@ module MathsAndPhysics
 
     def current_school
       [
-        I18n.t("questions.current_school"),
+        translate("questions.current_school"),
         eligibility.current_school_name,
         "current-school"
       ]
@@ -51,23 +53,23 @@ module MathsAndPhysics
 
     def initial_teacher_training_subject
       [
-        I18n.t("maths_and_physics.questions.initial_teacher_training_subject"),
-        I18n.t("maths_and_physics.answers.initial_teacher_training_subject.#{eligibility.initial_teacher_training_subject}"),
+        translate("maths_and_physics.questions.initial_teacher_training_subject"),
+        translate("maths_and_physics.answers.initial_teacher_training_subject.#{eligibility.initial_teacher_training_subject}"),
         "initial-teacher-training-subject"
       ]
     end
 
     def initial_teacher_training_subject_specialism
       [
-        I18n.t("maths_and_physics.questions.initial_teacher_training_subject_specialism"),
-        I18n.t("maths_and_physics.answers.initial_teacher_training_subject_specialism.#{eligibility.initial_teacher_training_subject_specialism}"),
+        translate("maths_and_physics.questions.initial_teacher_training_subject_specialism"),
+        translate("maths_and_physics.answers.initial_teacher_training_subject_specialism.#{eligibility.initial_teacher_training_subject_specialism}"),
         "initial-teacher-training-subject-specialism"
       ]
     end
 
     def has_uk_maths_or_physics_degree
       [
-        I18n.t("maths_and_physics.questions.has_uk_maths_or_physics_degree"),
+        translate("maths_and_physics.questions.has_uk_maths_or_physics_degree"),
         degree_answer,
         "has-uk-maths-or-physics-degree"
       ]
@@ -75,7 +77,7 @@ module MathsAndPhysics
 
     def qts_award_year
       [
-        I18n.t("questions.qts_award_year"),
+        translate("questions.qts_award_year"),
         eligibility.qts_award_year_answer,
         "qts-year"
       ]
@@ -83,7 +85,7 @@ module MathsAndPhysics
 
     def employed_as_supply_teacher
       [
-        I18n.t("maths_and_physics.questions.employed_as_supply_teacher"),
+        translate("maths_and_physics.questions.employed_as_supply_teacher"),
         (eligibility.employed_as_supply_teacher? ? "Yes" : "No"),
         "supply-teacher"
       ]
@@ -91,7 +93,7 @@ module MathsAndPhysics
 
     def has_entire_term_contract
       [
-        I18n.t("maths_and_physics.questions.has_entire_term_contract"),
+        translate("maths_and_physics.questions.has_entire_term_contract"),
         (eligibility.has_entire_term_contract? ? "Yes" : "No"),
         "entire-term-contract"
       ]
@@ -99,15 +101,15 @@ module MathsAndPhysics
 
     def employed_directly
       [
-        I18n.t("maths_and_physics.questions.employed_directly"),
-        I18n.t("maths_and_physics.answers.employed_directly.#{eligibility.employed_directly? ? "yes" : "no"}"),
+        translate("maths_and_physics.questions.employed_directly"),
+        translate("maths_and_physics.answers.employed_directly.#{eligibility.employed_directly? ? "yes" : "no"}"),
         "employed-directly"
       ]
     end
 
     def disciplinary_action
       [
-        I18n.t("maths_and_physics.questions.disciplinary_action"),
+        translate("maths_and_physics.questions.disciplinary_action"),
         (eligibility.subject_to_disciplinary_action? ? "Yes" : "No"),
         "disciplinary-action"
       ]
@@ -115,7 +117,7 @@ module MathsAndPhysics
 
     def formal_performance_action
       [
-        I18n.t("maths_and_physics.questions.formal_performance_action"),
+        translate("maths_and_physics.questions.formal_performance_action"),
         (eligibility.subject_to_formal_performance_action? ? "Yes" : "No"),
         "formal-performance-action"
       ]
@@ -125,7 +127,7 @@ module MathsAndPhysics
       case eligibility.has_uk_maths_or_physics_degree
       when "yes" then "Yes"
       when "no" then "No"
-      else I18n.t("maths_and_physics.answers.has_uk_maths_or_physics_degree.#{eligibility.has_uk_maths_or_physics_degree}")
+      else translate("maths_and_physics.answers.has_uk_maths_or_physics_degree.#{eligibility.has_uk_maths_or_physics_degree}")
       end
     end
   end

--- a/app/models/student_loans/admin_tasks_presenter.rb
+++ b/app/models/student_loans/admin_tasks_presenter.rb
@@ -20,7 +20,7 @@ module StudentLoans
     def employment
       [
         ["6 April 2018 to 5 April 2019", display_school(eligibility.claim_school)],
-        [I18n.t("admin.current_school"), display_school(eligibility.current_school)]
+        [translate("admin.current_school"), display_school(eligibility.current_school)]
       ]
     end
 

--- a/app/models/student_loans/eligibility_admin_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_admin_answers_presenter.rb
@@ -32,42 +32,42 @@ module StudentLoans
 
     def qts_award_year
       [
-        I18n.t("admin.qts_award_year"),
+        translate("admin.qts_award_year"),
         eligibility.qts_award_year_answer
       ]
     end
 
     def claim_school
       [
-        I18n.t("student_loans.admin.claim_school"),
+        translate("student_loans.admin.claim_school"),
         display_school(eligibility.claim_school)
       ]
     end
 
     def current_school
       [
-        I18n.t("admin.current_school"),
+        translate("admin.current_school"),
         display_school(eligibility.current_school)
       ]
     end
 
     def subjects_taught
       [
-        I18n.t("student_loans.admin.subjects_taught"),
+        translate("student_loans.admin.subjects_taught"),
         subject_list(eligibility.subjects_taught)
       ]
     end
 
     def had_leadership_position
       [
-        I18n.t("student_loans.admin.had_leadership_position"),
+        translate("student_loans.admin.had_leadership_position"),
         (eligibility.had_leadership_position? ? "Yes" : "No")
       ]
     end
 
     def mostly_performed_leadership_duties
       [
-        I18n.t("student_loans.admin.mostly_performed_leadership_duties"),
+        translate("student_loans.admin.mostly_performed_leadership_duties"),
         (eligibility.mostly_performed_leadership_duties? ? "Yes" : "No")
       ]
     end

--- a/app/models/student_loans/eligibility_answers_presenter.rb
+++ b/app/models/student_loans/eligibility_answers_presenter.rb
@@ -35,7 +35,7 @@ module StudentLoans
 
     def qts_award_year
       [
-        I18n.t("questions.qts_award_year"),
+        translate("questions.qts_award_year"),
         eligibility.qts_award_year_answer,
         "qts-year"
       ]
@@ -51,7 +51,7 @@ module StudentLoans
 
     def current_school
       [
-        I18n.t("questions.current_school"),
+        translate("questions.current_school"),
         eligibility.current_school_name,
         "still-teaching"
       ]


### PR DESCRIPTION
Following up on https://github.com/DFE-Digital/dfe-teachers-payment-service/pull/980, I've figured out why we didn't get an early warning about missing translation keys.

Rails’ `translate` method delegates to `I18n#translate`, but also performs additional functions, including raising an exception when a translation key is missing and the application is configured with `ActionView::Base.raise_on_missing_translations` set to true. By using this method we make it less likely that we will ship code where translations are missing as we should see exceptions raised in the specs.