### PR TITLE
Set healthcheck endpoint to monitor

### DIFF
--- a/azure/templates/app.json
+++ b/azure/templates/app.json
@@ -183,7 +183,8 @@
         "httpsOnly": true,
         "siteConfig": {
           "alwaysOn": "[parameters('appServiceAlwaysOn')]",
-          "appSettings": "[parameters('appServiceEnvironmentVariables')]"
+          "appSettings": "[parameters('appServiceEnvironmentVariables')]",
+          "healthCheckPath": "/healthcheck"
         }
       }
     },


### PR DESCRIPTION
This tells Azure to monitor the healthcheck endpoint every 2 minutes. If an instance does not respond within 10 minutes, the instance is taken out of the pool. It's a manual process to put the app back in the pool, and we're not (currently) able to be alerted if something is taken out of the pool (this is a Windows-only thing at the moment). That said, it's better than us accidentally routing people to a broken instance.

Ideally, we'll want to have autohealing, but this is (again) a Windows-only thing.

More on the Health Check functionality is [here](https://github.com/projectkudu/kudu/wiki/Health-Check-%28Preview%29)
