### PR TITLE
Exclude claims from previous academic years on matching claims screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Exclude claims from previous academic years on matching claims screen
+
 ## [Release 066] - 2020-03-25
 
 - Support searching for claims with more than just the reference

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -170,6 +170,7 @@ class Claim < ApplicationRecord
   scope :passed_decision_deadline, -> { awaiting_decision.where("submitted_at < ?", DECISION_DEADLINE.ago) }
   scope :payrollable, -> { approved.where(payment: nil) }
   scope :by_policy, ->(policy) { where(eligibility_type: policy::Eligibility.to_s) }
+  scope :by_academic_year, ->(academic_year) { where(academic_year: academic_year) }
 
   delegate :award_amount, to: :eligibility
   delegate :scheduled_payment_date, to: :payment, allow_nil: true

--- a/app/models/claim/matching_attribute_finder.rb
+++ b/app/models/claim/matching_attribute_finder.rb
@@ -41,6 +41,7 @@ class Claim
     def claims_to_compare
       Claim.submitted
         .by_policy(@source_claim.policy)
+        .by_academic_year(@source_claim.academic_year)
         .where.not(id: @source_claim.id)
     end
 

--- a/spec/models/claim/matching_attribute_finder_spec.rb
+++ b/spec/models/claim/matching_attribute_finder_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Claim::MatchingAttributeFinder do
         email_address: "genghis.khan@mongol-empire.com",
         bank_account_number: "34682151",
         bank_sort_code: "972654",
+        academic_year: AcademicYear.new("2019"),
         building_society_roll_number: "123456789/ABCD",
         policy: StudentLoans)
     }
@@ -33,6 +34,15 @@ RSpec.describe Claim::MatchingAttributeFinder do
 
     it "does not include claims that match, but have a different policy" do
       create(:claim, :submitted, teacher_reference_number: source_claim.teacher_reference_number, policy: MathsAndPhysics)
+
+      expect(matching_claims).to be_empty
+    end
+
+    it "does not include claims that match, but have a different academic year" do
+      create(:claim, :submitted,
+        teacher_reference_number: source_claim.teacher_reference_number,
+        academic_year: AcademicYear.new("2020"),
+        policy: source_claim.policy)
 
       expect(matching_claims).to be_empty
     end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -471,6 +471,19 @@ RSpec.describe Claim, type: :model do
     end
   end
 
+  describe "by_academic_year" do
+    let(:academic_year_2019) { AcademicYear.new("2019") }
+    let(:academic_year_2020) { AcademicYear.new("2020") }
+
+    let!(:academic_year_2019_claims) { create_list(:claim, 5, academic_year: academic_year_2019) }
+    let!(:academic_year_2020_claims) { create_list(:claim, 5, academic_year: academic_year_2020) }
+
+    it "returns claims for a specific academic year" do
+      expect(Claim.by_academic_year(academic_year_2019.dup)).to match_array(academic_year_2019_claims)
+      expect(Claim.by_academic_year(academic_year_2020.dup)).to match_array(academic_year_2020_claims)
+    end
+  end
+
   describe "#submittable?" do
     it "returns true when the claim is valid and has not been submitted" do
       claim = build(:claim, :submittable)


### PR DESCRIPTION
This adds a new scope to filter by academic year, and then uses that scope in the matching attribute finder to only find claims that are for the same academic year as the source claim.
